### PR TITLE
Fix for [CXF-5822]. 

### DIFF
--- a/api/src/main/java/org/apache/cxf/common/util/PropertiesLoaderUtils.java
+++ b/api/src/main/java/org/apache/cxf/common/util/PropertiesLoaderUtils.java
@@ -65,6 +65,10 @@ public final class PropertiesLoaderUtils {
                                                Logger logger, Level level, String msg)
         throws IOException {
         Properties properties = new Properties();
+        //set default class loader if neccessary
+        if (classLoader == null) {
+            classLoader = PropertiesLoaderUtils.class.getClassLoader();
+        }
         Enumeration<URL> urls = classLoader.getResources(resourceName);
 
         while (urls.hasMoreElements()) {


### PR DESCRIPTION
Checks classLoader for null and sets it to PropertiesLoaderUtils.class.getClassLoader() in case.
