### PR TITLE
[CXF-6421] Slim Exchange map down

### DIFF
--- a/core/src/main/java/org/apache/cxf/databinding/stax/StaxDataBindingInterceptor.java
+++ b/core/src/main/java/org/apache/cxf/databinding/stax/StaxDataBindingInterceptor.java
@@ -54,7 +54,7 @@ public class StaxDataBindingInterceptor extends AbstractInDatabindingInterceptor
         MessageContentsList parameters = new MessageContentsList();
 
         Exchange exchange = message.getExchange();
-        BindingOperationInfo bop = exchange.get(BindingOperationInfo.class);
+        BindingOperationInfo bop = exchange.getBindingOperationInfo();
 
         //if body is empty and we have BindingOperationInfo, we do not need to match 
         //operation anymore, just return
@@ -64,7 +64,7 @@ public class StaxDataBindingInterceptor extends AbstractInDatabindingInterceptor
         }
         
         if (bop == null) {
-            Endpoint ep = exchange.get(Endpoint.class);
+            Endpoint ep = exchange.getEndpoint();
             bop = ep.getBinding().getBindingInfo().getOperations().iterator().next();
         }
         

--- a/core/src/main/java/org/apache/cxf/endpoint/ClientImpl.java
+++ b/core/src/main/java/org/apache/cxf/endpoint/ClientImpl.java
@@ -65,9 +65,7 @@ import org.apache.cxf.service.model.BindingInfo;
 import org.apache.cxf.service.model.BindingMessageInfo;
 import org.apache.cxf.service.model.BindingOperationInfo;
 import org.apache.cxf.service.model.EndpointInfo;
-import org.apache.cxf.service.model.InterfaceInfo;
 import org.apache.cxf.service.model.MessageInfo;
-import org.apache.cxf.service.model.OperationInfo;
 import org.apache.cxf.service.model.ServiceInfo;
 import org.apache.cxf.transport.Conduit;
 import org.apache.cxf.transport.MessageObserver;
@@ -685,11 +683,9 @@ public class ClientImpl
             }
             if (!Boolean.TRUE.equals(exchange.get(FINISHED))) {
                 LogUtils.log(LOG, Level.WARNING, "RESPONSE_TIMEOUT",
-                    exchange.get(OperationInfo.class).getName().toString());
-                String msg = new org.apache.cxf.common.i18n.Message("RESPONSE_TIMEOUT", LOG, 
-                                                                    exchange.get(OperationInfo.class)
-                                                                        .getName().toString())
-                    .toString();
+                    exchange.getBindingOperationInfo().getOperationInfo().getName().toString());
+                String msg = new org.apache.cxf.common.i18n.Message("RESPONSE_TIMEOUT", LOG, exchange
+                    .getBindingOperationInfo().getOperationInfo().getName().toString()).toString();
                 throw new IOException(msg);
             }
         }
