### PR TITLE
[CXF-6167] Added ability to specify a function for parsing parsing error details from failed SOAP response

### DIFF
--- a/rt/javascript/javascript-rt/src/main/java/org/apache/cxf/javascript/service/ServiceJavascriptBuilder.java
+++ b/rt/javascript/javascript-rt/src/main/java/org/apache/cxf/javascript/service/ServiceJavascriptBuilder.java
@@ -420,7 +420,11 @@ public class ServiceJavascriptBuilder extends ServiceModelVisitor {
         utils.appendLine(" httpStatus = -1;");
         utils.appendLine(" httpStatusText = 'Error opening connection to server';");
         utils.appendLine("}");
+        utils.startIf("client.parseErrorDetails");
+        utils.appendLine("client.user_onerror(httpStatus, httpStatusText, client.parseErrorDetails(this));");
+        utils.appendElse();
         utils.appendLine("client.user_onerror(httpStatus, httpStatusText);");
+        utils.endBlock();
         utils.endBlock();
         code.append("}\n\n");
         code.append(currentInterfaceClassName + ".prototype."


### PR DESCRIPTION
- If _cxf-utils_ client has parseErrorDetails method it is now used for parsing error details
