### PR TITLE
CXF-6073: cxf-wsn installation in Karaf fails

### DIFF
--- a/osgi/karaf/features/src/main/resources/features.xml
+++ b/osgi/karaf/features/src/main/resources/features.xml
@@ -365,6 +365,8 @@
             cxf.wsn.activemq = vm:localhost
             cxf.wsn.rootUrl = http://0.0.0.0:8182
             cxf.wsn.context = /wsn
+            cxf.wsn.activemq.username = karaf
+            cxf.wsn.activemq.password = karaf
         </config>
         <feature version="[5.4,6)">activemq</feature>
         <feature version="${project.version}">cxf-wsn-api</feature>


### PR DESCRIPTION
Fix for https://issues.apache.org/jira/browse/CXF-6073. 

Please backport this fix in 3.0.x and 2.7.x too
