### PR TITLE
Optimisation usage of URLEncode / URLDecode to UrlUtils

### DIFF
--- a/core/src/main/java/org/apache/cxf/common/codec/IByteToCharEncoder.java
+++ b/core/src/main/java/org/apache/cxf/common/codec/IByteToCharEncoder.java
@@ -1,0 +1,13 @@
+package org.apache.cxf.common.codec;
+
+import java.nio.ByteBuffer;
+import java.nio.CharBuffer;
+
+/**
+ * @author Mark A. Ziesemer
+ * 	<a href="http://www.ziesemer.com.">&lt;www.ziesemer.com&gt;</a>
+ */
+public interface IByteToCharEncoder extends ICoder<ByteBuffer, CharBuffer>{
+	// Below not currently supported by javac: http://bugs.sun.com/bugdatabase/view_bug.do?bug_id=6294779
+	// public IByteToCharEncoder clone() throws CloneNotSupportedException;
+}

--- a/core/src/main/java/org/apache/cxf/common/codec/ICharToByteDecoder.java
+++ b/core/src/main/java/org/apache/cxf/common/codec/ICharToByteDecoder.java
@@ -1,0 +1,13 @@
+package org.apache.cxf.common.codec;
+
+import java.nio.ByteBuffer;
+import java.nio.CharBuffer;
+
+/**
+ * @author Mark A. Ziesemer
+ * 	<a href="http://www.ziesemer.com.">&lt;www.ziesemer.com&gt;</a>
+ */
+public interface ICharToByteDecoder extends ICoder<CharBuffer, ByteBuffer>{
+	// Below not currently supported by javac: http://bugs.sun.com/bugdatabase/view_bug.do?bug_id=6294779
+	// public ICharToByteDecoder clone() throws CloneNotSupportedException;
+}