@@ -869,16 +865,10 @@ public class ClientImpl
         if (endpoint != null) {
             exchange.put(Endpoint.class, endpoint);
             exchange.put(Service.class, endpoint.getService());
-            if (endpoint.getEndpointInfo().getService() != null) {
-                exchange.put(ServiceInfo.class, endpoint.getEndpointInfo().getService());
-                exchange.put(InterfaceInfo.class, endpoint.getEndpointInfo().getService().getInterface());
-            }
             exchange.put(Binding.class, endpoint.getBinding());
-            exchange.put(BindingInfo.class, endpoint.getEndpointInfo().getBinding());
         }
         if (boi != null) {
             exchange.put(BindingOperationInfo.class, boi);
-            exchange.put(OperationInfo.class, boi.getOperationInfo());
         }
 
         if (exchange.isSynchronous() || executor == null) {

--- a/core/src/main/java/org/apache/cxf/interceptor/AbstractFaultChainInitiatorObserver.java
+++ b/core/src/main/java/org/apache/cxf/interceptor/AbstractFaultChainInitiatorObserver.java
@@ -28,7 +28,6 @@ import org.apache.cxf.BusFactory;
 import org.apache.cxf.common.classloader.ClassLoaderUtils;
 import org.apache.cxf.common.classloader.ClassLoaderUtils.ClassLoaderHolder;
 import org.apache.cxf.common.logging.LogUtils;
-import org.apache.cxf.endpoint.Endpoint;
 import org.apache.cxf.message.Exchange;
 import org.apache.cxf.message.FaultMode;
 import org.apache.cxf.message.Message;
@@ -81,7 +80,7 @@ public abstract class AbstractFaultChainInitiatorObserver implements MessageObse
                 if (null == faultMessage) {
                     faultMessage = new MessageImpl();
                     faultMessage.setExchange(exchange);
-                    faultMessage = exchange.get(Endpoint.class).getBinding().createMessage(faultMessage);
+                    faultMessage = exchange.getEndpoint().getBinding().createMessage(faultMessage);
                 }
                 faultMessage.setContent(Exception.class, ex);
                 if (null != mode) {

--- a/core/src/main/java/org/apache/cxf/interceptor/AbstractInDatabindingInterceptor.java
+++ b/core/src/main/java/org/apache/cxf/interceptor/AbstractInDatabindingInterceptor.java
@@ -153,7 +153,7 @@ public abstract class AbstractInDatabindingInterceptor extends AbstractPhaseInte
     protected MessagePartInfo findMessagePart(Exchange exchange, Collection<OperationInfo> operations,
                                               QName name, boolean client, int index,
                                               Message message) {
-        Endpoint ep = exchange.get(Endpoint.class);
+        Endpoint ep = exchange.getEndpoint();
         MessagePartInfo lastChoice = null;
         BindingOperationInfo lastBoi = null;
         BindingMessageInfo lastMsgInfo = null;
@@ -190,7 +190,6 @@ public abstract class AbstractInDatabindingInterceptor extends AbstractPhaseInte
             }
             if (name.equals(p.getConcreteName())) {
                 exchange.put(BindingOperationInfo.class, boi);
-                exchange.put(OperationInfo.class, boi.getOperationInfo());
                 exchange.setOneWay(op.isOneWay());
                 return p;
             }
@@ -218,7 +217,6 @@ public abstract class AbstractInDatabindingInterceptor extends AbstractPhaseInte
         Exchange ex = message.getExchange();
         
         ex.put(BindingOperationInfo.class, operation);
-        ex.put(OperationInfo.class, operation.getOperationInfo());
         ex.setOneWay(operation.getOperationInfo().isOneWay());
 
         //Set standard MessageContext properties required by JAX_WS, but not specific to JAX_WS.
@@ -279,7 +277,6 @@ public abstract class AbstractInDatabindingInterceptor extends AbstractPhaseInte
         
         if (bop != null) {
             exchange.put(BindingOperationInfo.class, bop);
-            exchange.put(OperationInfo.class, bop.getOperationInfo());
         }
         return bop;
     }

--- a/core/src/main/java/org/apache/cxf/interceptor/ClientFaultConverter.java
+++ b/core/src/main/java/org/apache/cxf/interceptor/ClientFaultConverter.java
@@ -108,7 +108,7 @@ public class ClientFaultConverter extends AbstractInDatabindingInterceptor {
         QName qname = new QName(exDetail.getNamespaceURI(), exDetail.getLocalName());
         FaultInfo faultWanted = null;
         MessagePartInfo part = null;
-        BindingOperationInfo boi = msg.getExchange().get(BindingOperationInfo.class);
+        BindingOperationInfo boi = msg.getExchange().getBindingOperationInfo();
         if (boi == null) {
             return;
         }
@@ -145,7 +145,7 @@ public class ClientFaultConverter extends AbstractInDatabindingInterceptor {
         if (faultWanted == null) {
             return;
         }
-        Service s = msg.getExchange().get(Service.class);
+        Service s = msg.getExchange().getService();
         DataBinding dataBinding = s.getDataBinding();
 
         Object e = null;

--- a/core/src/main/java/org/apache/cxf/interceptor/FIStaxOutInterceptor.java
+++ b/core/src/main/java/org/apache/cxf/interceptor/FIStaxOutInterceptor.java
@@ -140,7 +140,7 @@ public class FIStaxOutInterceptor extends AbstractPhaseInterceptor<Message> {
     
     private StAXDocumentSerializer getOutput(Message m, OutputStream out) {
         /*
-        StAXDocumentSerializer serializer = (StAXDocumentSerializer)m.getExchange().get(Endpoint.class)
+        StAXDocumentSerializer serializer = (StAXDocumentSerializer)m.getExchange().getEndpoint()
             .remove(StAXDocumentSerializer.class.getName());
         if (serializer != null) {
             serializer.setOutputStream(out);

--- a/core/src/main/java/org/apache/cxf/interceptor/FaultOutInterceptor.java
+++ b/core/src/main/java/org/apache/cxf/interceptor/FaultOutInterceptor.java
@@ -68,7 +68,7 @@ public class FaultOutInterceptor extends AbstractPhaseInterceptor<Message> {
             return;
         }
         
-        BindingOperationInfo bop = message.getExchange().get(BindingOperationInfo.class);
+        BindingOperationInfo bop = message.getExchange().getBindingOperationInfo();
         if (bop == null) {
             return;
         }
@@ -77,7 +77,7 @@ public class FaultOutInterceptor extends AbstractPhaseInterceptor<Message> {
         if (cause instanceof Exception && fi != null) {
             Exception ex = (Exception)cause;
             Object bean = getFaultBean(cause, fi, message);
-            Service service = message.getExchange().get(Service.class);
+            Service service = message.getExchange().getService();
 
             MessagePartInfo part = fi.getFirstMessagePart();
             DataBinding db = service.getDataBinding();

--- a/core/src/main/java/org/apache/cxf/interceptor/InFaultChainInitiatorObserver.java
+++ b/core/src/main/java/org/apache/cxf/interceptor/InFaultChainInitiatorObserver.java
@@ -38,7 +38,7 @@ public class InFaultChainInitiatorObserver extends AbstractFaultChainInitiatorOb
     }
 
     protected void initializeInterceptors(Exchange ex, PhaseInterceptorChain chain) {
-        Endpoint e = ex.get(Endpoint.class);
+        Endpoint e = ex.getEndpoint();
         Client c = ex.get(Client.class);
         InterceptorProvider ip = ex.get(InterceptorProvider.class);
         

--- a/core/src/main/java/org/apache/cxf/interceptor/OneWayProcessorInterceptor.java
+++ b/core/src/main/java/org/apache/cxf/interceptor/OneWayProcessorInterceptor.java
@@ -25,7 +25,6 @@ import java.util.concurrent.Executor;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.logging.Logger;
 
-import org.apache.cxf.Bus;
 import org.apache.cxf.common.logging.LogUtils;
 import org.apache.cxf.endpoint.Endpoint;
 import org.apache.cxf.io.DelegatingInputStream;
@@ -129,7 +128,7 @@ public class OneWayProcessorInterceptor extends AbstractPhaseInterceptor<Message
                 try {
                     final Object lock = new Object();
                     synchronized (lock) {
-                        message.getExchange().get(Bus.class).getExtension(WorkQueueManager.class)
+                        message.getExchange().getBus().getExtension(WorkQueueManager.class)
                             .getAutomaticWorkQueue().execute(new Runnable() {
                                 public void run() {
                                     synchronized (lock) {
@@ -163,7 +162,7 @@ public class OneWayProcessorInterceptor extends AbstractPhaseInterceptor<Message
     }
     
     private static Message createMessage(Exchange exchange) {
-        Endpoint ep = exchange.get(Endpoint.class);
+        Endpoint ep = exchange.getEndpoint();
         Message msg = null;
         if (ep != null) {
             msg = new MessageImpl();

--- a/core/src/main/java/org/apache/cxf/interceptor/OutFaultChainInitiatorObserver.java
+++ b/core/src/main/java/org/apache/cxf/interceptor/OutFaultChainInitiatorObserver.java
@@ -38,7 +38,7 @@ public class OutFaultChainInitiatorObserver extends AbstractFaultChainInitiatorO
     }
 
     protected void initializeInterceptors(Exchange ex, PhaseInterceptorChain chain) {
-        Endpoint e = ex.get(Endpoint.class);
+        Endpoint e = ex.getEndpoint();
         Client c = ex.get(Client.class);
 
         chain.add(getBus().getOutFaultInterceptors());

--- a/core/src/main/java/org/apache/cxf/interceptor/OutgoingChainInterceptor.java
+++ b/core/src/main/java/org/apache/cxf/interceptor/OutgoingChainInterceptor.java
@@ -56,7 +56,7 @@ public class OutgoingChainInterceptor extends AbstractPhaseInterceptor<Message> 
 
     public void handleMessage(Message message) {
         Exchange ex = message.getExchange();
-        BindingOperationInfo binding = ex.get(BindingOperationInfo.class);
+        BindingOperationInfo binding = ex.getBindingOperationInfo();
         //if we get this far, we're going to be outputting some valid content, but we COULD
         //also be "echoing" some of the content from the input.   Thus, we need to 
         //mark it as requiring the input to be cached.   
@@ -104,7 +104,7 @@ public class OutgoingChainInterceptor extends AbstractPhaseInterceptor<Message> 
             try {
                 conduit = ex.getDestination().getBackChannel(ex.getInMessage());
                 ex.put(ConduitSelector.class, 
-                       new PreexistingConduitSelector(conduit, ex.get(Endpoint.class)));
+                       new PreexistingConduitSelector(conduit, ex.getEndpoint()));
             } catch (IOException e) {
                 // TODO Auto-generated catch block
                 e.printStackTrace();
@@ -114,12 +114,12 @@ public class OutgoingChainInterceptor extends AbstractPhaseInterceptor<Message> 
     }
     
     public static InterceptorChain getOutInterceptorChain(Exchange ex) {
-        Bus bus = ex.get(Bus.class);
-        Binding binding = ex.get(Binding.class);
+        Bus bus = ex.getBus();
+        Binding binding = ex.getBinding();
         PhaseManager pm = bus.getExtension(PhaseManager.class);
         PhaseInterceptorChain chain = new PhaseInterceptorChain(pm.getOutPhases());
         
-        Endpoint ep = ex.get(Endpoint.class);
+        Endpoint ep = ex.getEndpoint();
         List<Interceptor<? extends Message>> il = ep.getOutInterceptors();
         if (LOG.isLoggable(Level.FINE)) {
             LOG.fine("Interceptors contributed by endpoint: " + il);
@@ -172,10 +172,10 @@ public class OutgoingChainInterceptor extends AbstractPhaseInterceptor<Message> 
     }
     
     private static PhaseInterceptorChain getChain(Exchange ex, PhaseChainCache chainCache) {
-        Bus bus = ex.get(Bus.class);
-        Binding binding = ex.get(Binding.class);
+        Bus bus = ex.getBus();
+        Binding binding = ex.getBinding();
         
-        Endpoint ep = ex.get(Endpoint.class);
+        Endpoint ep = ex.getEndpoint();
         
         List<Interceptor<? extends Message>> i1 = bus.getOutInterceptors();
         if (LOG.isLoggable(Level.FINE)) {

--- a/core/src/main/java/org/apache/cxf/interceptor/ServiceInvokerInterceptor.java
+++ b/core/src/main/java/org/apache/cxf/interceptor/ServiceInvokerInterceptor.java
@@ -48,7 +48,7 @@ public class ServiceInvokerInterceptor extends AbstractPhaseInterceptor<Message>
 
     public void handleMessage(final Message message) {
         final Exchange exchange = message.getExchange();
-        final Endpoint endpoint = exchange.get(Endpoint.class);
+        final Endpoint endpoint = exchange.getEndpoint();
         final Service service = endpoint.getService();
         final Invoker invoker = service.getInvoker();        
 
@@ -58,7 +58,7 @@ public class ServiceInvokerInterceptor extends AbstractPhaseInterceptor<Message>
                 Exchange runableEx = message.getExchange();
                 Object result = invoker.invoke(runableEx, getInvokee(message));
                 if (!exchange.isOneWay()) {
-                    Endpoint ep = exchange.get(Endpoint.class);
+                    Endpoint ep = exchange.getEndpoint();
                     
                     Message outMessage = runableEx.getOutMessage();
                     if (outMessage == null) {

--- a/core/src/main/java/org/apache/cxf/interceptor/security/AbstractAuthorizingInInterceptor.java
+++ b/core/src/main/java/org/apache/cxf/interceptor/security/AbstractAuthorizingInInterceptor.java
@@ -30,7 +30,6 @@ import org.apache.cxf.message.Message;
 import org.apache.cxf.phase.AbstractPhaseInterceptor;
 import org.apache.cxf.phase.Phase;
 import org.apache.cxf.security.SecurityContext;
-import org.apache.cxf.service.Service;
 import org.apache.cxf.service.invoker.MethodDispatcher;
 import org.apache.cxf.service.model.BindingOperationInfo;
 
@@ -62,10 +61,10 @@ public abstract class AbstractAuthorizingInInterceptor extends AbstractPhaseInte
     }
     
     protected Method getTargetMethod(Message m) {
-        BindingOperationInfo bop = m.getExchange().get(BindingOperationInfo.class);
+        BindingOperationInfo bop = m.getExchange().getBindingOperationInfo();
         if (bop != null) {
             MethodDispatcher md = (MethodDispatcher) 
-                m.getExchange().get(Service.class).get(MethodDispatcher.class.getName());
+                m.getExchange().getService().get(MethodDispatcher.class.getName());
             return md.getMethod(bop);
         } 
         Method method = (Method)m.get("org.apache.cxf.resource.method");

--- a/core/src/main/java/org/apache/cxf/interceptor/security/OperationInfoAuthorizingInterceptor.java
+++ b/core/src/main/java/org/apache/cxf/interceptor/security/OperationInfoAuthorizingInterceptor.java
@@ -71,7 +71,7 @@ public class OperationInfoAuthorizingInterceptor extends SimpleAuthorizingInterc
     }
 
     protected OperationInfo getTargetOperationInfo(Message message) {
-        BindingOperationInfo bop = message.getExchange().get(BindingOperationInfo.class);
+        BindingOperationInfo bop = message.getExchange().getBindingOperationInfo();
         if (bop != null) {
             return bop.getOperationInfo();
         }

--- a/core/src/main/java/org/apache/cxf/message/ExchangeImpl.java
+++ b/core/src/main/java/org/apache/cxf/message/ExchangeImpl.java
@@ -103,10 +103,7 @@ public class ExchangeImpl extends ConcurrentHashMap<String, Object>  implements 
     public <T> void put(Class<T> key, T value) {
         if (value == null) {
             super.remove(key);
-        } else {
-            super.put(key.getName(), value);
-        }
-        if (key == Bus.class) {
+        } else if (key == Bus.class) {
             resetContextCaches();
             bus = (Bus)value;
         } else if (key == Endpoint.class) {
@@ -119,6 +116,8 @@ public class ExchangeImpl extends ConcurrentHashMap<String, Object>  implements 
             bindingOp = (BindingOperationInfo)value;
         } else if (key == Binding.class) {
             binding = (Binding)value;
+        } else {
+            super.put(key.getName(), value);
         }
     }
     
@@ -200,7 +199,7 @@ public class ExchangeImpl extends ConcurrentHashMap<String, Object>  implements 
 
     public void setConduit(Conduit c) {
         put(ConduitSelector.class,
-            new PreexistingConduitSelector(c, get(Endpoint.class)));
+            new PreexistingConduitSelector(c, getEndpoint()));
     }
 
     public void setOutMessage(Message m) {

--- a/core/src/main/java/org/apache/cxf/phase/PhaseInterceptorChain.java
+++ b/core/src/main/java/org/apache/cxf/phase/PhaseInterceptorChain.java
@@ -44,6 +44,7 @@ import org.apache.cxf.message.FaultMode;
 import org.apache.cxf.message.Message;
 import org.apache.cxf.message.MessageUtils;
 import org.apache.cxf.service.Service;
+import org.apache.cxf.service.model.BindingOperationInfo;
 import org.apache.cxf.service.model.OperationInfo;
 import org.apache.cxf.transport.MessageObserver;
 
@@ -370,11 +371,12 @@ public class PhaseInterceptorChain implements InterceptorChain {
         StringBuilder description = new StringBuilder();
         if (message.getExchange() != null) {
             Exchange exchange = message.getExchange();
-            Service service = exchange.get(Service.class);
+            Service service = exchange.getService();
             if (service != null) {
                 description.append('\'');
                 description.append(service.getName());
-                OperationInfo opInfo = exchange.get(OperationInfo.class);
+                BindingOperationInfo boi = exchange.getBindingOperationInfo();
+                OperationInfo opInfo = boi != null ? boi.getOperationInfo() : null;
                 if (opInfo != null) {
                     description.append("#").append(opInfo.getName());
                 }

--- a/core/src/main/java/org/apache/cxf/service/invoker/AbstractInvoker.java
+++ b/core/src/main/java/org/apache/cxf/service/invoker/AbstractInvoker.java
@@ -35,7 +35,6 @@ import org.apache.cxf.interceptor.Fault;
 import org.apache.cxf.message.Exchange;
 import org.apache.cxf.message.FaultMode;
 import org.apache.cxf.message.MessageContentsList;
-import org.apache.cxf.service.Service;
 import org.apache.cxf.service.model.BindingOperationInfo;
 
 /**
@@ -50,9 +49,9 @@ public abstract class AbstractInvoker implements Invoker {
         final Object serviceObject = getServiceObject(exchange);
         try {
 
-            BindingOperationInfo bop = exchange.get(BindingOperationInfo.class);
+            BindingOperationInfo bop = exchange.getBindingOperationInfo();
             MethodDispatcher md = (MethodDispatcher) 
-                exchange.get(Service.class).get(MethodDispatcher.class.getName());
+                exchange.getService().get(MethodDispatcher.class.getName());
             Method m = bop == null ? null : md.getMethod(bop);
             if (m == null && bop == null) {
                 LOG.severe(new Message("MISSING_BINDING_OPERATION", LOG).toString());

--- a/core/src/main/java/org/apache/cxf/service/invoker/PerRequestFactory.java
+++ b/core/src/main/java/org/apache/cxf/service/invoker/PerRequestFactory.java
@@ -53,7 +53,7 @@ public class PerRequestFactory implements Factory {
                 throw new Fault(new Message("SVC_CLASS_IS_ABSTRACT", BUNDLE, svcClass.getName()));
             }
             Object o = svcClass.newInstance();
-            Bus b = ex.get(Bus.class);
+            Bus b = ex.getBus();
             ResourceManager resourceManager = b.getExtension(ResourceManager.class);
             if (resourceManager != null) {
                 ResourceInjector injector = new ResourceInjector(resourceManager);

--- a/core/src/main/java/org/apache/cxf/service/invoker/SessionFactory.java
+++ b/core/src/main/java/org/apache/cxf/service/invoker/SessionFactory.java
@@ -50,7 +50,7 @@ public class SessionFactory implements Factory {
 
     /** {@inheritDoc}*/
     public Object create(Exchange e) throws Throwable {
-        Service serv = e.get(Service.class);
+        Service serv = e.getService();
         Object o = null;
         synchronized (serv) {
             o = e.getSession().get(serv.getName().toString());

--- a/core/src/main/java/org/apache/cxf/service/model/ServiceModelUtil.java
+++ b/core/src/main/java/org/apache/cxf/service/model/ServiceModelUtil.java
@@ -51,7 +51,7 @@ public final class ServiceModelUtil {
     }
 
     public static BindingOperationInfo getOperation(Exchange exchange, String opName) {
-        Endpoint ep = exchange.get(Endpoint.class);
+        Endpoint ep = exchange.getEndpoint();
         if (ep == null) {
             return null;
         }
@@ -66,7 +66,7 @@ public final class ServiceModelUtil {
     }
 
     public static BindingOperationInfo getOperation(Exchange exchange, QName opName) {
-        Endpoint ep = exchange.get(Endpoint.class);
+        Endpoint ep = exchange.getEndpoint();
         if (ep == null) {
             return null;
         }
@@ -77,7 +77,7 @@ public final class ServiceModelUtil {
                                                                      QName opName,
                                                                      boolean output) {
 
-        Endpoint ep = exchange.get(Endpoint.class);
+        Endpoint ep = exchange.getEndpoint();
         if (ep == null) {
             return null;
         }

--- a/core/src/main/java/org/apache/cxf/validation/AbstractValidationInterceptor.java
+++ b/core/src/main/java/org/apache/cxf/validation/AbstractValidationInterceptor.java
@@ -30,7 +30,6 @@ import org.apache.cxf.interceptor.Fault;
 import org.apache.cxf.message.Message;
 import org.apache.cxf.message.MessageContentsList;
 import org.apache.cxf.phase.AbstractPhaseInterceptor;
-import org.apache.cxf.service.Service;
 import org.apache.cxf.service.invoker.FactoryInvoker;
 import org.apache.cxf.service.invoker.Invoker;
 import org.apache.cxf.service.invoker.MethodDispatcher;
@@ -82,7 +81,7 @@ public abstract class AbstractValidationInterceptor extends AbstractPhaseInterce
         if (current != null) {
             return current;
         }
-        Endpoint e = message.getExchange().get(Endpoint.class);
+        Endpoint e = message.getExchange().getEndpoint();
         if (e != null && e.getService() != null) {
             Invoker invoker = e.getService().getInvoker();
             if (invoker instanceof FactoryInvoker) {
@@ -99,10 +98,10 @@ public abstract class AbstractValidationInterceptor extends AbstractPhaseInterce
         Message inMessage = message.getExchange().getInMessage();
         Method method = (Method)inMessage.get("org.apache.cxf.resource.method");
         if (method == null) {
-            BindingOperationInfo bop = inMessage.getExchange().get(BindingOperationInfo.class);
+            BindingOperationInfo bop = inMessage.getExchange().getBindingOperationInfo();
             if (bop != null) {
                 MethodDispatcher md = (MethodDispatcher) 
-                    inMessage.getExchange().get(Service.class).get(MethodDispatcher.class.getName());
+                    inMessage.getExchange().getService().get(MethodDispatcher.class.getName());
                 method = md.getMethod(bop);
             }
         }

--- a/core/src/main/java/org/apache/cxf/ws/addressing/ContextUtils.java
+++ b/core/src/main/java/org/apache/cxf/ws/addressing/ContextUtils.java
@@ -586,7 +586,7 @@ public final class ContextUtils {
      * @return the Method from the BindingOperationInfo
      */
     public static Message createMessage(Exchange exchange) {
-        Endpoint ep = exchange.get(Endpoint.class);
+        Endpoint ep = exchange.getEndpoint();
         Message msg = null;
         if (ep != null) {
             msg = new MessageImpl();
@@ -600,13 +600,13 @@ public final class ContextUtils {
     
     public static Destination createDecoupledDestination(Exchange exchange, 
                                                          final EndpointReferenceType reference) {
-        final EndpointInfo ei = exchange.get(Endpoint.class).getEndpointInfo();
+        final EndpointInfo ei = exchange.getEndpoint().getEndpointInfo();
         return new Destination() {
             public EndpointReferenceType getAddress() {
                 return reference;
             }
             public Conduit getBackChannel(Message inMessage) throws IOException {
-                Bus bus = inMessage.getExchange().get(Bus.class);
+                Bus bus = inMessage.getExchange().getBus();
                 //this is a response targeting a decoupled endpoint.   Treat it as a oneway so
                 //we don't wait for a response.
                 inMessage.getExchange().setOneWay(true);

--- a/rt/bindings/coloc/src/main/java/org/apache/cxf/binding/coloc/ColocInInterceptor.java
+++ b/rt/bindings/coloc/src/main/java/org/apache/cxf/binding/coloc/ColocInInterceptor.java
@@ -54,7 +54,7 @@ public class ColocInInterceptor extends AbstractPhaseInterceptor<Message> {
             return;
         }
 
-        Bus bus = ex.get(Bus.class);
+        Bus bus = ex.getBus();
         SortedSet<Phase> phases = new TreeSet<Phase>(bus.getExtension(PhaseManager.class).getOutPhases());
 
         //TODO Set Coloc FaultObserver chain
@@ -66,7 +66,7 @@ public class ColocInInterceptor extends AbstractPhaseInterceptor<Message> {
         }
 
         //Initiate OutBound Processing
-        BindingOperationInfo boi = ex.get(BindingOperationInfo.class);
+        BindingOperationInfo boi = ex.getBindingOperationInfo();
         Message outBound = ex.getOutMessage();
         if (boi != null) {
             outBound.put(MessageInfo.class, 

--- a/rt/bindings/coloc/src/main/java/org/apache/cxf/binding/coloc/ColocMessageObserver.java
+++ b/rt/bindings/coloc/src/main/java/org/apache/cxf/binding/coloc/ColocMessageObserver.java
@@ -82,7 +82,8 @@ public class ColocMessageObserver extends ChainInitiationObserver {
             inMsg.put(COLOCATED, Boolean.TRUE);
             inMsg.put(Message.REQUESTOR_ROLE, Boolean.FALSE);
             inMsg.put(Message.INBOUND_MESSAGE, Boolean.TRUE);
-            OperationInfo oi = ex.get(OperationInfo.class);
+            BindingOperationInfo boi = ex.getBindingOperationInfo();
+            OperationInfo oi = boi != null ? boi.getOperationInfo() : null;
             if (oi != null) {
                 inMsg.put(MessageInfo.class, oi.getInput());
             }
@@ -101,7 +102,8 @@ public class ColocMessageObserver extends ChainInitiationObserver {
             inMsg.setInterceptorChain(chain);
     
             //Convert the coloc object type if necessary
-            OperationInfo soi = m.getExchange().get(OperationInfo.class);
+            BindingOperationInfo bop = m.getExchange().getBindingOperationInfo();
+            OperationInfo soi = bop != null ? bop.getOperationInfo() : null;
             if (soi != null && oi != null) {
                 if (ColocUtil.isAssignableOperationInfo(soi, Source.class) 
                     && !ColocUtil.isAssignableOperationInfo(oi, Source.class)) {
@@ -161,11 +163,7 @@ public class ColocMessageObserver extends ChainInitiationObserver {
             boi = boi.getWrappedOperation();
         }
         
-        exchange.put(BindingInfo.class, bi);
         exchange.put(BindingOperationInfo.class, boi);
-        if (boi != null) {
-            exchange.put(OperationInfo.class, boi.getOperationInfo());
-        }
     }
     
     protected List<Interceptor<? extends Message>> addColocInterceptors() {

--- a/rt/bindings/coloc/src/main/java/org/apache/cxf/binding/coloc/ColocOutInterceptor.java
+++ b/rt/bindings/coloc/src/main/java/org/apache/cxf/binding/coloc/ColocOutInterceptor.java
@@ -70,7 +70,7 @@ public class ColocOutInterceptor extends AbstractPhaseInterceptor<Message> {
     
     public void handleMessage(Message message) throws Fault {
         if (bus == null) {
-            bus = message.getExchange().get(Bus.class);
+            bus = message.getExchange().getBus();
             if (bus == null) {
                 bus = BusFactory.getDefaultBus(false);
             }
@@ -86,14 +86,14 @@ public class ColocOutInterceptor extends AbstractPhaseInterceptor<Message> {
         }
         
         Exchange exchange = message.getExchange();
-        Endpoint senderEndpoint = exchange.get(Endpoint.class);
+        Endpoint senderEndpoint = exchange.getEndpoint();
 
         if (senderEndpoint == null) {
             throw new Fault(new org.apache.cxf.common.i18n.Message("ENDPOINT_NOT_FOUND", 
                                                                    BUNDLE));
         }
 
-        BindingOperationInfo boi = exchange.get(BindingOperationInfo.class);
+        BindingOperationInfo boi = exchange.getBindingOperationInfo();
         
         if (boi == null) {
             throw new Fault(new org.apache.cxf.common.i18n.Message("OPERATIONINFO_NOT_FOUND", 

--- a/rt/bindings/coloc/src/main/java/org/apache/cxf/binding/coloc/ColocUtil.java
+++ b/rt/bindings/coloc/src/main/java/org/apache/cxf/binding/coloc/ColocUtil.java
@@ -80,10 +80,10 @@ public final class ColocUtil {
     }
     
     public static InterceptorChain getOutInterceptorChain(Exchange ex, SortedSet<Phase> phases) {
-        Bus bus = ex.get(Bus.class);
+        Bus bus = ex.getBus();
         PhaseInterceptorChain chain = new PhaseInterceptorChain(phases);
         
-        Endpoint ep = ex.get(Endpoint.class);
+        Endpoint ep = ex.getEndpoint();
         List<Interceptor<? extends Message>> il = ep.getOutInterceptors();
         if (LOG.isLoggable(Level.FINE)) {
             LOG.fine("Interceptors contributed by endpoint: " + il);
@@ -113,10 +113,10 @@ public final class ColocUtil {
     }
     
     public static InterceptorChain getInInterceptorChain(Exchange ex, SortedSet<Phase> phases) {
-        Bus bus = ex.get(Bus.class);
+        Bus bus = ex.getBus();
         PhaseInterceptorChain chain = new PhaseInterceptorChain(phases);
         
-        Endpoint ep = ex.get(Endpoint.class);
+        Endpoint ep = ex.getEndpoint();
         List<Interceptor<? extends Message>> il = ep.getInInterceptors();
         if (LOG.isLoggable(Level.FINE)) {
             LOG.fine("Interceptors contributed by endpoint: " + il);
@@ -296,7 +296,7 @@ public final class ColocUtil {
     }
     
     private static MessageInfo getMessageInfo(Message message) {
-        OperationInfo oi = message.getExchange().get(OperationInfo.class);
+        OperationInfo oi = message.getExchange().getBindingOperationInfo().getOperationInfo();
         if (MessageUtils.isOutbound(message)) {
             return oi.getOutput();
         } else {

--- a/rt/bindings/coloc/src/main/java/org/apache/cxf/binding/coloc/WebFaultInInterceptor.java
+++ b/rt/bindings/coloc/src/main/java/org/apache/cxf/binding/coloc/WebFaultInInterceptor.java
@@ -57,7 +57,7 @@ public class WebFaultInInterceptor extends AbstractPhaseInterceptor<Message> {
             return;
         }
 
-        BindingOperationInfo boi = message.getExchange().get(BindingOperationInfo.class);
+        BindingOperationInfo boi = message.getExchange().getBindingOperationInfo();
         MessagePartInfo part = getFaultMessagePart(faultName, boi.getOperationInfo());
 
         if (part != null) {

--- a/rt/bindings/coloc/src/test/java/org/apache/cxf/binding/coloc/ColocMessageObserverTest.java
+++ b/rt/bindings/coloc/src/test/java/org/apache/cxf/binding/coloc/ColocMessageObserverTest.java
@@ -38,11 +38,8 @@ import org.apache.cxf.service.Service;
 import org.apache.cxf.service.model.BindingInfo;
 import org.apache.cxf.service.model.BindingOperationInfo;
 import org.apache.cxf.service.model.EndpointInfo;
-import org.apache.cxf.service.model.MessageInfo;
-import org.apache.cxf.service.model.OperationInfo;
 import org.easymock.EasyMock;
 import org.easymock.IMocksControl;
-
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -56,14 +53,12 @@ public class ColocMessageObserverTest extends Assert {
     private Service srv;
     private Endpoint ep;
     private Bus bus;
-    private OperationInfo oi;
 
     @Before
     public void setUp() throws Exception {
         ep = control.createMock(Endpoint.class);
         bus = control.createMock(Bus.class);
         srv = control.createMock(Service.class);
-        oi = control.createMock(OperationInfo.class);
         BusFactory.setDefaultBus(bus);        
         msg = new MessageImpl();
         ex = new ExchangeImpl();
@@ -88,7 +83,6 @@ public class ColocMessageObserverTest extends Assert {
         EasyMock.expect(ei.getBinding()).andReturn(bi);
         BindingOperationInfo boi = control.createMock(BindingOperationInfo.class);
         EasyMock.expect(bi.getOperation(opName)).andReturn(boi);
-        EasyMock.expect(boi.getOperationInfo()).andReturn(oi);        
         EasyMock.expect(bus.getExtension(ClassLoader.class)).andReturn(this.getClass().getClassLoader());
         control.replay();
         observer = new ColocMessageObserver(ep, bus);
@@ -96,17 +90,15 @@ public class ColocMessageObserverTest extends Assert {
         control.verify();
 
         assertNotNull("Bus should be set",
-                      ex.get(Bus.class));
+                      ex.getBus());
         assertNotNull("Endpoint should be set",
-                      ex.get(Endpoint.class));
+                      ex.getEndpoint());
         assertNotNull("Binding should be set",
-                      ex.get(Binding.class));
+                      ex.getBinding());
         assertNotNull("Service should be set",
-                      ex.get(Service.class));
+                      ex.getService());
         assertNotNull("BindingOperationInfo should be set",
-                      ex.get(BindingOperationInfo.class));
-        assertNotNull("OperationInfo should be set",
-                      ex.get(OperationInfo.class));
+                      ex.getBindingOperationInfo());
     }
 
     @Test
@@ -118,9 +110,6 @@ public class ColocMessageObserverTest extends Assert {
         
         Message inMsg = new MessageImpl();
         EasyMock.expect(binding.createMessage()).andReturn(inMsg);
-
-        MessageInfo mi = control.createMock(MessageInfo.class);
-        EasyMock.expect(oi.getInput()).andReturn(mi);
 
         EasyMock.expect(ep.getService()).andReturn(srv).anyTimes();
         EasyMock.expect(
@@ -143,8 +132,6 @@ public class ColocMessageObserverTest extends Assert {
         assertEquals("Message.INBOUND_MESSAGE should be true",
                      Boolean.TRUE,
                      inMsg.get(Message.INBOUND_MESSAGE));
-        assertNotNull("MessageInfo should be present in the Message instance",                     
-                     inMsg.get(MessageInfo.class));
         assertNotNull("Chain should be set", inMsg.getInterceptorChain());
         Exchange ex1 = msg.getExchange();
         assertNotNull("Exchange should be set", ex1);
@@ -159,7 +146,6 @@ public class ColocMessageObserverTest extends Assert {
             exchange.put(Bus.class, bus);
             exchange.put(Endpoint.class, ep);
             exchange.put(Service.class, srv);
-            exchange.put(OperationInfo.class, oi);
         }
         
         protected List<Interceptor<? extends Message>> addColocInterceptors() {

--- a/rt/bindings/corba/src/main/java/org/apache/cxf/binding/corba/CorbaConduit.java
+++ b/rt/bindings/corba/src/main/java/org/apache/cxf/binding/corba/CorbaConduit.java
@@ -136,7 +136,7 @@ public class CorbaConduit implements Conduit {
 
     public void close(Message message) throws IOException {
         if (message.get(CorbaConstants.CORBA_ENDPOINT_OBJECT) != null) {
-            BindingOperationInfo boi = message.getExchange().get(BindingOperationInfo.class);
+            BindingOperationInfo boi = message.getExchange().getBindingOperationInfo();
             OperationType opType = boi.getExtensor(OperationType.class);
             try {
                 if (message instanceof CorbaMessage) {
@@ -180,7 +180,7 @@ public class CorbaConduit implements Conduit {
     }
         
     public void buildRequest(CorbaMessage message, OperationType opType) throws Exception {        
-        ServiceInfo service = message.getExchange().get(ServiceInfo.class);
+        ServiceInfo service = message.getExchange().getEndpoint().getEndpointInfo().getService();
         NVList nvlist = getArguments(message);
         NamedValue ret = getReturn(message);
         Map<TypeCode, RaisesType> exceptions = getOperationExceptions(opType, typeMap);

--- a/rt/bindings/corba/src/main/java/org/apache/cxf/binding/corba/interceptors/CorbaStreamFaultInInterceptor.java
+++ b/rt/bindings/corba/src/main/java/org/apache/cxf/binding/corba/interceptors/CorbaStreamFaultInInterceptor.java
@@ -83,10 +83,10 @@ public class CorbaStreamFaultInInterceptor extends AbstractPhaseInterceptor<Mess
             if (exStreamable != null) {
                 DataReader<XMLStreamReader> reader = getDataReader(message);
 
-                BindingOperationInfo bopInfo = message.getExchange().get(BindingOperationInfo.class);
+                BindingOperationInfo bopInfo = message.getExchange().getBindingOperationInfo();
                 OperationInfo opInfo = bopInfo.getOperationInfo();
                 
-                ServiceInfo service = message.getExchange().get(ServiceInfo.class);
+                ServiceInfo service = message.getExchange().getEndpoint().getEndpointInfo().getService();
                 
                 org.omg.CORBA.ORB orb = (org.omg.CORBA.ORB) message.get(CorbaConstants.ORB);
                 if (orb == null) {

--- a/rt/bindings/corba/src/main/java/org/apache/cxf/binding/corba/interceptors/CorbaStreamFaultOutInterceptor.java
+++ b/rt/bindings/corba/src/main/java/org/apache/cxf/binding/corba/interceptors/CorbaStreamFaultOutInterceptor.java
@@ -171,10 +171,10 @@ public class CorbaStreamFaultOutInterceptor extends AbstractPhaseInterceptor<Mes
                     setUserExceptionFromFaultDetail(message, 
                             faultEx.getDetail(), 
                             exType, opInfo, writer,
-                            exchange.get(ServiceInfo.class));
+                            exchange.getEndpoint().getEndpointInfo().getService());
                 } else {
                     setUserException(message, ex, exType, opInfo, writer,
-                                    exchange.get(ServiceInfo.class));
+                                    exchange.getEndpoint().getEndpointInfo().getService());
                 }
             } else {
                 throw new CorbaBindingException(ex);

--- a/rt/bindings/corba/src/main/java/org/apache/cxf/binding/corba/interceptors/CorbaStreamInInterceptor.java
+++ b/rt/bindings/corba/src/main/java/org/apache/cxf/binding/corba/interceptors/CorbaStreamInInterceptor.java
@@ -94,7 +94,7 @@ public class CorbaStreamInInterceptor extends AbstractPhaseInterceptor<Message> 
             message.setContent(Exception.class, 
                                message.getExchange().getOutMessage().getContent(Exception.class));
 
-            Endpoint ep = message.getExchange().get(Endpoint.class);
+            Endpoint ep = message.getExchange().getEndpoint();
             message.getInterceptorChain().abort();
             if (ep.getInFaultObserver() != null) {
                 ep.getInFaultObserver().onMessage(message);
@@ -108,7 +108,7 @@ public class CorbaStreamInInterceptor extends AbstractPhaseInterceptor<Message> 
 
         CorbaTypeEventProducer eventProducer = null;
         Exchange exchange = message.getExchange();
-        BindingOperationInfo bindingOpInfo = exchange.get(BindingOperationInfo.class);  
+        BindingOperationInfo bindingOpInfo = exchange.getBindingOperationInfo();  
         BindingMessageInfo msgInfo = bindingOpInfo.getOutput();
 
         boolean wrap = false;

--- a/rt/bindings/corba/src/main/java/org/apache/cxf/binding/corba/interceptors/CorbaStreamOutEndingInterceptor.java
+++ b/rt/bindings/corba/src/main/java/org/apache/cxf/binding/corba/interceptors/CorbaStreamOutEndingInterceptor.java
@@ -62,8 +62,8 @@ public class CorbaStreamOutEndingInterceptor extends AbstractPhaseInterceptor<Me
         CorbaMessage message = (CorbaMessage) msg;
         orb = (org.omg.CORBA.ORB) message.get(CorbaConstants.ORB);
         Exchange exchange = message.getExchange();
-        BindingOperationInfo boi = exchange.get(BindingOperationInfo.class);
-        service = exchange.get(ServiceInfo.class);
+        BindingOperationInfo boi = exchange.getBindingOperationInfo();
+        service = exchange.getEndpoint().getEndpointInfo().getService();
         typeMap = message.getCorbaTypeMap();
 
         if (ContextUtils.isRequestor(message)) {

--- a/rt/bindings/corba/src/main/java/org/apache/cxf/binding/corba/interceptors/CorbaStreamOutInterceptor.java
+++ b/rt/bindings/corba/src/main/java/org/apache/cxf/binding/corba/interceptors/CorbaStreamOutInterceptor.java
@@ -56,9 +56,9 @@ public class CorbaStreamOutInterceptor extends AbstractPhaseInterceptor<Message>
         CorbaMessage message = (CorbaMessage) msg;
         orb = (org.omg.CORBA.ORB) message.get(CorbaConstants.ORB);
         Exchange exchange = message.getExchange();
-        service = exchange.get(ServiceInfo.class);
+        service = exchange.getEndpoint().getEndpointInfo().getService();
         typeMap = message.getCorbaTypeMap();
-        BindingOperationInfo boi = exchange.get(BindingOperationInfo.class);
+        BindingOperationInfo boi = exchange.getBindingOperationInfo();
         if (ContextUtils.isRequestor(message)) {
             handleOutBoundMessage(message, boi);
         } else {

--- a/rt/bindings/corba/src/test/java/org/apache/cxf/binding/corba/CorbaConduitTest.java
+++ b/rt/bindings/corba/src/test/java/org/apache/cxf/binding/corba/CorbaConduitTest.java
@@ -177,7 +177,7 @@ public class CorbaConduitTest extends Assert {
         Exchange exg = control.createMock(Exchange.class);
         EasyMock.expect(msg.getExchange()).andReturn(exg);
         BindingOperationInfo bopInfo = control.createMock(BindingOperationInfo.class);
-        EasyMock.expect(exg.get(BindingOperationInfo.class)).andReturn(bopInfo);
+        EasyMock.expect(exg.getBindingOperationInfo()).andReturn(bopInfo);
         OperationType opType = control.createMock(OperationType.class);
         bopInfo.getExtensor(OperationType.class);
         EasyMock.expectLastCall().andReturn(opType);

--- a/rt/bindings/object/src/main/java/org/apache/cxf/binding/object/ObjectDispatchInInterceptor.java
+++ b/rt/bindings/object/src/main/java/org/apache/cxf/binding/object/ObjectDispatchInInterceptor.java
@@ -50,7 +50,7 @@ public class ObjectDispatchInInterceptor extends AbstractPhaseInterceptor<Messag
             throw new Fault(new org.apache.cxf.common.i18n.Message("NO_OPERATION", BUNDLE));
         }
 
-        Endpoint ep = message.getExchange().get(Endpoint.class);
+        Endpoint ep = message.getExchange().getEndpoint();
         
         BindingInfo binding = null;
         

--- a/rt/bindings/object/src/main/java/org/apache/cxf/binding/object/ObjectDispatchOutInterceptor.java
+++ b/rt/bindings/object/src/main/java/org/apache/cxf/binding/object/ObjectDispatchOutInterceptor.java
@@ -44,7 +44,7 @@ public class ObjectDispatchOutInterceptor extends AbstractPhaseInterceptor<Messa
         message.put(LocalConduit.DIRECT_DISPATCH, Boolean.TRUE);
         message.put(LocalTransportFactory.MESSAGE_INCLUDE_PROPERTIES,
                     includes);
-        BindingOperationInfo bop = ex.get(BindingOperationInfo.class);
+        BindingOperationInfo bop = ex.getBindingOperationInfo();
         
         message.put(ObjectBinding.OPERATION, bop.getName());
         message.put(ObjectBinding.BINDING, bop.getBinding().getName());

--- a/rt/bindings/soap/src/main/java/org/apache/cxf/binding/soap/interceptor/CheckFaultInterceptor.java
+++ b/rt/bindings/soap/src/main/java/org/apache/cxf/binding/soap/interceptor/CheckFaultInterceptor.java
@@ -63,7 +63,7 @@ public class CheckFaultInterceptor extends AbstractSoapInterceptor {
                                 message.getVersion().getSender());
         }
         if (message.getVersion().getFault().equals(xmlReader.getName()) && isRequestor(message)) {
-            Endpoint ep = message.getExchange().get(Endpoint.class);
+            Endpoint ep = message.getExchange().getEndpoint();
             message.getInterceptorChain().abort();
             if (ep.getInFaultObserver() != null) {
                 ep.getInFaultObserver().onMessage(message);

--- a/rt/bindings/soap/src/main/java/org/apache/cxf/binding/soap/interceptor/RPCInInterceptor.java
+++ b/rt/bindings/soap/src/main/java/org/apache/cxf/binding/soap/interceptor/RPCInInterceptor.java
@@ -44,7 +44,6 @@ import org.apache.cxf.service.model.BindingOperationInfo;
 import org.apache.cxf.service.model.EndpointInfo;
 import org.apache.cxf.service.model.MessageInfo;
 import org.apache.cxf.service.model.MessagePartInfo;
-import org.apache.cxf.service.model.OperationInfo;
 import org.apache.cxf.service.model.ServiceInfo;
 import org.apache.cxf.service.model.ServiceModelUtil;
 import org.apache.cxf.staxutils.DepthXMLStreamReader;
@@ -63,7 +62,7 @@ public class RPCInInterceptor extends AbstractInDatabindingInterceptor {
     private BindingOperationInfo getOperation(Message message, QName opName) {
         BindingOperationInfo bop = ServiceModelUtil.getOperation(message.getExchange(), opName);
         if (bop == null) {
-            Endpoint ep = message.getExchange().get(Endpoint.class);
+            Endpoint ep = message.getExchange().getEndpoint();
             if (ep == null) {
                 return null;
             }
@@ -102,7 +101,7 @@ public class RPCInInterceptor extends AbstractInDatabindingInterceptor {
             opName = opName.substring(0, opName.length() - 8);
         }
 
-        if (message.getExchange().get(BindingOperationInfo.class) == null) {
+        if (message.getExchange().getBindingOperationInfo() == null) {
             operation = getOperation(message, new QName(xmlReader.getNamespaceURI(), opName));
             if (operation == null) {
                 // it's doc-lit-bare
@@ -112,7 +111,7 @@ public class RPCInInterceptor extends AbstractInDatabindingInterceptor {
                 setMessage(message, operation);
             }
         } else {
-            operation = message.getExchange().get(BindingOperationInfo.class);
+            operation = message.getExchange().getBindingOperationInfo();
         }
         MessageInfo msg;
         DataReader<XMLStreamReader> dr = getDataReader(message, XMLStreamReader.class);
@@ -193,7 +192,6 @@ public class RPCInInterceptor extends AbstractInDatabindingInterceptor {
                              BindingOperationInfo operation) {
         Exchange ex = message.getExchange();
         ex.put(BindingOperationInfo.class, operation);
-        ex.put(OperationInfo.class, operation.getOperationInfo());
         ex.setOneWay(operation.getOperationInfo().isOneWay());
 
         //Set standard MessageContext properties required by JAX_WS, but not specific to JAX_WS.
@@ -206,7 +204,7 @@ public class RPCInInterceptor extends AbstractInDatabindingInterceptor {
         QName interfaceQName = si.getInterface().getName();
         message.put(Message.WSDL_INTERFACE, interfaceQName);
 
-        EndpointInfo endpointInfo = ex.get(Endpoint.class).getEndpointInfo();
+        EndpointInfo endpointInfo = ex.getEndpoint().getEndpointInfo();
         QName portQName = endpointInfo.getName();
         message.put(Message.WSDL_PORT, portQName);
 

--- a/rt/bindings/soap/src/main/java/org/apache/cxf/binding/soap/interceptor/RPCOutInterceptor.java
+++ b/rt/bindings/soap/src/main/java/org/apache/cxf/binding/soap/interceptor/RPCOutInterceptor.java
@@ -53,8 +53,7 @@ public class RPCOutInterceptor extends AbstractOutDatabindingInterceptor {
             NSStack nsStack = new NSStack();
             nsStack.push();
 
-            BindingOperationInfo operation = (BindingOperationInfo) message.getExchange().get(
-                            BindingOperationInfo.class.getName());
+            BindingOperationInfo operation = (BindingOperationInfo) message.getExchange().getBindingOperationInfo();
 
             assert operation.getName() != null;
 
@@ -138,7 +137,6 @@ public class RPCOutInterceptor extends AbstractOutDatabindingInterceptor {
                                       boolean output,
                                       BindingOperationInfo boi) 
         throws XMLStreamException {
-        String responseSuffix = output ? "Response" : "";
         String ns = boi.getName().getNamespaceURI();
         SoapBody body = null;
         if (output) {
@@ -155,7 +153,8 @@ public class RPCOutInterceptor extends AbstractOutDatabindingInterceptor {
 
         nsStack.add(ns);
         String prefix = nsStack.getPrefix(ns);
-        StaxUtils.writeStartElement(xmlWriter, prefix, boi.getName().getLocalPart() + responseSuffix, ns);
+        String name = output ? boi.getName().getLocalPart() + "Response" : boi.getName().getLocalPart();
+        StaxUtils.writeStartElement(xmlWriter, prefix, name, ns);
         return ns;
     }
 

--- a/rt/bindings/soap/src/main/java/org/apache/cxf/binding/soap/interceptor/SoapActionInInterceptor.java
+++ b/rt/bindings/soap/src/main/java/org/apache/cxf/binding/soap/interceptor/SoapActionInInterceptor.java
@@ -119,7 +119,7 @@ public class SoapActionInInterceptor extends AbstractSoapInterceptor {
         }
         
         Exchange ex = message.getExchange();
-        Endpoint ep = ex.get(Endpoint.class);
+        Endpoint ep = ex.getEndpoint();
         if (ep == null) {
             return;
         }
@@ -159,7 +159,6 @@ public class SoapActionInInterceptor extends AbstractSoapInterceptor {
         }
         
         ex.put(BindingOperationInfo.class, bindingOp);
-        ex.put(OperationInfo.class, bindingOp.getOperationInfo());
     }
     private static boolean matchWSAAction(BindingOperationInfo boi, String action) {
         Object o = getWSAAction(boi);

--- a/rt/bindings/soap/src/main/java/org/apache/cxf/binding/soap/interceptor/SoapOutInterceptor.java
+++ b/rt/bindings/soap/src/main/java/org/apache/cxf/binding/soap/interceptor/SoapOutInterceptor.java
@@ -194,8 +194,7 @@ public class SoapOutInterceptor extends AbstractSoapInterceptor {
         //add MessagePart to soapHeader if necessary
         boolean endedHeader = false;
         Exchange exchange = message.getExchange();
-        BindingOperationInfo bop = (BindingOperationInfo)exchange.get(BindingOperationInfo.class
-                                                                            .getName());
+        BindingOperationInfo bop = exchange.getBindingOperationInfo();
         if (bop == null) {
             return endedHeader;
         }

--- a/rt/bindings/soap/src/main/java/org/apache/cxf/binding/soap/jms/interceptor/SoapJMSInInterceptor.java
+++ b/rt/bindings/soap/src/main/java/org/apache/cxf/binding/soap/jms/interceptor/SoapJMSInInterceptor.java
@@ -216,7 +216,7 @@ public class SoapJMSInInterceptor extends AbstractSoapInterceptor {
 
     private Fault createFault(SoapMessage message, JMSFault jmsFault) {
         Fault f = null;
-        Endpoint e = message.getExchange().get(Endpoint.class);
+        Endpoint e = message.getExchange().getEndpoint();
         Binding b = null;
         if (null != e) {
             b = e.getBinding();

--- a/rt/bindings/soap/src/main/java/org/apache/cxf/binding/soap/saaj/SAAJInInterceptor.java
+++ b/rt/bindings/soap/src/main/java/org/apache/cxf/binding/soap/saaj/SAAJInInterceptor.java
@@ -278,7 +278,7 @@ public class SAAJInInterceptor extends AbstractSoapInterceptor {
         }
         Element elem = DOMUtils.getFirstElement(header);
         while (elem != null) {
-            Bus b = message.getExchange() == null ? null : message.getExchange().get(Bus.class);
+            Bus b = message.getExchange() == null ? null : message.getExchange().getBus();
             HeaderProcessor p =  null;
             if (b != null && b.getExtension(HeaderManager.class) != null) {
                 p = b.getExtension(HeaderManager.class).getHeaderProcessor(elem.getNamespaceURI());

--- a/rt/bindings/xml/src/main/java/org/apache/cxf/binding/xml/interceptor/XMLMessageInInterceptor.java
+++ b/rt/bindings/xml/src/main/java/org/apache/cxf/binding/xml/interceptor/XMLMessageInInterceptor.java
@@ -39,7 +39,6 @@ import org.apache.cxf.service.model.BindingInfo;
 import org.apache.cxf.service.model.BindingMessageInfo;
 import org.apache.cxf.service.model.BindingOperationInfo;
 import org.apache.cxf.service.model.MessagePartInfo;
-import org.apache.cxf.service.model.OperationInfo;
 import org.apache.cxf.staxutils.DepthXMLStreamReader;
 import org.apache.cxf.staxutils.StaxUtils;
 import org.apache.cxf.wsdl.interceptors.DocLiteralInInterceptor;
@@ -60,7 +59,7 @@ public class XMLMessageInInterceptor extends AbstractInDatabindingInterceptor {
             LOG.fine("XMLMessageInInterceptor skipped in HTTP GET method");
             return;
         }
-        Endpoint ep = message.getExchange().get(Endpoint.class);
+        Endpoint ep = message.getExchange().getEndpoint();
 
         XMLStreamReader xsr = message.getContent(XMLStreamReader.class);
         if (xsr == null) {
@@ -83,14 +82,13 @@ public class XMLMessageInInterceptor extends AbstractInDatabindingInterceptor {
             }
         }
         // handling xml normal inbound message
-        BindingOperationInfo boi = ex.get(BindingOperationInfo.class);
+        BindingOperationInfo boi = ex.getBindingOperationInfo();
         boolean isRequestor = isRequestor(message);
         if (boi == null) {
             BindingInfo service = ep.getEndpointInfo().getBinding();
             boi = getBindingOperationInfo(isRequestor, startQName, service, xsr);
             if (boi != null) {
                 ex.put(BindingOperationInfo.class, boi);
-                ex.put(OperationInfo.class, boi.getOperationInfo());
                 ex.setOneWay(boi.getOperationInfo().isOneWay());
             }
         } else {

--- a/rt/bindings/xml/src/main/java/org/apache/cxf/binding/xml/interceptor/XMLMessageOutInterceptor.java
+++ b/rt/bindings/xml/src/main/java/org/apache/cxf/binding/xml/interceptor/XMLMessageOutInterceptor.java
@@ -52,7 +52,7 @@ public class XMLMessageOutInterceptor extends AbstractOutDatabindingInterceptor 
     }
 
     public void handleMessage(Message message) throws Fault {
-        BindingOperationInfo boi = message.getExchange().get(BindingOperationInfo.class);
+        BindingOperationInfo boi = message.getExchange().getBindingOperationInfo();
         MessageInfo mi;
         BindingMessageInfo bmi;
         if (isRequestor(message)) {

--- a/rt/features/clustering/src/main/java/org/apache/cxf/clustering/AbstractStaticFailoverStrategy.java
+++ b/rt/features/clustering/src/main/java/org/apache/cxf/clustering/AbstractStaticFailoverStrategy.java
@@ -131,7 +131,7 @@ public abstract class AbstractStaticFailoverStrategy implements FailoverStrategy
      * @return a List of alternate endpoints if available
      */
     protected List<Endpoint> getEndpoints(Exchange exchange, boolean acceptCandidatesWithSameAddress) {
-        Endpoint endpoint = exchange.get(Endpoint.class);
+        Endpoint endpoint = exchange.getEndpoint();
         Collection<ServiceInfo> services = endpoint.getService().getServiceInfos();
         QName currentBinding = endpoint.getBinding().getBindingInfo().getName();
         List<Endpoint> alternates = new ArrayList<Endpoint>();

--- a/rt/features/clustering/src/main/java/org/apache/cxf/clustering/FailoverTargetSelector.java
+++ b/rt/features/clustering/src/main/java/org/apache/cxf/clustering/FailoverTargetSelector.java
@@ -83,7 +83,7 @@ public class FailoverTargetSelector extends AbstractConduitSelector {
         
         InvocationKey key = new InvocationKey(exchange);
         if (getInvocationContext(key) == null) {
-            Endpoint endpoint = exchange.get(Endpoint.class);
+            Endpoint endpoint = exchange.getEndpoint();
             BindingOperationInfo bindingOperationInfo =
                 exchange.getBindingOperationInfo();
             Object[] params = message.getContent(List.class).toArray();

--- a/rt/frontend/jaxrs/src/main/java/org/apache/cxf/jaxrs/ext/MessageContextImpl.java
+++ b/rt/frontend/jaxrs/src/main/java/org/apache/cxf/jaxrs/ext/MessageContextImpl.java
@@ -233,7 +233,7 @@ public class MessageContextImpl implements MessageContext {
         
         Message message = m.getExchange().getOutMessage();
         if (message == null) {
-            Endpoint ep = m.getExchange().get(Endpoint.class);
+            Endpoint ep = m.getExchange().getEndpoint();
             message = new org.apache.cxf.message.MessageImpl();
             message.setExchange(m.getExchange());
             message = ep.getBinding().createMessage(message);

--- a/rt/frontend/jaxrs/src/main/java/org/apache/cxf/jaxrs/interceptor/JAXRSInInterceptor.java
+++ b/rt/frontend/jaxrs/src/main/java/org/apache/cxf/jaxrs/interceptor/JAXRSInInterceptor.java
@@ -264,7 +264,7 @@ public class JAXRSInInterceptor extends AbstractPhaseInterceptor<Message> {
     }
     
     private Message createOutMessage(Message inMessage, Response r) {
-        Endpoint e = inMessage.getExchange().get(Endpoint.class);
+        Endpoint e = inMessage.getExchange().getEndpoint();
         Message mout = e.getBinding().createMessage();
         mout.setContent(List.class, new MessageContentsList(r));
         mout.setExchange(inMessage.getExchange());

--- a/rt/frontend/jaxrs/src/main/java/org/apache/cxf/jaxrs/model/ClassResourceInfoComparator.java
+++ b/rt/frontend/jaxrs/src/main/java/org/apache/cxf/jaxrs/model/ClassResourceInfoComparator.java
@@ -21,7 +21,6 @@ package org.apache.cxf.jaxrs.model;
 
 import java.util.Comparator;
 
-import org.apache.cxf.endpoint.Endpoint;
 import org.apache.cxf.jaxrs.ext.ResourceComparator;
 import org.apache.cxf.message.Message;
 
@@ -33,7 +32,7 @@ public class ClassResourceInfoComparator implements Comparator<ClassResourceInfo
     public ClassResourceInfoComparator(Message m) {
         this.message = m;
         if (message != null) {
-            Object o = m.getExchange().get(Endpoint.class).get("org.apache.cxf.jaxrs.comparator");
+            Object o = m.getExchange().getEndpoint().get("org.apache.cxf.jaxrs.comparator");
             if (o != null) {
                 rc = (ResourceComparator)o;
             }

--- a/rt/frontend/jaxrs/src/main/java/org/apache/cxf/jaxrs/model/OperationResourceInfoComparator.java
+++ b/rt/frontend/jaxrs/src/main/java/org/apache/cxf/jaxrs/model/OperationResourceInfoComparator.java
@@ -26,7 +26,6 @@ import java.util.List;
 import javax.ws.rs.HttpMethod;
 import javax.ws.rs.core.MediaType;
 
-import org.apache.cxf.endpoint.Endpoint;
 import org.apache.cxf.jaxrs.ext.DefaultMethod;
 import org.apache.cxf.jaxrs.ext.ResourceComparator;
 import org.apache.cxf.jaxrs.utils.JAXRSUtils;
@@ -44,7 +43,7 @@ public class OperationResourceInfoComparator implements Comparator<OperationReso
     public OperationResourceInfoComparator(Message m, String method) {
         this.message = m;
         if (message != null) {
-            Object o = m.getExchange().get(Endpoint.class).get("org.apache.cxf.jaxrs.comparator");
+            Object o = m.getExchange().getEndpoint().get("org.apache.cxf.jaxrs.comparator");
             if (o != null) {
                 rc = (ResourceComparator)o;
             }

--- a/rt/frontend/jaxrs/src/main/java/org/apache/cxf/jaxrs/provider/JAXRSDataBinding.java
+++ b/rt/frontend/jaxrs/src/main/java/org/apache/cxf/jaxrs/provider/JAXRSDataBinding.java
@@ -99,9 +99,9 @@ public class JAXRSDataBinding extends AbstractDataBinding {
 
     // TODO: The method containing the actual annotations have to retrieved 
     protected Method getTargetMethod(Message m) {
-        BindingOperationInfo bop = m.getExchange().get(BindingOperationInfo.class);
+        BindingOperationInfo bop = m.getExchange().getBindingOperationInfo();
         MethodDispatcher md = (MethodDispatcher) 
-            m.getExchange().get(Service.class).get(MethodDispatcher.class.getName());
+            m.getExchange().getService().get(MethodDispatcher.class.getName());
         return md.getMethod(bop);
     }
     

--- a/rt/frontend/jaxrs/src/main/java/org/apache/cxf/jaxrs/provider/ProviderFactory.java
+++ b/rt/frontend/jaxrs/src/main/java/org/apache/cxf/jaxrs/provider/ProviderFactory.java
@@ -945,7 +945,7 @@ public abstract class ProviderFactory {
     }
     
     public static ProviderFactory getInstance(Message m) {
-        Endpoint e = m.getExchange().get(Endpoint.class);
+        Endpoint e = m.getExchange().getEndpoint();
         
         Message outM = m.getExchange().getOutMessage();
         boolean isClient = outM != null && MessageUtils.isRequestor(outM);

--- a/rt/frontend/jaxrs/src/main/java/org/apache/cxf/jaxrs/provider/ServerProviderFactory.java
+++ b/rt/frontend/jaxrs/src/main/java/org/apache/cxf/jaxrs/provider/ServerProviderFactory.java
@@ -120,7 +120,7 @@ public final class ServerProviderFactory extends ProviderFactory {
     }
     
     public static ServerProviderFactory getInstance(Message m) {
-        Endpoint e = m.getExchange().get(Endpoint.class);
+        Endpoint e = m.getExchange().getEndpoint();
         return (ServerProviderFactory)e.get(SERVER_FACTORY_NAME);
     }
     

--- a/rt/frontend/jaxrs/src/main/java/org/apache/cxf/jaxrs/utils/JAXRSUtils.java
+++ b/rt/frontend/jaxrs/src/main/java/org/apache/cxf/jaxrs/utils/JAXRSUtils.java
@@ -568,7 +568,7 @@ public final class JAXRSUtils {
     }
     
     public static List<ClassResourceInfo> getRootResources(Message message) {
-        Service service = message.getExchange().get(Service.class);
+        Service service = message.getExchange().getService();
         return ((JAXRSServiceImpl)service).getClassResourceInfos();
     }
     

--- a/rt/frontend/jaxws/src/main/java/org/apache/cxf/jaxws/AbstractJAXWSMethodInvoker.java
+++ b/rt/frontend/jaxws/src/main/java/org/apache/cxf/jaxws/AbstractJAXWSMethodInvoker.java
@@ -296,7 +296,7 @@ public abstract class AbstractJAXWSMethodInvoker extends FactoryInvoker {
         }
         Message m = exchange.getOutMessage();
         if (m == null && !exchange.isOneWay()) {
-            Endpoint ep = exchange.get(Endpoint.class);
+            Endpoint ep = exchange.getEndpoint();
             m = new MessageImpl();
             m.setExchange(exchange);
             m = ep.getBinding().createMessage(m);

--- a/rt/frontend/jaxws/src/main/java/org/apache/cxf/jaxws/context/WebServiceContextImpl.java
+++ b/rt/frontend/jaxws/src/main/java/org/apache/cxf/jaxws/context/WebServiceContextImpl.java
@@ -80,7 +80,7 @@ public class WebServiceContextImpl implements WebServiceContext {
     public EndpointReference getEndpointReference(Element... referenceParameters) {
         WrappedMessageContext ctx = (WrappedMessageContext)getMessageContext();
         org.apache.cxf.message.Message msg = ctx.getWrappedMessage();
-        Endpoint ep = msg.getExchange().get(Endpoint.class);
+        Endpoint ep = msg.getExchange().getEndpoint();
 
         W3CEndpointReferenceBuilder builder = new W3CEndpointReferenceBuilder();
         builder.address(ep.getEndpointInfo().getAddress());

--- a/rt/frontend/jaxws/src/main/java/org/apache/cxf/jaxws/context/WrappedMessageContext.java
+++ b/rt/frontend/jaxws/src/main/java/org/apache/cxf/jaxws/context/WrappedMessageContext.java
@@ -306,15 +306,15 @@ public class WrappedMessageContext implements MessageContext {
     }
     
     private static BindingOperationInfo getBindingOperationInfo(Exchange exchange) {
-        if (exchange != null && exchange.get(BindingOperationInfo.class) != null) {
-            return exchange.get(BindingOperationInfo.class);
+        if (exchange != null && exchange.getBindingOperationInfo() != null) {
+            return exchange.getBindingOperationInfo();
         }
         return null;
     }
 
     private static EndpointInfo getEndpointInfo(Exchange exchange) {
         if (exchange != null) {
-            Endpoint endpoint = exchange.get(Endpoint.class);
+            Endpoint endpoint = exchange.getEndpoint();
             if (endpoint != null) {
                 return endpoint.getEndpointInfo();
             }
@@ -336,7 +336,7 @@ public class WrappedMessageContext implements MessageContext {
                 m = exchange.getInMessage();
             }
             if (m == null) {
-                Endpoint ep = exchange.get(Endpoint.class);
+                Endpoint ep = exchange.getEndpoint();
                 m = new org.apache.cxf.message.MessageImpl();
                 m.setExchange(exchange);
                 m = ep.getBinding().createMessage(m);
@@ -348,7 +348,7 @@ public class WrappedMessageContext implements MessageContext {
                 m = exchange.getOutFaultMessage();
             }
             if (m == null) {
-                Endpoint ep = exchange.get(Endpoint.class);
+                Endpoint ep = exchange.getEndpoint();
                 m = new org.apache.cxf.message.MessageImpl();
                 m.setExchange(exchange);
                 m = ep.getBinding().createMessage(m);

--- a/rt/frontend/jaxws/src/main/java/org/apache/cxf/jaxws/handler/AbstractJAXWSHandlerInterceptor.java
+++ b/rt/frontend/jaxws/src/main/java/org/apache/cxf/jaxws/handler/AbstractJAXWSHandlerInterceptor.java
@@ -26,7 +26,6 @@ import org.apache.cxf.message.Exchange;
 import org.apache.cxf.message.Message;
 import org.apache.cxf.phase.AbstractPhaseInterceptor;
 import org.apache.cxf.service.model.BindingOperationInfo;
-import org.apache.cxf.service.model.OperationInfo;
 import org.apache.cxf.service.model.ServiceModelUtil;
 
 public abstract class AbstractJAXWSHandlerInterceptor<T extends Message> extends AbstractPhaseInterceptor<T> {
@@ -106,7 +105,7 @@ public abstract class AbstractJAXWSHandlerInterceptor<T extends Message> extends
     }
     
     protected void setupBindingOperationInfo(Exchange exch, Object data) {
-        if (exch.get(BindingOperationInfo.class) == null) {
+        if (exch.getBindingOperationInfo() == null) {
             //need to know the operation to determine if oneway
             QName opName = getOpQName(exch, data);
             if (opName == null) {
@@ -119,7 +118,6 @@ public abstract class AbstractJAXWSHandlerInterceptor<T extends Message> extends
             }
             if (bop != null) {
                 exch.put(BindingOperationInfo.class, bop);
-                exch.put(OperationInfo.class, bop.getOperationInfo());
                 if (bop.getOutput() == null) {
                     exch.setOneWay(true);
                 }

--- a/rt/frontend/jaxws/src/main/java/org/apache/cxf/jaxws/handler/logical/LogicalHandlerFaultOutInterceptor.java
+++ b/rt/frontend/jaxws/src/main/java/org/apache/cxf/jaxws/handler/logical/LogicalHandlerFaultOutInterceptor.java
@@ -30,7 +30,6 @@ import javax.xml.ws.Binding;
 import org.w3c.dom.Document;
 import org.w3c.dom.Node;
 
-import org.apache.cxf.endpoint.Endpoint;
 import org.apache.cxf.helpers.DOMUtils;
 import org.apache.cxf.interceptor.Fault;
 import org.apache.cxf.interceptor.InterceptorChain;
@@ -130,7 +129,7 @@ public class LogicalHandlerFaultOutInterceptor
                 if (null == faultMessage) {
                     faultMessage = new MessageImpl();
                     faultMessage.setExchange(message.getExchange());
-                    faultMessage = exchange.get(Endpoint.class).getBinding().createMessage(faultMessage);
+                    faultMessage = exchange.getEndpoint().getBinding().createMessage(faultMessage);
                 }
                 faultMessage.setContent(Exception.class, ex);
                 if (null != mode) {

--- a/rt/frontend/jaxws/src/main/java/org/apache/cxf/jaxws/handler/logical/LogicalHandlerInInterceptor.java
+++ b/rt/frontend/jaxws/src/main/java/org/apache/cxf/jaxws/handler/logical/LogicalHandlerInInterceptor.java
@@ -83,7 +83,7 @@ public class LogicalHandlerInInterceptor
 
         if (!message.getExchange().isOneWay()) {
             //server side inbound
-            Endpoint e = message.getExchange().get(Endpoint.class);
+            Endpoint e = message.getExchange().getEndpoint();
             Message responseMsg = new MessageImpl();
             responseMsg.setExchange(message.getExchange());
             responseMsg = e.getBinding().createMessage(responseMsg);            

--- a/rt/frontend/jaxws/src/main/java/org/apache/cxf/jaxws/handler/logical/LogicalHandlerOutInterceptor.java
+++ b/rt/frontend/jaxws/src/main/java/org/apache/cxf/jaxws/handler/logical/LogicalHandlerOutInterceptor.java
@@ -147,7 +147,7 @@ public class LogicalHandlerOutInterceptor
                     // client side - abort
                     message.getInterceptorChain().abort();
                     if (!message.getExchange().isOneWay()) {
-                        Endpoint e = message.getExchange().get(Endpoint.class);
+                        Endpoint e = message.getExchange().getEndpoint();
                         Message responseMsg = new MessageImpl();
                         responseMsg.setExchange(message.getExchange());
                         responseMsg = e.getBinding().createMessage(responseMsg);            

--- a/rt/frontend/jaxws/src/main/java/org/apache/cxf/jaxws/handler/soap/SOAPHandlerInterceptor.java
+++ b/rt/frontend/jaxws/src/main/java/org/apache/cxf/jaxws/handler/soap/SOAPHandlerInterceptor.java
@@ -134,7 +134,7 @@ public class SOAPHandlerInterceptor extends
                 }
             }
             if (isFault) {
-                Endpoint ep = message.getExchange().get(Endpoint.class);
+                Endpoint ep = message.getExchange().getEndpoint();
                 message.getInterceptorChain().abort();
                 if (ep.getInFaultObserver() != null) {
                     ep.getInFaultObserver().onMessage(message);
@@ -189,7 +189,7 @@ public class SOAPHandlerInterceptor extends
                 MessageObserver observer = message.getExchange().get(MessageObserver.class);
                 if (!message.getExchange().isOneWay()
                     && observer != null) {
-                    Endpoint e = message.getExchange().get(Endpoint.class);
+                    Endpoint e = message.getExchange().getEndpoint();
                     Message responseMsg = new MessageImpl();
                     responseMsg.setExchange(message.getExchange());
                     responseMsg = e.getBinding().createMessage(responseMsg);
@@ -219,7 +219,7 @@ public class SOAPHandlerInterceptor extends
             if (!getInvoker(message).isOutbound()) {
                 // server side inbound
                 message.getInterceptorChain().abort();
-                Endpoint e = message.getExchange().get(Endpoint.class);
+                Endpoint e = message.getExchange().getEndpoint();
                 if (!message.getExchange().isOneWay()) {
                     Message responseMsg = new MessageImpl();
                     responseMsg.setExchange(message.getExchange());

--- a/rt/frontend/jaxws/src/main/java/org/apache/cxf/jaxws/interceptors/MessageModeInInterceptor.java
+++ b/rt/frontend/jaxws/src/main/java/org/apache/cxf/jaxws/interceptors/MessageModeInInterceptor.java
@@ -68,7 +68,7 @@ public class MessageModeInInterceptor extends AbstractPhaseInterceptor<Message> 
     }
 
     public void handleMessage(Message message) throws Fault {
-        BindingOperationInfo bop = message.getExchange().get(BindingOperationInfo.class); 
+        BindingOperationInfo bop = message.getExchange().getBindingOperationInfo(); 
         if (bop == null || !bindingName.equals(bop.getBinding().getName())) {
             return;
         }

--- a/rt/frontend/jaxws/src/main/java/org/apache/cxf/jaxws/interceptors/MessageModeOutInterceptor.java
+++ b/rt/frontend/jaxws/src/main/java/org/apache/cxf/jaxws/interceptors/MessageModeOutInterceptor.java
@@ -91,7 +91,7 @@ public class MessageModeOutInterceptor extends AbstractPhaseInterceptor<Message>
         this.bindingName = bname;
     }
     public void handleMessage(Message message) throws Fault {
-        BindingOperationInfo bop = message.getExchange().get(BindingOperationInfo.class);
+        BindingOperationInfo bop = message.getExchange().getBindingOperationInfo();
         if (bop != null && !bindingName.equals(bop.getBinding().getName())) {
             return;
         }
@@ -316,7 +316,7 @@ public class MessageModeOutInterceptor extends AbstractPhaseInterceptor<Message>
                 }
             }
 
-            BindingOperationInfo bop = message.getExchange().get(BindingOperationInfo.class);
+            BindingOperationInfo bop = message.getExchange().getBindingOperationInfo();
             DocumentFragment frag = soapMessage.getSOAPPart().createDocumentFragment();
             try {
                 Node body = SAAJUtils.getBody(soapMessage);

--- a/rt/frontend/jaxws/src/main/java/org/apache/cxf/jaxws/interceptors/WebFaultOutInterceptor.java
+++ b/rt/frontend/jaxws/src/main/java/org/apache/cxf/jaxws/interceptors/WebFaultOutInterceptor.java
@@ -47,7 +47,6 @@ import org.apache.cxf.interceptor.FaultOutInterceptor;
 import org.apache.cxf.message.FaultMode;
 import org.apache.cxf.message.Message;
 import org.apache.cxf.service.Service;
-import org.apache.cxf.service.model.BindingOperationInfo;
 import org.apache.cxf.service.model.FaultInfo;
 import org.apache.cxf.service.model.MessagePartInfo;
 import org.apache.cxf.service.model.OperationInfo;
@@ -141,7 +140,7 @@ public class WebFaultOutInterceptor extends FaultOutInterceptor {
             } catch (IllegalArgumentException e) {
                 throw new Fault(new org.apache.cxf.common.i18n.Message("COULD_NOT_INVOKE", BUNDLE), e);
             }
-            Service service = message.getExchange().get(Service.class);
+            Service service = message.getExchange().getService();
 
             try {
                 DataWriter<XMLStreamWriter> writer 
@@ -153,7 +152,7 @@ public class WebFaultOutInterceptor extends FaultOutInterceptor {
                     writer.setSchema(schema);
                 }
 
-                OperationInfo op = message.getExchange().get(BindingOperationInfo.class).getOperationInfo();
+                OperationInfo op = message.getExchange().getBindingOperationInfo().getOperationInfo();
                 QName faultName = getFaultName(fault, cause.getClass(), op);
                 MessagePartInfo part = getFaultMessagePart(faultName, op);
                 if (f.hasDetails()) {

--- a/rt/frontend/jaxws/src/main/java/org/apache/cxf/jaxws/interceptors/WrapperClassInInterceptor.java
+++ b/rt/frontend/jaxws/src/main/java/org/apache/cxf/jaxws/interceptors/WrapperClassInInterceptor.java
@@ -98,7 +98,6 @@ public class WrapperClassInInterceptor extends AbstractPhaseInterceptor<Message>
             message.put(MessageInfo.class, messageInfo);
             message.put(BindingMessageInfo.class, bmi);
             ex.put(BindingOperationInfo.class, boi2);
-            ex.put(OperationInfo.class, op);
             
             if (isGET(message)) {
                 LOG.fine("WrapperClassInInterceptor skipped in HTTP GET method");

--- a/rt/frontend/jaxws/src/main/java/org/apache/cxf/jaxws/interceptors/WrapperClassOutInterceptor.java
+++ b/rt/frontend/jaxws/src/main/java/org/apache/cxf/jaxws/interceptors/WrapperClassOutInterceptor.java
@@ -41,7 +41,6 @@ import org.apache.cxf.service.model.BindingMessageInfo;
 import org.apache.cxf.service.model.BindingOperationInfo;
 import org.apache.cxf.service.model.MessageInfo;
 import org.apache.cxf.service.model.MessagePartInfo;
-import org.apache.cxf.service.model.OperationInfo;
 import org.apache.cxf.service.model.ServiceModelUtil;
 import org.apache.cxf.wsdl.service.factory.ReflectionServiceFactoryBean;
 
@@ -110,7 +109,6 @@ public class WrapperClassOutInterceptor extends AbstractPhaseInterceptor<Message
             
             // we've now wrapped the object, so use the wrapped binding op
             ex.put(BindingOperationInfo.class, newbop);
-            ex.put(OperationInfo.class, newbop.getOperationInfo());
             
             if (messageInfo == bop.getOperationInfo().getInput()) {
                 message.put(MessageInfo.class, newbop.getOperationInfo().getInput());

--- a/rt/frontend/simple/src/main/java/org/apache/cxf/frontend/WSDLGetInterceptor.java
+++ b/rt/frontend/simple/src/main/java/org/apache/cxf/frontend/WSDLGetInterceptor.java
@@ -76,7 +76,7 @@ public class WSDLGetInterceptor extends AbstractPhaseInterceptor<Message> {
         if (isRecognizedQuery(map)) {
             Document doc = getDocument(utils, message, baseUri, map, ctx);
             
-            Endpoint e = message.getExchange().get(Endpoint.class);
+            Endpoint e = message.getExchange().getEndpoint();
             Message mout = new MessageImpl();
             mout.setExchange(message.getExchange());
             mout = e.getBinding().createMessage(mout);

--- a/rt/management/src/main/java/org/apache/cxf/management/interceptor/AbstractMessageResponseTimeInterceptor.java
+++ b/rt/management/src/main/java/org/apache/cxf/management/interceptor/AbstractMessageResponseTimeInterceptor.java
@@ -90,7 +90,7 @@ public abstract class AbstractMessageResponseTimeInterceptor extends AbstractPha
     }
 
     private void increaseCounter(Exchange ex, MessageHandlingTimeRecorder mhtr) {
-        Bus bus = ex.get(Bus.class);
+        Bus bus = ex.getBus();
         if (null == bus) {
             LOG.log(Level.INFO, "CAN_NOT_GET_BUS_FROM_EXCHANGE");
             bus = BusFactory.getThreadDefaultBus();
@@ -110,13 +110,13 @@ public abstract class AbstractMessageResponseTimeInterceptor extends AbstractPha
     }
     
     protected ObjectName getServiceCounterName(Exchange ex) {
-        Bus bus = ex.get(Bus.class);
+        Bus bus = ex.getBus();
         StringBuilder buffer = new StringBuilder();
         if (ex.get("org.apache.cxf.management.service.counter.name") != null) {
             buffer.append((String)ex.get("org.apache.cxf.management.service.counter.name"));
         } else {
-            Service service = ex.get(Service.class);
-            Endpoint endpoint = ex.get(Endpoint.class);
+            Service service = ex.getService();
+            Endpoint endpoint = ex.getEndpoint();
 
             String serviceName = "\"" + escapePatternChars(service.getName().toString()) + "\"";
             String portName = "\"" + endpoint.getEndpointInfo().getName().getLocalPart() + "\"";
@@ -146,7 +146,7 @@ public abstract class AbstractMessageResponseTimeInterceptor extends AbstractPha
     }
   
     protected boolean isServiceCounterEnabled(Exchange ex) {
-        Bus bus = ex.get(Bus.class);
+        Bus bus = ex.getBus();
         CounterRepository counterRepo = bus.getExtension(CounterRepository.class);
         if (counterRepo == null) {
             return false;
@@ -158,7 +158,7 @@ public abstract class AbstractMessageResponseTimeInterceptor extends AbstractPha
     }
     
     protected ObjectName getOperationCounterName(Exchange ex, ObjectName sericeCounterName) {
-        OperationInfo opInfo = ex.get(OperationInfo.class);
+        OperationInfo opInfo = ex.getBindingOperationInfo().getOperationInfo();
         String operationName = opInfo == null ? null : "\"" + opInfo.getName().getLocalPart() + "\"";
 
         if (operationName == null) {

--- a/rt/management/src/main/java/org/apache/cxf/management/interceptor/PersistOutInterceptor.java
+++ b/rt/management/src/main/java/org/apache/cxf/management/interceptor/PersistOutInterceptor.java
@@ -164,10 +164,10 @@ public class PersistOutInterceptor extends AbstractPhaseInterceptor<Message> {
 
             try {
 
-                Service service = message.getExchange().get(Service.class);
+                Service service = message.getExchange().getService();
 
                 String serviceName = String.valueOf(service.getName());
-                OperationInfo opInfo = message.getExchange().get(OperationInfo.class);
+                OperationInfo opInfo = message.getExchange().getBindingOperationInfo().getOperationInfo();
                 String operationName = opInfo == null ? null : opInfo.getName().getLocalPart();
 
                 if (operationName == null) {

--- a/rt/management/src/test/java/org/apache/cxf/management/interceptor/AbstractMessageResponseTestBase.java
+++ b/rt/management/src/test/java/org/apache/cxf/management/interceptor/AbstractMessageResponseTestBase.java
@@ -30,6 +30,7 @@ import org.apache.cxf.management.counters.MessageHandlingTimeRecorder;
 import org.apache.cxf.message.Exchange;
 import org.apache.cxf.message.Message;
 import org.apache.cxf.service.Service;
+import org.apache.cxf.service.model.BindingOperationInfo;
 import org.apache.cxf.service.model.EndpointInfo;
 import org.apache.cxf.service.model.OperationInfo;
 import org.easymock.EasyMock;
@@ -106,18 +107,18 @@ public class AbstractMessageResponseTestBase extends Assert {
     }
     
     protected void setupExchangeForMessage() {
-        EasyMock.expect(exchange.get(Bus.class)).andReturn(bus).anyTimes();
+        EasyMock.expect(exchange.getBus()).andReturn(bus).anyTimes();
        
         Service service = EasyMock.createMock(Service.class);
         EasyMock.expect(service.getName()).andReturn(SERVICE_NAME).anyTimes();        
-        EasyMock.expect(exchange.get(Service.class)).andReturn(service).anyTimes();
+        EasyMock.expect(exchange.getService()).andReturn(service).anyTimes();
         EasyMock.replay(service);
         
         Endpoint endpoint = EasyMock.createMock(Endpoint.class);
         EndpointInfo endpointInfo = EasyMock.createMock(EndpointInfo.class);
         EasyMock.expect(endpointInfo.getName()).andReturn(PORT_NAME).anyTimes();
         EasyMock.expect(endpoint.getEndpointInfo()).andReturn(endpointInfo).anyTimes();
-        EasyMock.expect(exchange.get(Endpoint.class)).andReturn(endpoint).anyTimes();
+        EasyMock.expect(exchange.getEndpoint()).andReturn(endpoint).anyTimes();
         EasyMock.replay(endpointInfo);
         EasyMock.replay(endpoint);
         
@@ -128,9 +129,11 @@ public class AbstractMessageResponseTestBase extends Assert {
       
     protected void setupOperationForMessage() {
         OperationInfo op = EasyMock.createMock(OperationInfo.class);
-        EasyMock.expect(op.getName()).andReturn(OPERATION_NAME);        
-        EasyMock.expect(exchange.get(OperationInfo.class)).andReturn(op);
-        EasyMock.replay(op);
+        BindingOperationInfo bop = EasyMock.createMock(BindingOperationInfo.class);
+        EasyMock.expect(exchange.getBindingOperationInfo()).andReturn(bop);
+        EasyMock.expect(bop.getOperationInfo()).andReturn(op);
+        EasyMock.expect(op.getName()).andReturn(OPERATION_NAME);
+        EasyMock.replay(bop, op);
     }
 
 }

--- a/rt/management/src/test/java/org/apache/cxf/management/interceptor/ResponseTimeMessageOutInterceptorTest.java
+++ b/rt/management/src/test/java/org/apache/cxf/management/interceptor/ResponseTimeMessageOutInterceptorTest.java
@@ -19,7 +19,6 @@
 
 package org.apache.cxf.management.interceptor;
 
-import org.apache.cxf.Bus;
 import org.apache.cxf.interceptor.InterceptorChain;
 import org.apache.cxf.management.counters.MessageHandlingTimeRecorder;
 import org.apache.cxf.message.FaultMode;
@@ -140,7 +139,7 @@ public class ResponseTimeMessageOutInterceptorTest extends AbstractMessageRespon
     public void testClientMessageOut() {
         EasyMock.expect(message.get(Message.PARTIAL_RESPONSE_MESSAGE)).andReturn(Boolean.FALSE).anyTimes();
         EasyMock.expect(message.getExchange()).andReturn(exchange);
-        EasyMock.expect(exchange.get(Bus.class)).andReturn(bus);
+        EasyMock.expect(exchange.getBus()).andReturn(bus);
         EasyMock.expect(exchange.get("org.apache.cxf.management.counter.enabled")).andReturn(null);
         EasyMock.replay(exchange);
         EasyMock.replay(message);

--- a/rt/rs/client/src/main/java/org/apache/cxf/jaxrs/client/ClientProviderFactory.java
+++ b/rt/rs/client/src/main/java/org/apache/cxf/jaxrs/client/ClientProviderFactory.java
@@ -60,7 +60,7 @@ public final class ClientProviderFactory extends ProviderFactory {
     }
     
     public static ClientProviderFactory getInstance(Message m) {
-        Endpoint e = m.getExchange().get(Endpoint.class);
+        Endpoint e = m.getExchange().getEndpoint();
         return (ClientProviderFactory)e.get(CLIENT_FACTORY_NAME);
     }
     

--- a/rt/rs/client/src/main/java/org/apache/cxf/jaxrs/client/ClientProxyImpl.java
+++ b/rt/rs/client/src/main/java/org/apache/cxf/jaxrs/client/ClientProxyImpl.java
@@ -316,7 +316,7 @@ public class ClientProxyImpl extends AbstractClient implements
                 throw t;
             }
             
-            Endpoint ep = inMessage.getExchange().get(Endpoint.class);
+            Endpoint ep = inMessage.getExchange().getEndpoint();
             inMessage.getExchange().put(InterceptorProvider.class, getConfiguration());
             inMessage.setContent(Exception.class, new Fault(t));
             inMessage.getInterceptorChain().abort();

--- a/rt/rs/description/src/main/java/org/apache/cxf/jaxrs/model/wadl/WadlGenerator.java
+++ b/rt/rs/description/src/main/java/org/apache/cxf/jaxrs/model/wadl/WadlGenerator.java
@@ -121,7 +121,6 @@ import org.apache.cxf.jaxrs.utils.JAXRSUtils;
 import org.apache.cxf.jaxrs.utils.ResourceUtils;
 import org.apache.cxf.jaxrs.utils.schemas.SchemaHandler;
 import org.apache.cxf.message.Message;
-import org.apache.cxf.service.Service;
 import org.apache.cxf.service.model.EndpointInfo;
 import org.apache.cxf.staxutils.DelegatingXMLStreamWriter;
 import org.apache.cxf.staxutils.StaxUtils;
@@ -340,7 +339,7 @@ public class WadlGenerator implements ContainerRequestFilter {
     }
 
     private String getBaseURI(Message m, UriInfo ui) {
-        EndpointInfo ei = m.getExchange().get(Endpoint.class).getEndpointInfo();
+        EndpointInfo ei = m.getExchange().getEndpoint().getEndpointInfo();
         String publishedEndpointUrl = (String)ei.getProperty("publishedEndpointUrl");
         if (publishedEndpointUrl == null) {
             return ui.getBaseUri().toString();
@@ -1116,7 +1115,7 @@ public class WadlGenerator implements ContainerRequestFilter {
         if (!path.startsWith(slash)) {
             path = slash + path;
         }
-        List<ClassResourceInfo> all = ((JAXRSServiceImpl)m.getExchange().get(Service.class))
+        List<ClassResourceInfo> all = ((JAXRSServiceImpl)m.getExchange().getService())
             .getClassResourceInfos();
         boolean absolutePathSlashOn = checkAbsolutePathSlash && ui.getAbsolutePath().getPath().endsWith(slash);
         if (slash.equals(path) && !absolutePathSlashOn) {
@@ -1135,7 +1134,7 @@ public class WadlGenerator implements ContainerRequestFilter {
 
     // TODO: deal with caching later on
     public Response getExistingWadl(Message m, UriInfo ui, MediaType mt) {
-        Endpoint ep = m.getExchange().get(Endpoint.class);
+        Endpoint ep = m.getExchange().getEndpoint();
         if (ep != null) {
             String loc = (String)ep.get(JAXRSUtils.DOC_LOCATION);
             if (loc != null) {

--- a/rt/rs/security/jose/src/main/java/org/apache/cxf/rs/security/jose/jaxrs/JwtAuthenticationClientFilter.java
+++ b/rt/rs/security/jose/src/main/java/org/apache/cxf/rs/security/jose/jaxrs/JwtAuthenticationClientFilter.java
@@ -28,7 +28,6 @@ import javax.ws.rs.core.HttpHeaders;
 
 import org.apache.cxf.common.util.Base64UrlUtility;
 import org.apache.cxf.configuration.security.AuthorizationPolicy;
-import org.apache.cxf.endpoint.Endpoint;
 import org.apache.cxf.jaxrs.utils.JAXRSUtils;
 import org.apache.cxf.rs.security.jose.JoseException;
 import org.apache.cxf.rs.security.jose.JoseHeaders;
@@ -48,7 +47,7 @@ public class JwtAuthenticationClientFilter extends AbstractJoseJwtProducer
         boolean jweRequired = false;
         if (jwt == null) {
             AuthorizationPolicy ap = JAXRSUtils.getCurrentMessage().getExchange()
-                .get(Endpoint.class).getEndpointInfo().getExtensor(AuthorizationPolicy.class);
+                .getEndpoint().getEndpointInfo().getExtensor(AuthorizationPolicy.class);
             if (ap != null && ap.getUserName() != null) {
                 JwtClaims claims = new JwtClaims();
                 claims.setSubject(ap.getUserName());

--- a/rt/rs/security/xml/src/main/java/org/apache/cxf/rs/security/common/CryptoLoader.java
+++ b/rt/rs/security/xml/src/main/java/org/apache/cxf/rs/security/common/CryptoLoader.java
@@ -94,7 +94,7 @@ public class CryptoLoader {
     }
     
     public final Map<Object, Crypto> getCryptoCache(Message message) {
-        Endpoint endpoint = message.getExchange().get(Endpoint.class);
+        Endpoint endpoint = message.getExchange().getEndpoint();
         if (endpoint != null) {
             EndpointInfo info  = endpoint.getEndpointInfo();
             synchronized (info) {

--- a/rt/security-saml/src/main/java/org/apache/cxf/rt/security/saml/interceptor/ClaimsAuthorizingInterceptor.java
+++ b/rt/security-saml/src/main/java/org/apache/cxf/rt/security/saml/interceptor/ClaimsAuthorizingInterceptor.java
@@ -43,7 +43,6 @@ import org.apache.cxf.security.SecurityContext;
 import org.apache.cxf.security.claims.authorization.Claim;
 import org.apache.cxf.security.claims.authorization.ClaimMode;
 import org.apache.cxf.security.claims.authorization.Claims;
-import org.apache.cxf.service.Service;
 import org.apache.cxf.service.invoker.MethodDispatcher;
 import org.apache.cxf.service.model.BindingOperationInfo;
 
@@ -88,10 +87,10 @@ public class ClaimsAuthorizingInterceptor extends AbstractPhaseInterceptor<Messa
     }
     
     protected Method getTargetMethod(Message m) {
-        BindingOperationInfo bop = m.getExchange().get(BindingOperationInfo.class);
+        BindingOperationInfo bop = m.getExchange().getBindingOperationInfo();
         if (bop != null) {
             MethodDispatcher md = (MethodDispatcher) 
-                m.getExchange().get(Service.class).get(MethodDispatcher.class.getName());
+                m.getExchange().getService().get(MethodDispatcher.class.getName());
             return md.getMethod(bop);
         } 
         Method method = (Method)m.get("org.apache.cxf.resource.method");

--- a/rt/security/src/main/java/org/apache/cxf/rt/security/utils/SecurityUtils.java
+++ b/rt/security/src/main/java/org/apache/cxf/rt/security/utils/SecurityUtils.java
@@ -28,7 +28,6 @@ import java.util.logging.Logger;
 
 import javax.security.auth.callback.CallbackHandler;
 
-import org.apache.cxf.Bus;
 import org.apache.cxf.common.classloader.ClassLoaderUtils;
 import org.apache.cxf.common.classloader.ClassLoaderUtils.ClassLoaderHolder;
 import org.apache.cxf.common.logging.LogUtils;
@@ -78,8 +77,8 @@ public final class SecurityUtils {
             msg = PhaseInterceptorChain.getCurrentMessage();
         }
         ResourceManager manager = null;
-        if (msg != null && msg.getExchange() != null && msg.getExchange().get(Bus.class) != null) {
-            manager = msg.getExchange().get(Bus.class).getExtension(ResourceManager.class);
+        if (msg != null && msg.getExchange() != null && msg.getExchange().getBus() != null) {
+            manager = msg.getExchange().getBus().getExtension(ResourceManager.class);
         }
         return loadResource(manager, o);
     }

--- a/rt/transports/http/src/main/java/org/apache/cxf/transport/http/HTTPConduit.java
+++ b/rt/transports/http/src/main/java/org/apache/cxf/transport/http/HTTPConduit.java
@@ -1177,7 +1177,7 @@ public abstract class HTTPConduit
                         };
                     }
                     if (ex == null || forceWQ) {
-                        WorkQueueManager mgr = outMessage.getExchange().get(Bus.class)
+                        WorkQueueManager mgr = outMessage.getExchange().getBus()
                             .getExtension(WorkQueueManager.class);
                         AutomaticWorkQueue qu = mgr.getNamedWorkQueue("http-conduit");
                         if (qu == null) {

--- a/rt/ws/addr/src/main/java/org/apache/cxf/ws/addressing/impl/MAPAggregatorImpl.java
+++ b/rt/ws/addr/src/main/java/org/apache/cxf/ws/addressing/impl/MAPAggregatorImpl.java
@@ -206,7 +206,7 @@ public class MAPAggregatorImpl extends MAPAggregator {
     */
     private boolean hasUsingAddressing(Message message) {
         boolean ret = false;
-        Endpoint endpoint = message.getExchange().get(Endpoint.class);
+        Endpoint endpoint = message.getExchange().getEndpoint();
         if (null != endpoint) {
             Boolean b = (Boolean)endpoint.get(USING_ADDRESSING);
             if (null == b) {
@@ -716,7 +716,7 @@ public class MAPAggregatorImpl extends MAPAggregator {
     }
 
     protected String getActionUri(Message message, boolean checkMessage) {
-        BindingOperationInfo bop = message.getExchange().get(BindingOperationInfo.class);
+        BindingOperationInfo bop = message.getExchange().getBindingOperationInfo();
         if (bop == null || Boolean.TRUE.equals(bop.getProperty("operation.is.synthetic"))) {
             return null;
         }
@@ -910,7 +910,7 @@ public class MAPAggregatorImpl extends MAPAggregator {
     private EndpointReferenceType getReplyTo(Message message, 
                                              EndpointReferenceType originalReplyTo) {
         Exchange exchange = message.getExchange();
-        Endpoint info = exchange.get(Endpoint.class);
+        Endpoint info = exchange.getEndpoint();
         if (info == null) {
             return originalReplyTo;
         }
@@ -942,7 +942,7 @@ public class MAPAggregatorImpl extends MAPAggregator {
     private Destination createDecoupledDestination(Message message) {
         String replyToAddress = (String)message.getContextualProperty(WSAContextUtils.REPLYTO_PROPERTY);
         if (replyToAddress != null) {
-            return setUpDecoupledDestination(message.getExchange().get(Bus.class),
+            return setUpDecoupledDestination(message.getExchange().getBus(),
                                              replyToAddress, 
                                              message);
         }
@@ -981,7 +981,7 @@ public class MAPAggregatorImpl extends MAPAggregator {
         DestinationFactory factory =
             factoryManager.getDestinationFactoryForUri(address);
         if (factory != null) {
-            Endpoint ep = message.getExchange().get(Endpoint.class);
+            Endpoint ep = message.getExchange().getEndpoint();
             
             EndpointInfo ei = new EndpointInfo();
             ei.setName(new QName(ep.getEndpointInfo().getName().getNamespaceURI(),

--- a/rt/ws/addr/src/test/java/org/apache/cxf/ws/addressing/impl/ContextUtilsTest.java
+++ b/rt/ws/addr/src/test/java/org/apache/cxf/ws/addressing/impl/ContextUtilsTest.java
@@ -126,7 +126,7 @@ public class ContextUtilsTest extends Assert {
 
         // test 1 : retrieving the normal action prop from the message
         EasyMock.expect(msg.getExchange()).andReturn(exchange).anyTimes();
-        EasyMock.expect(exchange.get(BindingOperationInfo.class)).andReturn(boi);
+        EasyMock.expect(exchange.getBindingOperationInfo()).andReturn(boi);
         EasyMock.expect(msg.get(ContextUtils.ACTION)).andReturn("urn:foo:test:1");
         control.replay();
         
@@ -137,7 +137,7 @@ public class ContextUtilsTest extends Assert {
 
         // test 2 : retrieving the normal soap action prop from the message
         EasyMock.expect(msg.getExchange()).andReturn(exchange).anyTimes();
-        EasyMock.expect(exchange.get(BindingOperationInfo.class)).andReturn(boi);
+        EasyMock.expect(exchange.getBindingOperationInfo()).andReturn(boi);
         EasyMock.expect(msg.get(SoapBindingConstants.SOAP_ACTION)).andReturn("urn:foo:test:2");
         control.replay();
         
@@ -148,7 +148,7 @@ public class ContextUtilsTest extends Assert {
 
         // test 3 : retrieving the action prop from the message info
         EasyMock.expect(msg.getExchange()).andReturn(exchange).anyTimes();
-        EasyMock.expect(exchange.get(BindingOperationInfo.class)).andReturn(boi);
+        EasyMock.expect(exchange.getBindingOperationInfo()).andReturn(boi);
         messageInfo.setProperty(ContextUtils.ACTION, "urn:foo:test:3");
         control.replay();
         
@@ -161,7 +161,7 @@ public class ContextUtilsTest extends Assert {
         SoapFault fault = new SoapFault("faulty service", new RuntimeException(), fqname);
         EasyMock.expect(msg.getExchange()).andReturn(exchange).anyTimes();
         EasyMock.expect(msg.getContent(Exception.class)).andReturn(fault).anyTimes();
-        EasyMock.expect(exchange.get(BindingOperationInfo.class)).andReturn(boi);
+        EasyMock.expect(exchange.getBindingOperationInfo()).andReturn(boi);
         control.replay();
         
         action = InternalContextUtils.getAction(msg);
@@ -174,7 +174,7 @@ public class ContextUtilsTest extends Assert {
         faultInfo.addExtensionAttribute(Names.WSAW_ACTION_QNAME, "urn:foo:test:4");
         EasyMock.expect(msg.getExchange()).andReturn(exchange).anyTimes();
         EasyMock.expect(msg.getContent(Exception.class)).andReturn(fault).anyTimes();
-        EasyMock.expect(exchange.get(BindingOperationInfo.class)).andReturn(boi);
+        EasyMock.expect(exchange.getBindingOperationInfo()).andReturn(boi);
         control.replay();
         
         action = InternalContextUtils.getAction(msg);
@@ -188,7 +188,7 @@ public class ContextUtilsTest extends Assert {
                                         Names.ACTION_MISMATCH_NAME));
         EasyMock.expect(msg.getExchange()).andReturn(exchange).anyTimes();
         EasyMock.expect(msg.getContent(Exception.class)).andReturn(fault).anyTimes();
-        EasyMock.expect(exchange.get(BindingOperationInfo.class)).andReturn(boi);
+        EasyMock.expect(exchange.getBindingOperationInfo()).andReturn(boi);
         control.replay();
         
         action = InternalContextUtils.getAction(msg);

--- a/rt/ws/addr/src/test/java/org/apache/cxf/ws/addressing/impl/MAPAggregatorTest.java
+++ b/rt/ws/addr/src/test/java/org/apache/cxf/ws/addressing/impl/MAPAggregatorTest.java
@@ -637,7 +637,7 @@ public class MAPAggregatorTest extends Assert {
             EasyMock.expectLastCall().andReturn(serv).anyTimes();
             serv.getOutInterceptors();
             EasyMock.expectLastCall().andReturn(new ArrayList<Interceptor<? extends Message>>()).anyTimes();
-            exchange.get(Endpoint.class);
+            exchange.getEndpoint();
             EasyMock.expectLastCall().andReturn(endpoint).anyTimes();
         }
         control.replay();
@@ -820,7 +820,7 @@ public class MAPAggregatorTest extends Assert {
                              "org.apache.cxf.ws.addressing.partial.response.sent",
                              Boolean.FALSE);
         Endpoint endpoint = control.createMock(Endpoint.class);
-        exchange.get(Endpoint.class);
+        exchange.getEndpoint();
         EasyMock.expectLastCall().andReturn(endpoint);
         Binding binding = control.createMock(Binding.class);
         endpoint.getBinding();        
@@ -865,6 +865,7 @@ public class MAPAggregatorTest extends Assert {
                                                                        "opResponse",
                                                                        "opFault", method);
         setUpExchangeGet(exchange, BindingOperationInfo.class, bindingOpInfo);
+        EasyMock.expect(exchange.getBindingOperationInfo()).andReturn(bindingOpInfo).anyTimes();
         // Usual fun with EasyMock not always working as expected
         //BindingOperationInfo bindingOpInfo =
         //    EasyMock.createMock(BindingOperationInfo.class); 
@@ -905,7 +906,7 @@ public class MAPAggregatorTest extends Assert {
         EasyMock.expectLastCall().andReturn(new PhaseManagerImpl()).anyTimes();
         
         Exchange exchange = control.createMock(Exchange.class);
-        exchange.get(Bus.class);
+        exchange.getBus();
         EasyMock.expectLastCall().andReturn(bus).anyTimes();
         EasyMock.expect(exchange.isEmpty()).andReturn(true).anyTimes();
         return exchange;

--- a/rt/ws/policy/src/main/java/org/apache/cxf/ws/policy/ClientPolicyInFaultInterceptor.java
+++ b/rt/ws/policy/src/main/java/org/apache/cxf/ws/policy/ClientPolicyInFaultInterceptor.java
@@ -59,14 +59,14 @@ public class ClientPolicyInFaultInterceptor extends AbstractPolicyInterceptor {
         Exchange exchange = msg.getExchange();
         assert null != exchange;
         
-        Endpoint e = exchange.get(Endpoint.class);
+        Endpoint e = exchange.getEndpoint();
         if (null == e) {
             LOG.fine("No endpoint.");
             return;
         }
         EndpointInfo ei = e.getEndpointInfo();
         
-        Bus bus = exchange.get(Bus.class);
+        Bus bus = exchange.getBus();
         PolicyEngine pe = bus.getExtension(PolicyEngine.class);
         if (null == pe) {
             return;

--- a/rt/ws/policy/src/main/java/org/apache/cxf/ws/policy/PolicyInInterceptor.java
+++ b/rt/ws/policy/src/main/java/org/apache/cxf/ws/policy/PolicyInInterceptor.java
@@ -54,8 +54,8 @@ public class PolicyInInterceptor extends AbstractPolicyInterceptor {
     
     protected void handle(Message msg) {
         Exchange exchange = msg.getExchange();
-        Bus bus = exchange.get(Bus.class);
-        Endpoint e = exchange.get(Endpoint.class);
+        Bus bus = exchange.getBus();
+        Endpoint e = exchange.getEndpoint();
         if (null == e) {
             LOG.fine("No endpoint.");
             return;
@@ -84,7 +84,7 @@ public class PolicyInInterceptor extends AbstractPolicyInterceptor {
             assertions.addAll(effectivePolicy.getChosenAlternative());
         } else if (MessageUtils.isRequestor(msg)) {
             // 2. Process client policy
-            BindingOperationInfo boi = exchange.get(BindingOperationInfo.class);
+            BindingOperationInfo boi = exchange.getBindingOperationInfo();
             if (boi == null) {
                 Conduit conduit = exchange.getConduit(msg);
                 EndpointPolicy ep = pe.getClientEndpointPolicy(ei, conduit, msg);

--- a/rt/ws/policy/src/main/java/org/apache/cxf/ws/policy/PolicyOutInterceptor.java
+++ b/rt/ws/policy/src/main/java/org/apache/cxf/ws/policy/PolicyOutInterceptor.java
@@ -56,15 +56,15 @@ public class PolicyOutInterceptor extends AbstractPolicyInterceptor {
     
     protected void handle(Message msg) {        
         Exchange exchange = msg.getExchange();
-        Bus bus = exchange.get(Bus.class);
+        Bus bus = exchange.getBus();
         
-        BindingOperationInfo boi = exchange.get(BindingOperationInfo.class);
+        BindingOperationInfo boi = exchange.getBindingOperationInfo();
         if (null == boi) {
             LOG.fine("No binding operation info.");
             return;
         }
         
-        Endpoint e = exchange.get(Endpoint.class);
+        Endpoint e = exchange.getEndpoint();
         if (null == e) {
             LOG.fine("No endpoint.");
             return;

--- a/rt/ws/policy/src/main/java/org/apache/cxf/ws/policy/PolicyVerificationInFaultInterceptor.java
+++ b/rt/ws/policy/src/main/java/org/apache/cxf/ws/policy/PolicyVerificationInFaultInterceptor.java
@@ -67,20 +67,20 @@ public class PolicyVerificationInFaultInterceptor extends AbstractPolicyIntercep
         Exchange exchange = message.getExchange();
         assert null != exchange;
         
-        BindingOperationInfo boi = exchange.get(BindingOperationInfo.class);
+        BindingOperationInfo boi = exchange.getBindingOperationInfo();
         if (null == boi) {
             LOG.fine("No binding operation info.");
             return;
         }        
         
-        Endpoint e = exchange.get(Endpoint.class);
+        Endpoint e = exchange.getEndpoint();
         if (null == e) {
             LOG.fine("No endpoint.");
             return;
         }
         EndpointInfo ei = e.getEndpointInfo();
         
-        Bus bus = exchange.get(Bus.class);
+        Bus bus = exchange.getBus();
         PolicyEngine pe = bus.getExtension(PolicyEngine.class);
         if (null == pe) {
             return;

--- a/rt/ws/policy/src/main/java/org/apache/cxf/ws/policy/PolicyVerificationInInterceptor.java
+++ b/rt/ws/policy/src/main/java/org/apache/cxf/ws/policy/PolicyVerificationInInterceptor.java
@@ -70,14 +70,13 @@ public class PolicyVerificationInInterceptor extends AbstractPolicyInterceptor {
             return;
         }
         
-        Endpoint e = exchange.get(Endpoint.class);
+        Endpoint e = exchange.getEndpoint();
         if (null == e) {
             LOG.fine("No endpoint.");
             return;
         } 
-        EndpointInfo ei = e.getEndpointInfo();
 
-        Bus bus = exchange.get(Bus.class);
+        Bus bus = exchange.getBus();
         PolicyEngine pe = bus.getExtension(PolicyEngine.class);
         if (null == pe) {
             return;
@@ -92,6 +91,7 @@ public class PolicyVerificationInInterceptor extends AbstractPolicyInterceptor {
         
         EffectivePolicy effectivePolicy = message.get(EffectivePolicy.class);
         if (effectivePolicy == null) {
+            EndpointInfo ei = e.getEndpointInfo();
             if (MessageUtils.isRequestor(message)) {
                 effectivePolicy = pe.getEffectiveClientResponsePolicy(ei, boi, message);
             } else {

--- a/rt/ws/policy/src/main/java/org/apache/cxf/ws/policy/ServerPolicyOutFaultInterceptor.java
+++ b/rt/ws/policy/src/main/java/org/apache/cxf/ws/policy/ServerPolicyOutFaultInterceptor.java
@@ -61,20 +61,20 @@ public class ServerPolicyOutFaultInterceptor extends AbstractPolicyInterceptor {
         Exchange exchange = msg.getExchange();
         assert null != exchange;
         
-        BindingOperationInfo boi = exchange.get(BindingOperationInfo.class);
+        BindingOperationInfo boi = exchange.getBindingOperationInfo();
         if (null == boi) {
             LOG.fine("No binding operation info.");
             return;
         }
         
-        Endpoint e = exchange.get(Endpoint.class);
+        Endpoint e = exchange.getEndpoint();
         if (null == e) {
             LOG.fine("No endpoint.");
             return;
         }
         EndpointInfo ei = e.getEndpointInfo();
 
-        Bus bus = exchange.get(Bus.class);
+        Bus bus = exchange.getBus();
         PolicyEngine pe = bus.getExtension(PolicyEngine.class);
         if (null == pe) {
             return;

--- a/rt/ws/policy/src/test/java/org/apache/cxf/ws/policy/PolicyInterceptorsTest.java
+++ b/rt/ws/policy/src/test/java/org/apache/cxf/ws/policy/PolicyInterceptorsTest.java
@@ -410,12 +410,12 @@ public class PolicyInterceptorsTest extends Assert {
 
         EasyMock.expect(message.getExchange()).andReturn(exchange);
         
-        EasyMock.expect(exchange.get(Bus.class)).andReturn(bus).anyTimes();
+        EasyMock.expect(exchange.getBus()).andReturn(bus).anyTimes();
         if (usesOperationInfo) {
             if (null == boi && setupOperation) {
                 boi = control.createMock(BindingOperationInfo.class);
             }
-            EasyMock.expect(exchange.get(BindingOperationInfo.class)).andReturn(setupOperation ? boi : null)
+            EasyMock.expect(exchange.getBindingOperationInfo()).andReturn(setupOperation ? boi : null)
                 .anyTimes();
             if (!setupOperation) {
                 return;
@@ -425,7 +425,7 @@ public class PolicyInterceptorsTest extends Assert {
         if (null == endpoint && setupEndpoint) {
             endpoint = control.createMock(Endpoint.class);
         }
-        EasyMock.expect(exchange.get(Endpoint.class)).andReturn(setupEndpoint ? endpoint : null);
+        EasyMock.expect(exchange.getEndpoint()).andReturn(setupEndpoint ? endpoint : null);
         if (!setupEndpoint) {
             return;
         }

--- a/rt/ws/policy/src/test/java/org/apache/cxf/ws/policy/PolicyVerificationInFaultInterceptorTest.java
+++ b/rt/ws/policy/src/test/java/org/apache/cxf/ws/policy/PolicyVerificationInFaultInterceptorTest.java
@@ -149,14 +149,14 @@ public class PolicyVerificationInFaultInterceptorTest extends Assert {
         if (setupOperationInfo && null == boi) {
             boi = control.createMock(BindingOperationInfo.class);
         }
-        EasyMock.expect(exchange.get(BindingOperationInfo.class)).andReturn(boi);
+        EasyMock.expect(exchange.getBindingOperationInfo()).andReturn(boi);
         if (!setupOperationInfo) {
             return;
         }
         if (setupEndpoint && null == endpoint) {
             endpoint = control.createMock(Endpoint.class);
         }
-        EasyMock.expect(exchange.get(Endpoint.class)).andReturn(endpoint);
+        EasyMock.expect(exchange.getEndpoint()).andReturn(endpoint);
         if (!setupEndpoint) {
             return;
         }
@@ -165,7 +165,7 @@ public class PolicyVerificationInFaultInterceptorTest extends Assert {
         }
         EasyMock.expect(endpoint.getEndpointInfo()).andReturn(ei);
         
-        EasyMock.expect(exchange.get(Bus.class)).andReturn(bus);
+        EasyMock.expect(exchange.getBus()).andReturn(bus);
         if (setupPolicyEngine && null == engine) {
             engine = control.createMock(PolicyEngine.class);
         }

--- a/rt/ws/policy/src/test/java/org/apache/cxf/ws/policy/PolicyVerificationInInterceptorTest.java
+++ b/rt/ws/policy/src/test/java/org/apache/cxf/ws/policy/PolicyVerificationInInterceptorTest.java
@@ -143,7 +143,7 @@ public class PolicyVerificationInInterceptorTest extends Assert {
             return;
         }
         
-        EasyMock.expect(exchange.get(Bus.class)).andReturn(bus).anyTimes();
+        EasyMock.expect(exchange.getBus()).andReturn(bus).anyTimes();
         EasyMock.expect(message.getExchange()).andReturn(exchange);
         if (setupBindingOperationInfo && null == boi) {
             boi = control.createMock(BindingOperationInfo.class);
@@ -155,7 +155,7 @@ public class PolicyVerificationInInterceptorTest extends Assert {
         if (setupEndpoint && null == endpoint) {
             endpoint = control.createMock(Endpoint.class);
         }
-        EasyMock.expect(exchange.get(Endpoint.class)).andReturn(endpoint);
+        EasyMock.expect(exchange.getEndpoint()).andReturn(endpoint);
         if (!setupEndpoint) {
             return;
         }

--- a/rt/ws/rm/src/main/java/org/apache/cxf/ws/rm/AbstractRMInterceptor.java
+++ b/rt/ws/rm/src/main/java/org/apache/cxf/ws/rm/AbstractRMInterceptor.java
@@ -85,7 +85,7 @@ public abstract class AbstractRMInterceptor<T extends Message> extends AbstractP
             
             // log the fault as it may not be reported back to the client
             
-            Endpoint e = msg.getExchange().get(Endpoint.class);
+            Endpoint e = msg.getExchange().getEndpoint();
             Binding b = null;
             if (null != e) {
                 b = e.getBinding();

--- a/rt/ws/rm/src/main/java/org/apache/cxf/ws/rm/Destination.java
+++ b/rt/ws/rm/src/main/java/org/apache/cxf/ws/rm/Destination.java
@@ -223,7 +223,7 @@ public class Destination extends AbstractEndpoint {
     }
     
     private static Message createMessage(Exchange exchange) {
-        Endpoint ep = exchange.get(Endpoint.class);
+        Endpoint ep = exchange.getEndpoint();
         Message msg = null;
         if (ep != null) {
             msg = new MessageImpl();

--- a/rt/ws/rm/src/main/java/org/apache/cxf/ws/rm/InternalContextUtils.java
+++ b/rt/ws/rm/src/main/java/org/apache/cxf/ws/rm/InternalContextUtils.java
@@ -78,7 +78,7 @@ final class InternalContextUtils {
             if (ContextUtils.isNoneAddress(reference)) {
                 return null;
             }
-            Bus bus = inMessage.getExchange().get(Bus.class);
+            Bus bus = inMessage.getExchange().getBus();
             //this is a response targeting a decoupled endpoint.   Treat it as a oneway so
             //we don't wait for a response.
             inMessage.getExchange().setOneWay(true);
@@ -165,7 +165,7 @@ final class InternalContextUtils {
                         MessageUtils.isTrue(inMessage.getContextualProperty(Message.ROBUST_ONEWAY));
                     
                     if (robust) {
-                        BindingOperationInfo boi = exchange.get(BindingOperationInfo.class);
+                        BindingOperationInfo boi = exchange.getBindingOperationInfo();
                         // insert the executor in the exchange to fool the OneWayProcessorInterceptor
                         exchange.put(Executor.class, getExecutor(inMessage));
                         // pause dispatch on current thread and resume...
@@ -185,7 +185,7 @@ final class InternalContextUtils {
                     partialResponse.setInterceptorChain(chain);
                     exchange.put(ConduitSelector.class,
                                  new PreexistingConduitSelector(backChannel,
-                                                                exchange.get(Endpoint.class)));
+                                                                exchange.getEndpoint()));
 
                     if (chain != null && !chain.doIntercept(partialResponse) 
                         && partialResponse.getContent(Exception.class) != null) {
@@ -220,7 +220,7 @@ final class InternalContextUtils {
 
     private static Destination createDecoupledDestination(
         Exchange exchange, final EndpointReferenceType reference) {
-        final EndpointInfo ei = exchange.get(Endpoint.class).getEndpointInfo();
+        final EndpointInfo ei = exchange.getEndpoint().getEndpointInfo();
         return new DecoupledDestination(ei, reference);
     }
     
@@ -250,12 +250,12 @@ final class InternalContextUtils {
      * @return
      */
     private static Executor getExecutor(final Message message) {
-        Endpoint endpoint = message.getExchange().get(Endpoint.class);
+        Endpoint endpoint = message.getExchange().getEndpoint();
         Executor executor = endpoint.getService().getExecutor();
         
         if (executor == null || SynchronousExecutor.isA(executor)) {
             // need true asynchrony
-            Bus bus = message.getExchange().get(Bus.class);
+            Bus bus = message.getExchange().getBus();
             if (bus != null) {
                 WorkQueueManager workQueueManager =
                     bus.getExtension(WorkQueueManager.class);

--- a/rt/ws/rm/src/main/java/org/apache/cxf/ws/rm/RMCaptureOutInterceptor.java
+++ b/rt/ws/rm/src/main/java/org/apache/cxf/ws/rm/RMCaptureOutInterceptor.java
@@ -341,7 +341,6 @@ public class RMCaptureOutInterceptor extends AbstractRMInterceptor<Message>  {
         
         newex.put(BindingInfo.class, bi);
         newex.put(BindingOperationInfo.class, boi);
-        newex.put(OperationInfo.class, boi.getOperationInfo());
         
         msg.setExchange(newex);
         newex.setOutMessage(msg);

--- a/rt/ws/rm/src/main/java/org/apache/cxf/ws/rm/RMManager.java
+++ b/rt/ws/rm/src/main/java/org/apache/cxf/ws/rm/RMManager.java
@@ -53,9 +53,6 @@ import org.apache.cxf.message.Message;
 import org.apache.cxf.message.MessageImpl;
 import org.apache.cxf.phase.PhaseInterceptorChain;
 import org.apache.cxf.service.Service;
-import org.apache.cxf.service.model.BindingInfo;
-import org.apache.cxf.service.model.InterfaceInfo;
-import org.apache.cxf.service.model.ServiceInfo;
 import org.apache.cxf.transport.Conduit;
 import org.apache.cxf.ws.addressing.AddressingProperties;
 import org.apache.cxf.ws.addressing.ContextUtils;
@@ -312,7 +309,7 @@ public class RMManager {
     // The real stuff ...
 
     public RMEndpoint getReliableEndpoint(Message message) throws RMException {
-        Endpoint endpoint = message.getExchange().get(Endpoint.class);
+        Endpoint endpoint = message.getExchange().getEndpoint();
         QName name = endpoint.getEndpointInfo().getName();
         if (LOG.isLoggable(Level.FINE)) {
             LOG.fine("Getting RMEndpoint for endpoint with info: " + name);
@@ -380,7 +377,7 @@ public class RMManager {
                     AddressingProperties maps = RMContextUtils.retrieveMAPs(message, false, false);
                     replyTo = maps.getReplyTo();
                 }
-                Endpoint ei = message.getExchange().get(Endpoint.class);
+                Endpoint ei = message.getExchange().getEndpoint();
                 org.apache.cxf.transport.Destination dest 
                     = ei == null ? null : ei.getEndpointInfo()
                         .getProperty(MAPAggregator.DECOUPLED_DESTINATION, 
@@ -437,7 +434,7 @@ public class RMManager {
                 to = RMUtils.createReference(maps.getTo().getValue());
                 acksTo = maps.getReplyTo();
                 if (RMUtils.getAddressingConstants().getNoneURI().equals(acksTo.getAddress().getValue())) {
-                    Endpoint ei = message.getExchange().get(Endpoint.class);
+                    Endpoint ei = message.getExchange().getEndpoint();
                     org.apache.cxf.transport.Destination dest 
                         = ei == null ? null : ei.getEndpointInfo()
                                 .getProperty(MAPAggregator.DECOUPLED_DESTINATION, 
@@ -590,12 +587,7 @@ public class RMManager {
             }
             exchange.put(Endpoint.class, endpoint);
             exchange.put(Service.class, endpoint.getService());
-            if (endpoint.getEndpointInfo().getService() != null) {
-                exchange.put(ServiceInfo.class, endpoint.getEndpointInfo().getService());
-                exchange.put(InterfaceInfo.class, endpoint.getEndpointInfo().getService().getInterface());
-            }
             exchange.put(Binding.class, endpoint.getBinding());
-            exchange.put(BindingInfo.class, endpoint.getEndpointInfo().getBinding());
             exchange.put(Bus.class, bus);
             
             SequenceType st = new SequenceType();

--- a/rt/ws/rm/src/main/java/org/apache/cxf/ws/rm/Servant.java
+++ b/rt/ws/rm/src/main/java/org/apache/cxf/ws/rm/Servant.java
@@ -67,7 +67,7 @@ public class Servant implements Invoker {
     public Object invoke(Exchange exchange, Object o) {
         LOG.fine("Invoking on RM Endpoint");
         final ProtocolVariation protocol = RMContextUtils.getProtocolVariation(exchange.getInMessage());
-        OperationInfo oi = exchange.get(OperationInfo.class);
+        OperationInfo oi = exchange.getBindingOperationInfo().getOperationInfo();
         if (null == oi) {
             LOG.fine("No operation info."); 
             return null;
@@ -83,7 +83,7 @@ public class Servant implements Invoker {
                 LOG.log(Level.WARNING, "Sequence creation rejected", ex);
                 SequenceFault sf = 
                     new SequenceFaultFactory(protocol.getConstants()).createCreateSequenceRefusedFault();
-                Endpoint e = exchange.get(Endpoint.class);
+                Endpoint e = exchange.getEndpoint();
                 Binding b = null == e ? null : e.getBinding();
                 if (null != b) {
                     RMManager m = reliableEndpoint.getManager();

--- a/rt/ws/rm/src/main/java/org/apache/cxf/ws/rm/soap/RMSoapInInterceptor.java
+++ b/rt/ws/rm/src/main/java/org/apache/cxf/ws/rm/soap/RMSoapInInterceptor.java
@@ -53,7 +53,6 @@ import org.apache.cxf.phase.PhaseInterceptor;
 import org.apache.cxf.service.Service;
 import org.apache.cxf.service.model.BindingInfo;
 import org.apache.cxf.service.model.BindingOperationInfo;
-import org.apache.cxf.service.model.OperationInfo;
 import org.apache.cxf.ws.addressing.AddressingProperties;
 import org.apache.cxf.ws.addressing.AttributedURIType;
 import org.apache.cxf.ws.addressing.ContextUtils;
@@ -303,7 +302,6 @@ public class RMSoapInInterceptor extends AbstractSoapInterceptor {
             LOG.fine("No BindingInfo for action " + action);
         } else {
             exchange.put(BindingOperationInfo.class, boi);
-            exchange.put(OperationInfo.class, boi.getOperationInfo());
             exchange.setOneWay(isOneway); 
         }
         

--- a/rt/ws/rm/src/main/java/org/apache/cxf/ws/rm/soap/RetransmissionQueueImpl.java
+++ b/rt/ws/rm/src/main/java/org/apache/cxf/ws/rm/soap/RetransmissionQueueImpl.java
@@ -458,7 +458,7 @@ public class RetransmissionQueueImpl implements RetransmissionQueue {
         protected void initiate(boolean requestAcknowledge) {
             includeAckRequested = requestAcknowledge;
             pending = true;
-            Endpoint ep = message.getExchange().get(Endpoint.class);
+            Endpoint ep = message.getExchange().getEndpoint();
             Executor executor = ep.getExecutor();
             if (null == executor) {
                 executor = ep.getService().getExecutor();

--- a/rt/ws/rm/src/test/java/org/apache/cxf/ws/rm/AbstractRMInterceptorTest.java
+++ b/rt/ws/rm/src/test/java/org/apache/cxf/ws/rm/AbstractRMInterceptorTest.java
@@ -84,7 +84,7 @@ public class AbstractRMInterceptorTest extends Assert {
         Exchange ex = control.createMock(Exchange.class);
         EasyMock.expect(message.getExchange()).andReturn(ex).anyTimes();
         Endpoint e = control.createMock(Endpoint.class);
-        EasyMock.expect(ex.get(Endpoint.class)).andReturn(e);
+        EasyMock.expect(ex.getEndpoint()).andReturn(e);
         EasyMock.expect(e.getBinding()).andReturn(null);
         control.replay();
         try {
@@ -104,7 +104,7 @@ public class AbstractRMInterceptorTest extends Assert {
         Exchange ex = control.createMock(Exchange.class);
         EasyMock.expect(message.getExchange()).andReturn(ex).anyTimes();
         Endpoint e = control.createMock(Endpoint.class);
-        EasyMock.expect(ex.get(Endpoint.class)).andReturn(e);
+        EasyMock.expect(ex.getEndpoint()).andReturn(e);
         Binding b = control.createMock(Binding.class);
         EasyMock.expect(e.getBinding()).andReturn(b);        
         RMManager mgr = control.createMock(RMManager.class);

--- a/rt/ws/rm/src/test/java/org/apache/cxf/ws/rm/ManagedRMManagerTest.java
+++ b/rt/ws/rm/src/test/java/org/apache/cxf/ws/rm/ManagedRMManagerTest.java
@@ -458,7 +458,7 @@ public class ManagedRMManagerTest extends Assert {
         Exchange exchange = control.createMock(Exchange.class);
         
         EasyMock.expect(message.getExchange()).andReturn(exchange).anyTimes();
-        EasyMock.expect(exchange.get(Endpoint.class)).andReturn(endpoint);
+        EasyMock.expect(exchange.getEndpoint()).andReturn(endpoint);
         
         control.replay();
         return manager.getReliableEndpoint(message);

--- a/rt/ws/rm/src/test/java/org/apache/cxf/ws/rm/RMInInterceptorTest.java
+++ b/rt/ws/rm/src/test/java/org/apache/cxf/ws/rm/RMInInterceptorTest.java
@@ -403,7 +403,7 @@ public class RMInInterceptorTest extends Assert {
         Endpoint ep = control.createMock(Endpoint.class);
         EndpointInfo epi = control.createMock(EndpointInfo.class);
         EasyMock.expect(ep.getEndpointInfo()).andReturn(epi).anyTimes();
-        EasyMock.expect(exchange.get(Endpoint.class)).andReturn(ep).anyTimes();
+        EasyMock.expect(exchange.getEndpoint()).andReturn(ep).anyTimes();
         EasyMock.expect(maps.getFaultTo())
             .andReturn(RMUtils.createReference("http://localhost:9999/decoupled")).anyTimes();
         EasyMock.expect(message.get(JAXWSAConstants.ADDRESSING_PROPERTIES_INBOUND)).andReturn(maps);

--- a/rt/ws/rm/src/test/java/org/apache/cxf/ws/rm/RMManagerTest.java
+++ b/rt/ws/rm/src/test/java/org/apache/cxf/ws/rm/RMManagerTest.java
@@ -221,7 +221,7 @@ public class RMManagerTest extends Assert {
         Exchange exchange = control.createMock(Exchange.class);
         EasyMock.expect(message.getExchange()).andReturn(exchange).anyTimes();
         WrappedEndpoint wre = control.createMock(WrappedEndpoint.class);
-        EasyMock.expect(exchange.get(Endpoint.class)).andReturn(wre).anyTimes();
+        EasyMock.expect(exchange.getEndpoint()).andReturn(wre).anyTimes();
         EndpointInfo ei = control.createMock(EndpointInfo.class);
         EasyMock.expect(wre.getEndpointInfo()).andReturn(ei).anyTimes();
         QName name = RM10Constants.PORT_NAME;
@@ -250,7 +250,7 @@ public class RMManagerTest extends Assert {
 
         control.reset();
         EasyMock.expect(message.getExchange()).andReturn(exchange);
-        EasyMock.expect(exchange.get(Endpoint.class)).andReturn(wre);
+        EasyMock.expect(exchange.getEndpoint()).andReturn(wre);
         EasyMock.expect(wre.getEndpointInfo()).andReturn(ei);
         EasyMock.expect(ei.getName()).andReturn(name);
         EasyMock.expect(wre.getWrappedEndpoint()).andReturn(e); 
@@ -270,7 +270,7 @@ public class RMManagerTest extends Assert {
         Exchange exchange = control.createMock(Exchange.class);
         EasyMock.expect(message.getExchange()).andReturn(exchange).anyTimes();
         Endpoint endpoint = control.createMock(Endpoint.class);
-        EasyMock.expect(exchange.get(Endpoint.class)).andReturn(endpoint);
+        EasyMock.expect(exchange.getEndpoint()).andReturn(endpoint);
         EndpointInfo ei = control.createMock(EndpointInfo.class);
         EasyMock.expect(endpoint.getEndpointInfo()).andReturn(ei);
         QName name = new QName("http://x.y.z/a", "GreeterPort");
@@ -290,7 +290,7 @@ public class RMManagerTest extends Assert {
 
         control.reset();
         EasyMock.expect(message.getExchange()).andReturn(exchange);
-        EasyMock.expect(exchange.get(Endpoint.class)).andReturn(endpoint);
+        EasyMock.expect(exchange.getEndpoint()).andReturn(endpoint);
         EasyMock.expect(endpoint.getEndpointInfo()).andReturn(ei);
         EasyMock.expect(ei.getName()).andReturn(name);
     
@@ -313,7 +313,7 @@ public class RMManagerTest extends Assert {
         Exchange exchange = control.createMock(Exchange.class);
         EasyMock.expect(message.getExchange()).andReturn(exchange);
         Endpoint endpoint = control.createMock(Endpoint.class);
-        EasyMock.expect(exchange.get(Endpoint.class)).andReturn(endpoint);
+        EasyMock.expect(exchange.getEndpoint()).andReturn(endpoint);
         EndpointInfo ei = control.createMock(EndpointInfo.class);
         EasyMock.expect(endpoint.getEndpointInfo()).andReturn(ei);
         QName name = new QName("http://x.y.z/a", "GreeterPort");

--- a/rt/ws/security/src/main/java/org/apache/cxf/ws/security/policy/interceptors/KerberosTokenInterceptorProvider.java
+++ b/rt/ws/security/src/main/java/org/apache/cxf/ws/security/policy/interceptors/KerberosTokenInterceptorProvider.java
@@ -30,7 +30,6 @@ import javax.crypto.SecretKey;
 import javax.xml.namespace.QName;
 
 import org.apache.cxf.common.logging.LogUtils;
-import org.apache.cxf.endpoint.Endpoint;
 import org.apache.cxf.helpers.CastUtils;
 import org.apache.cxf.interceptor.Fault;
 import org.apache.cxf.message.Message;
@@ -126,7 +125,7 @@ public class KerberosTokenInterceptorProvider extends AbstractPolicyInterceptorP
                         for (AssertionInfo ai : ais) {
                             ai.setAsserted(true);
                         }
-                        message.getExchange().get(Endpoint.class).put(SecurityConstants.TOKEN_ID, 
+                        message.getExchange().getEndpoint().put(SecurityConstants.TOKEN_ID, 
                                                                       tok.getId());
                         message.getExchange().put(SecurityConstants.TOKEN_ID, 
                                                   tok.getId());

--- a/rt/ws/security/src/main/java/org/apache/cxf/ws/security/policy/interceptors/STSInvoker.java
+++ b/rt/ws/security/src/main/java/org/apache/cxf/ws/security/policy/interceptors/STSInvoker.java
@@ -30,7 +30,6 @@ import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.Node;
 import org.apache.cxf.common.logging.LogUtils;
-import org.apache.cxf.endpoint.Endpoint;
 import org.apache.cxf.helpers.DOMUtils;
 import org.apache.cxf.interceptor.Fault;
 import org.apache.cxf.message.Exchange;
@@ -168,7 +167,7 @@ abstract class STSInvoker implements Invoker {
         }
         writer.writeStartElement(prefix, "RequestSecurityTokenResponse", namespace);
         
-        TokenStore store = (TokenStore)exchange.get(Endpoint.class).getEndpointInfo()
+        TokenStore store = (TokenStore)exchange.getEndpoint().getEndpointInfo()
                 .getProperty(TokenStore.class.getName());
         store.remove(cancelToken.getId());
         // Put the token on the out message so that we can sign the response
@@ -192,7 +191,7 @@ abstract class STSInvoker implements Invoker {
                 new SecurityTokenReference(childElement, new BSPEnforcer());
             uri = ref.getReference().getURI();
         }
-        TokenStore store = (TokenStore)exchange.get(Endpoint.class).getEndpointInfo()
+        TokenStore store = (TokenStore)exchange.getEndpoint().getEndpointInfo()
                 .getProperty(TokenStore.class.getName());
         return store.getToken(uri);
     }

--- a/rt/ws/security/src/main/java/org/apache/cxf/ws/security/policy/interceptors/STSTokenHelper.java
+++ b/rt/ws/security/src/main/java/org/apache/cxf/ws/security/policy/interceptors/STSTokenHelper.java
@@ -26,7 +26,6 @@ import java.util.logging.Logger;
 
 import org.w3c.dom.Element;
 import org.apache.cxf.common.logging.LogUtils;
-import org.apache.cxf.endpoint.Endpoint;
 import org.apache.cxf.interceptor.Fault;
 import org.apache.cxf.message.Message;
 import org.apache.cxf.message.MessageUtils;
@@ -83,10 +82,10 @@ public final class STSTokenHelper {
                                               true)
                 && !isOneTimeUse(tok);
         if (cacheIssuedToken) {
-            message.getExchange().get(Endpoint.class).put(SecurityConstants.TOKEN, tok);
+            message.getExchange().getEndpoint().put(SecurityConstants.TOKEN, tok);
             message.getExchange().put(SecurityConstants.TOKEN, tok);
             message.getExchange().put(SecurityConstants.TOKEN_ID, tok.getId());
-            message.getExchange().get(Endpoint.class).put(SecurityConstants.TOKEN_ID,
+            message.getExchange().getEndpoint().put(SecurityConstants.TOKEN_ID,
                                                           tok.getId());
         } else {
             message.put(SecurityConstants.TOKEN, tok);
@@ -204,8 +203,8 @@ public final class STSTokenHelper {
         }
 
         // Remove token from cache
-        message.getExchange().get(Endpoint.class).remove(SecurityConstants.TOKEN);
-        message.getExchange().get(Endpoint.class).remove(SecurityConstants.TOKEN_ID);
+        message.getExchange().getEndpoint().remove(SecurityConstants.TOKEN);
+        message.getExchange().getEndpoint().remove(SecurityConstants.TOKEN_ID);
         message.getExchange().remove(SecurityConstants.TOKEN_ID);
         message.getExchange().remove(SecurityConstants.TOKEN);
         TokenStoreUtils.getTokenStore(message).remove(tok.getId());

--- a/rt/ws/security/src/main/java/org/apache/cxf/ws/security/policy/interceptors/SecureConversationInInterceptor.java
+++ b/rt/ws/security/src/main/java/org/apache/cxf/ws/security/policy/interceptors/SecureConversationInInterceptor.java
@@ -32,7 +32,6 @@ import org.w3c.dom.Element;
 import org.apache.cxf.binding.soap.SoapBindingConstants;
 import org.apache.cxf.binding.soap.SoapMessage;
 import org.apache.cxf.binding.soap.interceptor.SoapActionInInterceptor;
-import org.apache.cxf.endpoint.Endpoint;
 import org.apache.cxf.helpers.DOMUtils;
 import org.apache.cxf.interceptor.Fault;
 import org.apache.cxf.message.Exchange;
@@ -359,7 +358,7 @@ class SecureConversationInInterceptor extends AbstractPhaseInterceptor<SoapMessa
             writer.writeStartElement(prefix, "RequestedSecurityToken", namespace);
             SecurityContextToken sct;
             if (tokenIdToRenew != null) {
-                ((TokenStore)exchange.get(Endpoint.class).getEndpointInfo()
+                ((TokenStore)exchange.getEndpoint().getEndpointInfo()
                     .getProperty(TokenStore.class.getName())).remove(tokenIdToRenew);
                 sct = new SecurityContextToken(
                         NegotiationUtils.getWSCVersion(tokenType), writer.getDocument(),
@@ -415,7 +414,7 @@ class SecureConversationInInterceptor extends AbstractPhaseInterceptor<SoapMessa
                 token.setProperties(properties);
             }
 
-            ((TokenStore)exchange.get(Endpoint.class).getEndpointInfo()
+            ((TokenStore)exchange.getEndpoint().getEndpointInfo()
                     .getProperty(TokenStore.class.getName())).add(token);
 
 

--- a/rt/ws/security/src/main/java/org/apache/cxf/ws/security/policy/interceptors/SecureConversationOutInterceptor.java
+++ b/rt/ws/security/src/main/java/org/apache/cxf/ws/security/policy/interceptors/SecureConversationOutInterceptor.java
@@ -26,7 +26,6 @@ import java.util.logging.Logger;
 
 import org.apache.cxf.binding.soap.SoapMessage;
 import org.apache.cxf.common.logging.LogUtils;
-import org.apache.cxf.endpoint.Endpoint;
 import org.apache.cxf.interceptor.Fault;
 import org.apache.cxf.message.Message;
 import org.apache.cxf.message.MessageUtils;
@@ -87,8 +86,8 @@ class SecureConversationOutInterceptor extends AbstractPhaseInterceptor<SoapMess
                     for (AssertionInfo ai : ais) {
                         ai.setAsserted(true);
                     }
-                    message.getExchange().get(Endpoint.class).put(SecurityConstants.TOKEN, tok);
-                    message.getExchange().get(Endpoint.class).put(SecurityConstants.TOKEN_ID, tok.getId());
+                    message.getExchange().getEndpoint().put(SecurityConstants.TOKEN, tok);
+                    message.getExchange().getEndpoint().put(SecurityConstants.TOKEN_ID, tok.getId());
                     message.getExchange().put(SecurityConstants.TOKEN_ID, tok.getId());
                     message.getExchange().put(SecurityConstants.TOKEN, tok);
                     TokenStoreUtils.getTokenStore(message).add(tok);
@@ -114,8 +113,8 @@ class SecureConversationOutInterceptor extends AbstractPhaseInterceptor<SoapMess
         }
         
         // Remove the old token
-        message.getExchange().get(Endpoint.class).remove(SecurityConstants.TOKEN);
-        message.getExchange().get(Endpoint.class).remove(SecurityConstants.TOKEN_ID);
+        message.getExchange().getEndpoint().remove(SecurityConstants.TOKEN);
+        message.getExchange().getEndpoint().remove(SecurityConstants.TOKEN_ID);
         message.getExchange().remove(SecurityConstants.TOKEN_ID);
         message.getExchange().remove(SecurityConstants.TOKEN);
         TokenStoreUtils.getTokenStore(message).remove(tok.getId());

--- a/rt/ws/security/src/main/java/org/apache/cxf/ws/security/policy/interceptors/SpnegoContextTokenInInterceptor.java
+++ b/rt/ws/security/src/main/java/org/apache/cxf/ws/security/policy/interceptors/SpnegoContextTokenInInterceptor.java
@@ -29,7 +29,6 @@ import org.w3c.dom.Element;
 import org.apache.cxf.binding.soap.SoapBindingConstants;
 import org.apache.cxf.binding.soap.SoapMessage;
 import org.apache.cxf.binding.soap.interceptor.SoapActionInInterceptor;
-import org.apache.cxf.endpoint.Endpoint;
 import org.apache.cxf.helpers.DOMUtils;
 import org.apache.cxf.interceptor.Fault;
 import org.apache.cxf.message.Exchange;
@@ -253,7 +252,7 @@ class SpnegoContextTokenInInterceptor extends AbstractPhaseInterceptor<SoapMessa
             spnegoToken.clear();
             
             token.setSecret(secret);
-            ((TokenStore)exchange.get(Endpoint.class).getEndpointInfo()
+            ((TokenStore)exchange.getEndpoint().getEndpointInfo()
                     .getProperty(TokenStore.class.getName())).add(token);
         }
 

--- a/rt/ws/security/src/main/java/org/apache/cxf/ws/security/policy/interceptors/SpnegoContextTokenOutInterceptor.java
+++ b/rt/ws/security/src/main/java/org/apache/cxf/ws/security/policy/interceptors/SpnegoContextTokenOutInterceptor.java
@@ -24,7 +24,6 @@ import java.util.Collection;
 import javax.security.auth.callback.CallbackHandler;
 
 import org.apache.cxf.binding.soap.SoapMessage;
-import org.apache.cxf.endpoint.Endpoint;
 import org.apache.cxf.interceptor.Fault;
 import org.apache.cxf.phase.AbstractPhaseInterceptor;
 import org.apache.cxf.phase.Phase;
@@ -65,7 +64,7 @@ class SpnegoContextTokenOutInterceptor extends AbstractPhaseInterceptor<SoapMess
                     tok = TokenStoreUtils.getTokenStore(message).getToken(tokId);
                     
                     if (tok != null && tok.isExpired()) {
-                        message.getExchange().get(Endpoint.class).remove(SecurityConstants.TOKEN_ID);
+                        message.getExchange().getEndpoint().remove(SecurityConstants.TOKEN_ID);
                         message.getExchange().remove(SecurityConstants.TOKEN_ID);
                         TokenStoreUtils.getTokenStore(message).remove(tokId);
                         tok = null;
@@ -79,7 +78,7 @@ class SpnegoContextTokenOutInterceptor extends AbstractPhaseInterceptor<SoapMess
                     for (AssertionInfo ai : ais) {
                         ai.setAsserted(true);
                     }
-                    message.getExchange().get(Endpoint.class).put(SecurityConstants.TOKEN_ID, tok.getId());
+                    message.getExchange().getEndpoint().put(SecurityConstants.TOKEN_ID, tok.getId());
                     message.getExchange().put(SecurityConstants.TOKEN_ID, tok.getId());
                     TokenStoreUtils.getTokenStore(message).add(tok);
                 }

--- a/rt/ws/security/src/main/java/org/apache/cxf/ws/security/tokenstore/TokenStoreUtils.java
+++ b/rt/ws/security/src/main/java/org/apache/cxf/ws/security/tokenstore/TokenStoreUtils.java
@@ -18,7 +18,6 @@
  */
 package org.apache.cxf.ws.security.tokenstore;
 
-import org.apache.cxf.endpoint.Endpoint;
 import org.apache.cxf.message.Message;
 import org.apache.cxf.service.model.EndpointInfo;
 import org.apache.cxf.ws.security.SecurityConstants;
@@ -33,7 +32,7 @@ public final class TokenStoreUtils {
     }
 
     public static TokenStore getTokenStore(Message message) {
-        EndpointInfo info = message.getExchange().get(Endpoint.class).getEndpointInfo();
+        EndpointInfo info = message.getExchange().getEndpoint().getEndpointInfo();
         synchronized (info) {
             TokenStore tokenStore = 
                 (TokenStore)message.getContextualProperty(SecurityConstants.TOKEN_STORE_CACHE_INSTANCE);

--- a/rt/ws/security/src/main/java/org/apache/cxf/ws/security/trust/STSUtils.java
+++ b/rt/ws/security/src/main/java/org/apache/cxf/ws/security/trust/STSUtils.java
@@ -107,7 +107,7 @@ public final class STSUtils {
             .getContextualProperty(SecurityConstants.STS_CLIENT);
         if (client == null) {
             client = createSTSClient(message, type);
-            Bus bus = message.getExchange().get(Bus.class);
+            Bus bus = message.getExchange().getBus();
             
             // Check for the "default" case first
             bus.getExtension(Configurer.class).configureBean("default.sts-client", client);
@@ -166,8 +166,8 @@ public final class STSUtils {
         } else {
             type = "." + type + "-client";
         }
-        STSClient client = new STSClient(message.getExchange().get(Bus.class));
-        Endpoint ep = message.getExchange().get(Endpoint.class);
+        STSClient client = new STSClient(message.getExchange().getBus());
+        Endpoint ep = message.getExchange().getEndpoint();
         client.setEndpointName(ep.getEndpointInfo().getName().toString() + type);
         client.setBeanName(ep.getEndpointInfo().getName().toString() + type);
         if (MessageUtils.getContextualBoolean(message, SecurityConstants.STS_CLIENT_SOAP12_BINDING, false)) {

--- a/rt/ws/security/src/main/java/org/apache/cxf/ws/security/wss4j/AbstractTokenInterceptor.java
+++ b/rt/ws/security/src/main/java/org/apache/cxf/ws/security/wss4j/AbstractTokenInterceptor.java
@@ -35,7 +35,6 @@ import org.apache.cxf.binding.soap.SoapMessage;
 import org.apache.cxf.binding.soap.interceptor.AbstractSoapInterceptor;
 import org.apache.cxf.common.i18n.Message;
 import org.apache.cxf.common.logging.LogUtils;
-import org.apache.cxf.endpoint.Endpoint;
 import org.apache.cxf.headers.Header;
 import org.apache.cxf.helpers.DOMUtils;
 import org.apache.cxf.interceptor.Fault;
@@ -140,7 +139,7 @@ public abstract class AbstractTokenInterceptor extends AbstractSoapInterceptor {
     }
     
     protected TokenStore getTokenStore(SoapMessage message) {
-        EndpointInfo info = message.getExchange().get(Endpoint.class).getEndpointInfo();
+        EndpointInfo info = message.getExchange().getEndpoint().getEndpointInfo();
         synchronized (info) {
             TokenStore tokenStore = 
                 (TokenStore)message.getContextualProperty(SecurityConstants.TOKEN_STORE_CACHE_INSTANCE);

--- a/rt/ws/security/src/main/java/org/apache/cxf/ws/security/wss4j/AbstractWSS4JStaxInterceptor.java
+++ b/rt/ws/security/src/main/java/org/apache/cxf/ws/security/wss4j/AbstractWSS4JStaxInterceptor.java
@@ -41,7 +41,6 @@ import javax.xml.namespace.QName;
 import org.apache.cxf.binding.soap.SoapMessage;
 import org.apache.cxf.binding.soap.interceptor.SoapInterceptor;
 import org.apache.cxf.common.logging.LogUtils;
-import org.apache.cxf.endpoint.Endpoint;
 import org.apache.cxf.interceptor.Fault;
 import org.apache.cxf.message.Message;
 import org.apache.cxf.message.MessageUtils;
@@ -203,11 +202,11 @@ public abstract class AbstractWSS4JStaxInterceptor implements SoapInterceptor,
         }
             
         if (callbackHandler != null) {
-            EndpointInfo info = soapMessage.getExchange().get(Endpoint.class).getEndpointInfo();
+            EndpointInfo info = soapMessage.getExchange().getEndpoint().getEndpointInfo();
             synchronized (info) {
                 info.setProperty(SecurityConstants.CALLBACK_HANDLER, callbackHandler);
             }
-            soapMessage.getExchange().get(Endpoint.class).put(SecurityConstants.CALLBACK_HANDLER, 
+            soapMessage.getExchange().getEndpoint().put(SecurityConstants.CALLBACK_HANDLER, 
                                                               callbackHandler);
             soapMessage.getExchange().put(SecurityConstants.CALLBACK_HANDLER, callbackHandler);
         }

--- a/rt/ws/security/src/main/java/org/apache/cxf/ws/security/wss4j/PolicyBasedWSS4JInInterceptor.java
+++ b/rt/ws/security/src/main/java/org/apache/cxf/ws/security/wss4j/PolicyBasedWSS4JInInterceptor.java
@@ -133,17 +133,20 @@ public class PolicyBasedWSS4JInInterceptor extends WSS4JInInterceptor {
             signCrypto = getSignatureCrypto(s, message, data);
         }
         
+        final String signCryptoRefId = signCrypto != null ? "RefId-" + signCrypto.hashCode() : null;
+        
         if (signCrypto != null) {
-            message.put(WSHandlerConstants.DEC_PROP_REF_ID, "RefId-" + signCrypto.hashCode());
-            message.put("RefId-" + signCrypto.hashCode(), signCrypto);
+            message.put(WSHandlerConstants.DEC_PROP_REF_ID, signCryptoRefId);
+            message.put(signCryptoRefId, signCrypto);
         }
         
         if (encrCrypto != null) {
-            message.put(WSHandlerConstants.SIG_VER_PROP_REF_ID, "RefId-" + encrCrypto.hashCode());
-            message.put("RefId-" + encrCrypto.hashCode(), (Crypto)encrCrypto);
+            final String encCryptoRefId = "RefId-" + encrCrypto.hashCode();
+            message.put(WSHandlerConstants.SIG_VER_PROP_REF_ID, encCryptoRefId);
+            message.put(encCryptoRefId, (Crypto)encrCrypto);
         } else if (signCrypto != null) {
-            message.put(WSHandlerConstants.SIG_VER_PROP_REF_ID, "RefId-" + signCrypto.hashCode());
-            message.put("RefId-" + signCrypto.hashCode(), (Crypto)signCrypto);
+            message.put(WSHandlerConstants.SIG_VER_PROP_REF_ID, signCryptoRefId);
+            message.put(signCryptoRefId, (Crypto)signCrypto);
         }
      
         return action;
@@ -171,17 +174,19 @@ public class PolicyBasedWSS4JInInterceptor extends WSS4JInInterceptor {
             signCrypto = getSignatureCrypto(s, message, data);
         }
         
+        final String signCryptoRefId = signCrypto != null ? "RefId-" + signCrypto.hashCode() : null;
         if (signCrypto != null) {
-            message.put(WSHandlerConstants.DEC_PROP_REF_ID, "RefId-" + signCrypto.hashCode());
-            message.put("RefId-" + signCrypto.hashCode(), signCrypto);
+            message.put(WSHandlerConstants.DEC_PROP_REF_ID, signCryptoRefId);
+            message.put(signCryptoRefId, signCrypto);
         }
         
         if (encrCrypto != null) {
-            message.put(WSHandlerConstants.SIG_VER_PROP_REF_ID, "RefId-" + encrCrypto.hashCode());
-            message.put("RefId-" + encrCrypto.hashCode(), (Crypto)encrCrypto);
+            final String encCryptoRefId = "RefId-" + encrCrypto.hashCode();
+            message.put(WSHandlerConstants.SIG_VER_PROP_REF_ID, encCryptoRefId);
+            message.put(encCryptoRefId, (Crypto)encrCrypto);
         } else if (signCrypto != null) {
-            message.put(WSHandlerConstants.SIG_VER_PROP_REF_ID, "RefId-" + signCrypto.hashCode());
-            message.put("RefId-" + signCrypto.hashCode(), (Crypto)signCrypto);
+            message.put(WSHandlerConstants.SIG_VER_PROP_REF_ID, signCryptoRefId);
+            message.put(signCryptoRefId, (Crypto)signCrypto);
         }
 
         return action;
@@ -284,8 +289,9 @@ public class PolicyBasedWSS4JInInterceptor extends WSS4JInInterceptor {
                 crypto = signCrypto;
             }
             if (crypto != null) {
-                message.put(WSHandlerConstants.SIG_VER_PROP_REF_ID, "RefId-" + crypto.hashCode());
-                message.put("RefId-" + crypto.hashCode(), crypto);
+                final String refId = "RefId-" + crypto.hashCode();
+                message.put(WSHandlerConstants.SIG_VER_PROP_REF_ID, refId);
+                message.put(refId, crypto);
             }
             
             crypto = signCrypto;
@@ -293,8 +299,9 @@ public class PolicyBasedWSS4JInInterceptor extends WSS4JInInterceptor {
                 crypto = encrCrypto;
             }
             if (crypto != null) {
-                message.put(WSHandlerConstants.DEC_PROP_REF_ID, "RefId-" + crypto.hashCode());
-                message.put("RefId-" + crypto.hashCode(), crypto);
+                final String refId = "RefId-" + crypto.hashCode();
+                message.put(WSHandlerConstants.DEC_PROP_REF_ID, refId);
+                message.put(refId, crypto);
             }
         } else {
             Crypto crypto = signCrypto;
@@ -302,8 +309,9 @@ public class PolicyBasedWSS4JInInterceptor extends WSS4JInInterceptor {
                 crypto = encrCrypto;
             }
             if (crypto != null) {
-                message.put(WSHandlerConstants.SIG_VER_PROP_REF_ID, "RefId-" + crypto.hashCode());
-                message.put("RefId-" + crypto.hashCode(), crypto);
+                final String refId = "RefId-" + crypto.hashCode();
+                message.put(WSHandlerConstants.SIG_VER_PROP_REF_ID, refId);
+                message.put(refId, crypto);
             }
             
             crypto = encrCrypto;
@@ -311,8 +319,9 @@ public class PolicyBasedWSS4JInInterceptor extends WSS4JInInterceptor {
                 crypto = signCrypto;
             }
             if (crypto != null) {
-                message.put(WSHandlerConstants.DEC_PROP_REF_ID, "RefId-" + crypto.hashCode());
-                message.put("RefId-" + crypto.hashCode(), crypto);
+                final String refId = "RefId-" + crypto.hashCode();
+                message.put(WSHandlerConstants.DEC_PROP_REF_ID, refId);
+                message.put(refId, crypto);
             }
         }
         

--- a/rt/ws/security/src/main/java/org/apache/cxf/ws/security/wss4j/PolicyBasedWSS4JStaxInInterceptor.java
+++ b/rt/ws/security/src/main/java/org/apache/cxf/ws/security/wss4j/PolicyBasedWSS4JStaxInInterceptor.java
@@ -329,7 +329,7 @@ public class PolicyBasedWSS4JStaxInInterceptor extends WSS4JStaxInInterceptor {
         final List<SecurityEventListener> securityEventListeners = new ArrayList<>(2);
         securityEventListeners.addAll(super.configureSecurityEventListeners(msg, securityProperties));
         
-        Endpoint endoint = msg.getExchange().get(Endpoint.class);
+        Endpoint endoint = msg.getExchange().getEndpoint();
         
         PolicyEnforcer policyEnforcer = createPolicyEnforcer(endoint.getEndpointInfo(), msg);
         securityProperties.addInputProcessor(new PolicyInputProcessor(policyEnforcer, securityProperties));

--- a/rt/ws/security/src/main/java/org/apache/cxf/ws/security/wss4j/WSS4JInInterceptor.java
+++ b/rt/ws/security/src/main/java/org/apache/cxf/ws/security/wss4j/WSS4JInInterceptor.java
@@ -694,7 +694,7 @@ public class WSS4JInInterceptor extends AbstractWSS4JInterceptor {
             try {
                 cbHandler = getPasswordCallbackHandler(reqData);
             } catch (WSSecurityException sec) {
-                Endpoint ep = ((SoapMessage)reqData.getMsgContext()).getExchange().get(Endpoint.class);
+                Endpoint ep = ((SoapMessage)reqData.getMsgContext()).getExchange().getEndpoint();
                 if (ep != null && ep.getEndpointInfo() != null) {
                     TokenStore store = 
                         TokenStoreUtils.getTokenStore((SoapMessage)reqData.getMsgContext());
@@ -704,7 +704,7 @@ public class WSS4JInInterceptor extends AbstractWSS4JInterceptor {
             }
         }
             
-        Endpoint ep = ((SoapMessage)reqData.getMsgContext()).getExchange().get(Endpoint.class);
+        Endpoint ep = ((SoapMessage)reqData.getMsgContext()).getExchange().getEndpoint();
         if (ep != null && ep.getEndpointInfo() != null) {
             TokenStore store = TokenStoreUtils.getTokenStore((SoapMessage)reqData.getMsgContext());
             return new TokenStoreCallbackHandler(cbHandler, store);

--- a/rt/ws/security/src/main/java/org/apache/cxf/ws/security/wss4j/WSS4JUtils.java
+++ b/rt/ws/security/src/main/java/org/apache/cxf/ws/security/wss4j/WSS4JUtils.java
@@ -92,7 +92,7 @@ public final class WSS4JUtils {
         if (!specified && MessageUtils.isRequestor(message)) {
             return null;
         }
-        Endpoint ep = message.getExchange().get(Endpoint.class);
+        Endpoint ep = message.getExchange().getEndpoint();
         if (ep != null && ep.getEndpointInfo() != null) {
             EndpointInfo info = ep.getEndpointInfo();
             synchronized (info) {
@@ -277,7 +277,7 @@ public final class WSS4JUtils {
             encrCrypto = CryptoFactory.getInstance(props, Loader.getClassLoader(CryptoFactory.class),
                                                    passwordEncryptor);
 
-            EndpointInfo info = message.getExchange().get(Endpoint.class).getEndpointInfo();
+            EndpointInfo info = message.getExchange().getEndpoint().getEndpointInfo();
             synchronized (info) {
                 info.setProperty(SecurityConstants.ENCRYPT_CRYPTO, encrCrypto);
             }
@@ -305,7 +305,7 @@ public final class WSS4JUtils {
             signCrypto = CryptoFactory.getInstance(props, Loader.getClassLoader(CryptoFactory.class),
                                                    passwordEncryptor);
 
-            EndpointInfo info = message.getExchange().get(Endpoint.class).getEndpointInfo();
+            EndpointInfo info = message.getExchange().getEndpoint().getEndpointInfo();
             synchronized (info) {
                 info.setProperty(SecurityConstants.SIGNATURE_CRYPTO, signCrypto);
             }

--- a/rt/ws/security/src/main/java/org/apache/cxf/ws/security/wss4j/policyhandlers/AbstractBindingBuilder.java
+++ b/rt/ws/security/src/main/java/org/apache/cxf/ws/security/wss4j/policyhandlers/AbstractBindingBuilder.java
@@ -55,7 +55,6 @@ import org.apache.cxf.binding.soap.SoapMessage;
 import org.apache.cxf.binding.soap.saaj.SAAJUtils;
 import org.apache.cxf.common.logging.LogUtils;
 import org.apache.cxf.common.util.StringUtils;
-import org.apache.cxf.endpoint.Endpoint;
 import org.apache.cxf.helpers.CastUtils;
 import org.apache.cxf.helpers.DOMUtils;
 import org.apache.cxf.helpers.MapNamespaceContext;
@@ -288,7 +287,7 @@ public abstract class AbstractBindingBuilder extends AbstractCommonBindingHandle
     }
     
     protected final Map<Object, Crypto> getCryptoCache() {
-        EndpointInfo info = message.getExchange().get(Endpoint.class).getEndpointInfo();
+        EndpointInfo info = message.getExchange().getEndpoint().getEndpointInfo();
         synchronized (info) {
             Map<Object, Crypto> o = 
                 CastUtils.cast((Map<?, ?>)message.getContextualProperty(CRYPTO_CACHE));

--- a/rt/ws/security/src/test/java/org/apache/cxf/ws/security/wss4j/AbstractPolicySecurityTest.java
+++ b/rt/ws/security/src/test/java/org/apache/cxf/ws/security/wss4j/AbstractPolicySecurityTest.java
@@ -351,12 +351,12 @@ public abstract class AbstractPolicySecurityTest extends AbstractSecurityTest {
         cryptoType.setAlias(alias);
         issuedToken.setX509Certificate(crypto.getX509Certificates(cryptoType)[0], crypto);
         
-        msg.getExchange().get(Endpoint.class).put(SecurityConstants.TOKEN_ID, 
+        msg.getExchange().getEndpoint().put(SecurityConstants.TOKEN_ID, 
                 issuedToken.getId());
         msg.getExchange().put(SecurityConstants.TOKEN_ID, issuedToken.getId());
         
         TokenStore tokenStore = new MemoryTokenStore();
-        msg.getExchange().get(Endpoint.class).getEndpointInfo()
+        msg.getExchange().getEndpoint().getEndpointInfo()
             .setProperty(TokenStore.class.getName(), tokenStore);
         tokenStore.add(issuedToken);
         

--- a/rt/wsdl/src/main/java/org/apache/cxf/wsdl/interceptors/BareInInterceptor.java
+++ b/rt/wsdl/src/main/java/org/apache/cxf/wsdl/interceptors/BareInInterceptor.java
@@ -73,8 +73,8 @@ public class BareInInterceptor extends AbstractInDatabindingInterceptor {
         DataReader<XMLStreamReader> dr = getDataReader(message);
         MessageContentsList parameters = new MessageContentsList();
 
-        Endpoint ep = exchange.get(Endpoint.class);
-        BindingOperationInfo bop = exchange.get(BindingOperationInfo.class);
+        Endpoint ep = exchange.getEndpoint();
+        BindingOperationInfo bop = exchange.getBindingOperationInfo();
         ServiceInfo si = ep.getEndpointInfo().getService();
         // XXX - Should the BindingMessageInfo.class be put on
         // the message?
@@ -95,7 +95,6 @@ public class BareInInterceptor extends AbstractInDatabindingInterceptor {
                     if (bmsg.getMessagePartsNumber() == 0) {
                         BindingOperationInfo boi = ep.getEndpointInfo().getBinding().getOperation(op);
                         exchange.put(BindingOperationInfo.class, boi);
-                        exchange.put(OperationInfo.class, op);
                         exchange.setOneWay(op.isOneWay());
                     }
                 }

--- a/rt/wsdl/src/main/java/org/apache/cxf/wsdl/interceptors/BareOutInterceptor.java
+++ b/rt/wsdl/src/main/java/org/apache/cxf/wsdl/interceptors/BareOutInterceptor.java
@@ -37,8 +37,7 @@ public class BareOutInterceptor extends AbstractOutDatabindingInterceptor {
 
     public void handleMessage(Message message) {
         Exchange exchange = message.getExchange();
-        BindingOperationInfo operation = (BindingOperationInfo)exchange.get(BindingOperationInfo.class
-            .getName());
+        BindingOperationInfo operation = exchange.getBindingOperationInfo();
         
         if (operation == null) {
             return;

--- a/rt/wsdl/src/main/java/org/apache/cxf/wsdl/interceptors/DocLiteralInInterceptor.java
+++ b/rt/wsdl/src/main/java/org/apache/cxf/wsdl/interceptors/DocLiteralInInterceptor.java
@@ -132,7 +132,7 @@ public class DocLiteralInInterceptor extends AbstractInDatabindingInterceptor {
                 BindingMessageInfo msgInfo = null;
 
     
-                Endpoint ep = exchange.get(Endpoint.class);
+                Endpoint ep = exchange.getEndpoint();
                 ServiceInfo si = ep.getEndpointInfo().getService();
                 if (bop != null) { //for xml binding or client side
                     if (client) {
@@ -226,7 +226,6 @@ public class DocLiteralInInterceptor extends AbstractInDatabindingInterceptor {
                     && Constants.XSD_ANYTYPE.equals(bmsg.getFirstMessagePart().getTypeQName()))) {
                 BindingOperationInfo boi = ep.getEndpointInfo().getBinding().getOperation(op);
                 exchange.put(BindingOperationInfo.class, boi);
-                exchange.put(OperationInfo.class, op);
                 exchange.setOneWay(op.isOneWay());
             }
         }
@@ -347,7 +346,6 @@ public class DocLiteralInInterceptor extends AbstractInDatabindingInterceptor {
             
         if (bop != null) {
             exchange.put(BindingOperationInfo.class, bop);
-            exchange.put(OperationInfo.class, bop.getOperationInfo());
         }
         return bop;
     }

--- a/rt/wsdl/src/main/java/org/apache/cxf/wsdl/interceptors/WrappedOutInterceptor.java
+++ b/rt/wsdl/src/main/java/org/apache/cxf/wsdl/interceptors/WrappedOutInterceptor.java
@@ -67,7 +67,7 @@ public class WrappedOutInterceptor extends AbstractOutDatabindingInterceptor {
 
             try {
                 String pfx = null;
-                Service service = message.getExchange().get(Service.class);
+                Service service = message.getExchange().getService();
                 if (service.getDataBinding().getDeclaredNamespaceMappings() != null) {
                     pfx = service.getDataBinding().getDeclaredNamespaceMappings().get(name.getNamespaceURI());
                 }

--- a/systests/jaxws/src/test/java/org/apache/cxf/systest/jaxws/beanpostprocessor/WebServiceRUs.java
+++ b/systests/jaxws/src/test/java/org/apache/cxf/systest/jaxws/beanpostprocessor/WebServiceRUs.java
@@ -44,7 +44,7 @@ public class WebServiceRUs implements IWebServiceRUs {
         MessageContext ctx = injectedContext.getMessageContext();
         WrappedMessageContext wmc = (WrappedMessageContext) ctx;
         org.apache.cxf.message.Message msg = wmc.getWrappedMessage();
-        service = msg.getExchange().get(Service.class);
+        service = msg.getExchange().getService();
     }
     
     @WebMethod(exclude = true)

--- a/systests/transports/src/test/java/org/apache/cxf/systest/https/conduit/PushBack401.java
+++ b/systests/transports/src/test/java/org/apache/cxf/systest/https/conduit/PushBack401.java
@@ -178,7 +178,7 @@ public class PushBack401 extends AbstractPhaseInterceptor<Message> {
         Exchange exchange = message.getExchange();
         Message outMessage = exchange.getOutMessage();
         if (outMessage == null) {
-            Endpoint endpoint = exchange.get(Endpoint.class);
+            Endpoint endpoint = exchange.getEndpoint();
             outMessage = new MessageImpl();
             outMessage.putAll(message);
             outMessage.remove(Message.PROTOCOL_HEADERS);

--- a/systests/uncategorized/src/test/java/org/apache/cxf/systest/clustering/LoadDistributorSequentialStrategy.java
+++ b/systests/uncategorized/src/test/java/org/apache/cxf/systest/clustering/LoadDistributorSequentialStrategy.java
@@ -38,7 +38,7 @@ public class LoadDistributorSequentialStrategy extends SequentialStrategy {
         // This is only required if the client wants to always try one endpoint first,
         // which is not typically desired for a load distributed configuration
         // (but is required by one of the unit tests)        
-        Endpoint endpoint = exchange.get(Endpoint.class);
+        Endpoint endpoint = exchange.getEndpoint();
         String defaultAddress = endpoint.getEndpointInfo().getAddress();
         for (Endpoint alternate : alternateEndpoints) {            
             if (defaultAddress.equals(alternate.getEndpointInfo().getAddress())) {

--- a/systests/ws-specs/src/test/java/org/apache/cxf/systest/ws/policy/PolicyLoggingInterceptor.java
+++ b/systests/ws-specs/src/test/java/org/apache/cxf/systest/ws/policy/PolicyLoggingInterceptor.java
@@ -26,7 +26,6 @@ import java.util.logging.Logger;
 
 import org.apache.cxf.Bus;
 import org.apache.cxf.common.logging.LogUtils;
-import org.apache.cxf.endpoint.Endpoint;
 import org.apache.cxf.interceptor.Fault;
 import org.apache.cxf.message.Message;
 import org.apache.cxf.phase.AbstractPhaseInterceptor;
@@ -55,8 +54,8 @@ public class PolicyLoggingInterceptor extends AbstractPhaseInterceptor<Message> 
     }
     
     public void handleMessage(Message message) throws Fault {
-        EndpointInfo ei = message.getExchange().get(Endpoint.class).getEndpointInfo();
-        BindingOperationInfo boi = message.getExchange().get(BindingOperationInfo.class);
+        EndpointInfo ei = message.getExchange().getEndpoint().getEndpointInfo();
+        BindingOperationInfo boi = message.getExchange().getBindingOperationInfo();
         LOG.fine("Getting effective server request policy for endpoint " + ei
                  + " and binding operation " + boi);
         EffectivePolicy ep = 


### PR DESCRIPTION
* Avoid storing Bus, Service, Endpoint, Binding, BindingOperationInfo into Exchange's map as there're direct accessors for them
* Avoid storing ServiceInfo, InterfaceInfo, BindingInfo into Exchange's map as they're easily retrieved through other stuff in the map
* misc minor cleanups