### PR TITLE
Fix jax-rs swagger2 osgi example

### DIFF
--- a/distribution/src/main/release/samples/jax_rs/description_swagger2_osgi/README.txt
+++ b/distribution/src/main/release/samples/jax_rs/description_swagger2_osgi/README.txt
@@ -46,9 +46,9 @@ for this demo bundle.
 
   feature:install cxf-rs-description-swagger2
 
-Install this demo bundle
+Install this demo bundle (using the appropriate bundle version number)
 
-  install -s mvn:org.apache.cxf.samples/jax_rs_description_swagger2_osgi
+  install -s mvn:org.apache.cxf.samples/jax_rs_description_swagger2_osgi/3.n.m
 
 You can verify if the CXF JAX-RS Swagger2 Blueprint Demo is installed and started.
 


### PR DESCRIPTION
After the release of cxf-3.2.0, the readme text no longer works verbatim, as the latest cxf version no longer corresponds to the specific version mentioned in the readme.

This simply corrects the readme.