### PR TITLE
(CXF-6148) Added a basic support of xsd:choice elements in JS generator.

### DIFF
--- a/rt/javascript/javascript-rt/src/main/java/org/apache/cxf/javascript/JavascriptUtils.java
+++ b/rt/javascript/javascript-rt/src/main/java/org/apache/cxf/javascript/JavascriptUtils.java
@@ -338,6 +338,13 @@ public class JavascriptUtils {
     public void generateCodeToSerializeElement(ParticleInfo elementInfo,
                                                String referencePrefix,
                                                SchemaCollection schemaCollection) {
+        if (elementInfo.isGroup()) {
+            for (ParticleInfo childElement : elementInfo.getChildren()) {
+                generateCodeToSerializeElement(childElement, referencePrefix, schemaCollection);
+            }
+            return;
+        }
+
         XmlSchemaType type = elementInfo.getType();
         boolean nillable = elementInfo.isNillable();
         boolean optional = elementInfo.isOptional();
@@ -563,9 +570,10 @@ public class JavascriptUtils {
                                                 contextName, object);
         }
         if (!(object instanceof XmlSchemaElement)
-            && !(object instanceof XmlSchemaAny)) {
+            && !(object instanceof XmlSchemaAny)
+            && !(object instanceof XmlSchemaChoice)) {
             unsupportedConstruct("GROUP_CHILD",
-                                                object.getClass().getSimpleName(), contextName,
+                    object.getClass().getSimpleName(), contextName,
                                                 object);
         }
 

--- a/rt/javascript/javascript-rt/src/main/java/org/apache/cxf/javascript/Messages.properties
+++ b/rt/javascript/javascript-rt/src/main/java/org/apache/cxf/javascript/Messages.properties
@@ -25,3 +25,6 @@ IMPOSSIBLE_GLOBAL_ITEM= JavaScript limitation: Element or xs:any at {0} used in 
 MISSING_TYPE=Type {0} is missing from the WSDL schema for element {1}. {2}
 ELEMENT_DANGLING_REFERENCE= Element {0} refers to undefined element {1}.
 UNSUPPORTED_ATTRIBUTE_ITEM= Unsupported {0} in {1}.
+GROUP_ELEMENT_MULTI_OCCURS=Limitation: unsupported group element construct {0} with maxOccours > 1 found.
+GROUP_ELEMENT_ANY=Limitation: unsupported any element inside group element construct {0}
+GROUP_CHILD=Limitation: unsupported construct {0} found in {1}. {2}

--- a/tools/wsdlto/frontend/javascript/src/test/java/org/apache/cxf/tools/wsdlto/javascript/WSDLToJavaScriptTest.java
+++ b/tools/wsdlto/frontend/javascript/src/test/java/org/apache/cxf/tools/wsdlto/javascript/WSDLToJavaScriptTest.java
@@ -32,7 +32,17 @@ import org.junit.Test;
  * 
  */
 public class WSDLToJavaScriptTest extends ProcessorTestBase {
-    
+
+    public int countChar(String text, char symbol) {
+        int count = 0;
+        for (int i = 0; i < text.length(); i++) {
+            if (text.charAt(i) == symbol) {
+                count++;
+            }
+        }
+        return count;
+    }
+
     // just run with a minimum of fuss.
     @Test
     public void testGeneration() throws Exception {
@@ -52,6 +62,9 @@ public class WSDLToJavaScriptTest extends ProcessorTestBase {
         FileInputStream fis = new FileInputStream(resultFile);
         String javascript = IOUtils.readStringFromStream(fis);
         assertTrue(javascript.contains("xmlns:murble='http://apache.org/hello_world_soap_http'"));
+        assertEquals("Number of '{' does not match number of '}' in generated JavaScript.",
+                countChar(javascript, '{'),
+                countChar(javascript, '}'));
     }
    
     @Test
@@ -72,6 +85,9 @@ public class WSDLToJavaScriptTest extends ProcessorTestBase {
         FileInputStream fis = new FileInputStream(resultFile);
         String javascript = IOUtils.readStringFromStream(fis);
         assertTrue(javascript.contains("xmlns:murble='http://apache.org/hello_world_soap_http'"));
+        assertEquals("Number of '{' does not match number of '}' in generated JavaScript.",
+                countChar(javascript, '{'),
+                countChar(javascript, '}'));
     }
    
 }

--- a/tools/wsdlto/frontend/javascript/src/test/resources/org/apache/cxf/tools/wsdlto/javascript/hello_world.wsdl
+++ b/tools/wsdlto/frontend/javascript/src/test/resources/org/apache/cxf/tools/wsdlto/javascript/hello_world.wsdl
@@ -154,6 +154,30 @@ under the License.
                     <attribute name="id" type="int"/>
                 </complexType>
             </element>
+            <element name="testChoice">
+                <complexType>
+                    <sequence>
+                        <element name="arg0" type="string"/>
+                        <element name="arg1" type="string"/>
+                        <choice>
+                            <element name="arg2" type="string"/>
+                            <element name="arg3" type="string"/>
+                        </choice>
+                    </sequence>
+                </complexType>
+            </element>
+            <element name="testChoiceResponse">
+                <complexType>
+                    <sequence>
+                        <element name="arg0" type="string"/>
+                        <element name="arg1" type="string"/>
+                        <choice>
+                            <element name="arg2" type="string"/>
+                            <element name="arg3" type="string"/>
+                        </choice>
+                    </sequence>
+                </complexType>
+            </element>
         </schema>
     </wsdl:types>
     <wsdl:message name="sayHiRequest">
@@ -207,6 +231,13 @@ under the License.
     <wsdl:message name="testDocLitBareResponse">
         <wsdl:part name="out" element="x1:BareDocumentResponse"/>
     </wsdl:message>
+    <wsdl:message name="testChoiceRequest">
+        <wsdl:part name="in" element="x1:testChoice"/>
+    </wsdl:message>
+    <wsdl:message name="testChoiceResponse">
+        <wsdl:part name="out" element="x1:testChoiceResponse"/>
+    </wsdl:message>
+
     <wsdl:portType name="Greeter">
         <wsdl:operation name="sayHi">
             <wsdl:input name="sayHiRequest" message="tns:sayHiRequest"/>
@@ -236,6 +267,10 @@ under the License.
             <wsdl:output name="testDocLitFaultResponse" message="tns:testDocLitFaultResponse"/>
             <wsdl:fault name="NoSuchCodeLitFault" message="tns:NoSuchCodeLitFault"/>
             <wsdl:fault name="BadRecordLitFault" message="tns:BadRecordLitFault"/>
+        </wsdl:operation>
+        <wsdl:operation name="testChoice">
+            <wsdl:input name="testChoiceRequest" message="tns:testChoiceRequest"/>
+            <wsdl:output name="testChoiceResponse" message="tns:testChoiceResponse"/>
         </wsdl:operation>
     </wsdl:portType>
     <wsdl:portType name="DocLitBare">
@@ -311,6 +346,15 @@ under the License.
             <wsdl:fault name="BadRecordLitFault">
                 <soap:fault name="BadRecordLitFault" use="literal"/>
             </wsdl:fault>
+        </wsdl:operation>
+        <wsdl:operation name="testChoice">
+            <soap:operation style="document"/>
+            <wsdl:input>
+                <soap:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal"/>
+            </wsdl:output>
         </wsdl:operation>
     </wsdl:binding>
     <wsdl:binding name="Doc_Lit_Bare_SOAPBinding" type="tns:DocLitBare">


### PR DESCRIPTION
This fix adds a basic support for xsd:choice elements.
There are several limitations:
- JS does not check xsd:choice restrictions (it is currently possible to set several xsd:choice members at the same time, but this should eventually result in SOAP BE error)
- xsd:choice with maxOccurs > 1 still not support
- xsd:any inside xsd:choice is not supported as well

Covered it with tests and did small improvement to the tests.
Also added log message when not supported exception is raisen, since it was not enabled previously.