--- a/core/src/main/java/org/apache/cxf/common/codec/ICoder.java
+++ b/core/src/main/java/org/apache/cxf/common/codec/ICoder.java
@@ -1,0 +1,109 @@
+package org.apache.cxf.common.codec;
+
+import java.io.Serializable;
+import java.nio.Buffer;
+import java.nio.charset.CharacterCodingException;
+import java.nio.charset.CoderResult;
+
+/**
+ * <p>
+ * 	Base API for high-performance encoding and decoding between various {@link Buffer}s.
+ * 	Supports conversions between {@link java.nio.ByteBuffer}s and
+ * 		{@link java.nio.CharBuffer}s through the {@link IByteToCharEncoder} and
+ * 		{@link ICharToByteDecoder} child interfaces, e.g. URL/Percent and Base64 codecs.
+ * </p>
+ * <p>
+ * 	This API is similar in design to {@link java.nio.charset.CharsetEncoder} and
+ * 		{@link java.nio.charset.CharsetDecoder}.
+ * </p>
+ * @param <IN> The type of {@link Buffer} being read from.
+ * @param <OUT> The type of {@link Buffer} being written to.
+ * @author Mark A. Ziesemer
+ * 	<a href="http://www.ziesemer.com.">&lt;www.ziesemer.com&gt;</a>
+ */
+public interface ICoder<IN extends Buffer, OUT extends Buffer>
+		extends Cloneable, Serializable{
+
+	/**
+	 * <p>Configures this instances based upon another.
+	 * 	The passed-in parameter must be an instance of the current implementation,
+	 * 		or an {@link IllegalArgumentException} will be thrown.</p>
+	 * @param base The instance to copy the configuration from.
+	 * @return The current instance, supporting the builder pattern.
+	 * @throws IllegalArgumentException If the passed-in parameter is not a
+	 * 	class-compatible instance of the current implementation.
+	 */
+	ICoder<IN, OUT> config(ICoder<IN, OUT> base);
+
+	/**
+	 * <p>Another means for obtaining a configured instance copy from another.
+	 * 	Typically utilizes {@link #config(ICoder)}.</p>
+	 * @return A copy of the current instance with the same configuration.
+	 * @throws CloneNotSupportedException
+	 */
+	ICoder<IN, OUT> clone() throws CloneNotSupportedException;
+
+	/**
+	 * <p>Heuristic value of the minimum number of input units required to produce
+	 * 		one or more output units.</p>
+	 * <p>Similar to {@link #getAverageOutPerIn()} and {@link #getMaxOutPerIn()}.</p>
+	 */
+	float getMinInPerOut();
+
+	/**
+	 * <p>Heuristic value of the average number of output units generated per input unit.</p>
+	 * <p>Similar to {@link java.nio.charset.CharsetEncoder#averageBytesPerChar()}
+	 * 		and {@link java.nio.charset.CharsetDecoder#averageCharsPerByte()}.</p>
+	 */
+	float getAverageOutPerIn();
+
+	/**
+	 * <p>Heuristic value of the maximum number of output units generated per input unit.</p>
+	 * <p>Similar to {@link java.nio.charset.CharsetEncoder#maxBytesPerChar()}
+	 * 		and {@link java.nio.charset.CharsetDecoder#maxCharsPerByte()}.</p>
+	 */
+	float getMaxOutPerIn();
+	
+	/**
+	 * <p>Resets the coder, allowing it to be reused against new input and output,
+	 * 	while keeping the same configuration.</p>
+	 */
+	ICoder<IN, OUT> reset();
+	
+	/**
+	 * <p>Convenience method that encodes the passed-in input {@link Buffer} to a
+	 * 		returned output {@link Buffer}.</p>
+	 * <p>Functions similar to
+	 * 	{@link java.nio.charset.CharsetEncoder#encode(java.nio.CharBuffer)} and
+	 * 	{@link java.nio.charset.CharsetDecoder#decode(java.nio.ByteBuffer)}.</p>
+	 * @param in The input {@link Buffer} to read from.
+	 * @return The output {@link Buffer} written to.
+	 * @throws CharacterCodingException
+	 */
+	OUT code(IN in) throws CharacterCodingException;
+
+	/**
+	 * <p>Encodes as many units as possible from the given input buffer,
+	 * 		writing the results to the given output buffer.</p>
+	 * <p>Functions similar to
+	 * 	{@link java.nio.charset.CharsetEncoder#encode(java.nio.CharBuffer, java.nio.ByteBuffer, boolean)} and
+	 * 	{@link java.nio.charset.CharsetDecoder#decode(java.nio.ByteBuffer, java.nio.CharBuffer, boolean)}.</p>
+	 * @param in The input {@link Buffer} to read from.
+	 * @param out The output {@link Buffer} to write to.
+	 * @param endOfInput <code>true</code> if, and only if, the invoker can provide no
+	 * 	additional input characters beyond those in the given buffer.
+	 */
+	CoderResult code(IN in, OUT out, boolean endOfInput);
+
+	/**
+	 * <p>Writes any final output after the entire input has been processed.
+	 * 	Should be called after {@link #code(Buffer, Buffer, boolean)} is
+	 * 		called for the final time.</p>
+	 * <p>Functions similar to
+	 * 	{@link java.nio.charset.CharsetEncoder#flush(java.nio.ByteBuffer)} and
+	 * 	{@link java.nio.charset.CharsetDecoder#flush(java.nio.CharBuffer)}.</p>
+	 * @param out The output {@link Buffer} to write to.
+	 */
+	CoderResult flush(OUT out);
+
+}

