### PR TITLE
Store the protocol headers if they need initialized

### DIFF
--- a/rt/rs/security/xml/src/main/java/org/apache/cxf/rs/security/saml/SamlHeaderOutInterceptor.java
+++ b/rt/rs/security/xml/src/main/java/org/apache/cxf/rs/security/saml/SamlHeaderOutInterceptor.java
@@ -72,6 +72,7 @@ public class SamlHeaderOutInterceptor extends AbstractSamlOutInterceptor {
             CastUtils.cast((Map<?, ?>)message.get(Message.PROTOCOL_HEADERS));
         if (headers == null) {
             headers = new HashMap<String, List<String>>();
+            message.put(Message.PROTOCOL_HEADERS, headers);
         }
         return headers;
     }


### PR DESCRIPTION
Currently, if SamlHeaderOutInterceptor finds no protocol headers in the message, it still proceeds to create the assertion, but it stores it in a new map which is not stored anywhere. The assertion doesn't appear in the HTTP headers output by CXF...

Simply storing the created map as the message's protocol headers fixes this.