### PR TITLE
CXF-6343 Support and parse EncryptedHeader

### DIFF
--- a/rt/ws/security/src/main/java/org/apache/cxf/ws/security/wss4j/AbstractWSS4JInterceptor.java
+++ b/rt/ws/security/src/main/java/org/apache/cxf/ws/security/wss4j/AbstractWSS4JInterceptor.java
@@ -51,6 +51,7 @@ public abstract class AbstractWSS4JInterceptor extends WSHandler implements Soap
         HEADERS.add(new QName(WSConstants.WSSE_NS, "Security"));
         HEADERS.add(new QName(WSConstants.WSSE11_NS, "Security"));
         HEADERS.add(new QName(WSConstants.ENC_NS, "EncryptedData"));
+        HEADERS.add(new QName(WSConstants.WSSE11_NS, "EncryptedHeader"));
     }
 
     private Map<String, Object> properties = new ConcurrentHashMap<String, Object>();

--- a/rt/ws/security/src/main/java/org/apache/cxf/ws/security/wss4j/AbstractWSS4JStaxInterceptor.java
+++ b/rt/ws/security/src/main/java/org/apache/cxf/ws/security/wss4j/AbstractWSS4JStaxInterceptor.java
@@ -75,6 +75,7 @@ public abstract class AbstractWSS4JStaxInterceptor implements SoapInterceptor,
         HEADERS.add(new QName(WSSConstants.NS_WSSE10, "Security"));
         HEADERS.add(new QName(WSSConstants.NS_WSSE11, "Security"));
         HEADERS.add(new QName(WSSConstants.NS_XMLENC, "EncryptedData"));
+        HEADERS.add(new QName(WSSConstants.NS_WSSE11, "EncryptedHeader"));
     }
     
     private static final Logger LOG = LogUtils.getL7dLogger(AbstractWSS4JStaxInterceptor.class);

--- a/rt/ws/security/src/main/java/org/apache/cxf/ws/security/wss4j/policyhandlers/AbstractBindingBuilder.java
+++ b/rt/ws/security/src/main/java/org/apache/cxf/ws/security/wss4j/policyhandlers/AbstractBindingBuilder.java
@@ -1054,7 +1054,7 @@ public abstract class AbstractBindingBuilder extends AbstractCommonBindingHandle
             for (Header head : parts.getHeaders()) {
                 WSEncryptionPart wep = new WSEncryptionPart(head.getName(),
                                                             head.getNamespace(),
-                                                            "Element");
+                                                            "Header");
                 signedParts.add(wep);
             }
             
@@ -1128,7 +1128,7 @@ public abstract class AbstractBindingBuilder extends AbstractCommonBindingHandle
             for (Header head : parts.getHeaders()) {
                 WSEncryptionPart wep = new WSEncryptionPart(head.getName(),
                                                             head.getNamespace(),
-                                                            "Element");
+                                                            "Header");
                 signedParts.add(wep);
             }
             Attachments attachments = parts.getAttachments();
@@ -1193,7 +1193,7 @@ public abstract class AbstractBindingBuilder extends AbstractCommonBindingHandle
         result.addAll(this.getParts(sign, includeBody, parts, found));
         
         // Handle sign/enc elements
