### PR TITLE
Compatibility to Jetty 9.3+

### DIFF
--- a/rt/transports/http-jetty/src/main/java/org/apache/cxf/transport/http_jetty/JettyHTTPServerEngine.java
+++ b/rt/transports/http-jetty/src/main/java/org/apache/cxf/transport/http_jetty/JettyHTTPServerEngine.java
@@ -591,8 +591,22 @@ public class JettyHTTPServerEngine implements ServerEngine {
             decorateCXFJettySslSocketConnector(sslcf);
         }
         AbstractConnector result = null;
-        if (!Server.getVersion().startsWith("8")) {
-            result = createConnectorJetty9(sslcf, hosto, porto);
+        
+        int major = 0;
+        int minor = 0;
+        try
+        {
+            String[] version = Server.getVersion().split("\\.");
+            int major = Integer.parseInt(version[0]);
+            int minor = Integer.parseInt(version[1]);
+        }
+        catch (Exception e)
+        {
+            // unparsable version
+        }
+    
+        if (major >= 9) {
+            result = createConnectorJetty9(sslcf, hosto, porto, major, minor);
         } else {
             result = createConnectorJetty8(sslcf, hosto, porto);
         }        
@@ -612,7 +626,7 @@ public class JettyHTTPServerEngine implements ServerEngine {
         return result;
     }
     
-    AbstractConnector createConnectorJetty9(SslContextFactory sslcf, String hosto, int porto) {
+    AbstractConnector createConnectorJetty9(SslContextFactory sslcf, String hosto, int porto, int major, int minor) {
         //Jetty 9
         AbstractConnector result = null;
         try {
@@ -642,7 +656,8 @@ public class JettyHTTPServerEngine implements ServerEngine {
                                                                                      String.class)
                                                         .newInstance(sslcf, "HTTP/1.1");
                 connectionFactories.add(scf);
-                result.getClass().getMethod("setDefaultProtocol", String.class).invoke(result, "SSL-HTTP/1.1");
+                String proto = (major > 9 || (major == 9 && minor >= 3)) ? "SSL" : "SSL-HTTP";
+                result.getClass().getMethod("setDefaultProtocol", String.class).invoke(result, proto + "/1.1");
             }
             connectionFactories.add(httpFactory);
             result.getClass().getMethod("setConnectionFactories", Collection.class)


### PR DESCRIPTION
Jetty 9.3 contains a tiny (but fatal) change in SslConnectionFactory:

  public SslConnectionFactory(@Name("sslContextFactory") SslContextFactory factory, @Name("next") String nextProtocol)
  {
    -        super("SSL-"+nextProtocol);
   +        super("SSL");

See:
http://git.eclipse.org/c/jetty/org.eclipse.jetty.project.git/tree/jetty-server/src/main/java/org/eclipse/jetty/server/SslConnectionFactory.java
http://git.eclipse.org/c/jetty/org.eclipse.jetty.project.git/commit/jetty-server/src/main/java/org/eclipse/jetty/server/SslConnectionFactory.java?id=287e86b7aa787c9836fccbe2816dd08b4b6c599e

The protocol is now named "SSL" (was "SSL-HTTP" before).

If you still use "SSL-HTTP" as default protocol name, the "doStart" of the jetty connector will fail in 9.3+:

(from org.eclipse.jetty.server.AbstractConnector):

  protected void doStart() throws Exception
  {
        _defaultConnectionFactory = getConnectionFactory(_defaultProtocol);
        if(_defaultConnectionFactory==null)
            throw new IllegalStateException("No protocol factory for default protocol: "+_defaultProtocol);
    ...