### PR TITLE
Add MIME types for FastInfoset encoded XML sent via SOAP-JMS.

### DIFF
--- a/rt/bindings/soap/src/main/java/org/apache/cxf/binding/soap/jms/interceptor/SoapJMSInInterceptor.java
+++ b/rt/bindings/soap/src/main/java/org/apache/cxf/binding/soap/jms/interceptor/SoapJMSInInterceptor.java
@@ -181,6 +181,8 @@ public class SoapJMSInInterceptor extends AbstractSoapInterceptor {
             String contentType = ct.get(0);
             if (!contentType.startsWith("text/xml")
                 && !contentType.startsWith("application/soap+xml")
+                && !contentType.startsWith("application/fastinfoset")
+                && !contentType.startsWith("application/soap+fastinfoset")
                 && !contentType.startsWith("multipart/related")) {
                 jmsFault = JMSFaultFactory.createContentTypeMismatchFault(contentType);
             }


### PR DESCRIPTION
Add support for allowing FastInfoset messages through the SoapJMSInInterceptor. The CXF stack will properly apply the FastInfoset encoding when the feature is added, and force is set to true. However, the interceptor will return a fault when the MIME type appears via the JMS channel. The present workaround is to remove the SoapJMSInInterceptor from the list of interceptors at runtime. It is preferable to add the MIME type to the allowable list of types.