### PR TITLE
[CXF-6621] Schema imports are not handled correctly in generated WSDL

### DIFF
--- a/rt/frontend/simple/src/main/java/org/apache/cxf/frontend/WSDLGetUtils.java
+++ b/rt/frontend/simple/src/main/java/org/apache/cxf/frontend/WSDLGetUtils.java
@@ -60,6 +60,7 @@ import org.apache.cxf.catalog.OASISCatalogManagerHelper;
 import org.apache.cxf.common.logging.LogUtils;
 import org.apache.cxf.common.util.StringUtils;
 import org.apache.cxf.common.util.URIParserUtil;
+import org.apache.cxf.common.util.UrlUtils;
 import org.apache.cxf.helpers.CastUtils;
 import org.apache.cxf.helpers.DOMUtils;
 import org.apache.cxf.message.Message;
@@ -356,7 +357,8 @@ public class WSDLGetUtils {
                                     Map<String, Definition> done,
                                     Map<String, SchemaReference> doneSchemas,
                                     String base,
-                                    String docBase) {
+                                    String docBase,
+                                    String parentResolvedLocation) {
         OASISCatalogManager catalogs = OASISCatalogManager.getCatalogManager(bus);
 
         Collection<List<?>> imports = CastUtils.cast((Collection<?>)def.getImports().values());
@@ -364,7 +366,7 @@ public class WSDLGetUtils {
             List<Import> impLst = CastUtils.cast(lst);
             for (Import imp : impLst) {
                 String start = imp.getLocationURI();
-                String decodedStart = null;
+                String decodedStart;
                 // Always use the URL decoded version to ensure that we have a
                 // canonical representation of the import URL for lookup.
 
@@ -391,13 +393,20 @@ public class WSDLGetUtils {
                             //ignore
                         }
                         if (done.put(decodedStart, imp.getDefinition()) == null) {
-                            updateDefinition(bus, imp.getDefinition(), done, doneSchemas, base, start);
+                            if (imp.getDefinition() != null && imp.getDefinition().getDocumentBaseURI() != null) {
+                                done.put(imp.getDefinition().getDocumentBaseURI(), imp.getDefinition());
+                            }
+                            updateDefinition(bus, imp.getDefinition(), done, doneSchemas, base, start, null);
                         }
                     }
                 } else {
                     if (done.put(decodedStart, imp.getDefinition()) == null) {
                         done.put(resolvedSchemaLocation, imp.getDefinition());
-                        updateDefinition(bus, imp.getDefinition(), done, doneSchemas, base, start);
+                        if (imp.getDefinition() != null && imp.getDefinition().getDocumentBaseURI() != null) {
+                            done.put(imp.getDefinition().getDocumentBaseURI(), imp.getDefinition());
+                        }
+                        updateDefinition(bus, imp.getDefinition(), done, doneSchemas, base, start,
+                                resolvedSchemaLocation);
                     }
                 }
             }
@@ -412,7 +421,7 @@ public class WSDLGetUtils {
             for (ExtensibilityElement el
                 : CastUtils.cast(types.getExtensibilityElements(), ExtensibilityElement.class)) {
                 if (el instanceof Schema) {
-                    updateSchemaImports(bus, (Schema)el, docBase, doneSchemas, base);
+                    updateSchemaImports(bus, (Schema)el, docBase, doneSchemas, base, parentResolvedLocation);
                 }
             }
         }
