### PR TITLE
Downgrade loglevel for regular requests

### DIFF
--- a/rt/rs/security/oauth-parent/oauth2/src/main/java/org/apache/cxf/rs/security/oauth2/filters/OAuthRequestFilter.java
+++ b/rt/rs/security/oauth-parent/oauth2/src/main/java/org/apache/cxf/rs/security/oauth2/filters/OAuthRequestFilter.java
@@ -146,7 +146,7 @@ public class OAuthRequestFilter extends AbstractAccessTokenValidator
         }
         if (!foundValidScope) {
             String message = "Invalid request URI: " + request.getRequestURL().toString();
-            LOG.warning(message);
+            LOG.fine(message);
         }
         return foundValidScope;
     }


### PR DESCRIPTION
Every request, even if successful, results in many warning entries, alerting developer unnecessarily. This modification downgrades log level to "fine", like in "checkHttpVerb" method. So, regular and authorized requests do not increase log file with WARNS.
