### PR TITLE
Fix for [CXF-6161]

### DIFF
--- a/tools/wsdlto/core/src/main/java/org/apache/cxf/tools/wsdlto/WSDLToJavaContainer.java
+++ b/tools/wsdlto/core/src/main/java/org/apache/cxf/tools/wsdlto/WSDLToJavaContainer.java
@@ -777,16 +777,12 @@ public class WSDLToJavaContainer extends AbstractCXFToolContainer {
             }
            
             //get imported wsdls
+            int wsdlImportCount = 0;
             List<Definition> defs = (List<Definition>)context.get(ToolConstants.IMPORTED_DEFINITION);            
             Map<String, String> importWSDLMap = new HashMap<String, String>();
             for (Definition importDef : defs) {
-                File importedWsdlFile = null;
-                if (!StringUtils.isEmpty(importDef.getDocumentBaseURI())) {
-                    importedWsdlFile = new File(importDef.getDocumentBaseURI());
-                } else {
-                    importedWsdlFile = new File(importDef.getQName().getLocalPart() + ".wsdl");
-                }
-                importWSDLMap.put(importDef.getTargetNamespace(), importedWsdlFile.getName());
+                String localWsdlFileName = "import" + (++wsdlImportCount) + ".wsdl";
+                importWSDLMap.put(importDef.getTargetNamespace(), localWsdlFileName);
             }
             
             


### PR DESCRIPTION
Instead of using a local filename based on the original URL of an
wsdl:import use a numbered name: importNN.wsdl. Similar to schema
imports. This should resolve issue [CXF-6161] in which an invalid
filename may be generated.