@@ -469,138 +478,84 @@ public class WSDLGetUtils {
                                        Schema schema,
                                        String docBase,
                                        Map<String, SchemaReference> doneSchemas,
-                                       String base) {
-        OASISCatalogManager catalogs = OASISCatalogManager.getCatalogManager(bus);
+                                       String base,
+                                       String parentResolved) {
         Collection<List<?>>  imports = CastUtils.cast((Collection<?>)schema.getImports().values());
         for (List<?> lst : imports) {
             List<SchemaImport> impLst = CastUtils.cast(lst);
             for (SchemaImport imp : impLst) {
-                String start = findSchemaLocation(doneSchemas, imp, docBase);
-
-                if (start != null) {
-                    String decodedStart = null;
-                    // Always use the URL decoded version to ensure that we have a
-                    // canonical representation of the import URL for lookup.
-                    try {
-                        decodedStart = URLDecoder.decode(start, "utf-8");
-                    } catch (UnsupportedEncodingException e) {
-                        throw new WSDLQueryException(
-                            new org.apache.cxf.common.i18n.Message("COULD_NOT_PROVIDE_WSDL",
-                                LOG,
-                                start), e);
-                    }
-
-                    if (!doneSchemas.containsKey(decodedStart)) {
-                        String resolvedSchemaLocation = resolveWithCatalogs(catalogs, start, base);
-                        if (resolvedSchemaLocation == null) {
-                            resolvedSchemaLocation = resolveWithCatalogs(catalogs, imp.getSchemaLocationURI(), base);
-                        }
-                        if (resolvedSchemaLocation == null) {
-                            try {
-                                //check to see if it's already in a URL format.  If so, leave it.
-                                new URL(start);
-                            } catch (MalformedURLException e) {
-                                if (doneSchemas.put(decodedStart, imp) == null) {
-                                    putResolvedSchemaLocationIfRelative(doneSchemas, decodedStart, imp);
-                                    updateSchemaImports(bus, imp.getReferencedSchema(), start, doneSchemas, base);
-                                }
-                            }
-                        } else {
-                            if (doneSchemas.put(decodedStart, imp) == null) {
-                                doneSchemas.put(resolvedSchemaLocation, imp);
-                                String p = getAndSaveRelativeSchemaLocationIfCatalogResolved(doneSchemas,
-                                                                                             resolvedSchemaLocation,
-                                                                                             schema,
-                                                                                             imp);
-                                updateSchemaImports(bus, imp.getReferencedSchema(), p, doneSchemas, base);
-                            }
-                        }
-                    }
-                }
+                processSchemaReference(imp, bus, schema, docBase, doneSchemas, base, parentResolved);
             }
         }
 
         List<SchemaReference> includes = CastUtils.cast(schema.getIncludes());
         for (SchemaReference included : includes) {
-            String start = findSchemaLocation(doneSchemas, included, docBase);
-
-            if (start != null) {
-                String decodedStart = null;
-                // Always use the URL decoded version to ensure that we have a
-                // canonical representation of the import URL for lookup.
-                try {
-                    decodedStart = URLDecoder.decode(start, "utf-8");
-                } catch (UnsupportedEncodingException e) {
-                    throw new WSDLQueryException(
-                        new org.apache.cxf.common.i18n.Message("COULD_NOT_PROVIDE_WSDL",
-                            LOG,
-                            start), e);
-                }
-
-                String resolvedSchemaLocation = resolveWithCatalogs(catalogs, start, base);
-                if (resolvedSchemaLocation == null) {
-                    if (!doneSchemas.containsKey(decodedStart)) {
-                        try {
-                            //check to see if it's aleady in a URL format.  If so, leave it.
-                            new URL(start);
-                        } catch (MalformedURLException e) {
-                            if (doneSchemas.put(decodedStart, included) == null) {
-                                putResolvedSchemaLocationIfRelative(doneSchemas, decodedStart, included);
-                                updateSchemaImports(bus, included.getReferencedSchema(), start, doneSchemas, base);
-                            }
-                        }
-                    }
-                } else if (!doneSchemas.containsKey(decodedStart)
-                    || !doneSchemas.containsKey(resolvedSchemaLocation)) {
-                    doneSchemas.put(decodedStart, included);
-                    doneSchemas.put(resolvedSchemaLocation, included);
-                    String p = getAndSaveRelativeSchemaLocationIfCatalogResolved(doneSchemas,
-                                                                                 resolvedSchemaLocation,
-                                                                                 schema,
-                                                                                 included);
-                    updateSchemaImports(bus, included.getReferencedSchema(), p, doneSchemas, base);
-                }
-            }
+            processSchemaReference(included, bus, schema, docBase, doneSchemas, base, parentResolved);
         }
         List<SchemaReference> redefines = CastUtils.cast(schema.getRedefines());
         for (SchemaReference included : redefines) {
-            String start = findSchemaLocation(doneSchemas, included, docBase);
+            processSchemaReference(included, bus, schema, docBase, doneSchemas, base, parentResolved);
+        }
+    }
 