--- a/core/src/main/java/org/apache/cxf/common/codec/base/BaseCoder.java
+++ b/core/src/main/java/org/apache/cxf/common/codec/base/BaseCoder.java
@@ -1,0 +1,219 @@
+package org.apache.cxf.common.codec.base;
+
+import java.nio.Buffer;
+import java.nio.BufferOverflowException;
+import java.nio.BufferUnderflowException;
+import java.nio.charset.CharacterCodingException;
+import java.nio.charset.CoderMalfunctionError;
+import java.nio.charset.CoderResult;
+
+import org.apache.cxf.common.codec.ICoder;
+
+/**
+ * @param <IN> The type of {@link Buffer} being read from.
+ * @param <OUT> The type of {@link Buffer} being written to.
+ * @param <T> The concrete type that is extending this class.
+ * 	Used to provide automatic covariant return types for
+ * 		{@link #config(ICoder)}, {@link #clone()}, and {@link #reset()}.
+ * @author Mark A. Ziesemer
+ * 	<a href="http://www.ziesemer.com.">&lt;www.ziesemer.com&gt;</a>
+ */
+public abstract class BaseCoder<IN extends Buffer, OUT extends Buffer, T extends BaseCoder<IN, OUT, T>>
+		implements ICoder<IN, OUT>{
+
+	private static final long serialVersionUID = 1L;
+
+	protected float minInPerOut;
+	protected float averageOutPerIn;
+	protected float maxOutPerIn;
+
+	protected transient CodingStates state = CodingStates.CONFIG;
+
+	protected BaseCoder(float minInPerOut, float averageOutPerIn, float maxOutPerIn){
+		this.minInPerOut = minInPerOut;
+		this.averageOutPerIn = averageOutPerIn;
+		this.maxOutPerIn = maxOutPerIn;
+	}
+
+	@SuppressWarnings("unchecked")
+	public T config(ICoder<IN, OUT> base){
+		checkConfigAllowed();
+		if(!getClass().isInstance(base)){
+			throw new IllegalArgumentException(base.getClass().getName()
+				+ " not an instance of " + getClass().getName());
+		}
+		configImpl((T)base);
+		return (T)this;
+	}
+
+	/**
+	 * <p>Hook for implementations to configure themselves from another instance.
+	 * 	The base implementation does nothing.</p>
+	 * @param base The instance to copy the configuration from.
+	 */
+	protected void configImpl(T base){
+		// Hook; nothing to do by default.
+	}
+
+	@SuppressWarnings("unchecked")
+	@Override
+	public T clone() throws CloneNotSupportedException{
+		T base = (T)super.clone();
+		base.config(this);
+		return base;
+	}
+
+	/**
+	 * <p>Hook called once after the first coding operation is started.
+	 * 	The base implementation does nothing.</p>
+	 */
+	protected void init(){
+		// Hook.
+	}
+
+	protected <TA> TA checkNullArgument(TA o){
+		if(o == null){
+			throw new IllegalArgumentException("Argument must not be null.");
+		}
+		return o;
+	}
+
+	public float getMinInPerOut(){
+		return minInPerOut;
+	}
+
+	public float getAverageOutPerIn(){
+		return averageOutPerIn;
+	}
+
+	public float getMaxOutPerIn(){
+		return maxOutPerIn;
+	}
+
+	@SuppressWarnings("unchecked")
+	public T reset(){
+		resetImpl();
+		if(state == CodingStates.CONFIG){
+			init();
+		}
+		state = CodingStates.RESET;
+		return (T)this;
+	}
+
+	/**
+	 * <p>Hook called from {@link #reset()}.
+	 * 	The base implementation does nothing.</p>
+	 */
+	protected void resetImpl(){
+		// Hook.
+	}
+
+	public OUT code(final IN in) throws CharacterCodingException{
+		int n = (int)Math.ceil(in.remaining() * averageOutPerIn);
+		OUT out = allocate(n);
+
+		if(in.remaining() > 0){
+			while(true){
+				CoderResult cr;
+				if(in.hasRemaining()){
+					cr = code(in, out, true);
+				}else{
+					cr = CoderResult.UNDERFLOW;
+				}
+				if(cr.isUnderflow()){
+					cr = flush(out);
+				}
+				if(cr.isUnderflow()){
+					break;
+				}
+				if(cr.isOverflow()){
+					out.flip();
+					n = (n << 1) | 1; // Ensure progress; n might be 0!
+					out = put(allocate(n), out);
+				}else{
+					cr.throwException();
+				}
+			}
+		}
+		reset();
+		out.flip();
+		return out;
+	}
+
+	protected abstract OUT allocate(int capacity);
+
+	protected abstract OUT put(OUT base, OUT put);
+
+	public CoderResult code(final IN in, final OUT out, final boolean endOfInput){
+		CodingStates newState = endOfInput ? CodingStates.END : CodingStates.CODING;
+		if(!(state.ordinal() <= CodingStates.CODING.ordinal())
+				&& !(endOfInput && (state == CodingStates.END))){
+			throwIllegalStateException(state, newState);
+		}else if(state == CodingStates.CONFIG){
+			init();
+		}
+		state = newState;
+
+		CoderResult cr;
+		try{
+			cr = codingLoop(in, out, endOfInput);
+		}catch(BufferUnderflowException x){
+			throw new CoderMalfunctionError(x);
+		}catch(BufferOverflowException x){
+			throw new CoderMalfunctionError(x);
+		}
+
+		if(cr.isOverflow()){
+			return cr;
+		}
+
+		if(cr.isUnderflow()){
+			if(endOfInput && in.hasRemaining()){
+				return CoderResult.malformedForLength(in.remaining());
+			}
+			return cr;
+		}
+
+		if(cr.isError()){
+			return cr;
+		}
+
+		throw new CoderMalfunctionError(new Exception("Unexpected CoderResult."));
+	}
+
+	protected abstract CoderResult codingLoop(IN in, OUT out, boolean endOfInput);
+
+	public CoderResult flush(final OUT out){
+		if(state == CodingStates.END){
+			CoderResult cr = implFlush(out);
+			state = CodingStates.FLUSHED;
+			return cr;
+		}
+
+		if(state != CodingStates.FLUSHED){
+			throwIllegalStateException(state, CodingStates.FLUSHED);
+		}
+
+		return CoderResult.UNDERFLOW; // Already flushed
+	}
+
+	/**
+	 * @see java.nio.charset.CharsetEncoder#implFlush(java.nio.ByteBuffer)
+	 * @see java.nio.charset.CharsetDecoder#implFlush(java.nio.CharBuffer)
+	 */
+	protected CoderResult implFlush(final OUT out){
+		return CoderResult.UNDERFLOW;
+	}
+
+	protected void checkConfigAllowed(){
+		if(state.ordinal() > CodingStates.RESET.ordinal()){
+			throw new IllegalStateException("Configuration not allowed unless reset.");
+		}
+		state = CodingStates.CONFIG;
+	}
+
+	protected void throwIllegalStateException(CodingStates from, CodingStates to){
+		throw new IllegalStateException("Current state = " + from
+			+ ", new state = " + to);
+	}
+}

