### PR TITLE
[CXF-6561] [CXF-6562] ResourceOwnerGrantHandler improvements

### DIFF
--- a/rt/rs/security/oauth-parent/oauth2/src/main/java/org/apache/cxf/rs/security/oauth2/grants/owner/ResourceOwnerGrantHandler.java
+++ b/rt/rs/security/oauth-parent/oauth2/src/main/java/org/apache/cxf/rs/security/oauth2/grants/owner/ResourceOwnerGrantHandler.java
@@ -48,13 +48,10 @@ public class ResourceOwnerGrantHandler extends AbstractGrantHandler {
                  new OAuthError(OAuthConstants.INVALID_REQUEST));
         }
         
-        UserSubject subject = null;
-        try {
-            subject = loginHandler.createSubject(ownerName, ownerPassword);
-        } catch (RuntimeException ex) { 
-            throw ex;
-        } catch (Exception ex) { 
-            throw new OAuthServiceException(OAuthConstants.INVALID_GRANT, ex);
+        UserSubject subject = loginHandler.createSubject(ownerName, ownerPassword);
+        
+        if (subject == null) {
+            throw new OAuthServiceException(OAuthConstants.INVALID_GRANT);
         }
         
         return doCreateAccessToken(client, 

--- a/rt/rs/security/oauth-parent/oauth2/src/main/java/org/apache/cxf/rs/security/oauth2/grants/owner/ResourceOwnerGrantHandler.java
+++ b/rt/rs/security/oauth-parent/oauth2/src/main/java/org/apache/cxf/rs/security/oauth2/grants/owner/ResourceOwnerGrantHandler.java
@@ -58,6 +58,10 @@ public class ResourceOwnerGrantHandler extends AbstractGrantHandler {
                                    subject,
                                    params);
     }
+    
+    public ResourceOwnerLoginHandler getLoginHandler() {
+        return this.loginHandler;
+    }
 
     public void setLoginHandler(ResourceOwnerLoginHandler loginHandler) {
         this.loginHandler = loginHandler;

--- a/rt/rs/security/oauth-parent/oauth2/src/main/java/org/apache/cxf/rs/security/oauth2/grants/owner/ResourceOwnerLoginHandler.java
+++ b/rt/rs/security/oauth-parent/oauth2/src/main/java/org/apache/cxf/rs/security/oauth2/grants/owner/ResourceOwnerLoginHandler.java
@@ -21,5 +21,13 @@ package org.apache.cxf.rs.security.oauth2.grants.owner;
 import org.apache.cxf.rs.security.oauth2.common.UserSubject;
 
 public interface ResourceOwnerLoginHandler {
+    
+    /**
+     * Create a {@link UserSubject} for the name and password parameters, or return null if the name and password
+     * are invalid.
+     * @param name
+     * @param password
+     * @return A {@link UserSubject} representing the user, or null.
+     */
     UserSubject createSubject(String name, String password);
 }


### PR DESCRIPTION
ResourceOwnerGrantHandler calls a customisable ResourceOwnerLoginHandler instance, however the `createSubject(String, String)` method declares no exceptions, and a null return value is not handled. This can possibly result in the issuing of an access token if the DataProvider doesn't check for the null subject.
ResourceOwnerGrantHandler.createAccessToken(...) appears to expect that the ResourceOwnerLoginHandler will throw an `Exception` (literally any Exception), however the method signature of the ResourceOwnerLoginHandler interface doesn't allow that.

Also, ResourceOwnerGrantHandler has a setter for loginHandler but not a getter. Minor, but perhaps we should add one for completeness?