### PR TITLE
Fix for XMLStreamException in WSDLGetOutInterceptor.

### DIFF
--- a/rt/frontend/simple/src/main/java/org/apache/cxf/frontend/WSDLGetOutInterceptor.java
+++ b/rt/frontend/simple/src/main/java/org/apache/cxf/frontend/WSDLGetOutInterceptor.java
@@ -52,7 +52,7 @@ public class WSDLGetOutInterceptor extends AbstractPhaseInterceptor<Message> {
         }
         message.put(Message.CONTENT_TYPE, "text/xml");
         try {
-            StaxUtils.writeNode(doc, writer, true);
+            StaxUtils.writeDocument(doc, writer, false, true);
         } catch (XMLStreamException e) {
             throw new Fault(e);
         }


### PR DESCRIPTION
Fix for generated WSDL (http://foo/bar?wsdl)
Both StaxOutInterceptor and WSDLGetOutInterceptor tried to write an XML prolog which caused an error in a writer.