--- a/core/src/main/java/org/apache/cxf/common/codec/base/ByteToCharEncoder.java
+++ b/core/src/main/java/org/apache/cxf/common/codec/base/ByteToCharEncoder.java
@@ -1,0 +1,43 @@
+package org.apache.cxf.common.codec.base;
+
+import java.nio.ByteBuffer;
+import java.nio.CharBuffer;
+import java.nio.charset.CharacterCodingException;
+
+import org.apache.cxf.common.codec.IByteToCharEncoder;
+
+/**
+ * @author Mark A. Ziesemer
+ * 	<a href="http://www.ziesemer.com.">&lt;www.ziesemer.com&gt;</a>
+ * @see java.nio.charset.CharsetDecoder
+ */
+public abstract class ByteToCharEncoder<T extends ByteToCharEncoder<T>>
+		extends BaseCoder<ByteBuffer, CharBuffer, T>
+		implements IByteToCharEncoder{
+
+	private static final long serialVersionUID = 1L;
+
+	protected ByteToCharEncoder(float minInPerOut, float averageCharsPerByte, float maxCharsPerByte){
+		super(minInPerOut, averageCharsPerByte, maxCharsPerByte);
+	}
+
+	@Override
+	protected CharBuffer allocate(int capacity){
+		return CharBuffer.allocate(capacity);
+	}
+
+	@Override
+	protected CharBuffer put(CharBuffer base, CharBuffer put){
+		return base.put(put);
+	}
+
+	/**
+	 * Convenience method for {@link #code(java.nio.Buffer)}.
+	 * Does not handle all desired variations by design, e.g. only encoding a portion of the input.
+	 */
+	public String encodeToString(byte[] in) throws CharacterCodingException{
+		CharBuffer out = code(ByteBuffer.wrap(in));
+		return out.toString();
+	}
+
+}

