### PR TITLE
[CXF-6163] Fixed xsd:any behaviour when used with minOccurs=0, maxOccurs>1

### DIFF
--- a/rt/javascript/javascript-rt/src/main/java/org/apache/cxf/javascript/JavascriptUtils.java
+++ b/rt/javascript/javascript-rt/src/main/java/org/apache/cxf/javascript/JavascriptUtils.java
@@ -473,7 +473,8 @@ public class JavascriptUtils {
      */
     public void generateCodeToSerializeAny(ParticleInfo itemInfo, String prefix,
                                            SchemaCollection schemaCollection) {
-        boolean optional = XmlSchemaUtils.isParticleOptional(itemInfo.getParticle());
+        boolean optional = XmlSchemaUtils.isParticleOptional(itemInfo.getParticle())
+                || (itemInfo.isArray() && itemInfo.getMinOccurs() == 0);
         boolean array = XmlSchemaUtils.isParticleArray(itemInfo.getParticle());
 
         appendLine("var anyHolder = this._" + itemInfo.getJavascriptName() + ";");

--- a/rt/javascript/javascript-rt/src/main/java/org/apache/cxf/javascript/types/SchemaJavascriptBuilder.java
+++ b/rt/javascript/javascript-rt/src/main/java/org/apache/cxf/javascript/types/SchemaJavascriptBuilder.java
@@ -533,6 +533,8 @@ public class SchemaJavascriptBuilder {
         // non-matching case
         utils.startIf("anyNeeded > 0");
         utils.appendLine("throw 'not enough ws:any elements';");
+        utils.appendElse(); // else non-match
+        utils.appendLine("break;");
         utils.endBlock(); // non-match+required
         utils.endBlock(); // match/non-match.
         utils.endBlock(); // while


### PR DESCRIPTION
- xsd:any deserializer does not go into infinite loop when xsd:any cannot match any element and minOccurs=0

Here is how generated code now looks like:

``` javascript
    var anyObject = [];
    var matcher = new org_apache_cxf_any_ns_matcher(org_apache_cxf_any_ns_matcher.ANY, 'urn:...', [], null);
    var anyNeeded = 0;
    var anyAllowed = 9223372036854775807;
    while (anyNeeded > 0 || anyAllowed > 0) {
     var anyURI;
     var anyLocalPart;
     var anyMatched = false;
     if (curElement) {
      anyURI = cxfjsutils.getElementNamespaceURI(curElement);
      anyLocalPart = cxfjsutils.getNodeLocalName(curElement);
      var anyQName = '{' + anyURI + '}' + anyLocalPart;
      cxfjsutils.trace('any match: ' + anyQName);
      anyMatched = matcher.match(anyURI, anyLocalPart)
      cxfjsutils.trace(' --> ' + anyMatched);
     }
     if (anyMatched) {
      anyDeserializer = cxfjsutils.interfaceObject.globalElementDeserializers[anyQName];
      cxfjsutils.trace(' deserializer: ' + anyDeserializer);
      if (anyDeserializer) {
       var anyValue = anyDeserializer(cxfjsutils, curElement);
      } else {
       var anyValue = curElement.nodeValue;
      }
      anyObject.push(anyValue);
      anyNeeded--;
      anyAllowed--;
      curElement = cxfjsutils.getNextElementSibling(curElement);
     } else {
      if (anyNeeded > 0) {
       throw 'not enough ws:any elements';
      } else {
       break;
      }
     }
    }
    var anyHolder = new org_apache_cxf_any_holder(anyURI, anyLocalPart, anyValue);
    newobject.setAny(anyHolder);
```
- xsd:any serializer does not throw an exception when xsd:any element is being passed as empty array and minOccurs=0
