### PR TITLE
Schema imports are not handled correctly in generated WSDL and XSD files

### DIFF
--- a/rt/frontend/simple/src/main/java/org/apache/cxf/frontend/WSDLGetUtils.java
+++ b/rt/frontend/simple/src/main/java/org/apache/cxf/frontend/WSDLGetUtils.java
@@ -73,7 +73,7 @@ import org.apache.cxf.wsdl11.ServiceWSDLBuilder;
 
 
 /**
- * 
+ *
  */
 public class WSDLGetUtils {
 
@@ -84,9 +84,9 @@ public class WSDLGetUtils {
 
     private static final String WSDLS_KEY = WSDLGetUtils.class.getName() + ".WSDLs";
     private static final String SCHEMAS_KEY = WSDLGetUtils.class.getName() + ".Schemas";
-    
+
     private static final Logger LOG = LogUtils.getL7dLogger(WSDLGetInterceptor.class);
-    
+
     public WSDLGetUtils() {
     }
 
@@ -97,10 +97,10 @@ public class WSDLGetUtils {
                             EndpointInfo endpointInfo) {
         Map<String, String> params = new HashMap<String, String>();
         params.put("wsdl", "");
-        getDocument(message, base, 
-                    params, ctxUri, 
+        getDocument(message, base,
+                    params, ctxUri,
                     endpointInfo);
-        
+
         Map<String, Definition> mp = CastUtils.cast((Map<?, ?>)endpointInfo.getService()
                                                     .getProperty(WSDLS_KEY));
         return mp.keySet();
@@ -111,19 +111,19 @@ public class WSDLGetUtils {
                                                   EndpointInfo endpointInfo) {
         Map<String, String> params = new HashMap<String, String>();
         params.put("wsdl", "");
-        getDocument(message, base, 
-                    params, ctxUri, 
+        getDocument(message, base,
+                    params, ctxUri,
                     endpointInfo);
-      
+
         Map<String, SchemaReference> mp = CastUtils.cast((Map<?, ?>)endpointInfo.getService()
                                                          .getProperty(SCHEMAS_KEY));
-        
+
         Map<String, String> schemas = new HashMap<String, String>();
         for (Map.Entry<String, SchemaReference> ent : mp.entrySet()) {
             params.clear();
             params.put("xsd", ent.getKey());
             Document doc = getDocument(message, base, params, ctxUri, endpointInfo);
-            schemas.put(doc.getDocumentElement().getAttribute("targetNamespace"), 
+            schemas.put(doc.getDocumentElement().getAttribute("targetNamespace"),
                         buildUrl(base, ctxUri, "xsd=" + ent.getKey()));
         }
         return schemas;
@@ -162,15 +162,24 @@ public class WSDLGetUtils {
         }
         return doc;
     }
-    
-    protected String mapUri(String base, Map<String, SchemaReference> smp, String loc, String xsd)
+
+    protected String mapUri(Bus bus, String base, Map<String, SchemaReference> smp, String loc, String xsd)
         throws UnsupportedEncodingException {
         String key = loc;
         try {
-            if (!(new URI(loc).isAbsolute()) && xsd != null) {
+            if (!(new URI(loc).isAbsolute()) && xsd != null) { // XSD request
+                // resolve requested location with relative import path
                 key = new URI(xsd).resolve(loc).toString();
-            }
-            if (!(new URI(loc).isAbsolute()) && xsd == null) {
+
+                if (!smp.containsKey(URLDecoder.decode(key, "utf-8"))) {
+                    // if the result is not known, check if we can resolve it into something known
+                    String resolved = resolveWithCatalogs(OASISCatalogManager.getCatalogManager(bus), key, base);
+                    if (smp.containsKey(URLDecoder.decode(resolved, "utf-8"))) {
+                        // if it is resolvable, we can use it
+                        return base + "?xsd=" + key.replace(" ", "%20");
+                    }
+                }
+            } else if (!(new URI(loc).isAbsolute()) && xsd == null) { // WSDL request
                 key = new URI(".").resolve(loc).toString();
             }
         } catch (URISyntaxException e) {
@@ -190,6 +199,7 @@ public class WSDLGetUtils {
                              Message message,
                              String xsd,
                              String wsdl) {
+        Bus bus = message.getExchange().getBus();
         List<Element> elementList = null;
 
         try {
@@ -197,7 +207,7 @@ public class WSDLGetUtils {
                                                               "http://www.w3.org/2001/XMLSchema", "import");
             for (Element el : elementList) {
                 String sl = el.getAttribute("schemaLocation");
-                sl = mapUri(base, smp, sl, xsd);
+                sl = mapUri(bus, base, smp, sl, xsd);
                 if (sl != null) {
                     el.setAttribute("schemaLocation", sl);
                 }
@@ -208,7 +218,7 @@ public class WSDLGetUtils {
                                                               "include");
             for (Element el : elementList) {
                 String sl = el.getAttribute("schemaLocation");
-                sl = mapUri(base, smp, sl, xsd);
+                sl = mapUri(bus, base, smp, sl, xsd);
                 if (sl != null) {
                     el.setAttribute("schemaLocation", sl);
                 }
@@ -218,7 +228,7 @@ public class WSDLGetUtils {
                                                               "redefine");
             for (Element el : elementList) {
                 String sl = el.getAttribute("schemaLocation");
-                sl = mapUri(base, smp, sl, xsd);
+                sl = mapUri(bus, base, smp, sl, xsd);
                 if (sl != null) {
                     el.setAttribute("schemaLocation", sl);
                 }
@@ -393,7 +403,7 @@ public class WSDLGetUtils {
                 : CastUtils.cast(types.getExtensibilityElements(), ExtensibilityElement.class)) {
                 if (el instanceof Schema) {
                     Schema see = (Schema)el;
-                    updateSchemaImports(bus, see, see.getDocumentBaseURI(), doneSchemas, base, null);
+                    updateSchemaImports(bus, see, see.getDocumentBaseURI(), doneSchemas, base);
                 }
             }
         }
@@ -450,8 +460,7 @@ public class WSDLGetUtils {
                                        Schema schema,
                                        String docBase,
                                        Map<String, SchemaReference> doneSchemas,
-                                       String base,
-                                       String parent) {
+                                       String base) {
         OASISCatalogManager catalogs = OASISCatalogManager.getCatalogManager(bus);
         Collection<List<?>>  imports = CastUtils.cast((Collection<?>)schema.getImports().values());
         for (List<?> lst : imports) {
@@ -476,36 +485,23 @@ public class WSDLGetUtils {
                         String resolvedSchemaLocation = resolveWithCatalogs(catalogs, start, base);
                         if (resolvedSchemaLocation == null) {
                             resolvedSchemaLocation = resolveWithCatalogs(catalogs, imp.getSchemaLocationURI(), base);
-                        }                        
+                        }
                         if (resolvedSchemaLocation == null) {
                             try {
                                 //check to see if it's already in a URL format.  If so, leave it.
                                 new URL(start);
                             } catch (MalformedURLException e) {
                                 if (doneSchemas.put(decodedStart, imp) == null) {
-                                    try {
-                                        //CHECKSTYLE:OFF:NestedIfDepth
-                                        if (!(new URI(decodedStart).isAbsolute()) && parent != null) {
-                                            resolvedSchemaLocation = new URI(parent).resolve(decodedStart).toString();
-                                            decodedStart = URLDecoder.decode(resolvedSchemaLocation, "utf-8");
-                                            doneSchemas.put(resolvedSchemaLocation, imp);
-                                        }
-                                        //CHECKSTYLE:ON:NestedIfDepth 
-                                    } catch (URISyntaxException ex) {
-                                        // ignore
-                                    } catch (UnsupportedEncodingException ex) {
-                                        // ignore
-                                    }
+                                    putResolvedSchemaLocationIfRelative(doneSchemas, decodedStart, imp);
                                     updateSchemaImports(bus, imp.getReferencedSchema(), docBase,
-                                                        doneSchemas, base, decodedStart);
+                                                        doneSchemas, base);
                                 }
                             }
                         } else {
                             if (doneSchemas.put(decodedStart, imp) == null) {
                                 doneSchemas.put(resolvedSchemaLocation, imp);
                                 doneSchemas.put(imp.getSchemaLocationURI(), imp);
-                                updateSchemaImports(bus, imp.getReferencedSchema(), docBase,
-                                                    doneSchemas, base, decodedStart);
+                                updateSchemaImports(bus, imp.getReferencedSchema(), docBase, doneSchemas, base);
                             }
                         }
                     }
@@ -538,8 +534,8 @@ public class WSDLGetUtils {
                             new URL(start);
                         } catch (MalformedURLException e) {
                             if (doneSchemas.put(decodedStart, included) == null) {
-                                updateSchemaImports(bus, included.getReferencedSchema(), 
-                                                    docBase, doneSchemas, base, decodedStart);
+                                putResolvedSchemaLocationIfRelative(doneSchemas, decodedStart, included);
+                                updateSchemaImports(bus, included.getReferencedSchema(), docBase, doneSchemas, base);
                             }
                         }
                     }
@@ -547,7 +543,7 @@ public class WSDLGetUtils {
                     || !doneSchemas.containsKey(resolvedSchemaLocation)) {
                     doneSchemas.put(decodedStart, included);
                     doneSchemas.put(resolvedSchemaLocation, included);
-                    updateSchemaImports(bus, included.getReferencedSchema(), docBase, doneSchemas, base, decodedStart);
+                    updateSchemaImports(bus, included.getReferencedSchema(), docBase, doneSchemas, base);
                 }
             }
         }
@@ -576,21 +572,8 @@ public class WSDLGetUtils {
                             new URL(start);
                         } catch (MalformedURLException e) {
                             if (doneSchemas.put(decodedStart, included) == null) {
-                                try {
-                                    //CHECKSTYLE:OFF:NestedIfDepth
-                                    if (!(new URI(decodedStart).isAbsolute()) && parent != null) {
-                                        resolvedSchemaLocation = new URI(parent).resolve(decodedStart).toString();
-                                        decodedStart = URLDecoder.decode(resolvedSchemaLocation, "utf-8");
-                                        doneSchemas.put(resolvedSchemaLocation, included);
-                                    }
-                                    //CHECKSTYLE:ON:NestedIfDepth
-                                } catch (URISyntaxException ex) {
-                                    // ignore
-                                } catch (UnsupportedEncodingException ex) {
-                                    // ignore
-                                }
-                                updateSchemaImports(bus, included.getReferencedSchema(),
-                                                    docBase, doneSchemas, base, decodedStart);
+                                putResolvedSchemaLocationIfRelative(doneSchemas, decodedStart, included);
+                                updateSchemaImports(bus, included.getReferencedSchema(), docBase, doneSchemas, base);
                             }
                         }
                     }
@@ -598,9 +581,28 @@ public class WSDLGetUtils {
                     || !doneSchemas.containsKey(resolvedSchemaLocation)) {
                     doneSchemas.put(decodedStart, included);
                     doneSchemas.put(resolvedSchemaLocation, included);
-                    updateSchemaImports(bus, included.getReferencedSchema(), docBase, doneSchemas, base, decodedStart);
+                    updateSchemaImports(bus, included.getReferencedSchema(), docBase, doneSchemas, base);
                 }
             }
+        }
+    }
+
+    /**
+     * If given decodedStart is relative path, resolves a real location of given schema and puts it into schema map.
+     *
+     * @param doneSchemas schema map
+     * @param decodedStart path referencing schema
+     * @param schemaReference referenced schema
+     */
+    private void putResolvedSchemaLocationIfRelative(Map<String, SchemaReference> doneSchemas, String decodedStart,
+                                                     SchemaReference schemaReference) {
+        try {
+            if (!(new URI(decodedStart).isAbsolute())) {
+                String resolved = schemaReference.getReferencedSchema().getDocumentBaseURI();
+                doneSchemas.put(resolved, schemaReference);
+            }
+        } catch (URISyntaxException ex) {
+            // ignore
         }
     }
 

--- a/systests/jaxws/src/test/java/org/apache/cxf/systest/jaxws/OASISCatalogTest.java
+++ b/systests/jaxws/src/test/java/org/apache/cxf/systest/jaxws/OASISCatalogTest.java
@@ -19,6 +19,7 @@
 
 package org.apache.cxf.systest.jaxws;
 
+import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
 import java.util.Enumeration;
@@ -60,28 +61,70 @@ public class OASISCatalogTest extends Assert {
     @Test
     public void testWSDLPublishWithCatalogs() throws Exception {
         Endpoint ep = Endpoint.publish("http://localhost:" + PORT + "/SoapContext/SoapPort",
-                                       new GreeterImpl());
-        try {
-            URL url = new URL("http://localhost:" + PORT + "/SoapContext/SoapPort?"
-                              + "xsd=hello_world_schema2.xsd");
-            assertNotNull(url.getContent());
-            String result = IOUtils.toString((InputStream)url.getContent());
-            assertTrue(result, result.contains("xsd=hello_world_schema.xsd"));
-            
-            
-            url = new URL("http://localhost:" + PORT + "/SoapContext/SoapPort"
-                          + "?xsd=hello_world_schema.xsd");
-            result = IOUtils.toString((InputStream)url.getContent());
-            assertTrue(result, result.contains("xsd=hello_world_schema2.xsd"));
+                new GreeterImpl());
 
-            url = new URL("http://localhost:" + PORT + "/SoapContext/SoapPort"
-                          + "?wsdl=testutils/others/hello_world_messages_catalog.wsdl");
-            result = IOUtils.toString((InputStream)url.getContent());
-            assertTrue(result, result.contains("xsd=hello_world_schema.xsd"));
+        String result = readUrl("http://localhost:" + PORT + "/SoapContext/SoapPort?"
+                + "xsd=hello_world_schema2.xsd");
+        assertTrue(result, result.contains("xsd=hello_world_schema.xsd"));
+        assertTrue(result, result.contains("xsd=hello_world_schema3.xsd"));
+        assertTrue(result, result.contains("xsd=d/hello_world_schema4.xsd"));
 
-        } finally {
-            ep.stop();
-        }
+        result = readUrl("http://localhost:" + PORT + "/SoapContext/SoapPort?"
+                + "xsd=hello_world_schema3.xsd");
+        assertTrue(result.length() > 0);
+
+        result = readUrl("http://localhost:" + PORT + "/SoapContext/SoapPort?"
+                + "xsd=d/hello_world_schema4.xsd");
+        assertTrue(result, result.contains("xsd=d/d/hello_world_schema4.xsd"));
+
+        result = readUrl("http://localhost:" + PORT + "/SoapContext/SoapPort"
+                + "?xsd=hello_world_schema.xsd");
+        assertTrue(result, result.contains("xsd=http://apache.org/hello_world/types2/hello_world_schema2.xsd"));
+
+        result = readUrl("http://localhost:" + PORT + "/SoapContext/SoapPort"
+                + "?wsdl=testutils/others/hello_world_messages_catalog.wsdl");
+        assertTrue(result, result.contains("xsd=hello_world_schema.xsd"));
+
+        ep.stop();
+    }
+
+    /**
+     * This is test case for https://issues.apache.org/jira/browse/CXF-6234
+     *
+     * It's using paths that will be rewritten by following catalog rule:
+     *
+     *     &lt;rewriteSystem systemIdStartString="http://apache.org/hello_world/types2/"
+     *          rewritePrefix="/wsdl/others/"/&gt;
+     *
+     */
+    @Test
+    public void testWSDLPublishWithCatalogsRewritePaths() {
+        Endpoint ep = Endpoint.publish("http://localhost:" + PORT + "/SoapContext/SoapPort",
+                new GreeterImpl());
+
+        String result = readUrl("http://localhost:" + PORT + "/SoapContext/SoapPort?"
+                + "xsd=http://apache.org/hello_world/types2/hello_world_schema2.xsd");
+        assertTrue(result, result.contains("xsd=http://apache.org/hello_world/types2/hello_world_schema.xsd"));
+        assertTrue(result, result.contains("xsd=http://apache.org/hello_world/types2/hello_world_schema3.xsd"));
+        assertTrue(result, result.contains("xsd=http://apache.org/hello_world/types2/d/hello_world_schema4.xsd"));
+
+        result = readUrl("http://localhost:" + PORT + "/SoapContext/SoapPort?"
+                + "xsd=http://apache.org/hello_world/types2/hello_world_schema.xsd");
+        assertTrue(result, result.contains("xsd=http://apache.org/hello_world/types2/hello_world_schema2.xsd"));
+
+        result = readUrl("http://localhost:" + PORT + "/SoapContext/SoapPort?"
+                + "xsd=http://apache.org/hello_world/types2/hello_world_schema3.xsd");
+        assertTrue(result.length() > 0);
+
+        result = readUrl("http://localhost:" + PORT + "/SoapContext/SoapPort?"
+                + "xsd=http://apache.org/hello_world/types2/d/hello_world_schema4.xsd");
+        assertTrue(result, result.contains("xsd=http://apache.org/hello_world/types2/d/d/hello_world_schema4.xsd"));
+
+        result = readUrl("http://localhost:" + PORT + "/SoapContext/SoapPort?"
+                + "xsd=http://apache.org/hello_world/types2/d/d/hello_world_schema4.xsd");
+        assertTrue(result.length() > 0);
+
+        ep.stop();
     }
     
     @Test
@@ -168,6 +211,19 @@ public class OASISCatalogTest extends Assert {
         } catch (WSDLException e) {
             // ignore
         }
+    }
+
+    private String readUrl(String address) {
+        String content = null;
+        try {
+            URL url = new URL(address);
+            assertNotNull(url.getContent());
+            content = IOUtils.toString((InputStream) url.getContent());
+        } catch (IOException e) {
+            e.printStackTrace(System.err);
+            Assert.fail("Couldn't read URL: " + e.getMessage());
+        }
+        return content;
     }
 
 }

--- a/testutils/src/main/resources/wsdl/others/d/d/hello_world_schema4.xsd
+++ b/testutils/src/main/resources/wsdl/others/d/d/hello_world_schema4.xsd
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0"?>
 <!--
     Licensed to the Apache Software Foundation (ASF) under one
     or more contributor license agreements.  See the NOTICE file
@@ -7,9 +7,9 @@
     to you under the Apache License, Version 2.0 (the
     "License"); you may not use this file except in compliance
     with the License.  You may obtain a copy of the License at
-    
+
      http://www.apache.org/licenses/LICENSE-2.0
-    
+
     Unless required by applicable law or agreed to in writing,
     software distributed under the License is distributed on an
     "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -17,11 +17,11 @@
     specific language governing permissions and limitations
     under the License.
 -->
-<catalog xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog" prefer="system">
-    <rewriteSystem systemIdStartString="http://apache.org/hello_world/types2/" rewritePrefix="/wsdl/others/"/>
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" 
+    targetNamespace="http://apache.org/hello_world/types5"
+            elementFormDefault="qualified">
 
-    <rewriteSystem systemIdStartString="doesnotexist" rewritePrefix="../wsdl/catalog"/>
-    <rewriteSystem systemIdStartString="nopath" rewritePrefix="../wsdl"/>
-
-    <rewriteSystem systemIdStartString="testutils" rewritePrefix="classpath:/wsdl"/>
-</catalog>
+    <xsd:element name="sayHi5">
+        <xsd:complexType/>
+    </xsd:element>
+</xsd:schema>

--- a/testutils/src/main/resources/wsdl/others/d/hello_world_schema4.xsd
+++ b/testutils/src/main/resources/wsdl/others/d/hello_world_schema4.xsd
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0"?>
 <!--
     Licensed to the Apache Software Foundation (ASF) under one
     or more contributor license agreements.  See the NOTICE file
@@ -7,9 +7,9 @@
     to you under the Apache License, Version 2.0 (the
     "License"); you may not use this file except in compliance
     with the License.  You may obtain a copy of the License at
-    
+
      http://www.apache.org/licenses/LICENSE-2.0
-    
+
     Unless required by applicable law or agreed to in writing,
     software distributed under the License is distributed on an
     "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -17,11 +17,14 @@
     specific language governing permissions and limitations
     under the License.
 -->
-<catalog xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog" prefer="system">
-    <rewriteSystem systemIdStartString="http://apache.org/hello_world/types2/" rewritePrefix="/wsdl/others/"/>
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" 
+    targetNamespace="http://apache.org/hello_world/types4"
+            elementFormDefault="qualified">
 
-    <rewriteSystem systemIdStartString="doesnotexist" rewritePrefix="../wsdl/catalog"/>
-    <rewriteSystem systemIdStartString="nopath" rewritePrefix="../wsdl"/>
+    <xsd:import namespace="http://apache.org/hello_world/types5"
+                schemaLocation="d/hello_world_schema4.xsd"/>
 
-    <rewriteSystem systemIdStartString="testutils" rewritePrefix="classpath:/wsdl"/>
-</catalog>
+    <xsd:element name="sayHi4">
+        <xsd:complexType/>
+    </xsd:element>
+</xsd:schema>

--- a/testutils/src/main/resources/wsdl/others/hello_world_schema.xsd
+++ b/testutils/src/main/resources/wsdl/others/hello_world_schema.xsd
@@ -24,7 +24,7 @@
             elementFormDefault="qualified">
 
     <import namespace="http://apache.org/hello_world/types2" 
-        schemaLocation="hello_world_schema2.xsd"/>
+        schemaLocation="http://apache.org/hello_world/types2/hello_world_schema2.xsd"/>
 
 
     <element name="sayHi">

--- a/testutils/src/main/resources/wsdl/others/hello_world_schema2.xsd
+++ b/testutils/src/main/resources/wsdl/others/hello_world_schema2.xsd
@@ -23,6 +23,10 @@
 
     <xsd:import namespace="http://apache.org/hello_world/types"
         schemaLocation="hello_world_schema.xsd"/>
+    <xsd:import namespace="http://apache.org/hello_world/types4"
+                schemaLocation="d/hello_world_schema4.xsd"/>
+
+    <xsd:include schemaLocation="hello_world_schema3.xsd"/>
 
     <xsd:element name="sayHi2">
         <xsd:complexType/>

--- a/testutils/src/main/resources/wsdl/others/hello_world_schema3.xsd
+++ b/testutils/src/main/resources/wsdl/others/hello_world_schema3.xsd
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0"?>
 <!--
     Licensed to the Apache Software Foundation (ASF) under one
     or more contributor license agreements.  See the NOTICE file
@@ -7,9 +7,9 @@
     to you under the Apache License, Version 2.0 (the
     "License"); you may not use this file except in compliance
     with the License.  You may obtain a copy of the License at
-    
+
      http://www.apache.org/licenses/LICENSE-2.0
-    
+
     Unless required by applicable law or agreed to in writing,
     software distributed under the License is distributed on an
     "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -17,11 +17,11 @@
     specific language governing permissions and limitations
     under the License.
 -->
-<catalog xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog" prefer="system">
-    <rewriteSystem systemIdStartString="http://apache.org/hello_world/types2/" rewritePrefix="/wsdl/others/"/>
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" 
+    targetNamespace="http://apache.org/hello_world/types2"
+            elementFormDefault="qualified">
 
-    <rewriteSystem systemIdStartString="doesnotexist" rewritePrefix="../wsdl/catalog"/>
-    <rewriteSystem systemIdStartString="nopath" rewritePrefix="../wsdl"/>
-
-    <rewriteSystem systemIdStartString="testutils" rewritePrefix="classpath:/wsdl"/>
-</catalog>
+    <xsd:element name="sayHi3">
+        <xsd:complexType/>
+    </xsd:element>
+</xsd:schema>


### PR DESCRIPTION
Proposed fix and test case for https://issues.apache.org/jira/browse/CXF-6392

- XSD files cannot be accessed by URLs that should be enabled by XML catalog rules.
- Under some circumstances, schema location attributes in <include> elements are not rewritten to "?xsd=location" form