--- a/core/src/main/java/org/apache/cxf/common/codec/base/CharToByteDecoder.java
+++ b/core/src/main/java/org/apache/cxf/common/codec/base/CharToByteDecoder.java
@@ -1,0 +1,46 @@
+package org.apache.cxf.common.codec.base;
+
+import java.nio.ByteBuffer;
+import java.nio.CharBuffer;
+import java.nio.charset.CharacterCodingException;
+
+import org.apache.cxf.common.codec.ICharToByteDecoder;
+
+/**
+ * @author Mark A. Ziesemer
+ * 	<a href="http://www.ziesemer.com.">&lt;www.ziesemer.com&gt;</a>
+ * @see java.nio.charset.CharsetEncoder
+ */
+public abstract class CharToByteDecoder<T extends CharToByteDecoder<T>>
+		extends BaseCoder<CharBuffer, ByteBuffer, T>
+		implements ICharToByteDecoder{
+
+	private static final long serialVersionUID = 1L;
+
+	protected CharToByteDecoder(float minInPerOut, float averageBytesPerChar, float maxBytesPerChar){
+		super(minInPerOut, averageBytesPerChar, maxBytesPerChar);
+	}
+
+	@Override
+	protected ByteBuffer allocate(int capacity){
+		return ByteBuffer.allocate(capacity);
+	}
+
+	@Override
+	protected ByteBuffer put(ByteBuffer base, ByteBuffer put){
+		return base.put(put);
+	}
+
+	/**
+	 * Convenience method for {@link #code(java.nio.Buffer)}.
+	 * Does not handle all desired variations by design, e.g. only decoding a portion of the input.
+	 * (In this case, pass-in the result of {@link CharSequence#subSequence(int, int)} instead.)
+	 */
+	public byte[] decodeToBytes(CharSequence in) throws CharacterCodingException{
+		ByteBuffer out = code(CharBuffer.wrap(in));
+		byte[] result = new byte[out.remaining()];
+		out.get(result);
+		return result;
+	}
+
+}

--- a/core/src/main/java/org/apache/cxf/common/codec/base/CodingStates.java
+++ b/core/src/main/java/org/apache/cxf/common/codec/base/CodingStates.java
@@ -1,0 +1,13 @@
+package org.apache.cxf.common.codec.base;
+
+/**
+ * @author Mark A. Ziesemer
+ * 	<a href="http://www.ziesemer.com.">&lt;www.ziesemer.com&gt;</a>
+ */
+public enum CodingStates{
+	CONFIG,
+	RESET,
+	CODING,
+	END,
+	FLUSHED
+}

--- a/core/src/main/java/org/apache/cxf/common/codec/charlist/HexUpperCharList.java
+++ b/core/src/main/java/org/apache/cxf/common/codec/charlist/HexUpperCharList.java
@@ -1,0 +1,21 @@
+package org.apache.cxf.common.codec.charlist;
+
+/**
+ * @author Mark A. Ziesemer
+ * 	<a href="http://www.ziesemer.com.">&lt;www.ziesemer.com&gt;</a>
+ */
+public class HexUpperCharList extends ReadOnlyCharList{
+	
+	public HexUpperCharList(){
+		super(build());
+	}
+	
+	public static char[] build(){
+		char[] chars = new char[0x10];
+		for(int i=0; i < chars.length; i++){
+			chars[i] = Character.toUpperCase(Character.forDigit(i, chars.length));
+		}
+		return chars;
+	}
+	
+}