-            if (start != null) {
-                String decodedStart = null;
-                // Always use the URL decoded version to ensure that we have a
-                // canonical representation of the import URL for lookup.
-                try {
-                    decodedStart = URLDecoder.decode(start, "utf-8");
-                } catch (UnsupportedEncodingException e) {
-                    throw new WSDLQueryException(
+    private void processSchemaReference(SchemaReference schemaReference,
+                                        Bus bus,
+                                        Schema schema,
+                                        String docBase,
+                                        Map<String, SchemaReference> doneSchemas,
+                                        String base,
+                                        String parentResolved) {
+        OASISCatalogManager catalogs = OASISCatalogManager.getCatalogManager(bus);
+        String start = findSchemaLocation(doneSchemas, schemaReference, docBase);
+        String origLocation = schemaReference.getSchemaLocationURI();
+
+        if (start != null) {
+            String decodedStart;
+            String decodedOrigLocation;
+            // Always use the URL decoded version to ensure that we have a
+            // canonical representation of the import URL for lookup.
+            try {
+                decodedStart = URLDecoder.decode(start, "utf-8");
+                decodedOrigLocation = URLDecoder.decode(origLocation, "utf-8");
+            } catch (UnsupportedEncodingException e) {
+                throw new WSDLQueryException(
                         new org.apache.cxf.common.i18n.Message("COULD_NOT_PROVIDE_WSDL",
-                            LOG,
-                            start), e);
-                }
+                                LOG,
+                                start), e);
+            }
 
+            if (!doneSchemas.containsKey(decodedStart)) {
                 String resolvedSchemaLocation = resolveWithCatalogs(catalogs, start, base);
                 if (resolvedSchemaLocation == null) {
-                    if (!doneSchemas.containsKey(decodedStart)) {
+                    resolvedSchemaLocation =
+                            resolveWithCatalogs(catalogs, schemaReference.getSchemaLocationURI(), base);
+                }
+                if (resolvedSchemaLocation == null) {
+                    try {
+                        //check to see if it's already in a URL format.  If so, leave it.
+                        new URL(start);
+                    } catch (MalformedURLException e) {
+                        doneSchemas.put(decodedStart, schemaReference);
+                        doneSchemas.put(schemaReference.getReferencedSchema().getDocumentBaseURI(), schemaReference);
                         try {
-                            //check to see if it's aleady in a URL format.  If so, leave it.
-                            new URL(start);
-                        } catch (MalformedURLException e) {
-                            if (doneSchemas.put(decodedStart, included) == null) {
-                                putResolvedSchemaLocationIfRelative(doneSchemas, decodedStart, included);
-                                updateSchemaImports(bus, included.getReferencedSchema(), start, doneSchemas, base);
+                            if (!(new URI(origLocation).isAbsolute()) && parentResolved != null) {
+                                resolvedSchemaLocation = resolveRelativePath(parentResolved, decodedOrigLocation);
+                                doneSchemas.put(resolvedSchemaLocation, schemaReference);
                             }
+                        } catch (URISyntaxException e1) {
+                            // ignore
                         }
+                        updateSchemaImports(bus, schemaReference.getReferencedSchema(), start, doneSchemas, base,
+                                resolvedSchemaLocation);
                     }
-                } else if (!doneSchemas.containsKey(decodedStart)
-                    || !doneSchemas.containsKey(resolvedSchemaLocation)) {
-                    doneSchemas.put(decodedStart, included);
-                    doneSchemas.put(resolvedSchemaLocation, included);
+                } else if (doneSchemas.put(decodedStart, schemaReference) == null) {
+                    doneSchemas.put(resolvedSchemaLocation, schemaReference);
                     String p = getAndSaveRelativeSchemaLocationIfCatalogResolved(doneSchemas,
-                                                                                 resolvedSchemaLocation,
-                                                                                 schema,
-                                                                                 included);
-                    updateSchemaImports(bus, included.getReferencedSchema(), p, doneSchemas, base);
+                            resolvedSchemaLocation,
+                            schema,
+                            schemaReference);
+                    updateSchemaImports(bus, schemaReference.getReferencedSchema(), p, doneSchemas, base,
+                            resolvedSchemaLocation);
                 }
             }
         }
@@ -650,25 +605,6 @@ public class WSDLGetUtils {
         return path;
     }
 
-    /**
-     * If given decodedStart is relative path, resolves a real location of given schema and puts it into schema map.
-     *
-     * @param doneSchemas schema map
-     * @param decodedStart path referencing schema
-     * @param schemaReference referenced schema
-     */
-    private void putResolvedSchemaLocationIfRelative(Map<String, SchemaReference> doneSchemas, String decodedStart,
-                                                     SchemaReference schemaReference) {
-        try {
-            if (!(new URI(decodedStart).isAbsolute())) {
-                String resolved = schemaReference.getReferencedSchema().getDocumentBaseURI();
-                doneSchemas.put(resolved, schemaReference);
-            }
-        } catch (URISyntaxException ex) {
-            // ignore
-        }
-    }
-
     private String findSchemaLocation(Map<String, SchemaReference> doneSchemas,
                                       SchemaReference imp,
                                       String docBase) {
@@ -695,6 +631,12 @@ public class WSDLGetUtils {
         return schemaLocationURI;
     }
 
+    private String resolveRelativePath(String parentUri, String relativePath) {
+        // can not use `new URI(uri).resolve(path)`, because that doesn't work with "jar:file:x!y" kind of URIs
+        String base = UrlUtils.getStem(parentUri);
+        return base + '/' + relativePath;
+    }
+
     /**
      * Write the contents of a wsdl Definition object to a file.
      *
@@ -714,7 +656,7 @@ public class WSDLGetUtils {
                                       String base,
                                       EndpointInfo endpointInfo) throws WSDLException {
 
-        Document doc = null;
+        Document doc;
         Bus bus = message.getExchange().getBus();
         Definition def = lookupDefinition(bus, mp, wsdl, base);
         String epurl = base;
@@ -822,7 +764,7 @@ public class WSDLGetUtils {
             Definition def = builder.build(new HashMap<String, SchemaInfo>());
 
             mp.put("", def);
-            updateDefinition(bus, def, mp, smp, base, "");
+            updateDefinition(bus, def, mp, smp, base, "", "");
         }
 
     }

--- a/systests/jaxws/src/test/java/org/apache/cxf/systest/jaxws/OASISCatalogTest.java
+++ b/systests/jaxws/src/test/java/org/apache/cxf/systest/jaxws/OASISCatalogTest.java
@@ -63,29 +63,31 @@ public class OASISCatalogTest extends Assert {
         Endpoint ep = Endpoint.publish("http://localhost:" + PORT + "/SoapContext/SoapPort",
                                        new GreeterImpl());
 
-        String result = readUrl("http://localhost:" + PORT + "/SoapContext/SoapPort?"
-                + "xsd=hello_world_schema2.xsd");
-        assertTrue(result, result.contains("xsd=hello_world_schema.xsd"));
-        assertTrue(result, result.contains("xsd=hello_world_schema3.xsd"));
-        assertTrue(result, result.contains("xsd=d/hello_world_schema4.xsd"));
+        try {
+            String result = readUrl("http://localhost:" + PORT + "/SoapContext/SoapPort?"
+                    + "xsd=hello_world_schema2.xsd");
+            assertTrue(result, result.contains("xsd=hello_world_schema.xsd"));
+            assertTrue(result, result.contains("xsd=hello_world_schema3.xsd"));
+            assertTrue(result, result.contains("xsd=d/hello_world_schema4.xsd"));
 
-        result = readUrl("http://localhost:" + PORT + "/SoapContext/SoapPort?"
-                + "xsd=hello_world_schema3.xsd");
-        assertTrue(result.length() > 0);
+            result = readUrl("http://localhost:" + PORT + "/SoapContext/SoapPort?"
+                    + "xsd=hello_world_schema3.xsd");
+            assertTrue(result.length() > 0);
 
-        result = readUrl("http://localhost:" + PORT + "/SoapContext/SoapPort?"
-                + "xsd=d/hello_world_schema4.xsd");
-        assertTrue(result, result.contains("xsd=d/d/hello_world_schema4.xsd"));
+            result = readUrl("http://localhost:" + PORT + "/SoapContext/SoapPort?"
+                    + "xsd=d/hello_world_schema4.xsd");
+            assertTrue(result, result.contains("xsd=d/d/hello_world_schema4.xsd"));
 
-        result = readUrl("http://localhost:" + PORT + "/SoapContext/SoapPort"
-                + "?xsd=hello_world_schema.xsd");
-        assertTrue(result, result.contains("xsd=http://apache.org/hello_world/types2/hello_world_schema2.xsd"));
+            result = readUrl("http://localhost:" + PORT + "/SoapContext/SoapPort"
+                    + "?xsd=hello_world_schema.xsd");
+            assertTrue(result, result.contains("xsd=http://apache.org/hello_world/types2/hello_world_schema2.xsd"));
 
-        result = readUrl("http://localhost:" + PORT + "/SoapContext/SoapPort"
-                + "?wsdl=hello_world_messages_catalog.wsdl");
-        assertTrue(result, result.contains("xsd=hello_world_schema.xsd"));
-
-        ep.stop();
+            result = readUrl("http://localhost:" + PORT + "/SoapContext/SoapPort"
+                    + "?wsdl=hello_world_messages_catalog.wsdl");
+            assertTrue(result, result.contains("xsd=hello_world_schema.xsd"));
+        } finally {
+            ep.stop();
+        }
     }
 
     /**
@@ -101,30 +103,65 @@ public class OASISCatalogTest extends Assert {
     public void testWSDLPublishWithCatalogsRewritePaths() {
         Endpoint ep = Endpoint.publish("http://localhost:" + PORT + "/SoapContext/SoapPort",
                 new GreeterImpl());
+        try {
+            // schemas in the same directory as WSDL
 
-        String result = readUrl("http://localhost:" + PORT + "/SoapContext/SoapPort?"
-                + "xsd=http://apache.org/hello_world/types2/hello_world_schema2.xsd");
-        assertTrue(result, result.contains("xsd=http://apache.org/hello_world/types2/hello_world_schema.xsd"));
-        assertTrue(result, result.contains("xsd=http://apache.org/hello_world/types2/hello_world_schema3.xsd"));
-        assertTrue(result, result.contains("xsd=http://apache.org/hello_world/types2/d/hello_world_schema4.xsd"));
+            String result = readUrl("http://localhost:" + PORT + "/SoapContext/SoapPort?"
+                    + "xsd=http://apache.org/hello_world/types2/hello_world_schema2.xsd");
+            assertTrue(result, result.contains("xsd=http://apache.org/hello_world/types2/hello_world_schema.xsd"));
+            assertTrue(result, result.contains("xsd=http://apache.org/hello_world/types2/hello_world_schema3.xsd"));
+            assertTrue(result, result.contains("xsd=http://apache.org/hello_world/types2/d/hello_world_schema4.xsd"));
 
-        result = readUrl("http://localhost:" + PORT + "/SoapContext/SoapPort?"
-                + "xsd=http://apache.org/hello_world/types2/hello_world_schema.xsd");
-        assertTrue(result, result.contains("xsd=http://apache.org/hello_world/types2/hello_world_schema2.xsd"));
+            result = readUrl("http://localhost:" + PORT + "/SoapContext/SoapPort?"
+                    + "xsd=http://apache.org/hello_world/types2/hello_world_schema.xsd");
+            assertTrue(result, result.contains("xsd=http://apache.org/hello_world/types2/hello_world_schema2.xsd"));
 
-        result = readUrl("http://localhost:" + PORT + "/SoapContext/SoapPort?"
-                + "xsd=http://apache.org/hello_world/types2/hello_world_schema3.xsd");
-        assertTrue(result.length() > 0);
+            result = readUrl("http://localhost:" + PORT + "/SoapContext/SoapPort?"
+                    + "xsd=http://apache.org/hello_world/types2/hello_world_schema3.xsd");
+            assertTrue(result.length() > 0);
 
-        result = readUrl("http://localhost:" + PORT + "/SoapContext/SoapPort?"
-                + "xsd=http://apache.org/hello_world/types2/d/hello_world_schema4.xsd");
-        assertTrue(result, result.contains("xsd=http://apache.org/hello_world/types2/d/d/hello_world_schema4.xsd"));
+            result = readUrl("http://localhost:" + PORT + "/SoapContext/SoapPort?"
+                    + "xsd=http://apache.org/hello_world/types2/d/hello_world_schema4.xsd");
+            assertTrue(result, result.contains("xsd=http://apache.org/hello_world/types2/d/d/hello_world_schema4.xsd"));
 
-        result = readUrl("http://localhost:" + PORT + "/SoapContext/SoapPort?"
-                + "xsd=http://apache.org/hello_world/types2/d/d/hello_world_schema4.xsd");
-        assertTrue(result.length() > 0);
+            result = readUrl("http://localhost:" + PORT + "/SoapContext/SoapPort?"
+                    + "xsd=http://apache.org/hello_world/types2/d/d/hello_world_schema4.xsd");
+            assertFalse(result.contains("schemaLocation"));
 
-        ep.stop();
+            // schemas in separate directory which is not subdirectory of WSDL dir
+
+            result = readUrl("http://localhost:" + PORT + "/SoapContext/SoapPort?"
+                    + "wsdl=http://apache.org/hello_world/types2/hello_world_messages_catalog.wsdl");
+            assertTrue(result, result.contains("xsd=http://apache.org/hello_world/schemas-in-separate-dir/schema.xsd"));
+
+            result = readUrl("http://localhost:" + PORT + "/SoapContext/SoapPort?"
+                    + "xsd=http://apache.org/hello_world/schemas-in-separate-dir/schema.xsd");
+            assertTrue(result,
+                    result.contains("xsd=http://apache.org/hello_world/schemas-in-separate-dir/d/included.xsd"));
+
+            result = readUrl("http://localhost:" + PORT + "/SoapContext/SoapPort?"
+                    + "xsd=http://apache.org/hello_world/schemas-in-separate-dir/d/included.xsd");
+            assertTrue(result,
+                    result.contains("xsd=http://apache.org/hello_world/schemas-in-separate-dir/d/d/included.xsd"));
+
+            result = readUrl("http://localhost:" + PORT + "/SoapContext/SoapPort?"
+                    + "xsd=http://apache.org/hello_world/schemas-in-separate-dir/d/d/included.xsd");
+            assertFalse(result, result.contains("schemaLocation"));
+
+            // rewrite rule that doesn't begin with 'classpath:' but contains only the path
+
+            result = readUrl("http://localhost:" + PORT + "/SoapContext/SoapPort?"
+                    + "xsd=http://apache.org/hello_world/schemas-in-separate-dir-non-cp/another-schema.xsd");
+            assertTrue(result, result.contains("xsd=http://apache.org/hello_world/schemas-in-separate-dir-non-cp/d/"
+                    + "another-included.xsd"));
+
+            result = readUrl("http://localhost:" + PORT + "/SoapContext/SoapPort?"
+                    + "xsd=http://apache.org/hello_world/schemas-in-separate-dir-non-cp/d/another-included.xsd");
+            assertTrue(result, result.contains("xsd=http://apache.org/hello_world/schemas-in-separate-dir-non-cp/d/d/"
+                    + "another-included.xsd"));
+        } finally {
+            ep.stop();
+        }
     }
     
     @Test

--- a/testutils/src/main/resources/wsdl/others/hello_world_messages_catalog.wsdl
+++ b/testutils/src/main/resources/wsdl/others/hello_world_messages_catalog.wsdl
@@ -22,6 +22,16 @@
         <schema xmlns="http://www.w3.org/2001/XMLSchema" targetNamespace="http://apache.org/hello_world/types/schema" elementFormDefault="qualified">
             <xsd:import namespace="http://apache.org/hello_world/types" schemaLocation="hello_world_schema.xsd"/>
         </schema>
+        <schema targetNamespace="http://apache.org/hello_world/schemas-in-separate-dir"
+                xmlns="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified">
+            <xsd:import namespace="http://apache.org/hello_world/schemas-in-separate-dir"
+                        schemaLocation="http://apache.org/hello_world/schemas-in-separate-dir/schema.xsd"/>
+        </schema>
+        <schema targetNamespace="http://apache.org/hello_world/schemas-in-separate-dir"
+                xmlns="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified">
+            <xsd:import namespace="http://apache.org/hello_world/schemas-in-separate-dir"
+                        schemaLocation="http://apache.org/hello_world/schemas-in-separate-dir-non-cp/another-schema.xsd"/>
+        </schema>
     </wsdl:types>
     <wsdl:message name="sayHiRequest">
         <wsdl:part name="in" element="x1:sayHi"/>

--- a/testutils/src/main/resources/wsdl/schemas/another-schema.xsd
+++ b/testutils/src/main/resources/wsdl/schemas/another-schema.xsd
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0"?>
 <!--
     Licensed to the Apache Software Foundation (ASF) under one
     or more contributor license agreements.  See the NOTICE file
@@ -7,9 +7,9 @@
     to you under the Apache License, Version 2.0 (the
     "License"); you may not use this file except in compliance
     with the License.  You may obtain a copy of the License at
-    
+
      http://www.apache.org/licenses/LICENSE-2.0
-    
+
     Unless required by applicable law or agreed to in writing,
     software distributed under the License is distributed on an
     "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -17,11 +17,13 @@
     specific language governing permissions and limitations
     under the License.
 -->
-<catalog xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog" prefer="system">
-    <rewriteSystem systemIdStartString="http://apache.org/hello_world/types2/" rewritePrefix="/wsdl/others/"/>
-    <rewriteSystem systemIdStartString="http://apache.org/hello_world/schemas-in-separate-dir/" rewritePrefix="classpath:/wsdl/schemas/"/>
-    <rewriteSystem systemIdStartString="http://apache.org/hello_world/schemas-in-separate-dir-non-cp/" rewritePrefix="/wsdl/schemas/"/>
-    <rewriteSystem systemIdStartString="doesnotexist" rewritePrefix="../wsdl/catalog"/>
-    <rewriteSystem systemIdStartString="nopath" rewritePrefix="../wsdl"/>
-    <rewriteSystem systemIdStartString="testutils" rewritePrefix="classpath:/wsdl"/>
-</catalog>
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" 
+    targetNamespace="http://apache.org/hello_world/schemas-in-separate-dir"
+            elementFormDefault="qualified">
+
+    <xsd:import schemaLocation="d/another-included.xsd" namespace="http://apache.org/hello_world/schemas-in-separate-dir"/>
+
+    <xsd:element name="sayHi5">
+        <xsd:complexType/>
+    </xsd:element>
+</xsd:schema>

--- a/testutils/src/main/resources/wsdl/schemas/d/another-included.xsd
+++ b/testutils/src/main/resources/wsdl/schemas/d/another-included.xsd
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0"?>
 <!--
     Licensed to the Apache Software Foundation (ASF) under one
     or more contributor license agreements.  See the NOTICE file
@@ -7,9 +7,9 @@
     to you under the Apache License, Version 2.0 (the
     "License"); you may not use this file except in compliance
     with the License.  You may obtain a copy of the License at
-    
+
      http://www.apache.org/licenses/LICENSE-2.0
-    
+
     Unless required by applicable law or agreed to in writing,
     software distributed under the License is distributed on an
     "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -17,11 +17,13 @@
     specific language governing permissions and limitations
     under the License.
 -->
-<catalog xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog" prefer="system">
-    <rewriteSystem systemIdStartString="http://apache.org/hello_world/types2/" rewritePrefix="/wsdl/others/"/>
-    <rewriteSystem systemIdStartString="http://apache.org/hello_world/schemas-in-separate-dir/" rewritePrefix="classpath:/wsdl/schemas/"/>
-    <rewriteSystem systemIdStartString="http://apache.org/hello_world/schemas-in-separate-dir-non-cp/" rewritePrefix="/wsdl/schemas/"/>
-    <rewriteSystem systemIdStartString="doesnotexist" rewritePrefix="../wsdl/catalog"/>
-    <rewriteSystem systemIdStartString="nopath" rewritePrefix="../wsdl"/>
-    <rewriteSystem systemIdStartString="testutils" rewritePrefix="classpath:/wsdl"/>
-</catalog>
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" 
+    targetNamespace="http://apache.org/hello_world/schemas-in-separate-dir"
+            elementFormDefault="qualified">
+
+    <xsd:import schemaLocation="d/another-included.xsd" namespace="http://apache.org/hello_world/schemas-in-separate-dir"/>
+
+    <xsd:element name="sayHi6">
+        <xsd:complexType/>
+    </xsd:element>
+</xsd:schema>

--- a/testutils/src/main/resources/wsdl/schemas/d/d/another-included.xsd
+++ b/testutils/src/main/resources/wsdl/schemas/d/d/another-included.xsd
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0"?>
 <!--
     Licensed to the Apache Software Foundation (ASF) under one
     or more contributor license agreements.  See the NOTICE file
@@ -7,9 +7,9 @@
     to you under the Apache License, Version 2.0 (the
     "License"); you may not use this file except in compliance
     with the License.  You may obtain a copy of the License at
-    
+
      http://www.apache.org/licenses/LICENSE-2.0
-    
+
     Unless required by applicable law or agreed to in writing,
     software distributed under the License is distributed on an
     "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -17,11 +17,11 @@
     specific language governing permissions and limitations
     under the License.
 -->
-<catalog xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog" prefer="system">
-    <rewriteSystem systemIdStartString="http://apache.org/hello_world/types2/" rewritePrefix="/wsdl/others/"/>
-    <rewriteSystem systemIdStartString="http://apache.org/hello_world/schemas-in-separate-dir/" rewritePrefix="classpath:/wsdl/schemas/"/>
-    <rewriteSystem systemIdStartString="http://apache.org/hello_world/schemas-in-separate-dir-non-cp/" rewritePrefix="/wsdl/schemas/"/>
-    <rewriteSystem systemIdStartString="doesnotexist" rewritePrefix="../wsdl/catalog"/>
-    <rewriteSystem systemIdStartString="nopath" rewritePrefix="../wsdl"/>
-    <rewriteSystem systemIdStartString="testutils" rewritePrefix="classpath:/wsdl"/>
-</catalog>
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" 
+    targetNamespace="http://apache.org/hello_world/schemas-in-separate-dir"
+            elementFormDefault="qualified">
+
+    <xsd:element name="sayHi6">
+        <xsd:complexType/>
+    </xsd:element>
+</xsd:schema>

--- a/testutils/src/main/resources/wsdl/schemas/d/d/included.xsd
+++ b/testutils/src/main/resources/wsdl/schemas/d/d/included.xsd
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0"?>
 <!--
     Licensed to the Apache Software Foundation (ASF) under one
     or more contributor license agreements.  See the NOTICE file
@@ -7,9 +7,9 @@
     to you under the Apache License, Version 2.0 (the
     "License"); you may not use this file except in compliance
     with the License.  You may obtain a copy of the License at
-    
+
      http://www.apache.org/licenses/LICENSE-2.0
-    
+
     Unless required by applicable law or agreed to in writing,
     software distributed under the License is distributed on an
     "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -17,11 +17,11 @@
     specific language governing permissions and limitations
     under the License.
 -->
-<catalog xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog" prefer="system">
-    <rewriteSystem systemIdStartString="http://apache.org/hello_world/types2/" rewritePrefix="/wsdl/others/"/>
-    <rewriteSystem systemIdStartString="http://apache.org/hello_world/schemas-in-separate-dir/" rewritePrefix="classpath:/wsdl/schemas/"/>
-    <rewriteSystem systemIdStartString="http://apache.org/hello_world/schemas-in-separate-dir-non-cp/" rewritePrefix="/wsdl/schemas/"/>
-    <rewriteSystem systemIdStartString="doesnotexist" rewritePrefix="../wsdl/catalog"/>
-    <rewriteSystem systemIdStartString="nopath" rewritePrefix="../wsdl"/>
-    <rewriteSystem systemIdStartString="testutils" rewritePrefix="classpath:/wsdl"/>
-</catalog>
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" 
+    targetNamespace="http://apache.org/hello_world/schemas-in-separate-dir"
+            elementFormDefault="qualified">
+
+    <xsd:element name="sayHi4">
+        <xsd:complexType/>
+    </xsd:element>
+</xsd:schema>

--- a/testutils/src/main/resources/wsdl/schemas/d/included.xsd
+++ b/testutils/src/main/resources/wsdl/schemas/d/included.xsd
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0"?>
 <!--
     Licensed to the Apache Software Foundation (ASF) under one
     or more contributor license agreements.  See the NOTICE file
@@ -7,9 +7,9 @@
     to you under the Apache License, Version 2.0 (the
     "License"); you may not use this file except in compliance
     with the License.  You may obtain a copy of the License at
-    
+
      http://www.apache.org/licenses/LICENSE-2.0
-    
+
     Unless required by applicable law or agreed to in writing,
     software distributed under the License is distributed on an
     "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -17,11 +17,13 @@
     specific language governing permissions and limitations
     under the License.
 -->
-<catalog xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog" prefer="system">
-    <rewriteSystem systemIdStartString="http://apache.org/hello_world/types2/" rewritePrefix="/wsdl/others/"/>
-    <rewriteSystem systemIdStartString="http://apache.org/hello_world/schemas-in-separate-dir/" rewritePrefix="classpath:/wsdl/schemas/"/>
-    <rewriteSystem systemIdStartString="http://apache.org/hello_world/schemas-in-separate-dir-non-cp/" rewritePrefix="/wsdl/schemas/"/>
-    <rewriteSystem systemIdStartString="doesnotexist" rewritePrefix="../wsdl/catalog"/>
-    <rewriteSystem systemIdStartString="nopath" rewritePrefix="../wsdl"/>
-    <rewriteSystem systemIdStartString="testutils" rewritePrefix="classpath:/wsdl"/>
-</catalog>
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" 
+    targetNamespace="http://apache.org/hello_world/schemas-in-separate-dir"
+            elementFormDefault="qualified">
+
+    <xsd:import schemaLocation="d/included.xsd" namespace="http://apache.org/hello_world/schemas-in-separate-dir"/>
+
+    <xsd:element name="sayHi3">
+        <xsd:complexType/>
+    </xsd:element>
+</xsd:schema>

--- a/testutils/src/main/resources/wsdl/schemas/schema.xsd
+++ b/testutils/src/main/resources/wsdl/schemas/schema.xsd
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0"?>
 <!--
     Licensed to the Apache Software Foundation (ASF) under one
     or more contributor license agreements.  See the NOTICE file
@@ -7,9 +7,9 @@
     to you under the Apache License, Version 2.0 (the
     "License"); you may not use this file except in compliance
     with the License.  You may obtain a copy of the License at
-    
+
      http://www.apache.org/licenses/LICENSE-2.0
-    
+
     Unless required by applicable law or agreed to in writing,
     software distributed under the License is distributed on an
     "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -17,11 +17,13 @@
     specific language governing permissions and limitations
     under the License.
 -->
-<catalog xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog" prefer="system">
-    <rewriteSystem systemIdStartString="http://apache.org/hello_world/types2/" rewritePrefix="/wsdl/others/"/>
-    <rewriteSystem systemIdStartString="http://apache.org/hello_world/schemas-in-separate-dir/" rewritePrefix="classpath:/wsdl/schemas/"/>
-    <rewriteSystem systemIdStartString="http://apache.org/hello_world/schemas-in-separate-dir-non-cp/" rewritePrefix="/wsdl/schemas/"/>
-    <rewriteSystem systemIdStartString="doesnotexist" rewritePrefix="../wsdl/catalog"/>
-    <rewriteSystem systemIdStartString="nopath" rewritePrefix="../wsdl"/>
-    <rewriteSystem systemIdStartString="testutils" rewritePrefix="classpath:/wsdl"/>
-</catalog>
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" 
+    targetNamespace="http://apache.org/hello_world/schemas-in-separate-dir"
+            elementFormDefault="qualified">
+
+    <xsd:import schemaLocation="d/included.xsd" namespace="http://apache.org/hello_world/schemas-in-separate-dir"/>
+
+    <xsd:element name="sayHi2">
+        <xsd:complexType/>
+    </xsd:element>
+</xsd:schema>


### PR DESCRIPTION
...and XSD files when using catalog rewrites

Fixes these issues:

- import of nested XSDs that lies in different directory tree from WSDL
  files

  example:

  ```
jax-ws-catalog.xml contains:
  <rewriteSystem systemIdStartString="http://example.org/uri/" rewritePrefix="/xsd/"/>

WSDL structure:
  /wsdl/service.wsdl - imports "http://example.org/uri/schema.xsd"
  /xsd/schema.xsd

  ```

- import and access of nested XSDs with equal relative paths when XSDs
  are outside of WSDL directory (previously this was working only when
  XSDs were inside WSDL directory)

  example:

  ```
jax-ws-catalog.xml contains:
  <rewriteSystem systemIdStartString="http://example.org/uri/" rewritePrefix="/xsd/"/>

WSDL structure:
  /wsdl/service.wsdl - imports "http://example.org/uri/schema.xsd"
  /xsd/schema.xsd - imports "d/included.xsd"
  /xsd/d/included.xsd - imports "d/included.xsd"
  /xsd/d/d/included.xsd
  ```

- accessing nested XSD and WSDL under URIs affected by rewrite rules
  which aren't directly used by WSDLs/XSDs

  example:

  ```
jax-ws-catalog.xml contains:
	  <rewriteSystem systemIdStartString="http://example.org/uri/" rewritePrefix="/wsdl/"/>

WSDL structure:
  /wsdl/service.wsdl - imports "./included.wsdl"
  /wsdl/included.wsdl

request for: http://example.org/uri/included.wsdl
  ```

- in some cases imports weren't working when catalog rule rewritePrefix
  was "/path" instead of "classpath:/path" - catalog resolves those two
  into different values