### PR TITLE
Formatting issues in impl.vm

### DIFF
--- a/tools/wsdlto/frontend/jaxws/src/main/java/org/apache/cxf/tools/wsdlto/frontend/jaxws/template/impl.vm
+++ b/tools/wsdlto/frontend/jaxws/src/main/java/org/apache/cxf/tools/wsdlto/frontend/jaxws/template/impl.vm
@@ -64,12 +64,12 @@ public class ${implName} implements $intf.Name {
 
 #foreach ($method in $intf.Methods)
     /* (non-Javadoc)
-     * @see $intf.PackageName.$intf.Name#${method.Name}(#foreach ($parameter in $method.Parameters)$parameter.ClassName  $parameter.Name #if ($velocityCount != $method.getParameters().size()),#end)#end*
+     * @see $intf.PackageName.$intf.Name#${method.Name}(#foreach ($parameter in $method.Parameters)$parameter.ClassName $parameter.Name#if ($velocityCount != $method.getParameters().size()), #end#end)*
      */
 #if ($mark-generated == "true")
     @Generated(value = "org.apache.cxf.tools.wsdlto.WSDLToJava", date = "$currentdate")
 #end
-    public $method.return.ClassName ${method.Name}(#if($method.ParameterListWithoutAnnotation.size() == 0))#end#if($method.ParameterListWithoutAnnotation.size() != 0)#foreach($param in ${method.ParameterListWithoutAnnotation})$param#end)#end#if($method.Exceptions.size() > 0) throws #foreach($exception in $method.Exceptions)$exception.ClassName #if($velocityCount != $method.Exceptions.size()),#end #end #end { 
+    public $method.return.ClassName ${method.Name}(#if($method.ParameterListWithoutAnnotation.size() == 0))#end#if($method.ParameterListWithoutAnnotation.size() != 0)#foreach($param in ${method.ParameterListWithoutAnnotation})$param#if($velocityCount != $method.ParameterListWithoutAnnotation.size()) #end#end)#end#if($method.Exceptions.size() > 0) throws #foreach($exception in $method.Exceptions)$exception.ClassName#if($velocityCount != $method.Exceptions.size()), #end #end #end { 
 #if ($method.Async)
        return null;
        /* not called */


### PR DESCRIPTION
I noticed some oddities in the automatically generated Impl code so I figured I'd adjust the spacing and the extra parens in the non-javadoc comment. Feel free to reject if this behavior is intended.