--- a/core/src/main/java/org/apache/cxf/common/codec/charlist/ReadOnlyCharList.java
+++ b/core/src/main/java/org/apache/cxf/common/codec/charlist/ReadOnlyCharList.java
@@ -1,0 +1,38 @@
+package org.apache.cxf.common.codec.charlist;
+
+import java.util.AbstractList;
+import java.util.RandomAccess;
+
+/**
+ * @author Mark A. Ziesemer
+ * 	<a href="http://www.ziesemer.com.">&lt;www.ziesemer.com&gt;</a>
+ */
+public class ReadOnlyCharList extends AbstractList<Character> implements RandomAccess{
+	
+	protected final char[] chars;
+	
+	public ReadOnlyCharList(char[] chars){
+		this.chars = chars;
+	}
+	
+	/**
+	 * <p>Same as {@link #get(int)}, but avoids auto-boxing.</p>
+	 */
+	public char getChar(int index){
+		return chars[index];
+	}
+	
+	/**
+	 * <p>Use {@link #getChar(int)} if a char primitive is desired, to avoid auto-boxing.</p>
+	 */
+	@Override
+	public Character get(int index){
+		return chars[index];
+	}
+
+	@Override
+	public int size(){
+		return chars.length;
+	}
+
+}

--- a/core/src/main/java/org/apache/cxf/common/codec/impl/URLDecoder.java
+++ b/core/src/main/java/org/apache/cxf/common/codec/impl/URLDecoder.java
@@ -1,0 +1,63 @@
+package org.apache.cxf.common.codec.impl;
+
+import java.nio.ByteBuffer;
+import java.nio.CharBuffer;
+import java.nio.charset.CoderResult;
+
+import org.apache.cxf.common.codec.base.CharToByteDecoder;
+
+/**
+ * <p>
+ * 	Decodes from &quot;Percent-Encoding&quot; (a.k.a. &quot;URL-Encoding&quot;),
+ * 		as specified by <a href="http://tools.ietf.org/html/rfc3986#section-2"
+ * 		>http://tools.ietf.org/html/rfc3986#section-2</a>.
+ * </p>
+ * @author Mark A. Ziesemer
+ * 	<a href="http://www.ziesemer.com.">&lt;www.ziesemer.com&gt;</a>
+ */
+public class URLDecoder
+		extends CharToByteDecoder<URLDecoder>{
+
+	private static final long serialVersionUID = 1L;
+
+	public URLDecoder(){
+		// Any byte may require 1-3 characters to represent.
+		// Using the median of 2 as the mean for average characters per byte.
+		// Reciprocal for average bytes per character is 1 / 2, or 0.5.
+		super(3, 0.5f, 1);
+	}
+
+	@Override
+	protected CoderResult codingLoop(final CharBuffer in, final ByteBuffer out, final boolean endOfInput){
+		while(in.hasRemaining()){
+			if(out.remaining() < maxOutPerIn){
+				return CoderResult.OVERFLOW;
+			}
+
+			int mark = in.position();
+			final char c = in.get();
+			if(c == '%'){
+				if(in.remaining() >= 2){
+					int x, y;
+					if((x = Character.digit(in.get(), 0x10)) == -1
+							|| (y = Character.digit(in.get(), 0x10)) == -1){
+						int malLength = in.position() - mark;
+						in.position(mark);
+						return CoderResult.malformedForLength(malLength);
+					}
+					out.put((byte)((x << 4) + y));
+				}else{
+					// Push back the '%', and wait for more.
+					in.position(in.position() - 1);
+					return CoderResult.UNDERFLOW;
+				}
+			}else if(c == '+'){
+				out.put((byte)' ');
+			}else{
+				out.put((byte)c);
+			}
+		}
+		return CoderResult.UNDERFLOW;
+	}
+
+}

