### PR TITLE
Fix index out of bounds crash in HttpHeaderHelper.findCharset

### DIFF
--- a/core/src/main/java/org/apache/cxf/helpers/HttpHeaderHelper.java
+++ b/core/src/main/java/org/apache/cxf/helpers/HttpHeaderHelper.java
@@ -84,11 +84,11 @@ public final class HttpHeaderHelper {
         int idx = contentType.indexOf("charset=");
         if (idx != -1) {
             String charset = contentType.substring(idx + 8);
-            if (charset.isEmpty()) {
-                return null;
-            }
             if (charset.indexOf(";") != -1) {
                 charset = charset.substring(0, charset.indexOf(";")).trim();
+            }
+            if (charset.isEmpty()) {
+                return null;
             }
             if (charset.charAt(0) == '\"') {
                 charset = charset.substring(1, charset.length() - 1);

--- a/core/src/main/java/org/apache/cxf/helpers/HttpHeaderHelper.java
+++ b/core/src/main/java/org/apache/cxf/helpers/HttpHeaderHelper.java
@@ -84,6 +84,9 @@ public final class HttpHeaderHelper {
         int idx = contentType.indexOf("charset=");
         if (idx != -1) {
             String charset = contentType.substring(idx + 8);
+            if (charset.isEmpty()) {
+                return null;
+            }
             if (charset.indexOf(";") != -1) {
                 charset = charset.substring(0, charset.indexOf(";")).trim();
             }

--- a/core/src/test/java/org/apache/cxf/helpers/HttpHeaderHelperTest.java
+++ b/core/src/test/java/org/apache/cxf/helpers/HttpHeaderHelperTest.java
@@ -43,6 +43,7 @@ public class HttpHeaderHelperTest {
     @Test
     public void testFindCharsetDoesNotCrashOnEmptyCharset() {
         HttpHeaderHelper.findCharset("foo/bar; charset=");
+        HttpHeaderHelper.findCharset("foo/bar; charset=;");
     }
 
 }

--- a/core/src/test/java/org/apache/cxf/helpers/HttpHeaderHelperTest.java
+++ b/core/src/test/java/org/apache/cxf/helpers/HttpHeaderHelperTest.java
@@ -40,4 +40,9 @@ public class HttpHeaderHelperTest {
         assertEquals(Charset.forName("utf-8").name(), cs);
     }
 
+    @Test
+    public void testFindCharsetDoesNotCrashOnEmptyCharset() {
+        HttpHeaderHelper.findCharset("foo/bar; charset=");
+    }
+
 }


### PR DESCRIPTION
Sending an HTTP request with the header `"Content-Type: foo/bar; charset="`
would previously make this method throw a `StringIndexOutOfBoundsException`
that would go uncaught and cause a 500 response:

    java.lang.StringIndexOutOfBoundsException: String index out of range: 0
            at java.lang.String.charAt(String.java:658)
            at org.apache.cxf.helpers.HttpHeaderHelper.findCharset(HttpHeaderHelper.java:90)