-        result.addAll(this.getElements("Element", xpaths, found, sign));
+        result.addAll(this.getElements("Header", xpaths, found, sign));
         
         if (!sign) {
             // Handle content encrypted elements
@@ -2172,7 +2172,7 @@ public abstract class AbstractBindingBuilder extends AbstractCommonBindingHandle
                 if (signedPart.getId() == null && !"Token".equals(signedPart.getName())) {
                     throw new IllegalArgumentException(
                             "WSEncryptionPart must be ID based but no id was found.");
-                } else if (encryptedPart.getEncModifier().equals("Element")
+                } else if (encryptedPart.getEncModifier().equals("Header")
                         && signedPart.getId().equals(encryptedPart.getId())) {
                     // We are to sign something that has already been encrypted.
                     // We need to preserve the original aspects of signedPart but

--- a/rt/ws/security/src/test/java/org/apache/cxf/ws/security/wss4j/AbstractPolicySecurityTest.java
+++ b/rt/ws/security/src/test/java/org/apache/cxf/ws/security/wss4j/AbstractPolicySecurityTest.java
@@ -137,9 +137,9 @@ public abstract class AbstractPolicySecurityTest extends AbstractSecurityTest {
         //DOMUtils.writeXml(inDoc, System.out);
         
         // Use this snippet if you need intermediate output for debugging.
-
-        dumpDocument(inDoc);
-
+        /*
+         * dumpDocument(inDoc);
+         */
 
         /* This verifies of the header elements have been
          * wrapped in an EncryptedHeader
@@ -578,7 +578,7 @@ public abstract class AbstractPolicySecurityTest extends AbstractSecurityTest {
                 0, strDataNodes.getLength());
     }
 
-    private void dumpDocument(Document document) throws Exception {
+    private void dumpDocument(Document document) throws Exception { //NOPMD
         TransformerFactory tf = TransformerFactory.newInstance();
         Transformer t = tf.newTransformer();
         t.setOutputProperty(OutputKeys.INDENT, "yes");

--- a/rt/ws/security/src/test/java/org/apache/cxf/ws/security/wss4j/AbstractPolicySecurityTest.java
+++ b/rt/ws/security/src/test/java/org/apache/cxf/ws/security/wss4j/AbstractPolicySecurityTest.java
@@ -32,6 +32,11 @@ import javax.xml.namespace.QName;
 import javax.xml.soap.Node;
 import javax.xml.soap.SOAPException;
 import javax.xml.soap.SOAPMessage;
+import javax.xml.transform.OutputKeys;
+import javax.xml.transform.Transformer;
+import javax.xml.transform.TransformerFactory;
+import javax.xml.transform.dom.DOMSource;
+import javax.xml.transform.stream.StreamResult;
 import javax.xml.xpath.XPath;
 import javax.xml.xpath.XPathConstants;
 import javax.xml.xpath.XPathExpression;
@@ -132,14 +137,16 @@ public abstract class AbstractPolicySecurityTest extends AbstractSecurityTest {
         //DOMUtils.writeXml(inDoc, System.out);
         
         // Use this snippet if you need intermediate output for debugging.
-        /*
-        TransformerFactory tf = TransformerFactory.newInstance();
-        Transformer t = tf.newTransformer();
-        t.setOutputProperty(OutputKeys.INDENT, "no");
-        t.transform(new DOMSource(inDoc), new StreamResult(System.out));
-        */
-        
-        
+
+        dumpDocument(inDoc);
+
+
+        /* This verifies of the header elements have been
+         * wrapped in an EncryptedHeader
+         * See SOAP Message Security 1.1, chapter 9.3
+         */
+        verifyEncryptedHeader(originalDoc, inDoc);
+
         this.runInInterceptorAndValidate(inDoc,
                 inPolicy, inAssertions.getAssertedAssertions(),
                 inAssertions.getNotAssertedAssertions(), types);
@@ -535,8 +542,8 @@ public abstract class AbstractPolicySecurityTest extends AbstractSecurityTest {
         assertNotNull("SecurityTokenReference for " + assertionId + " not found in security header.", strId);
         
         // Verify STR is included in the signature references
-        final XPathExpression sigRefExpr = xpath.compile(
-            "/s:Envelope/s:Header/wsse:Security/ds:Signature/ds:SignedInfo/ds:Reference");
+        final XPathExpression sigRefExpr =
+                xpath.compile("/s:Envelope/s:Header/wsse:Security/ds:Signature/ds:SignedInfo/ds:Reference");
         
         final NodeList sigReferenceNodes = 
             (NodeList) sigRefExpr.evaluate(signedDoc, XPathConstants.NODESET);
@@ -550,10 +557,34 @@ public abstract class AbstractPolicySecurityTest extends AbstractSecurityTest {
                 break;
             }
         }
-        
+
         assertTrue("SecurityTokenReference for " + assertionId + " is not signed.", foundStrReference);
     }
-    
+
+    protected void verifyEncryptedHeader(Document originalDoc, Document processedDoc) throws Exception {
+        XPathFactory factory = XPathFactory.newInstance();
+        XPath xpath = factory.newXPath();
+        final NamespaceContext nsContext = this.getNamespaceContext();
+        xpath.setNamespaceContext(nsContext);
+
+        // Find EncryptedData in the message, should not be there
+        final XPathExpression strData = xpath.compile(
+                "/s:Envelope/s:Header/xenc:EncryptedData");
+
+        final NodeList strDataNodes =
+                (NodeList) strData.evaluate(processedDoc, XPathConstants.NODESET);
+
+        assertEquals("EncryptedData found without in header without being wrapped in an EncryptedHeader.",
+                0, strDataNodes.getLength());
+    }
+
+    private void dumpDocument(Document document) throws Exception {
+        TransformerFactory tf = TransformerFactory.newInstance();
+        Transformer t = tf.newTransformer();
+        t.setOutputProperty(OutputKeys.INDENT, "yes");
+        t.transform(new DOMSource(document), new StreamResult(System.out));
+    }
+
     protected static final class MockEndpoint extends 
         AbstractAttributedInterceptorProvider implements Endpoint {
 

--- a/rt/ws/security/src/test/java/org/apache/cxf/ws/security/wss4j/CryptoCoverageCheckerTest.java
+++ b/rt/ws/security/src/test/java/org/apache/cxf/ws/security/wss4j/CryptoCoverageCheckerTest.java
@@ -186,6 +186,16 @@ public class CryptoCoverageCheckerTest extends AbstractSecurityTest {
                        new XPathExpression(
                                "//ser:Header", CoverageType.ENCRYPTED, CoverageScope.ELEMENT)),
                true);
+
+        this.runInterceptorAndValidate(
+                "wss-242-with-encryptedheader.xml",
+                this.getPrefixes(),
+                Arrays.asList(
+                        new XPathExpression(
+                                "//ser:Header", CoverageType.SIGNED, CoverageScope.ELEMENT),
+                        new XPathExpression(
+                                "//ser:Header", CoverageType.ENCRYPTED, CoverageScope.ELEMENT)),
+                true);
     }
     
     private Map<String, String> getPrefixes() {

--- a/rt/ws/security/src/test/java/org/apache/cxf/ws/security/wss4j/PolicyBasedWss4JInOutTest.java
+++ b/rt/ws/security/src/test/java/org/apache/cxf/ws/security/wss4j/PolicyBasedWss4JInOutTest.java
@@ -420,7 +420,15 @@ public class PolicyBasedWss4JInOutTest extends AbstractPolicySecurityTest {
                         SP12Constants.SIGNED_PARTS),
                 null,
                 Arrays.asList(CoverageType.ENCRYPTED, CoverageType.SIGNED));
-        
+
+        this.runInInterceptorAndValidate(
+                "encrypted_body_content_signed_with_encrypted_header.xml",
+                "encrypted_parts_policy_header_and_body_signed.xml",
+                Arrays.asList(SP12Constants.ENCRYPTED_PARTS,
+                        SP12Constants.SIGNED_PARTS),
+                null,
+                Arrays.asList(CoverageType.ENCRYPTED, CoverageType.SIGNED));
+
         this.runAndValidate(
                 "wsse-request-clean.xml",
                 "encrypted_parts_policy_header_and_body_signed.xml",
@@ -543,5 +551,5 @@ public class PolicyBasedWss4JInOutTest extends AbstractPolicySecurityTest {
         
         // TODO: Tests for derived keys.
     }
-  
+
 }

--- a/rt/ws/security/src/test/resources/org/apache/cxf/ws/security/wss4j/encrypted_body_content_signed_with_encrypted_header.xml
+++ b/rt/ws/security/src/test/resources/org/apache/cxf/ws/security/wss4j/encrypted_body_content_signed_with_encrypted_header.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?><soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xenc="http://www.w3.org/2001/04/xmlenc#" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <soap:Header xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">
+      <wsse11:EncryptedHeader wsu:Id="_9" xmlns:wsse11="http://docs.oasis-open.org/wss/oasis-wss-wssecurity-secext-1.1.xsd" xmlns:wsu="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd"><xenc:EncryptedData Id="EncDataId-2" Type="http://www.w3.org/2001/04/xmlenc#Element" xmlns:xenc="http://www.w3.org/2001/04/xmlenc#"><xenc:EncryptionMethod Algorithm="http://www.w3.org/2001/04/xmlenc#aes128-cbc"/><ds:KeyInfo xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
+<wsse:SecurityTokenReference xmlns:wsse="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd"><wsse:Reference URI="#EncKeyId-1E2C13B4F0925A9D1112658614360512" xmlns:wsse="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd"/></wsse:SecurityTokenReference>
+</ds:KeyInfo><xenc:CipherData><xenc:CipherValue>4H3QKBMT3XS3GaAeWLILwZOwOhjL1WFROluoHd8ybdEI5a5veKo6tobnwRxGAoMIJ3qpQRCTcnS9
+kpLEudM/8HRcJS93EaJrrDnkT5GWMHtZJOwfKtjCzvVGohc6Jj9Uvi4CxCvEGTygidPb2YawpgfZ
+4pev0u+8ghw1J2oghnLJczhzhVm4aOq0g/QzCOFa0aDwv490nTYEvU+61ltbonGq5iDQy0wJe6NY
+/aqaOnJll3moRFGs+9F9/AmOwJmX</xenc:CipherValue></xenc:CipherData></xenc:EncryptedData></wsse11:EncryptedHeader>
+      <wsse11:EncryptedHeader wsu:Id="_9" xmlns:wsse11="http://docs.oasis-open.org/wss/oasis-wss-wssecurity-secext-1.1.xsd" xmlns:wsu="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd"><xenc:EncryptedData Id="EncDataId-3" Type="http://www.w3.org/2001/04/xmlenc#Element" xmlns:xenc="http://www.w3.org/2001/04/xmlenc#"><xenc:EncryptionMethod Algorithm="http://www.w3.org/2001/04/xmlenc#aes128-cbc"/><ds:KeyInfo xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
+<wsse:SecurityTokenReference xmlns:wsse="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd"><wsse:Reference URI="#EncKeyId-1E2C13B4F0925A9D1112658614360512" xmlns:wsse="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd"/></wsse:SecurityTokenReference>
+</ds:KeyInfo><xenc:CipherData><xenc:CipherValue>YYcOEd7SjhpApsHPJAmzJMnX5ruj1jFNcIPs6t5a3N9P6A7NlzFAoi90KnBvWbq0rugAVI/RKbwH
+AayYBdOaniW7zd+xAqgSpy+b9ymhHyAQabw3OPuMDafgDfnAmT2/rlh3DX9PzvuHcd8i1W2nXwxM
+6AAVr0sshM+xMw43u84ylGm03s+/zohHzaNu8cW/x5fCOYJiBcdsyZKiEN9FzsDUyIBctM5QFPBu
+7wLjEedxf7z/tcV4ZzGmohXxtSKP</xenc:CipherValue></xenc:CipherData></xenc:EncryptedData></wsse11:EncryptedHeader>
+  <wsse:Security xmlns:wsse="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd" soap:mustUnderstand="1"><xenc:EncryptedKey Id="EncKeyId-1E2C13B4F0925A9D1112658614360512" xmlns:xenc="http://www.w3.org/2001/04/xmlenc#"><xenc:EncryptionMethod Algorithm="http://www.w3.org/2001/04/xmlenc#rsa-oaep-mgf1p"/><ds:KeyInfo xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
+<wsse:SecurityTokenReference xmlns:wsse="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd"><wsse:Reference URI="#1E2C13B4F0925A9D1112658614354581" ValueType="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-x509-token-profile-1.0#X509v3" xmlns:wsse="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd"/></wsse:SecurityTokenReference>
+</ds:KeyInfo><xenc:CipherData><xenc:CipherValue>FMP4IlDNOiqSE5G7HpABr3cHSrtJ2aWJC1sBXiuPbubTcalGSA6wGxG/yajOTJdktKfl4SCrlW3Nw7bu5ZrW6cmV7RHJjcV+wizd/Vvtnqd1I6axqUHh6uJB52E7ADL3loxnTG/1QoO84IzDEtQRLd7YCgvCzqsApzb7pQvYYJY=</xenc:CipherValue></xenc:CipherData></xenc:EncryptedKey><wsse:BinarySecurityToken xmlns:wsu="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd" EncodingType="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-soap-message-security-1.0#Base64Binary" ValueType="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-x509-token-profile-1.0#X509v3" wsu:Id="1E2C13B4F0925A9D1112658614354581" xmlns:wsse="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd">MIIBmDCCAQECBEZu1OowDQYJKoZIhvcNAQEEBQAwEjEQMA4GA1UEAxMHbXlBbGlhczAgFw0wNzA2MTIxNzE2MjZaGA80NzQ1MDUwOTE3MTYyNlowEjEQMA4GA1UEAxMHbXlBbGlhczCBnzANBgkqhkiG9w0BAQEFAAOBjQAwgYkCgYEApeOd8EfprmTD+6/nOe3nK3eXFlPsaiRnz5+R3gA6xz4WOOOQX7l1Pa4S65TZmVOxkfPzP+rFvbOJ4sn7ct0EtMiAYuqwnDiHVkqYIhz5WkoPBQet6J7dtcPIAEI9i5Mmf5gsiIMTo8UxqXnsrjCNX6MSrLFr2yspdR/xFYK5IqkCAwEAATANBgkqhkiG9w0BAQQFAAOBgQB/nqtFF6u4FJI90JS+RogSTYFc9mngpvXv8WJsfdR+IQovdFjzqCufOAGPctuq6olgW1A5DRNLIQwr7sIPUhHBFZssuggwEQtF/lvJ51MGhp+pqySbpcPo31WppQO+t4Zsu78DZO4GB3Njr1MqOnux5gPGHftujzlJh31SpkEfjA==</wsse:BinarySecurityToken><ds:Signature xmlns:ds="http://www.w3.org/2000/09/xmldsig#" Id="Signature-4">
+<ds:SignedInfo>
+<ds:CanonicalizationMethod Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/>
+<ds:SignatureMethod Algorithm="http://www.w3.org/2000/09/xmldsig#hmac-sha1"/>
+<ds:Reference URI="#Id-30584859">
+<ds:Transforms>
+<ds:Transform Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/>
+</ds:Transforms>
+<ds:DigestMethod Algorithm="http://www.w3.org/2000/09/xmldsig#sha1"/>
+<ds:DigestValue>R3fi13BPvyCoTr2pLCR4ZM43KwA=</ds:DigestValue>
+</ds:Reference>
+<ds:Reference URI="#EncDataId-2">
+<ds:Transforms>
+<ds:Transform Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/>
+</ds:Transforms>
+<ds:DigestMethod Algorithm="http://www.w3.org/2000/09/xmldsig#sha1"/>
+<ds:DigestValue>ccXM3uehEf2MjaKCkKA3QQcGeVY=</ds:DigestValue>
+</ds:Reference>
+<ds:Reference URI="#EncDataId-3">
+<ds:Transforms>
+<ds:Transform Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/>
+</ds:Transforms>
+<ds:DigestMethod Algorithm="http://www.w3.org/2000/09/xmldsig#sha1"/>
+<ds:DigestValue>Ry0nymsPSvTYzSqNIyim0/bA7ag=</ds:DigestValue>
+</ds:Reference>
+</ds:SignedInfo>
+<ds:SignatureValue>yh3oRtWvO4xJOMIiKBlo+QFGiro=</ds:SignatureValue>
+<ds:KeyInfo Id="KeyId-1E2C13B4F0925A9D1112658614361143">
+<wsse:SecurityTokenReference xmlns:wsu="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd" wsu:Id="STRId-1E2C13B4F0925A9D1112658614361144" xmlns:wsse="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd"><wsse:Reference URI="#EncKeyId-1E2C13B4F0925A9D1112658614360512" ValueType="http://docs.oasis-open.org/wss/oasis-wss-saml-token-profile-1.0#EncryptedKey" xmlns:wsse="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd"/></wsse:SecurityTokenReference>
+</ds:KeyInfo>
+</ds:Signature><xenc:ReferenceList xmlns:xenc="http://www.w3.org/2001/04/xmlenc#"><xenc:DataReference URI="#EncDataId-1"/><xenc:DataReference URI="#EncDataId-2"/><xenc:DataReference URI="#EncDataId-3"/></xenc:ReferenceList></wsse:Security></soap:Header>
+  <soap:Body xmlns:wsu="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd" wsu:Id="Id-30584859" xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/"><xenc:EncryptedData Id="EncDataId-1" Type="http://www.w3.org/2001/04/xmlenc#Content" xmlns:xenc="http://www.w3.org/2001/04/xmlenc#"><xenc:EncryptionMethod Algorithm="http://www.w3.org/2001/04/xmlenc#aes128-cbc"/><ds:KeyInfo xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
+<wsse:SecurityTokenReference xmlns:wsse="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd"><wsse:Reference URI="#EncKeyId-1E2C13B4F0925A9D1112658614360512" xmlns:wsse="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd"/></wsse:SecurityTokenReference>
+</ds:KeyInfo><xenc:CipherData><xenc:CipherValue>o9lcAarzBuBeIwwQQZzZtGcARbZf++hwESI5+VGKEwM7QTZHgvDtJiPK8fvIMzJ61Ak5WcFTVo2B
+d1y8Sd0ITz9YXwwXU0PBygcvxQ2v4/qTOddKSH+G+LIMp65+HqzHgYmnmcdK+kcYGZRQ7a9zrhOl
+qhIgIdCgkaVxZx6qwCgalkTNmIw306t3kT+PwsMzOdldhhOjtnuxRKsi4eQRjtZQWxX5gORerpk7
+u1HIqq6A4iu4wQIxOBaVAHcuh7nFASVhkUDhKFeASRZh7VHvuuMX9cnTT16hkfHXivyIVqgTuoDp
+J3vcDLYUWXdDWDgbe586S3CiDIatnR60Mk/O1PfqErEedW9Mrd+wjnbP5plW5s+Ag6asaqHaTr4T
+/1UDb8VM7Wn/mMBjQJMCqBx/qhqReykCS2fRxqDKt5LmAMenpllLIEXm7Ru7LX+pgZl7EEM4Do1Z
+rnH7JPMV+SZCWyWwY1Cu1ZRZ6fXOpIwkIM2bMoalREXW/YHn/rAyg2uARTV33zqiYVdV1KkRqTM5
+xA==</xenc:CipherValue></xenc:CipherData></xenc:EncryptedData></soap:Body>
+</soap:Envelope>

--- a/rt/ws/security/src/test/resources/org/apache/cxf/ws/security/wss4j/wss-242-with-encryptedheader.xml
+++ b/rt/ws/security/src/test/resources/org/apache/cxf/ws/security/wss4j/wss-242-with-encryptedheader.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xenc="http://www.w3.org/2001/04/xmlenc#" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <soap:Header><wsse:Security xmlns:wsse="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd"><wsse:BinarySecurityToken EncodingType="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-soap-message-security-1.0#Base64Binary" ValueType="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-x509-token-profile-1.0#X509PKIPathv1" wsu:Id="CertId-C861510A9B785DAD9E128300845684018" xmlns:wsu="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd">MIIBnDCCAZgwggEBAgRGbtTqMA0GCSqGSIb3DQEBBAUAMBIxEDAOBgNVBAMTB215QWxpYXMwIBcNMDcwNjEyMTcxNjI2WhgPNDc0NTA1MDkxNzE2MjZaMBIxEDAOBgNVBAMTB215QWxpYXMwgZ8wDQYJKoZIhvcNAQEBBQADgY0AMIGJAoGBAKXjnfBH6a5kw/uv5znt5yt3lxZT7GokZ8+fkd4AOsc+FjjjkF+5dT2uEuuU2ZlTsZHz8z/qxb2zieLJ+3LdBLTIgGLqsJw4h1ZKmCIc+VpKDwUHreie3bXDyABCPYuTJn+YLIiDE6PFMal57K4wjV+jEqyxa9srKXUf8RWCuSKpAgMBAAEwDQYJKoZIhvcNAQEEBQADgYEAf56rRReruBSSPdCUvkaIEk2BXPZp4Kb17/FibH3UfiEKL3RY86grnzgBj3LbquqJYFtQOQ0TSyEMK+7CD1IRwRWbLLoIMBELRf5byedTBoafqaskm6XD6N9VqaUDvreGbLu/A2TuBgdzY69TKjp7seYDxh37bo85SYd9UqZBH4w=</wsse:BinarySecurityToken><ds:Signature Id="Signature-5" xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
+<ds:SignedInfo>
+<ds:CanonicalizationMethod Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/>
+<ds:SignatureMethod Algorithm="http://www.w3.org/2000/09/xmldsig#rsa-sha1"/>
+<ds:Reference URI="#id-6">
+<ds:Transforms>
+<ds:Transform Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/>
+</ds:Transforms>
+<ds:DigestMethod Algorithm="http://www.w3.org/2000/09/xmldsig#sha1"/>
+<ds:DigestValue>dpKLrXAVkzXtLT8uMgjyRPw/7+A=</ds:DigestValue>
+</ds:Reference>
+</ds:SignedInfo>
+<ds:SignatureValue>
+WEdruhR6zu4nfTjfiOmy8U3aQjSrkCsdKW4Mc6ok/yYJWui6FDkUrXIh5CHwAOXgthR6wFew3mCU
+WOjH0W5aa8ssGXJKEPaQQPbUqTplOBjJzwYdNWV5MNEitxbQLuULuSp6o0mrO30TI8Jh9qOvP+Nk
+ug2YiNMlclOLqH3Zpew=
+</ds:SignatureValue>
+<ds:KeyInfo Id="KeyId-C861510A9B785DAD9E128300845684019">
+<wsse:SecurityTokenReference wsu:Id="STRId-C861510A9B785DAD9E128300845684020" xmlns:wsu="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd"><wsse:Reference URI="#CertId-C861510A9B785DAD9E128300845684018" ValueType="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-x509-token-profile-1.0#X509PKIPathv1"/></wsse:SecurityTokenReference>
+</ds:KeyInfo>
+</ds:Signature><xenc:EncryptedKey Id="EncKeyId-C861510A9B785DAD9E128300845663717"><xenc:EncryptionMethod Algorithm="http://www.w3.org/2001/04/xmlenc#rsa-1_5"/><ds:KeyInfo xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
+<wsse:SecurityTokenReference><ds:X509Data>
+<ds:X509IssuerSerial>
+<ds:X509IssuerName>CN=myAlias</ds:X509IssuerName>
+<ds:X509SerialNumber>1181668586</ds:X509SerialNumber>
+</ds:X509IssuerSerial>
+</ds:X509Data></wsse:SecurityTokenReference>
+</ds:KeyInfo><xenc:CipherData><xenc:CipherValue>jy/4f/WWk6ZNDC2LfmRm6LKlbqBURfRPIbJuYeswcTmktfkMV5KGbfOd1TJTnDfjoQqy3ZM/kzVQw/u2RoLG2hSkXhgsU88XfnpFuZ7cbxyKV+cerG1hOowd1ETqdW/QTPtck5fpL0mdXUTkSCCRDRhZd6HlOkxICOUlvqZ251c=</xenc:CipherValue></xenc:CipherData><xenc:ReferenceList><xenc:DataReference URI="#EncDataId-4"/></xenc:ReferenceList></xenc:EncryptedKey></wsse:Security>
+      <wsse11:EncryptedHeader wsu:Id="_9" xmlns:wsse11="http://docs.oasis-open.org/wss/oasis-wss-wssecurity-secext-1.1.xsd" xmlns:wsu="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd"><xenc:EncryptedData Id="EncDataId-4" Type="http://www.w3.org/2001/04/xmlenc#Element" wsu:Id="id-6" xmlns:wsu="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd"><xenc:EncryptionMethod Algorithm="http://www.w3.org/2001/04/xmlenc#aes128-cbc"/><ds:KeyInfo xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
+<wsse:SecurityTokenReference xmlns:wsse="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd"><wsse:Reference URI="#EncKeyId-C861510A9B785DAD9E128300845663717"/></wsse:SecurityTokenReference>
+</ds:KeyInfo><xenc:CipherData><xenc:CipherValue>44MglCtaRqTdRWQwTc3rCTRznona1qxUF6SRS48KqNpJ26ZFW6J+CUBhQpQaQbF33xM8vFduX0Zz
+cZ5DaQX3QQdEs5o4MBS8R/q9z1UoAYdcdg/FJdPnAcqCn+mmDWLJr/xqBGeMGvuh2eLQwraj1JeD
+Y18UQZJcehm927kJGjEW8FNuC5QLWGjFw3464LjMQ///WVtnmSP8gAlqpwv5lW34dqUzVNJezvpq
+BHRhLbz3BV9O8dTN/ychY4998jAt/2vwcURPbsaYaddXgm1AlTEGOjRG/gqjmDO5jrEskVIh8qSQ
+qaYRfOnIMOwZPc5hmQQToWvytaI6PKqZs/j9oOGhk+0vtTleDfd2PTKCAdQ=</xenc:CipherValue></xenc:CipherData></xenc:EncryptedData></wsse11:EncryptedHeader>
+  </soap:Header>
+  <soap:Body>
+    <echo xmlns="http://www.sdj.pl">
+      <in0>A</in0>    
+    </echo>
+  </soap:Body>
+</soap:Envelope>


### PR DESCRIPTION
SOAP Message Security 1.1 paragraph 9.3 mentions that EncryptedHeader is recommended to be used when a header part is encrypted. Recent .NET implementations do this and for interop CXF needs to be able to handle this. WSS4J already does, this fix will make CXF pass the right information on to WSS4J