--- a/core/src/main/java/org/apache/cxf/common/codec/impl/URLEncoder.java
+++ b/core/src/main/java/org/apache/cxf/common/codec/impl/URLEncoder.java
@@ -1,0 +1,86 @@
+package org.apache.cxf.common.codec.impl;
+
+import java.nio.ByteBuffer;
+import java.nio.CharBuffer;
+import java.nio.charset.CoderResult;
+import java.util.BitSet;
+
+import org.apache.cxf.common.codec.base.ByteToCharEncoder;
+import org.apache.cxf.common.codec.charlist.HexUpperCharList;
+
+/**
+ * <p>
+ * 	Encodes to &quot;Percent-Encoding&quot; (a.k.a. &quot;URL-Encoding&quot;),
+ * 		as specified by <a href="http://tools.ietf.org/html/rfc3986#section-2"
+ * 		>http://tools.ietf.org/html/rfc3986#section-2</a>.
+ * </p>
+ * @author Mark A. Ziesemer
+ * 	<a href="http://www.ziesemer.com.">&lt;www.ziesemer.com&gt;</a>
+ */
+public class URLEncoder
+		extends ByteToCharEncoder<URLEncoder>{
+
+	private static final long serialVersionUID = 1L;
+
+	/**
+	 * <p><a href="http://tools.ietf.org/html/rfc3986#section-2.3"
+	 * 		>http://tools.ietf.org/html/rfc3986#section-2.3</a>.</p>
+	 */
+	private static final BitSet UNRESERVED = new BitSet(0x100);
+
+	/**
+	 * <p>Per <a href="http://tools.ietf.org/html/rfc3986#section-2.1"
+	 * 		>http://tools.ietf.org/html/rfc3986#section-2.1</a>, upper-case should be
+	 * 		used for encoding (though both lower- and upper-case should be decoded).</p>
+	 */
+	private static final char[] HEX_CHARS = HexUpperCharList.build();
+
+	static{
+		// http://tools.ietf.org/html/rfc3986#section-2.3
+		for(int i = 'a'; i <= 'z'; i++){
+			UNRESERVED.set(i);
+		}
+		for(int i = 'A'; i <= 'Z'; i++){
+			UNRESERVED.set(i);
+		}
+		for(int i = '0'; i <= '9'; i++){
+			UNRESERVED.set(i);
+		}
+
+		UNRESERVED.set('-');
+		UNRESERVED.set('_');
+		UNRESERVED.set('.');
+		UNRESERVED.set('*');
+		// Will be replaced with '+'.
+		UNRESERVED.set(' ');
+	}
+
+	public URLEncoder(){
+		// Any byte may require 1-3 characters to represent.
+		// Using the median of 2 as the mean.
+		super(1, 2, 3);
+	}
+
+	@Override
+	protected CoderResult codingLoop(final ByteBuffer in, final CharBuffer out, final boolean endOfInput){
+		while(in.hasRemaining()){
+			if(out.remaining() < maxOutPerIn){
+				return CoderResult.OVERFLOW;
+			}
+
+			int b = in.get() & 0xFF;
+			if(UNRESERVED.get(b)){
+				if(b == ' '){
+					b = '+';
+				}
+				out.put((char)b);
+			}else{
+				out.put('%');
+				out.put(HEX_CHARS[(b >> 4) & 0xF]);
+				out.put(HEX_CHARS[b & 0xF]);
+			}
+		}
+		return CoderResult.UNDERFLOW;
+	}
+
+}

