### PR TITLE
Fix null pointer exception when importing a WSDL

### DIFF
--- a/rt/wsdl/src/main/java/org/apache/cxf/wsdl11/WSDLServiceFactory.java
+++ b/rt/wsdl/src/main/java/org/apache/cxf/wsdl11/WSDLServiceFactory.java
@@ -133,7 +133,7 @@ public class WSDLServiceFactory extends AbstractServiceFactoryBean {
                     && (!PartialWSDLProcessor.isBindingExisted(definition, serviceName))
                     && (PartialWSDLProcessor.isPortTypeExisted(definition, serviceName))) {
                     try {
-                        Map<QName, PortType> portTypes = CastUtils.cast(definition.getPortTypes());
+                        Map<QName, PortType> portTypes = CastUtils.cast(definition.getAllPortTypes());
                         String existPortName = null;
                         PortType portType = null;
                         for (Map.Entry<QName, PortType> entry : portTypes.entrySet()) {


### PR DESCRIPTION
PartialWSDLProcessor.isPortTypeExisted() checks against definition.getAllPortTypes() (line 64), while the loop in WSDLServiceFactory iterates only over definition.getPortTypes() (line 136). This causes a null pointer exception in cases when additional WSDLs containing port type definitions are imported, but none are defined in the parent WSDL.