### PR TITLE
CXF-6464 Add attachment support to derived key sign/encrypt

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -146,7 +146,7 @@
         <cxf.woodstox.core.version>4.4.1</cxf.woodstox.core.version>
         <cxf.woodstox.stax2-api.version>3.1.4</cxf.woodstox.stax2-api.version>
         <cxf.wsdl4j.version>1.6.3</cxf.wsdl4j.version>
-        <cxf.wss4j.version>2.1.1</cxf.wss4j.version>
+        <cxf.wss4j.version>2.1.2-SNAPSHOT</cxf.wss4j.version>
         <cxf.xerces.version>2.11.0</cxf.xerces.version>
         <cxf.xmlbeans.version>2.6.0</cxf.xmlbeans.version>
         <cxf.xmlschema.version>2.2.1</cxf.xmlschema.version>

--- a/rt/ws/security/src/main/java/org/apache/cxf/ws/security/wss4j/policyhandlers/SymmetricBindingHandler.java
+++ b/rt/ws/security/src/main/java/org/apache/cxf/ws/security/wss4j/policyhandlers/SymmetricBindingHandler.java
@@ -403,6 +403,7 @@ public class SymmetricBindingHandler extends AbstractBindingBuilder {
             WSSecDKEncrypt dkEncr = new WSSecDKEncrypt();
             dkEncr.setIdAllocator(wssConfig.getIdAllocator());
             dkEncr.setCallbackLookup(callbackLookup);
+            dkEncr.setAttachmentCallbackHandler(new AttachmentCallbackHandler(message));
             if (recToken.getToken().getVersion() == SPConstants.SPVersion.SP11) {
                 dkEncr.setWscVersion(ConversationConstants.VERSION_05_02);
             }
@@ -486,10 +487,21 @@ public class SymmetricBindingHandler extends AbstractBindingBuilder {
             encrDKTokenElem = dkEncr.getdktElement();
             addDerivedKeyElement(encrDKTokenElem);
             Element refList = dkEncr.encryptForExternalRef(null, encrParts);
+            List<Element> attachments = dkEncr.getAttachmentEncryptedDataElements();
             if (atEnd) {
                 this.insertBeforeBottomUp(refList);
+                if (attachments != null) {
+                    for (Element attachment : attachments) {
+                        this.insertBeforeBottomUp(attachment);
+                    }
+                }
             } else {
-                this.addDerivedKeyElement(refList);                        
+                this.addDerivedKeyElement(refList);
+                if (attachments != null) {
+                    for (Element attachment : attachments) {
+                        this.addDerivedKeyElement(attachment);
+                    }
+                }
             }
             return dkEncr;
         } catch (Exception e) {
@@ -631,6 +643,7 @@ public class SymmetricBindingHandler extends AbstractBindingBuilder {
         WSSecDKSign dkSign = new WSSecDKSign();
         dkSign.setIdAllocator(wssConfig.getIdAllocator());
         dkSign.setCallbackLookup(callbackLookup);
+        dkSign.setAttachmentCallbackHandler(new AttachmentCallbackHandler(message));
         if (policyAbstractTokenWrapper.getToken().getVersion() == SPConstants.SPVersion.SP11) {
             dkSign.setWscVersion(ConversationConstants.VERSION_05_02);
         }


### PR DESCRIPTION
This depends on WSS-541 and won't build until that change is merged.

Note the dependency change to wss4j 2.1.2-SNAPSHOT to reflect this.