### PR TITLE
[CXF-6621] Schema imports are not handled correctly in generated WSDL

### DIFF
--- a/api/src/main/java/org/apache/cxf/common/util/URIParserUtil.java
+++ b/api/src/main/java/org/apache/cxf/common/util/URIParserUtil.java
@@ -300,4 +300,78 @@ public final class URIParserUtil {
             return normalize(arg);
         }
     }
+
+    public static String relativize(String base, String toBeRelativized) throws URISyntaxException {
+        if (base == null || toBeRelativized == null) {
+            return null;
+        }
+        return relativize(new URI(base), new URI(toBeRelativized));
+    }
+
+    /**
+     * This is a custom implementation for doing what URI.relativize(URI uri) should be
+     * doing but is not actually doing when URI roots do not fully match.
+     * See http://bugs.java.com/bugdatabase/view_bug.do?bug_id=6226081
+     *
+     * @param baseURI           The base URI
+     * @param toBeRelativizedURI The URI to be realivized
+     * @return                  The string value of the URI you'd expect to get as result
+     *                          of calling baseURI.relativize(toBeRelativizedURI).
+     *                          null is returned if the parameters are null or are not
+     *                          both absolute or not absolute.
+     * @throws URISyntaxException
+     */
+    public static String relativize(URI baseURI, URI toBeRelativizedURI) throws URISyntaxException {
+        if (baseURI == null || toBeRelativizedURI == null) {
+            return null;
+        }
+        if (baseURI.isAbsolute() ^ toBeRelativizedURI.isAbsolute()) {
+            return null;
+        }
+        final String base = baseURI.getSchemeSpecificPart();
+        final String toBeRelativized = toBeRelativizedURI.getSchemeSpecificPart();
+        final int l1 = base.length();
+        final int l2 = toBeRelativized.length();
+        if (l1 == 0) {
+            return toBeRelativized;
+        }
+        int slashes = 0;
+        StringBuilder sb = new StringBuilder();
+        boolean differenceFound = false;
+        for (int i = 0; i < l1; i++) {
+            char c = base.charAt(i);
+            if (i < l2) {
+                if (!differenceFound && c == toBeRelativized.charAt(i)) {
+                    sb.append(c);
+                } else {
+                    differenceFound = true;
+                    if (c == '/') {
+                        slashes++;
+                    }
+                }
+            } else {
+                if (c == '/') {
+                    slashes++;
+                }
+            }
+        }
+        String rResolved = new URI(getRoot(sb.toString())).relativize(new URI(toBeRelativized)).toString();
+        StringBuilder relativizedPath = new StringBuilder();
+        for (int i = 0; i < slashes; i++) {
+            relativizedPath.append("../");
+        }
+        relativizedPath.append(rResolved);
+        return relativizedPath.toString();
+    }
+
+    private static String getRoot(String uri) {
+        int idx = uri.lastIndexOf('/');
+        if (idx == uri.length() - 1) {
+            return uri;
+        } else if (idx == -1) {
+            return "";
+        } else {
+            return uri.substring(0, idx + 1);
+        }
+    }
 }

--- a/rt/frontend/simple/src/main/java/org/apache/cxf/frontend/WSDLGetUtils.java
+++ b/rt/frontend/simple/src/main/java/org/apache/cxf/frontend/WSDLGetUtils.java
@@ -60,6 +60,7 @@ import org.apache.cxf.catalog.OASISCatalogManagerHelper;
 import org.apache.cxf.common.logging.LogUtils;
 import org.apache.cxf.common.util.StringUtils;
 import org.apache.cxf.common.util.URIParserUtil;
+import org.apache.cxf.common.util.UrlUtils;
 import org.apache.cxf.helpers.CastUtils;
 import org.apache.cxf.helpers.DOMUtils;
 import org.apache.cxf.message.Message;
@@ -357,7 +358,8 @@ public class WSDLGetUtils {
                                     Map<String, Definition> done,
                                     Map<String, SchemaReference> doneSchemas,
                                     String base,
-                                    String docBase) {
+                                    String docBase,
+                                    String parentResolvedLocation) {
         OASISCatalogManager catalogs = OASISCatalogManager.getCatalogManager(bus);
 
         Collection<List<?>> imports = CastUtils.cast((Collection<?>)def.getImports().values());
@@ -365,7 +367,7 @@ public class WSDLGetUtils {
             List<Import> impLst = CastUtils.cast(lst);
             for (Import imp : impLst) {
                 String start = imp.getLocationURI();
-                String decodedStart = null;
+                String decodedStart;
                 // Always use the URL decoded version to ensure that we have a
                 // canonical representation of the import URL for lookup.
 
@@ -392,13 +394,20 @@ public class WSDLGetUtils {
                             //ignore
                         }
                         if (done.put(decodedStart, imp.getDefinition()) == null) {
-                            updateDefinition(bus, imp.getDefinition(), done, doneSchemas, base, start);
+                            if (imp.getDefinition() != null && imp.getDefinition().getDocumentBaseURI() != null) {
+                                done.put(imp.getDefinition().getDocumentBaseURI(), imp.getDefinition());
+                            }
+                            updateDefinition(bus, imp.getDefinition(), done, doneSchemas, base, start, null);
                         }
                     }
                 } else {
                     if (done.put(decodedStart, imp.getDefinition()) == null) {
                         done.put(resolvedSchemaLocation, imp.getDefinition());
-                        updateDefinition(bus, imp.getDefinition(), done, doneSchemas, base, start);
+                        if (imp.getDefinition() != null && imp.getDefinition().getDocumentBaseURI() != null) {
+                            done.put(imp.getDefinition().getDocumentBaseURI(), imp.getDefinition());
+                        }
+                        updateDefinition(bus, imp.getDefinition(), done, doneSchemas, base, start,
+                                resolvedSchemaLocation);
                     }
                 }
             }
@@ -413,7 +422,7 @@ public class WSDLGetUtils {
             for (ExtensibilityElement el
                 : CastUtils.cast(types.getExtensibilityElements(), ExtensibilityElement.class)) {
                 if (el instanceof Schema) {
-                    updateSchemaImports(bus, (Schema)el, docBase, doneSchemas, base);
+                    updateSchemaImports(bus, (Schema)el, docBase, doneSchemas, base, parentResolvedLocation);
                 }
             }
         }
