### PR TITLE
    CXF-6138  JAXB unmarshaller Properties cleared by initialize()

### DIFF
--- a/rt/databinding/jaxb/src/main/java/org/apache/cxf/jaxb/JAXBDataBinding.java
+++ b/rt/databinding/jaxb/src/main/java/org/apache/cxf/jaxb/JAXBDataBinding.java
@@ -305,9 +305,9 @@ public class JAXBDataBinding extends AbstractInterceptorProvidingDataBinding
 
         contextClasses = new LinkedHashSet<Class<?>>();
         
-        if(this.getUnmarshallerProperties()==null||this.getUnmarshallerProperties().isEmpty()){
-        	Map<String, Object> unmarshallerProps = new HashMap<String, Object>();
-        	this.setUnmarshallerProperties(unmarshallerProps);
+        if (this.getUnmarshallerProperties() == null || this.getUnmarshallerProperties().isEmpty()) {
+            Map<String, Object> unmarshallerProps = new HashMap<String, Object>();
+            this.setUnmarshallerProperties(unmarshallerProps);
         }
         
         for (ServiceInfo serviceInfo : service.getServiceInfos()) {

--- a/rt/databinding/jaxb/src/test/java/org/apache/cxf/jaxb/DataBindingMarshallerPropertiesTest.java
+++ b/rt/databinding/jaxb/src/test/java/org/apache/cxf/jaxb/DataBindingMarshallerPropertiesTest.java
@@ -1,3 +1,22 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package org.apache.cxf.jaxb;
 
 import java.util.HashMap;
@@ -11,10 +30,10 @@ public class DataBindingMarshallerPropertiesTest extends TestBase {
         JAXBDataBinding db = new JAXBDataBinding();
         Map<String, Object> unmarshallerProperties = new HashMap<String, Object>();
         unmarshallerProperties.put("someproperty", "somevalue");
-    	db.setUnmarshallerProperties(unmarshallerProperties);
+        db.setUnmarshallerProperties(unmarshallerProperties);
         
-      	db.initialize(service);
+        db.initialize(service);
         
-		assertTrue("somevalue".equals(db.getUnmarshallerProperties().get("someproperty")));
+        assertTrue("somevalue".equals(db.getUnmarshallerProperties().get("someproperty")));
     }
 }


### PR DESCRIPTION
The existing functionality, of setting an empty HashMap for unmarshallerProperies upon initialize() is now conditional upon the existing value being null or empty.