--- a/core/src/test/java/org/apache/cxf/common/util/UrlUtilsTest.java
+++ b/core/src/test/java/org/apache/cxf/common/util/UrlUtilsTest.java
@@ -24,17 +24,34 @@ import org.junit.Test;
 
 
 public class UrlUtilsTest extends Assert {
-    
+
+    @Test
+    public void testUrlEncode() {
+        assertEquals("%2B+", UrlUtils.urlEncode("+ "));
+        assertEquals("random+word+%C2%A3500+%24", UrlUtils.urlEncode("random word £500 $"));
+    }
+
+    @Test
+    public void testUrlEncodeWithEncoding() {
+        assertEquals("random+word+%A3500+%24", UrlUtils.urlEncode("random word £500 $", "ISO-8859-15"));
+    }
+
     @Test
     public void testUrlDecode() {
         assertEquals("+ ", UrlUtils.urlDecode("%2B+"));
+        assertEquals("random word £500 $", UrlUtils.urlDecode("random+word+%C2%A3500+%24"));
     }
-    
+
+    @Test
+    public void testUrlDecodeWithEncoding() {
+        assertEquals("random word £500 $", UrlUtils.urlDecode("random+word+%A3500+%24", "ISO-8859-15"));
+    }
+
     @Test
     public void testUrlDecodeReserved() {
         assertEquals("!$&'()*,;=", UrlUtils.urlDecode("!$&'()*,;="));
     }
-    
+
     @Test
     public void testPathDecode() {
         assertEquals("+++", UrlUtils.pathDecode("+%2B+"));


### PR DESCRIPTION
Hi, 

I found an [old library](http://blogger.ziesemer.com/2009/09/markutils-codec-base64-url-bytechar.html) that optimizes usage of URLEncode and URLDecode.

This library is under GPL licence. So, I added a portion of this code directly in cxf-core.

I did some benchmark (with JMH) and below the results.

```
Benchmark                                                    Mode  Samples        Score        Error   Units
o.a.c.UrlUtilsBenchmark.testDecodeNew                       thrpt      100  6879909,009 ± 117296,419   ops/s
o.a.c.UrlUtilsBenchmark.testDecodeNew:@gc.count.profiled    thrpt      100     2395,000 ±        NaN  counts
o.a.c.UrlUtilsBenchmark.testDecodeNew:@gc.count.total       thrpt      100      730,000 ±        NaN  counts
o.a.c.UrlUtilsBenchmark.testDecodeNew:@gc.time.profiled     thrpt      100     8288,000 ±        NaN      ms
o.a.c.UrlUtilsBenchmark.testDecodeNew:@gc.time.total        thrpt      100     2532,000 ±        NaN      ms
o.a.c.UrlUtilsBenchmark.testDecodeOld                       thrpt      100  5805570,177 ± 131254,628   ops/s
o.a.c.UrlUtilsBenchmark.testDecodeOld:@gc.count.profiled    thrpt      100     2433,000 ±        NaN  counts
o.a.c.UrlUtilsBenchmark.testDecodeOld:@gc.count.total       thrpt      100      745,000 ±        NaN  counts
o.a.c.UrlUtilsBenchmark.testDecodeOld:@gc.time.profiled     thrpt      100     8415,000 ±        NaN      ms
o.a.c.UrlUtilsBenchmark.testDecodeOld:@gc.time.total        thrpt      100     2649,000 ±        NaN      ms
o.a.c.UrlUtilsBenchmark.testEncodeNew                       thrpt      100  8054882,333 ± 194851,987   ops/s
o.a.c.UrlUtilsBenchmark.testEncodeNew:@gc.count.profiled    thrpt      100     2779,000 ±        NaN  counts
o.a.c.UrlUtilsBenchmark.testEncodeNew:@gc.count.total       thrpt      100      860,000 ±        NaN  counts
o.a.c.UrlUtilsBenchmark.testEncodeNew:@gc.time.profiled     thrpt      100     9874,000 ±        NaN      ms
o.a.c.UrlUtilsBenchmark.testEncodeNew:@gc.time.total        thrpt      100     3062,000 ±        NaN      ms
o.a.c.UrlUtilsBenchmark.testEncodeOld                       thrpt      100  3710430,547 ±  79856,593   ops/s
o.a.c.UrlUtilsBenchmark.testEncodeOld:@gc.count.profiled    thrpt      100     2428,000 ±        NaN  counts
o.a.c.UrlUtilsBenchmark.testEncodeOld:@gc.count.total       thrpt      100      766,000 ±        NaN  counts
o.a.c.UrlUtilsBenchmark.testEncodeOld:@gc.time.profiled     thrpt      100     9105,000 ±        NaN      ms
o.a.c.UrlUtilsBenchmark.testEncodeOld:@gc.time.total        thrpt      100     2867,000 ±        NaN      ms
```