@@ -470,138 +479,84 @@ public class WSDLGetUtils {
                                        Schema schema,
                                        String docBase,
                                        Map<String, SchemaReference> doneSchemas,
-                                       String base) {
-        OASISCatalogManager catalogs = OASISCatalogManager.getCatalogManager(bus);
+                                       String base,
+                                       String parentResolved) {
         Collection<List<?>>  imports = CastUtils.cast((Collection<?>)schema.getImports().values());
         for (List<?> lst : imports) {
             List<SchemaImport> impLst = CastUtils.cast(lst);
             for (SchemaImport imp : impLst) {
-                String start = findSchemaLocation(doneSchemas, imp, docBase);
-
-                if (start != null) {
-                    String decodedStart = null;
-                    // Always use the URL decoded version to ensure that we have a
-                    // canonical representation of the import URL for lookup.
-                    try {
-                        decodedStart = URLDecoder.decode(start, "utf-8");
-                    } catch (UnsupportedEncodingException e) {
-                        throw new WSDLQueryException(
-                            new org.apache.cxf.common.i18n.Message("COULD_NOT_PROVIDE_WSDL",
-                                LOG,
-                                start), e);
-                    }
-
-                    if (!doneSchemas.containsKey(decodedStart)) {
-                        String resolvedSchemaLocation = resolveWithCatalogs(catalogs, start, base);
-                        if (resolvedSchemaLocation == null) {
-                            resolvedSchemaLocation = resolveWithCatalogs(catalogs, imp.getSchemaLocationURI(), base);
-                        }
-                        if (resolvedSchemaLocation == null) {
-                            try {
-                                //check to see if it's already in a URL format.  If so, leave it.
-                                new URL(start);
-                            } catch (MalformedURLException e) {
-                                if (doneSchemas.put(decodedStart, imp) == null) {
-                                    putResolvedSchemaLocationIfRelative(doneSchemas, decodedStart, imp);
-                                    updateSchemaImports(bus, imp.getReferencedSchema(), start, doneSchemas, base);
-                                }
-                            }
-                        } else {
-                            if (doneSchemas.put(decodedStart, imp) == null) {
-                                doneSchemas.put(resolvedSchemaLocation, imp);
-                                String p = getAndSaveRelativeSchemaLocationIfCatalogResolved(doneSchemas,
-                                                                                             resolvedSchemaLocation,
-                                                                                             schema,
-                                                                                             imp);
-                                updateSchemaImports(bus, imp.getReferencedSchema(), p, doneSchemas, base);
-                            }
-                        }
-                    }
-                }
+                processSchemaReference(imp, bus, schema, docBase, doneSchemas, base, parentResolved);
             }
         }
 
         List<SchemaReference> includes = CastUtils.cast(schema.getIncludes());
         for (SchemaReference included : includes) {
-            String start = findSchemaLocation(doneSchemas, included, docBase);
-
-            if (start != null) {
-                String decodedStart = null;
-                // Always use the URL decoded version to ensure that we have a
-                // canonical representation of the import URL for lookup.
-                try {
-                    decodedStart = URLDecoder.decode(start, "utf-8");
-                } catch (UnsupportedEncodingException e) {
-                    throw new WSDLQueryException(
-                        new org.apache.cxf.common.i18n.Message("COULD_NOT_PROVIDE_WSDL",
-                            LOG,
-                            start), e);
-                }
-
-                String resolvedSchemaLocation = resolveWithCatalogs(catalogs, start, base);
-                if (resolvedSchemaLocation == null) {
-                    if (!doneSchemas.containsKey(decodedStart)) {
-                        try {
-                            //check to see if it's aleady in a URL format.  If so, leave it.
-                            new URL(start);
-                        } catch (MalformedURLException e) {
-                            if (doneSchemas.put(decodedStart, included) == null) {
-                                putResolvedSchemaLocationIfRelative(doneSchemas, decodedStart, included);
-                                updateSchemaImports(bus, included.getReferencedSchema(), start, doneSchemas, base);
-                            }
-                        }
-                    }
-                } else if (!doneSchemas.containsKey(decodedStart)
-                    || !doneSchemas.containsKey(resolvedSchemaLocation)) {
-                    doneSchemas.put(decodedStart, included);
-                    doneSchemas.put(resolvedSchemaLocation, included);
-                    String p = getAndSaveRelativeSchemaLocationIfCatalogResolved(doneSchemas,
-                                                                                 resolvedSchemaLocation,
-                                                                                 schema,
-                                                                                 included);
-                    updateSchemaImports(bus, included.getReferencedSchema(), p, doneSchemas, base);
-                }
-            }
+            processSchemaReference(included, bus, schema, docBase, doneSchemas, base, parentResolved);
         }
         List<SchemaReference> redefines = CastUtils.cast(schema.getRedefines());
         for (SchemaReference included : redefines) {
-            String start = findSchemaLocation(doneSchemas, included, docBase);
+            processSchemaReference(included, bus, schema, docBase, doneSchemas, base, parentResolved);
+        }
+    }
 
-            if (start != null) {
-                String decodedStart = null;
-                // Always use the URL decoded version to ensure that we have a
-                // canonical representation of the import URL for lookup.
-                try {
-                    decodedStart = URLDecoder.decode(start, "utf-8");
-                } catch (UnsupportedEncodingException e) {
-                    throw new WSDLQueryException(
+    private void processSchemaReference(SchemaReference schemaReference,
+                                        Bus bus,
+                                        Schema schema,
+                                        String docBase,
+                                        Map<String, SchemaReference> doneSchemas,
+                                        String base,
+                                        String parentResolved) {
+        OASISCatalogManager catalogs = OASISCatalogManager.getCatalogManager(bus);
+        String start = findSchemaLocation(doneSchemas, schemaReference, docBase);
+        String origLocation = schemaReference.getSchemaLocationURI();
+
+        if (start != null) {
+            String decodedStart;
+            String decodedOrigLocation;
+            // Always use the URL decoded version to ensure that we have a
+            // canonical representation of the import URL for lookup.
+            try {
+                decodedStart = URLDecoder.decode(start, "utf-8");
+                decodedOrigLocation = URLDecoder.decode(origLocation, "utf-8");
+            } catch (UnsupportedEncodingException e) {
+                throw new WSDLQueryException(
                         new org.apache.cxf.common.i18n.Message("COULD_NOT_PROVIDE_WSDL",
-                            LOG,
-                            start), e);
-                }
+                                LOG,
+                                start), e);
+            }
 
+            if (!doneSchemas.containsKey(decodedStart)) {
                 String resolvedSchemaLocation = resolveWithCatalogs(catalogs, start, base);
                 if (resolvedSchemaLocation == null) {
-                    if (!doneSchemas.containsKey(decodedStart)) {
+                    resolvedSchemaLocation =
+                            resolveWithCatalogs(catalogs, schemaReference.getSchemaLocationURI(), base);
+                }
+                if (resolvedSchemaLocation == null) {
+                    try {
+                        //check to see if it's already in a URL format.  If so, leave it.
+                        new URL(start);
+                    } catch (MalformedURLException e) {
+                        doneSchemas.put(decodedStart, schemaReference);
+                        doneSchemas.put(schemaReference.getReferencedSchema().getDocumentBaseURI(), schemaReference);
                         try {
-                            //check to see if it's aleady in a URL format.  If so, leave it.
-                            new URL(start);
-                        } catch (MalformedURLException e) {
-                            if (doneSchemas.put(decodedStart, included) == null) {
-                                putResolvedSchemaLocationIfRelative(doneSchemas, decodedStart, included);
-                                updateSchemaImports(bus, included.getReferencedSchema(), start, doneSchemas, base);
+                            if (!(new URI(origLocation).isAbsolute()) && parentResolved != null) {
+                                resolvedSchemaLocation = resolveRelativePath(parentResolved, decodedOrigLocation);
+                                doneSchemas.put(resolvedSchemaLocation, schemaReference);
                             }
+                        } catch (URISyntaxException e1) {
+                            // ignore
                         }
+                        updateSchemaImports(bus, schemaReference.getReferencedSchema(), start, doneSchemas, base,
+                                resolvedSchemaLocation);
                     }
-                } else if (!doneSchemas.containsKey(decodedStart)
-                    || !doneSchemas.containsKey(resolvedSchemaLocation)) {
-                    doneSchemas.put(decodedStart, included);
-                    doneSchemas.put(resolvedSchemaLocation, included);
+                } else if (doneSchemas.put(decodedStart, schemaReference) == null) {
+                    doneSchemas.put(resolvedSchemaLocation, schemaReference);
                     String p = getAndSaveRelativeSchemaLocationIfCatalogResolved(doneSchemas,
-                                                                                 resolvedSchemaLocation,
-                                                                                 schema,
-                                                                                 included);
-                    updateSchemaImports(bus, included.getReferencedSchema(), p, doneSchemas, base);
+                            resolvedSchemaLocation,
+                            schema,
+                            schemaReference);
+                    updateSchemaImports(bus, schemaReference.getReferencedSchema(), p, doneSchemas, base,
+                            resolvedSchemaLocation);
                 }
             }
         }
@@ -651,25 +606,6 @@ public class WSDLGetUtils {
         return path;
     }
 
-    /**
-     * If given decodedStart is relative path, resolves a real location of given schema and puts it into schema map.
-     *
-     * @param doneSchemas schema map
-     * @param decodedStart path referencing schema
-     * @param schemaReference referenced schema
-     */
-    private void putResolvedSchemaLocationIfRelative(Map<String, SchemaReference> doneSchemas, String decodedStart,
-                                                     SchemaReference schemaReference) {
-        try {
-            if (!(new URI(decodedStart).isAbsolute())) {
-                String resolved = schemaReference.getReferencedSchema().getDocumentBaseURI();
-                doneSchemas.put(resolved, schemaReference);
-            }
-        } catch (URISyntaxException ex) {
-            // ignore
-        }
-    }
-
     private String findSchemaLocation(Map<String, SchemaReference> doneSchemas,
                                       SchemaReference imp,
                                       String docBase) {
@@ -696,6 +632,12 @@ public class WSDLGetUtils {
         return schemaLocationURI;
     }
 
+    private String resolveRelativePath(String parentUri, String relativePath) {
+        // can not use `new URI(uri).resolve(path)`, because that doesn't work with "jar:file:x!y" kind of URIs
+        String base = UrlUtils.getStem(parentUri);
+        return base + '/' + relativePath;
+    }
+
     /**
      * Write the contents of a wsdl Definition object to a file.
      *
@@ -715,7 +657,7 @@ public class WSDLGetUtils {
                                       String base,
                                       EndpointInfo endpointInfo) throws WSDLException {
 
-        Document doc = null;
+        Document doc;
         Bus bus = message.getExchange().getBus();
         Definition def = lookupDefinition(bus, mp, wsdl, base);
         String epurl = base;
@@ -823,7 +765,7 @@ public class WSDLGetUtils {
             Definition def = builder.build(new HashMap<String, SchemaInfo>());
 
             mp.put("", def);
-            updateDefinition(bus, def, mp, smp, base, "");
+            updateDefinition(bus, def, mp, smp, base, "", "");
         }
 
     }

--- a/rt/frontend/simple/src/main/java/org/apache/cxf/frontend/WSDLGetUtils.java
+++ b/rt/frontend/simple/src/main/java/org/apache/cxf/frontend/WSDLGetUtils.java
@@ -59,7 +59,7 @@ import org.apache.cxf.catalog.OASISCatalogManager;
 import org.apache.cxf.catalog.OASISCatalogManagerHelper;
 import org.apache.cxf.common.logging.LogUtils;
 import org.apache.cxf.common.util.StringUtils;
-import org.apache.cxf.common.util.UrlUtils;
+import org.apache.cxf.common.util.URIParserUtil;
 import org.apache.cxf.helpers.CastUtils;
 import org.apache.cxf.helpers.DOMUtils;
 import org.apache.cxf.message.Message;
@@ -150,7 +150,7 @@ public class WSDLGetUtils {
             } else if (params.get("xsd") != null) {
                 String xsd = URLDecoder.decode(params.get("xsd"), "utf-8");
                 doc = readXSDDocument(bus, xsd, smp, base);
-                updateDoc(doc, base, mp, smp, message, xsd, null);
+                updateDoc(doc, base, mp, smp, message, xsd);
             }
         } catch (WSDLQueryException wex) {
             throw wex;
@@ -193,6 +193,7 @@ public class WSDLGetUtils {
         return null;
     }
 
+    @Deprecated
     protected void updateDoc(Document doc,
                              String base,
                              Map<String, Definition> mp,
@@ -200,6 +201,15 @@ public class WSDLGetUtils {
                              Message message,
                              String xsd,
                              String wsdl) {
+        updateDoc(doc, base, mp, smp, message, xsd != null ? xsd : wsdl);
+    }
+
+    protected void updateDoc(Document doc,
+                             String base,
+                             Map<String, Definition> mp,
+                             Map<String, SchemaReference> smp,
+                             Message message,
+                             String xsdWsdlPar) {
         Bus bus = message.getExchange().getBus();
         List<Element> elementList = null;
 
@@ -208,7 +218,7 @@ public class WSDLGetUtils {
                                                               "http://www.w3.org/2001/XMLSchema", "import");
             for (Element el : elementList) {
                 String sl = el.getAttribute("schemaLocation");
-                sl = mapUri(bus, base, smp, sl, xsd);
+                sl = mapUri(bus, base, smp, sl, xsdWsdlPar);
                 if (sl != null) {
                     el.setAttribute("schemaLocation", sl);
                 }
@@ -219,7 +229,7 @@ public class WSDLGetUtils {
                                                               "include");
             for (Element el : elementList) {
                 String sl = el.getAttribute("schemaLocation");
-                sl = mapUri(bus, base, smp, sl, xsd);
+                sl = mapUri(bus, base, smp, sl, xsdWsdlPar);
                 if (sl != null) {
                     el.setAttribute("schemaLocation", sl);
                 }
@@ -229,7 +239,7 @@ public class WSDLGetUtils {
                                                               "redefine");
             for (Element el : elementList) {
                 String sl = el.getAttribute("schemaLocation");
-                sl = mapUri(bus, base, smp, sl, xsd);
+                sl = mapUri(bus, base, smp, sl, xsdWsdlPar);
                 if (sl != null) {
                     el.setAttribute("schemaLocation", sl);
                 }
@@ -240,7 +250,7 @@ public class WSDLGetUtils {
             for (Element el : elementList) {
                 String sl = el.getAttribute("location");
                 try {
-                    sl = getLocationURI(sl, wsdl);
+                    sl = getLocationURI(sl, xsdWsdlPar);
                 } catch (URISyntaxException e) {
                     //ignore
                 }
@@ -403,8 +413,7 @@ public class WSDLGetUtils {
             for (ExtensibilityElement el
                 : CastUtils.cast(types.getExtensibilityElements(), ExtensibilityElement.class)) {
                 if (el instanceof Schema) {
-                    Schema see = (Schema)el;
-                    updateSchemaImports(bus, see, see.getDocumentBaseURI(), doneSchemas, base);
+                    updateSchemaImports(bus, (Schema)el, docBase, doneSchemas, base);
                 }
             }
         }
@@ -494,15 +503,17 @@ public class WSDLGetUtils {
                             } catch (MalformedURLException e) {
                                 if (doneSchemas.put(decodedStart, imp) == null) {
                                     putResolvedSchemaLocationIfRelative(doneSchemas, decodedStart, imp);
-                                    updateSchemaImports(bus, imp.getReferencedSchema(), docBase,
-                                                        doneSchemas, base);
+                                    updateSchemaImports(bus, imp.getReferencedSchema(), start, doneSchemas, base);
                                 }
                             }
                         } else {
                             if (doneSchemas.put(decodedStart, imp) == null) {
                                 doneSchemas.put(resolvedSchemaLocation, imp);
-                                doneSchemas.put(imp.getSchemaLocationURI(), imp);
-                                updateSchemaImports(bus, imp.getReferencedSchema(), docBase, doneSchemas, base);
+                                String p = getAndSaveRelativeSchemaLocationIfCatalogResolved(doneSchemas,
+                                                                                             resolvedSchemaLocation,
+                                                                                             schema,
+                                                                                             imp);
+                                updateSchemaImports(bus, imp.getReferencedSchema(), p, doneSchemas, base);
                             }
                         }
                     }
@@ -536,7 +547,7 @@ public class WSDLGetUtils {
                         } catch (MalformedURLException e) {
                             if (doneSchemas.put(decodedStart, included) == null) {
                                 putResolvedSchemaLocationIfRelative(doneSchemas, decodedStart, included);
-                                updateSchemaImports(bus, included.getReferencedSchema(), docBase, doneSchemas, base);
+                                updateSchemaImports(bus, included.getReferencedSchema(), start, doneSchemas, base);
                             }
                         }
                     }
@@ -544,7 +555,11 @@ public class WSDLGetUtils {
                     || !doneSchemas.containsKey(resolvedSchemaLocation)) {
                     doneSchemas.put(decodedStart, included);
                     doneSchemas.put(resolvedSchemaLocation, included);
-                    updateSchemaImports(bus, included.getReferencedSchema(), docBase, doneSchemas, base);
+                    String p = getAndSaveRelativeSchemaLocationIfCatalogResolved(doneSchemas,
+                                                                                 resolvedSchemaLocation,
+                                                                                 schema,
+                                                                                 included);
+                    updateSchemaImports(bus, included.getReferencedSchema(), p, doneSchemas, base);
                 }
             }
         }
@@ -574,7 +589,7 @@ public class WSDLGetUtils {
                         } catch (MalformedURLException e) {
                             if (doneSchemas.put(decodedStart, included) == null) {
                                 putResolvedSchemaLocationIfRelative(doneSchemas, decodedStart, included);
-                                updateSchemaImports(bus, included.getReferencedSchema(), docBase, doneSchemas, base);
+                                updateSchemaImports(bus, included.getReferencedSchema(), start, doneSchemas, base);
                             }
                         }
                     }
@@ -582,10 +597,58 @@ public class WSDLGetUtils {
                     || !doneSchemas.containsKey(resolvedSchemaLocation)) {
                     doneSchemas.put(decodedStart, included);
                     doneSchemas.put(resolvedSchemaLocation, included);
-                    updateSchemaImports(bus, included.getReferencedSchema(), docBase, doneSchemas, base);
+                    String p = getAndSaveRelativeSchemaLocationIfCatalogResolved(doneSchemas,
+                                                                                 resolvedSchemaLocation,
+                                                                                 schema,
+                                                                                 included);
+                    updateSchemaImports(bus, included.getReferencedSchema(), p, doneSchemas, base);
                 }
             }
         }
+    }
+
+    /**
+     * When the imported schema location has been resolved through catalog, we need to:
+     * 1) get a valid relative location to use for recursion into the imported schema
+     * 2) add an entry to the doneSchemas map using such a valid relative location, as that's
+     *    what will be used later for import links
+     * 
+     * The valid relative location for the imported schema is computed by first obtaining the
+     * relative uri that maps the importing schema resolved location into the imported schema
+     * resolved location, then such value is resolved on top of the valid relative location
+     * that's saved in the doneSchemas map for the importing schema.
+     * 
+     * @param doneSchemas
+     * @param resolvedSchemaLocation
+     * @param currentSchema
+     * @param schemaReference
+     * @return
+     */
+    private String getAndSaveRelativeSchemaLocationIfCatalogResolved(Map<String, SchemaReference> doneSchemas,
+                                                                     String resolvedSchemaLocation,
+                                                                     Schema currentSchema,
+                                                                     SchemaReference schemaReference) {
+        String path = null;
+        for (Map.Entry<String, SchemaReference> entry : doneSchemas.entrySet()) {
+            Schema rs = entry.getValue().getReferencedSchema();
+            String k = entry.getKey();
+            String rsURI = rs.getDocumentBaseURI();
+            if (currentSchema.equals(rs) && !rsURI.equals(k)) {
+                try {
+                    String p = URIParserUtil.relativize(rsURI, resolvedSchemaLocation);
+                    if (p != null) {
+                        path = new URI(k).resolve(p).toString();
+                        break;
+                    }
+                } catch (URISyntaxException e) {
+                    // ignore
+                }
+            }
+        }
+        if (path != null) {
+            doneSchemas.put(path, schemaReference);
+        }
+        return path;
     }
 
     /**
@@ -611,13 +674,9 @@ public class WSDLGetUtils {
                                       SchemaReference imp,
                                       String docBase) {
         String schemaLocationURI = imp.getSchemaLocationURI();
-        if (docBase != null && imp.getReferencedSchema() != null) {
+        if (docBase != null && schemaLocationURI != null) {
             try {
-                String baseURI = URLDecoder.decode(UrlUtils.getStem(docBase), "utf-8");
-                String importURI = URLDecoder.decode(imp.getReferencedSchema().getDocumentBaseURI(), "utf-8");
-                if (importURI.contains(baseURI)) {
-                    schemaLocationURI = importURI.substring(baseURI.length() + 1);
-                }
+                schemaLocationURI = getLocationURI(schemaLocationURI, docBase);
             } catch (Exception e) {
                 //ignore
             }
@@ -672,7 +731,7 @@ public class WSDLGetUtils {
             doc = wsdlWriter.getDocument(def);
         }
 
-        updateDoc(doc, epurl, mp, smp, message, null, wsdl);
+        updateDoc(doc, epurl, mp, smp, message, wsdl);
         return doc;
     }
 

--- a/systests/jaxws/src/test/java/org/apache/cxf/systest/jaxws/OASISCatalogTest.java
+++ b/systests/jaxws/src/test/java/org/apache/cxf/systest/jaxws/OASISCatalogTest.java
@@ -82,7 +82,7 @@ public class OASISCatalogTest extends Assert {
         assertTrue(result, result.contains("xsd=http://apache.org/hello_world/types2/hello_world_schema2.xsd"));
 
         result = readUrl("http://localhost:" + PORT + "/SoapContext/SoapPort"
-                + "?wsdl=testutils/others/hello_world_messages_catalog.wsdl");
+                + "?wsdl=hello_world_messages_catalog.wsdl");
         assertTrue(result, result.contains("xsd=hello_world_schema.xsd"));
 
         ep.stop();

--- a/systests/jaxws/src/test/java/org/apache/cxf/systest/jaxws/OASISCatalogTest.java
+++ b/systests/jaxws/src/test/java/org/apache/cxf/systest/jaxws/OASISCatalogTest.java
@@ -63,29 +63,31 @@ public class OASISCatalogTest extends Assert {
         Endpoint ep = Endpoint.publish("http://localhost:" + PORT + "/SoapContext/SoapPort",
                                        new GreeterImpl());
 
-        String result = readUrl("http://localhost:" + PORT + "/SoapContext/SoapPort?"
-                + "xsd=hello_world_schema2.xsd");
-        assertTrue(result, result.contains("xsd=hello_world_schema.xsd"));
-        assertTrue(result, result.contains("xsd=hello_world_schema3.xsd"));
-        assertTrue(result, result.contains("xsd=d/hello_world_schema4.xsd"));
+        try {
+            String result = readUrl("http://localhost:" + PORT + "/SoapContext/SoapPort?"
+                    + "xsd=hello_world_schema2.xsd");
+            assertTrue(result, result.contains("xsd=hello_world_schema.xsd"));
+            assertTrue(result, result.contains("xsd=hello_world_schema3.xsd"));
+            assertTrue(result, result.contains("xsd=d/hello_world_schema4.xsd"));
 
-        result = readUrl("http://localhost:" + PORT + "/SoapContext/SoapPort?"
-                + "xsd=hello_world_schema3.xsd");
-        assertTrue(result.length() > 0);
+            result = readUrl("http://localhost:" + PORT + "/SoapContext/SoapPort?"
+                    + "xsd=hello_world_schema3.xsd");
+            assertTrue(result.length() > 0);
 
-        result = readUrl("http://localhost:" + PORT + "/SoapContext/SoapPort?"
-                + "xsd=d/hello_world_schema4.xsd");
-        assertTrue(result, result.contains("xsd=d/d/hello_world_schema4.xsd"));
+            result = readUrl("http://localhost:" + PORT + "/SoapContext/SoapPort?"
+                    + "xsd=d/hello_world_schema4.xsd");
+            assertTrue(result, result.contains("xsd=d/d/hello_world_schema4.xsd"));
 
-        result = readUrl("http://localhost:" + PORT + "/SoapContext/SoapPort"
-                + "?xsd=hello_world_schema.xsd");
-        assertTrue(result, result.contains("xsd=http://apache.org/hello_world/types2/hello_world_schema2.xsd"));
+            result = readUrl("http://localhost:" + PORT + "/SoapContext/SoapPort"
+                    + "?xsd=hello_world_schema.xsd");
+            assertTrue(result, result.contains("xsd=http://apache.org/hello_world/types2/hello_world_schema2.xsd"));
 
-        result = readUrl("http://localhost:" + PORT + "/SoapContext/SoapPort"
-                + "?wsdl=hello_world_messages_catalog.wsdl");
-        assertTrue(result, result.contains("xsd=hello_world_schema.xsd"));
-
-        ep.stop();
+            result = readUrl("http://localhost:" + PORT + "/SoapContext/SoapPort"
+                    + "?wsdl=hello_world_messages_catalog.wsdl");
+            assertTrue(result, result.contains("xsd=hello_world_schema.xsd"));
+        } finally {
+            ep.stop();
+        }
     }
 
     /**
@@ -101,30 +103,65 @@ public class OASISCatalogTest extends Assert {
     public void testWSDLPublishWithCatalogsRewritePaths() {
         Endpoint ep = Endpoint.publish("http://localhost:" + PORT + "/SoapContext/SoapPort",
                 new GreeterImpl());
+        try {
+            // schemas in the same directory as WSDL
 
-        String result = readUrl("http://localhost:" + PORT + "/SoapContext/SoapPort?"
-                + "xsd=http://apache.org/hello_world/types2/hello_world_schema2.xsd");
-        assertTrue(result, result.contains("xsd=http://apache.org/hello_world/types2/hello_world_schema.xsd"));
-        assertTrue(result, result.contains("xsd=http://apache.org/hello_world/types2/hello_world_schema3.xsd"));
-        assertTrue(result, result.contains("xsd=http://apache.org/hello_world/types2/d/hello_world_schema4.xsd"));
+            String result = readUrl("http://localhost:" + PORT + "/SoapContext/SoapPort?"
+                    + "xsd=http://apache.org/hello_world/types2/hello_world_schema2.xsd");
+            assertTrue(result, result.contains("xsd=http://apache.org/hello_world/types2/hello_world_schema.xsd"));
+            assertTrue(result, result.contains("xsd=http://apache.org/hello_world/types2/hello_world_schema3.xsd"));
+            assertTrue(result, result.contains("xsd=http://apache.org/hello_world/types2/d/hello_world_schema4.xsd"));
 
-        result = readUrl("http://localhost:" + PORT + "/SoapContext/SoapPort?"
-                + "xsd=http://apache.org/hello_world/types2/hello_world_schema.xsd");
-        assertTrue(result, result.contains("xsd=http://apache.org/hello_world/types2/hello_world_schema2.xsd"));
+            result = readUrl("http://localhost:" + PORT + "/SoapContext/SoapPort?"
+                    + "xsd=http://apache.org/hello_world/types2/hello_world_schema.xsd");
+            assertTrue(result, result.contains("xsd=http://apache.org/hello_world/types2/hello_world_schema2.xsd"));
 
-        result = readUrl("http://localhost:" + PORT + "/SoapContext/SoapPort?"
-                + "xsd=http://apache.org/hello_world/types2/hello_world_schema3.xsd");
-        assertTrue(result.length() > 0);
+            result = readUrl("http://localhost:" + PORT + "/SoapContext/SoapPort?"
+                    + "xsd=http://apache.org/hello_world/types2/hello_world_schema3.xsd");
+            assertTrue(result.length() > 0);
 
-        result = readUrl("http://localhost:" + PORT + "/SoapContext/SoapPort?"
-                + "xsd=http://apache.org/hello_world/types2/d/hello_world_schema4.xsd");
-        assertTrue(result, result.contains("xsd=http://apache.org/hello_world/types2/d/d/hello_world_schema4.xsd"));
+            result = readUrl("http://localhost:" + PORT + "/SoapContext/SoapPort?"
+                    + "xsd=http://apache.org/hello_world/types2/d/hello_world_schema4.xsd");
+            assertTrue(result, result.contains("xsd=http://apache.org/hello_world/types2/d/d/hello_world_schema4.xsd"));
 
-        result = readUrl("http://localhost:" + PORT + "/SoapContext/SoapPort?"
-                + "xsd=http://apache.org/hello_world/types2/d/d/hello_world_schema4.xsd");
-        assertTrue(result.length() > 0);
+            result = readUrl("http://localhost:" + PORT + "/SoapContext/SoapPort?"
+                    + "xsd=http://apache.org/hello_world/types2/d/d/hello_world_schema4.xsd");
+            assertFalse(result.contains("schemaLocation"));
 
-        ep.stop();
+            // schemas in separate directory which is not subdirectory of WSDL dir
+
+            result = readUrl("http://localhost:" + PORT + "/SoapContext/SoapPort?"
+                    + "wsdl=http://apache.org/hello_world/types2/hello_world_messages_catalog.wsdl");
+            assertTrue(result, result.contains("xsd=http://apache.org/hello_world/schemas-in-separate-dir/schema.xsd"));
+
+            result = readUrl("http://localhost:" + PORT + "/SoapContext/SoapPort?"
+                    + "xsd=http://apache.org/hello_world/schemas-in-separate-dir/schema.xsd");
+            assertTrue(result,
+                    result.contains("xsd=http://apache.org/hello_world/schemas-in-separate-dir/d/included.xsd"));
+
+            result = readUrl("http://localhost:" + PORT + "/SoapContext/SoapPort?"
+                    + "xsd=http://apache.org/hello_world/schemas-in-separate-dir/d/included.xsd");
+            assertTrue(result,
+                    result.contains("xsd=http://apache.org/hello_world/schemas-in-separate-dir/d/d/included.xsd"));
+
+            result = readUrl("http://localhost:" + PORT + "/SoapContext/SoapPort?"
+                    + "xsd=http://apache.org/hello_world/schemas-in-separate-dir/d/d/included.xsd");
+            assertFalse(result, result.contains("schemaLocation"));
+
+            // rewrite rule that doesn't begin with 'classpath:' but contains only the path
+
+            result = readUrl("http://localhost:" + PORT + "/SoapContext/SoapPort?"
+                    + "xsd=http://apache.org/hello_world/schemas-in-separate-dir-non-cp/another-schema.xsd");
+            assertTrue(result, result.contains("xsd=http://apache.org/hello_world/schemas-in-separate-dir-non-cp/d/"
+                    + "another-included.xsd"));
+
+            result = readUrl("http://localhost:" + PORT + "/SoapContext/SoapPort?"
+                    + "xsd=http://apache.org/hello_world/schemas-in-separate-dir-non-cp/d/another-included.xsd");
+            assertTrue(result, result.contains("xsd=http://apache.org/hello_world/schemas-in-separate-dir-non-cp/d/d/"
+                    + "another-included.xsd"));
+        } finally {
+            ep.stop();
+        }
     }
     
     @Test

--- a/systests/uncategorized/src/test/java/org/apache/cxf/systest/schemaimport/SayHiImpl2.java
+++ b/systests/uncategorized/src/test/java/org/apache/cxf/systest/schemaimport/SayHiImpl2.java
@@ -1,0 +1,64 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.cxf.systest.schemaimport;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.jws.WebMethod;
+import javax.jws.WebParam;
+import javax.jws.WebResult;
+import javax.jws.WebService;
+import javax.xml.ws.RequestWrapper;
+import javax.xml.ws.ResponseWrapper;
+
+@WebService(targetNamespace = "http://apache.org/sayHi", name = "SayHi", 
+            wsdlLocation = "classpath:/wsdl_systest/e/sayHi.wsdl", 
+            endpointInterface = "org.apache.cxf.systest.schemaimport.SayHi")
+public class SayHiImpl2 implements SayHi {
+
+    @Override
+    @WebResult(name = "return", targetNamespace = "")
+    @RequestWrapper(localName = "sayHiArray", 
+                    targetNamespace = "http://apache.org/sayHi2", 
+                    className = "org.apache.sayhi2.SayHiArray")
+    @WebMethod
+    @ResponseWrapper(localName = "sayHiArrayResponse", 
+                     targetNamespace = "http://apache.org/sayHi2", 
+                     className = "org.apache.sayhi2.SayHiArrayResponse")
+    public List<String> sayHiArray(@WebParam(name = "arg0", targetNamespace = "") List<String> arg0) {
+        List<String> list = new ArrayList<String>();
+        list.add("Hi");
+        return list;
+    }
+
+    @Override
+    @WebResult(name = "return", targetNamespace = "http://apache.org/sayHi1")
+    @RequestWrapper(localName = "sayHi", 
+                    targetNamespace = "http://apache.org/sayHi1", 
+                    className = "org.apache.sayhi1.SayHi")
+    @WebMethod
+    @ResponseWrapper(localName = "sayHiResponse", 
+                     targetNamespace = "http://apache.org/sayHi1", 
+                     className = "org.apache.sayhi1.SayHiResponse")
+    public String sayHi(@WebParam(name = "arg0", targetNamespace = "http://apache.org/sayHi1") String arg0) {
+        return "Hi";
+    }
+
+}

--- a/systests/uncategorized/src/test/java/org/apache/cxf/systest/schemaimport/SchemaImportTest.java
+++ b/systests/uncategorized/src/test/java/org/apache/cxf/systest/schemaimport/SchemaImportTest.java
@@ -55,6 +55,21 @@ public class SchemaImportTest extends AbstractBusClientServerTestBase {
     }
 
     @Test
+    public void testImportSchema2() throws Exception {
+        String schemaURL = "http://localhost:" + PORT + "/schemaimport/sayHi2"
+                           + "?xsd=../sayhi/sayhi/sayhi-schema1.xsd";
+        URL url = new URL(schemaURL);
+        try {
+            InputStream ins = url.openStream();
+            String output = IOUtils.toString(ins);
+            assertTrue(output.indexOf("sayHiArray") > -1);
+        } catch (Exception e) {
+            e.printStackTrace();
+            fail("Can not access the import schema");
+        }
+    }
+
+    @Test
     public void testImportWsdl() throws Exception {
         String wsdlURL = "http://localhost:" + PORT + "/schemaimport/sayHi"  + "?wsdl=sayhi/sayhi/a.wsdl";
         URL url = new URL(wsdlURL);
@@ -73,8 +88,22 @@ public class SchemaImportTest extends AbstractBusClientServerTestBase {
             }
         }
     }
-    
-    
+
+    @Test
+    public void testImportWsdl2() throws Exception {
+        String wsdlURL = "http://localhost:" + PORT + "/schemaimport/sayHi2" + "?wsdl=../sayhi/sayhi/a.wsdl";
+        URL url = new URL(wsdlURL);
+        try {
+            InputStream ins = url.openStream();
+            String output = IOUtils.toString(ins);
+            assertTrue(output.indexOf("sayHiArray") > -1);
+        } catch (Exception e) {
+            e.printStackTrace();
+            fail("Can not access the import wsdl");
+
+        }
+    }
+
     @Test
     public void testAnotherSchemaImportl() throws Exception {
         String schemaURL = "http://localhost:" + PORT + "/schemaimport/service"  + "?xsd=schema1.xsd";

--- a/systests/uncategorized/src/test/java/org/apache/cxf/systest/schemaimport/Server.java
+++ b/systests/uncategorized/src/test/java/org/apache/cxf/systest/schemaimport/Server.java
@@ -38,6 +38,9 @@ public class Server extends AbstractBusTestServerBase {
         Object implementor3 = new ServiceImpl();
         String address3 = "http://localhost:" + PORT + "/schemainclude/service";
         Endpoint.publish(address3, implementor3);
+        Object implementor4 = new SayHiImpl2();
+        String address4 = "http://localhost:" + PORT + "/schemaimport/sayHi2";
+        Endpoint.publish(address4, implementor4);
     }
 
     public static void main(String[] args) {

--- a/systests/uncategorized/src/test/resources/wsdl_systest/e/sayHi.wsdl
+++ b/systests/uncategorized/src/test/resources/wsdl_systest/e/sayHi.wsdl
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements. See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership. The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License. You may obtain a copy of the License at
+ 
+  http://www.apache.org/licenses/LICENSE-2.0
+ 
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied. See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+<definitions xmlns:tns="http://apache.org/sayHi" xmlns:sayhi1="http://apache.org/sayHi1" xmlns:sayhi2="http://apache.org/sayHi2" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/" xmlns="http://schemas.xmlsoap.org/wsdl/" targetNamespace="http://apache.org/sayHi" name="SayHiService">
+    <import namespace="http://apache.org/sayHi" location="../sayhi/a.wsdl"/>
+    <types>
+        <xsd:schema>
+            <xsd:import namespace="http://apache.org/sayHi1" schemaLocation="../sayhi/sayhi-schema1.xsd"/>
+        </xsd:schema>
+    </types>
+    <portType name="SayHi">
+        <operation name="sayHi">
+            <input message="tns:sayHi"/>
+            <output message="tns:sayHiResponse"/>
+        </operation>
+        <operation name="sayHiArray">
+            <input message="tns:sayHiArray"/>
+            <output message="tns:sayHiArrayResponse"/>
+        </operation>
+    </portType>    
+    <binding name="SayHiPortBinding" type="tns:SayHi">
+        <soap:binding transport="http://schemas.xmlsoap.org/soap/http" style="document"/>
+        <operation name="sayHi">
+            <soap:operation soapAction=""/>
+            <input>
+                <soap:body use="literal"/>
+            </input>
+            <output>
+                <soap:body use="literal"/>
+            </output>
+        </operation>
+        <operation name="sayHiArray">
+            <soap:operation soapAction=""/>
+            <input>
+                <soap:body use="literal"/>
+            </input>
+            <output>
+                <soap:body use="literal"/>
+            </output>
+        </operation>
+    </binding>
+    <service name="SayHiService">
+        <port name="SayHiPort" binding="tns:SayHiPortBinding">
+            <soap:address location="http://localhost:9090/sayHi2"/>
+        </port>
+    </service>
+</definitions>

--- a/testutils/src/main/resources/wsdl/others/hello_world_bindings_catalog.wsdl
+++ b/testutils/src/main/resources/wsdl/others/hello_world_bindings_catalog.wsdl
@@ -17,19 +17,8 @@ KIND, either express or implied. See the License for the
 specific language governing permissions and limitations
 under the License.
 -->
-<wsdl:definitions name="HelloWorld"
-          xmlns="http://schemas.xmlsoap.org/wsdl/"
-          xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
-          xmlns:x2="http://apache.org/hello_world"
-          xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/"
-          xmlns:xsd="http://www.w3.org/2001/XMLSchema"
-          targetNamespace="http://apache.org/hello_world/bindings">
-
-
-    <wsdl:import
-    namespace="http://apache.org/hello_world"
-    location="testutils/others/hello_world_wsdl_import_catalog.wsdl"/>
-
+<wsdl:definitions xmlns="http://schemas.xmlsoap.org/wsdl/" xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/" xmlns:x2="http://apache.org/hello_world" xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" xmlns:xsd="http://www.w3.org/2001/XMLSchema" name="HelloWorld" targetNamespace="http://apache.org/hello_world/bindings">
+    <wsdl:import namespace="http://apache.org/hello_world" location="hello_world_wsdl_import_catalog.wsdl"/>
     <wsdl:binding name="SOAPBinding" type="x2:Greeter">
         <soap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http"/>
         <wsdl:operation name="sayHi">

--- a/testutils/src/main/resources/wsdl/others/hello_world_messages_catalog.wsdl
+++ b/testutils/src/main/resources/wsdl/others/hello_world_messages_catalog.wsdl
@@ -31,6 +31,16 @@
             <xsd:import namespace="http://apache.org/hello_world/types" 
                 schemaLocation="hello_world_schema.xsd"/>
         </schema>
+        <schema targetNamespace="http://apache.org/hello_world/schemas-in-separate-dir"
+                xmlns="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified">
+            <xsd:import namespace="http://apache.org/hello_world/schemas-in-separate-dir"
+                        schemaLocation="http://apache.org/hello_world/schemas-in-separate-dir/schema.xsd"/>
+        </schema>
+        <schema targetNamespace="http://apache.org/hello_world/schemas-in-separate-dir"
+                xmlns="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified">
+            <xsd:import namespace="http://apache.org/hello_world/schemas-in-separate-dir"
+                        schemaLocation="http://apache.org/hello_world/schemas-in-separate-dir-non-cp/another-schema.xsd"/>
+        </schema>
     </wsdl:types>
     <wsdl:message name="sayHiRequest">
         <wsdl:part name="in" element="x1:sayHi"/>

--- a/testutils/src/main/resources/wsdl/others/hello_world_services_catalog.wsdl
+++ b/testutils/src/main/resources/wsdl/others/hello_world_services_catalog.wsdl
@@ -17,20 +17,8 @@ KIND, either express or implied. See the License for the
 specific language governing permissions and limitations
 under the License.
 -->
-<wsdl:definitions name="HelloWorld"
-		  xmlns="http://schemas.xmlsoap.org/wsdl/"
-		  xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"		 
-		  xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/"
-		  xmlns:tns="http://apache.org/hello_world/services"
-		  xmlns:xsd="http://www.w3.org/2001/XMLSchema"
-		  xmlns:x1="http://apache.org/hello_world/bindings"
-		  xmlns:x2="http://apache.org/hello_world"
-		  targetNamespace="http://apache.org/hello_world/services">
-
-    <wsdl:import
-        namespace="http://apache.org/hello_world/bindings"
-        location="testutils/others/hello_world_bindings_catalog.wsdl"/>
-
+<wsdl:definitions xmlns="http://schemas.xmlsoap.org/wsdl/" xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/" xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" xmlns:tns="http://apache.org/hello_world/services" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:x1="http://apache.org/hello_world/bindings" xmlns:x2="http://apache.org/hello_world" name="HelloWorld" targetNamespace="http://apache.org/hello_world/services">
+    <wsdl:import namespace="http://apache.org/hello_world/bindings" location="hello_world_bindings_catalog.wsdl"/>
     <wsdl:service name="SOAPService">
 	<wsdl:port name="SoapPort" binding="x1:SOAPBinding">
 	    <soap:address location="http://localhost:9000/SoapContext/SoapPort"/>

--- a/testutils/src/main/resources/wsdl/others/hello_world_wsdl_import_catalog.wsdl
+++ b/testutils/src/main/resources/wsdl/others/hello_world_wsdl_import_catalog.wsdl
@@ -17,19 +17,8 @@
   specific language governing permissions and limitations
   under the License.
 -->
-<wsdl:definitions name="HelloWorldImport"
-    xmlns="http://schemas.xmlsoap.org/wsdl/"
-    xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
-    xmlns:tns="http://apache.org/hello_world"
-    xmlns:x1="http://apache.org/hello_world/messages"
-    xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/"
-    xmlns:xsd="http://www.w3.org/2001/XMLSchema"
-    targetNamespace="http://apache.org/hello_world">
-
-    <wsdl:import
-        namespace="http://apache.org/hello_world/messages"
-        location="testutils/others/hello_world_messages_catalog.wsdl"/>
-
+<wsdl:definitions xmlns="http://schemas.xmlsoap.org/wsdl/" xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/" xmlns:tns="http://apache.org/hello_world" xmlns:x1="http://apache.org/hello_world/messages" xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" xmlns:xsd="http://www.w3.org/2001/XMLSchema" name="HelloWorldImport" targetNamespace="http://apache.org/hello_world">
+    <wsdl:import namespace="http://apache.org/hello_world/messages" location="hello_world_messages_catalog.wsdl"/>
     <wsdl:portType name="Greeter">
         <wsdl:operation name="sayHi">
             <wsdl:input message="x1:sayHiRequest"/>

--- a/testutils/src/main/resources/wsdl/schemas/another-schema.xsd
+++ b/testutils/src/main/resources/wsdl/schemas/another-schema.xsd
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0"?>
 <!--
     Licensed to the Apache Software Foundation (ASF) under one
     or more contributor license agreements.  See the NOTICE file
@@ -7,9 +7,9 @@
     to you under the Apache License, Version 2.0 (the
     "License"); you may not use this file except in compliance
     with the License.  You may obtain a copy of the License at
-    
+
      http://www.apache.org/licenses/LICENSE-2.0
-    
+
     Unless required by applicable law or agreed to in writing,
     software distributed under the License is distributed on an
     "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -17,12 +17,13 @@
     specific language governing permissions and limitations
     under the License.
 -->
-<catalog xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog" prefer="system">
-    <rewriteSystem systemIdStartString="http://apache.org/hello_world/types2/" rewritePrefix="/wsdl/others/"/>
-    <rewriteSystem systemIdStartString="http://apache.org/hello_world/schemas-in-separate-dir/" rewritePrefix="classpath:/wsdl/schemas/"/>
-    <rewriteSystem systemIdStartString="http://apache.org/hello_world/schemas-in-separate-dir-non-cp/" rewritePrefix="/wsdl/schemas/"/>
-    <rewriteSystem systemIdStartString="doesnotexist" rewritePrefix="../wsdl/catalog"/>
-    <rewriteSystem systemIdStartString="nopath" rewritePrefix="../wsdl"/>
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" 
+    targetNamespace="http://apache.org/hello_world/schemas-in-separate-dir"
+            elementFormDefault="qualified">
 
-    <rewriteSystem systemIdStartString="testutils" rewritePrefix="classpath:/wsdl"/>
-</catalog>
+    <xsd:import schemaLocation="d/another-included.xsd" namespace="http://apache.org/hello_world/schemas-in-separate-dir"/>
+
+    <xsd:element name="sayHi5">
+        <xsd:complexType/>
+    </xsd:element>
+</xsd:schema>

--- a/testutils/src/main/resources/wsdl/schemas/d/another-included.xsd
+++ b/testutils/src/main/resources/wsdl/schemas/d/another-included.xsd
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0"?>
 <!--
     Licensed to the Apache Software Foundation (ASF) under one
     or more contributor license agreements.  See the NOTICE file
@@ -7,9 +7,9 @@
     to you under the Apache License, Version 2.0 (the
     "License"); you may not use this file except in compliance
     with the License.  You may obtain a copy of the License at
-    
+
      http://www.apache.org/licenses/LICENSE-2.0
-    
+
     Unless required by applicable law or agreed to in writing,
     software distributed under the License is distributed on an
     "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -17,12 +17,13 @@
     specific language governing permissions and limitations
     under the License.
 -->
-<catalog xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog" prefer="system">
-    <rewriteSystem systemIdStartString="http://apache.org/hello_world/types2/" rewritePrefix="/wsdl/others/"/>
-    <rewriteSystem systemIdStartString="http://apache.org/hello_world/schemas-in-separate-dir/" rewritePrefix="classpath:/wsdl/schemas/"/>
-    <rewriteSystem systemIdStartString="http://apache.org/hello_world/schemas-in-separate-dir-non-cp/" rewritePrefix="/wsdl/schemas/"/>
-    <rewriteSystem systemIdStartString="doesnotexist" rewritePrefix="../wsdl/catalog"/>
-    <rewriteSystem systemIdStartString="nopath" rewritePrefix="../wsdl"/>
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" 
+    targetNamespace="http://apache.org/hello_world/schemas-in-separate-dir"
+            elementFormDefault="qualified">
 
-    <rewriteSystem systemIdStartString="testutils" rewritePrefix="classpath:/wsdl"/>
-</catalog>
+    <xsd:import schemaLocation="d/another-included.xsd" namespace="http://apache.org/hello_world/schemas-in-separate-dir"/>
+
+    <xsd:element name="sayHi6">
+        <xsd:complexType/>
+    </xsd:element>
+</xsd:schema>

--- a/testutils/src/main/resources/wsdl/schemas/d/d/another-included.xsd
+++ b/testutils/src/main/resources/wsdl/schemas/d/d/another-included.xsd
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0"?>
 <!--
     Licensed to the Apache Software Foundation (ASF) under one
     or more contributor license agreements.  See the NOTICE file
@@ -7,9 +7,9 @@
     to you under the Apache License, Version 2.0 (the
     "License"); you may not use this file except in compliance
     with the License.  You may obtain a copy of the License at
-    
+
      http://www.apache.org/licenses/LICENSE-2.0
-    
+
     Unless required by applicable law or agreed to in writing,
     software distributed under the License is distributed on an
     "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -17,12 +17,11 @@
     specific language governing permissions and limitations
     under the License.
 -->
-<catalog xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog" prefer="system">
-    <rewriteSystem systemIdStartString="http://apache.org/hello_world/types2/" rewritePrefix="/wsdl/others/"/>
-    <rewriteSystem systemIdStartString="http://apache.org/hello_world/schemas-in-separate-dir/" rewritePrefix="classpath:/wsdl/schemas/"/>
-    <rewriteSystem systemIdStartString="http://apache.org/hello_world/schemas-in-separate-dir-non-cp/" rewritePrefix="/wsdl/schemas/"/>
-    <rewriteSystem systemIdStartString="doesnotexist" rewritePrefix="../wsdl/catalog"/>
-    <rewriteSystem systemIdStartString="nopath" rewritePrefix="../wsdl"/>
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" 
+    targetNamespace="http://apache.org/hello_world/schemas-in-separate-dir"
+            elementFormDefault="qualified">
 
-    <rewriteSystem systemIdStartString="testutils" rewritePrefix="classpath:/wsdl"/>
-</catalog>
+    <xsd:element name="sayHi6">
+        <xsd:complexType/>
+    </xsd:element>
+</xsd:schema>

--- a/testutils/src/main/resources/wsdl/schemas/d/d/included.xsd
+++ b/testutils/src/main/resources/wsdl/schemas/d/d/included.xsd
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0"?>
 <!--
     Licensed to the Apache Software Foundation (ASF) under one
     or more contributor license agreements.  See the NOTICE file
@@ -7,9 +7,9 @@
     to you under the Apache License, Version 2.0 (the
     "License"); you may not use this file except in compliance
     with the License.  You may obtain a copy of the License at
-    
+
      http://www.apache.org/licenses/LICENSE-2.0
-    
+
     Unless required by applicable law or agreed to in writing,
     software distributed under the License is distributed on an
     "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -17,12 +17,11 @@
     specific language governing permissions and limitations
     under the License.
 -->
-<catalog xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog" prefer="system">
-    <rewriteSystem systemIdStartString="http://apache.org/hello_world/types2/" rewritePrefix="/wsdl/others/"/>
-    <rewriteSystem systemIdStartString="http://apache.org/hello_world/schemas-in-separate-dir/" rewritePrefix="classpath:/wsdl/schemas/"/>
-    <rewriteSystem systemIdStartString="http://apache.org/hello_world/schemas-in-separate-dir-non-cp/" rewritePrefix="/wsdl/schemas/"/>
-    <rewriteSystem systemIdStartString="doesnotexist" rewritePrefix="../wsdl/catalog"/>
-    <rewriteSystem systemIdStartString="nopath" rewritePrefix="../wsdl"/>
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" 
+    targetNamespace="http://apache.org/hello_world/schemas-in-separate-dir"
+            elementFormDefault="qualified">
 
-    <rewriteSystem systemIdStartString="testutils" rewritePrefix="classpath:/wsdl"/>
-</catalog>
+    <xsd:element name="sayHi4">
+        <xsd:complexType/>
+    </xsd:element>
+</xsd:schema>

--- a/testutils/src/main/resources/wsdl/schemas/d/included.xsd
+++ b/testutils/src/main/resources/wsdl/schemas/d/included.xsd
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0"?>
 <!--
     Licensed to the Apache Software Foundation (ASF) under one
     or more contributor license agreements.  See the NOTICE file
@@ -7,9 +7,9 @@
     to you under the Apache License, Version 2.0 (the
     "License"); you may not use this file except in compliance
     with the License.  You may obtain a copy of the License at
-    
+
      http://www.apache.org/licenses/LICENSE-2.0
-    
+
     Unless required by applicable law or agreed to in writing,
     software distributed under the License is distributed on an
     "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -17,12 +17,13 @@
     specific language governing permissions and limitations
     under the License.
 -->
-<catalog xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog" prefer="system">
-    <rewriteSystem systemIdStartString="http://apache.org/hello_world/types2/" rewritePrefix="/wsdl/others/"/>
-    <rewriteSystem systemIdStartString="http://apache.org/hello_world/schemas-in-separate-dir/" rewritePrefix="classpath:/wsdl/schemas/"/>
-    <rewriteSystem systemIdStartString="http://apache.org/hello_world/schemas-in-separate-dir-non-cp/" rewritePrefix="/wsdl/schemas/"/>
-    <rewriteSystem systemIdStartString="doesnotexist" rewritePrefix="../wsdl/catalog"/>
-    <rewriteSystem systemIdStartString="nopath" rewritePrefix="../wsdl"/>
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" 
+    targetNamespace="http://apache.org/hello_world/schemas-in-separate-dir"
+            elementFormDefault="qualified">
 
-    <rewriteSystem systemIdStartString="testutils" rewritePrefix="classpath:/wsdl"/>
-</catalog>
+    <xsd:import schemaLocation="d/included.xsd" namespace="http://apache.org/hello_world/schemas-in-separate-dir"/>
+
+    <xsd:element name="sayHi3">
+        <xsd:complexType/>
+    </xsd:element>
+</xsd:schema>

--- a/testutils/src/main/resources/wsdl/schemas/schema.xsd
+++ b/testutils/src/main/resources/wsdl/schemas/schema.xsd
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0"?>
 <!--
     Licensed to the Apache Software Foundation (ASF) under one
     or more contributor license agreements.  See the NOTICE file
@@ -7,9 +7,9 @@
     to you under the Apache License, Version 2.0 (the
     "License"); you may not use this file except in compliance
     with the License.  You may obtain a copy of the License at
-    
+
      http://www.apache.org/licenses/LICENSE-2.0
-    
+
     Unless required by applicable law or agreed to in writing,
     software distributed under the License is distributed on an
     "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -17,12 +17,13 @@
     specific language governing permissions and limitations
     under the License.
 -->
-<catalog xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog" prefer="system">
-    <rewriteSystem systemIdStartString="http://apache.org/hello_world/types2/" rewritePrefix="/wsdl/others/"/>
-    <rewriteSystem systemIdStartString="http://apache.org/hello_world/schemas-in-separate-dir/" rewritePrefix="classpath:/wsdl/schemas/"/>
-    <rewriteSystem systemIdStartString="http://apache.org/hello_world/schemas-in-separate-dir-non-cp/" rewritePrefix="/wsdl/schemas/"/>
-    <rewriteSystem systemIdStartString="doesnotexist" rewritePrefix="../wsdl/catalog"/>
-    <rewriteSystem systemIdStartString="nopath" rewritePrefix="../wsdl"/>
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" 
+    targetNamespace="http://apache.org/hello_world/schemas-in-separate-dir"
+            elementFormDefault="qualified">
 
-    <rewriteSystem systemIdStartString="testutils" rewritePrefix="classpath:/wsdl"/>
-</catalog>
+    <xsd:import schemaLocation="d/included.xsd" namespace="http://apache.org/hello_world/schemas-in-separate-dir"/>
+
+    <xsd:element name="sayHi2">
+        <xsd:complexType/>
+    </xsd:element>
+</xsd:schema>

--- a/tools/common/src/test/java/org/apache/cxf/tools/util/URIParserUtilTest.java
+++ b/tools/common/src/test/java/org/apache/cxf/tools/util/URIParserUtilTest.java
@@ -19,6 +19,7 @@
 
 package org.apache.cxf.tools.util;
 
+import java.net.URISyntaxException;
 import java.net.URLDecoder;
 
 import org.apache.cxf.common.util.URIParserUtil;
@@ -102,5 +103,29 @@ public class URIParserUtilTest extends Assert {
         orig = "/foo" + orig + ".txt";
         String s = URIParserUtil.escapeChars(orig);
         assertEquals(orig, URLDecoder.decode(s, "UTF-8"));
+    }
+
+    @Test
+    public void testRelativize() throws URISyntaxException {
+        assertNull(URIParserUtil.relativize(null, "foo"));
+        assertNull(URIParserUtil.relativize("foo", null));
+        assertEquals("", URIParserUtil.relativize("", ""));
+        assertEquals("", URIParserUtil.relativize("fds", ""));
+        assertEquals("../", URIParserUtil.relativize("fds/", ""));
+        assertEquals("fdsfs", URIParserUtil.relativize("", "fdsfs"));
+        assertEquals("fdsfs/a", URIParserUtil.relativize("", "fdsfs/a"));
+        assertEquals("../de", URIParserUtil.relativize("ab/cd", "de"));
+        assertEquals("../de/fe/gh", URIParserUtil.relativize("ab/cd", "de/fe/gh"));
+        assertEquals("../../../de/fe/gh", URIParserUtil.relativize("/abc/def/", "de/fe/gh"));
+        assertNull(URIParserUtil.relativize("file:/c:/abc/def/", "de/fe/gh")); // null as the URI obtained by
+        // the 2 strings are not both
+        // absolute or not absolute
+        assertEquals("pippo2.xsd", URIParserUtil.relativize("/abc/def/pippo1.xsd", "/abc/def/pippo2.xsd"));
+        assertEquals("../default/pippo2.xsd",
+                URIParserUtil.relativize("/abc/def/pippo1.xsd", "/abc/default/pippo2.xsd"));
+        assertEquals("def/pippo2.xsd", URIParserUtil.relativize("/abc/def", "/abc/def/pippo2.xsd"));
+        assertEquals("hello_world_schema2.xsd",
+                URIParserUtil.relativize("jar:file:/home/a.jar!/wsdl/others/",
+                        "jar:file:/home/a.jar!/wsdl/others/hello_world_schema2.xsd"));
     }
 }


### PR DESCRIPTION
...and XSD files when using catalog rewrites

Fixes these issues:

- import of nested XSDs that lies in different directory tree from
  WSDL files

  example:

  ```
jax-ws-catalog.xml contains:
  <rewriteSystem systemIdStartString="http://example.org/uri/"
rewritePrefix="/xsd/"/>

WSDL structure:
  /wsdl/service.wsdl - imports "http://example.org/uri/schema.xsd"
  /xsd/schema.xsd
  ```

- import and access of nested XSDs with equal relative paths when XSDs
  are outside of WSDL directory (previously this was working only when
  XSDs were inside WSDL directory)

  example:

  ```
jax-ws-catalog.xml contains:
  <rewriteSystem systemIdStartString="http://example.org/uri/" rewritePrefix="/xsd/"/>

WSDL structure:
  /wsdl/service.wsdl - imports "http://example.org/uri/schema.xsd"
  /xsd/schema.xsd - imports "d/included.xsd"
  /xsd/d/included.xsd - imports "d/included.xsd"
  /xsd/d/d/included.xsd
  ```

- accessing nested XSD and WSDL under URIs affected by rewrite rules
  which aren't directly used by WSDLs/XSDs

  example:

  ```
jax-ws-catalog.xml contains:
  <rewriteSystem systemIdStartString="http://example.org/uri/" rewritePrefix="/wsdl/"/>

WSDL structure:
  /wsdl/service.wsdl - imports "./included.wsdl"
  /wsdl/included.wsdl

request for: http://example.org/uri/included.wsdl
  ```

- in some cases imports weren't working when catalog rule rewritePrefix
  was "/path" instead of "classpath:/path" - catalog resolves those two
  into different values