### PR TITLE
CXF-6795 WS-Discovery add support for discovery on localhost

### DIFF
--- a/rt/transports/udp/src/main/java/org/apache/cxf/transport/udp/UDPConduit.java
+++ b/rt/transports/udp/src/main/java/org/apache/cxf/transport/udp/UDPConduit.java
@@ -243,6 +243,10 @@ public class UDPConduit extends AbstractConduit {
                 socket.setSendBufferSize(this.size());
                 socket.setReceiveBufferSize(64 * 1024);
                 socket.setBroadcast(true);
+                socket.setReuseAddress(true);
+                if (multicast != null) {
+                    ((MulticastSocket)socket).setLoopbackMode(false);
+                }
                 
                 if (multicast == null) {
                     Enumeration<NetworkInterface> interfaces = NetworkInterface.getNetworkInterfaces();

--- a/rt/transports/udp/src/main/java/org/apache/cxf/transport/udp/UDPDestination.java
+++ b/rt/transports/udp/src/main/java/org/apache/cxf/transport/udp/UDPDestination.java
@@ -172,6 +172,7 @@ public class UDPDestination extends AbstractDestination {
                 socket.setReceiveBufferSize(64 * 1024);
                 socket.setSendBufferSize(64 * 1024);
                 socket.setTimeToLive(1);
+                socket.setLoopbackMode(false);
                 socket.bind(new InetSocketAddress(isa.getPort()));
                 socket.setNetworkInterface(findNetworkInterface());
                 socket.joinGroup(isa.getAddress());

--- a/rt/transports/udp/src/main/java/org/apache/cxf/transport/udp/UDPDestination.java
+++ b/rt/transports/udp/src/main/java/org/apache/cxf/transport/udp/UDPDestination.java
@@ -25,15 +25,11 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.DatagramPacket;
 import java.net.InetSocketAddress;
-import java.net.InterfaceAddress;
 import java.net.MulticastSocket;
 import java.net.NetworkInterface;
 import java.net.SocketException;
 import java.net.SocketTimeoutException;
 import java.net.URI;
-import java.util.ArrayList;
-import java.util.Enumeration;
-import java.util.List;
 import java.util.logging.Logger;
 
 import org.apache.cxf.Bus;
@@ -174,7 +170,10 @@ public class UDPDestination extends AbstractDestination {
                 socket.setTimeToLive(1);
                 socket.setLoopbackMode(false);
                 socket.bind(new InetSocketAddress(isa.getPort()));
-                socket.setNetworkInterface(findNetworkInterface());
+                NetworkInterface ni = findNetworkInterface();
+                if (ni != null) {
+                    socket.setNetworkInterface(ni);
+                }
                 socket.joinGroup(isa.getAddress());
                 mcast = socket;
                 queue.execute(new MCastListener());
@@ -195,30 +194,14 @@ public class UDPDestination extends AbstractDestination {
             throw new RuntimeException(ex);
         }
     }
+
     private NetworkInterface findNetworkInterface() throws SocketException {
-        String name = (String)this.getEndpointInfo().getProperty(UDPDestination.NETWORK_INTERFACE);
+        //Allow configuring a default interface, but do not try to guess. 
+        //Instead delegate this to the OS routing table.
+        String name = (String) this.getEndpointInfo().getProperty(UDPDestination.NETWORK_INTERFACE);
         NetworkInterface ret = null;
         if (!StringUtils.isEmpty(name)) {
             ret = NetworkInterface.getByName(name);
-        }
-        if (ret == null) {
-            Enumeration<NetworkInterface> ifcs = NetworkInterface.getNetworkInterfaces();
-            List<NetworkInterface> possibles = new ArrayList<NetworkInterface>();
-            while (ifcs.hasMoreElements()) {
-                NetworkInterface ni = ifcs.nextElement();
-                if (ni.supportsMulticast()
-                    && ni.isUp()) {
-                    for (InterfaceAddress ia : ni.getInterfaceAddresses()) {
-                        if (ia.getAddress() instanceof java.net.Inet4Address
-                            && !ia.getAddress().isLoopbackAddress()
-                            && !ni.getDisplayName().startsWith("vnic")) {
-                            possibles.add(ni);
-                        }
-                    }
-                }
-            }
-            ret = possibles.isEmpty() ? null : possibles.get(possibles.size() - 1);
-
         }
         return ret;
     }

--- a/services/ws-discovery/ws-discovery-api/src/test/java/org/apache/cxf/ws/discovery/WSDiscoveryClientTest.java
+++ b/services/ws-discovery/ws-discovery-api/src/test/java/org/apache/cxf/ws/discovery/WSDiscoveryClientTest.java
@@ -110,6 +110,8 @@ public final class WSDiscoveryClientTest {
                     MulticastSocket s = new MulticastSocket(Integer.parseInt(PORT));
                     s.setBroadcast(true);
                     s.setNetworkInterface(findIpv4Interface());
+                    s.setLoopbackMode(false);
+                    s.setReuseAddress(true);
                     s.joinGroup(address);
                     s.setReceiveBufferSize(64 * 1024);
                     s.setSoTimeout(5000);

--- a/services/ws-discovery/ws-discovery-api/src/test/java/org/apache/cxf/ws/discovery/WSDiscoveryClientTest.java
+++ b/services/ws-discovery/ws-discovery-api/src/test/java/org/apache/cxf/ws/discovery/WSDiscoveryClientTest.java
@@ -22,14 +22,11 @@ package org.apache.cxf.ws.discovery;
 import java.io.InputStream;
 import java.net.DatagramPacket;
 import java.net.InetAddress;
-import java.net.InterfaceAddress;
 import java.net.MulticastSocket;
 import java.net.NetworkInterface;
 import java.net.SocketAddress;
 import java.nio.charset.StandardCharsets;
-import java.util.ArrayList;
 import java.util.Enumeration;
-import java.util.List;
 
 import javax.jws.WebMethod;
 import javax.jws.WebService;
@@ -59,25 +56,6 @@ import org.junit.Test;
 public final class WSDiscoveryClientTest {
     public static final String PORT = TestUtil.getPortNumber(WSDiscoveryClientTest.class);
    
-    static NetworkInterface findIpv4Interface() throws Exception {
-        Enumeration<NetworkInterface> ifcs = NetworkInterface.getNetworkInterfaces();
-        List<NetworkInterface> possibles = new ArrayList<NetworkInterface>();
-        while (ifcs.hasMoreElements()) {
-            NetworkInterface ni = ifcs.nextElement();
-            if (ni.supportsMulticast()
-                && ni.isUp()) {
-                for (InterfaceAddress ia : ni.getInterfaceAddresses()) {
-                    if (ia.getAddress() instanceof java.net.Inet4Address
-                        && !ia.getAddress().isLoopbackAddress()
-                        && !ni.getDisplayName().startsWith("vnic")) {
-                        possibles.add(ni);
-                    }
-                }
-            }
-        }
-        return possibles.isEmpty() ? null : possibles.get(possibles.size() - 1);
-    }
-    
     @Test
     public void testMultiResponses() throws Exception {
         // Disable the test on Redhat Enterprise Linux which doesn't enable the UDP broadcast by default
@@ -91,7 +69,7 @@ public final class WSDiscoveryClientTest {
         int count = 0;
         while (interfaces.hasMoreElements()) {
             NetworkInterface networkInterface = interfaces.nextElement();
-            if (!networkInterface.isUp() || networkInterface.isLoopback()) {
+            if (!networkInterface.isUp()) {
                 continue;  
             }
             count++;
@@ -109,7 +87,6 @@ public final class WSDiscoveryClientTest {
                     InetAddress address = InetAddress.getByName("239.255.255.250");
                     MulticastSocket s = new MulticastSocket(Integer.parseInt(PORT));
                     s.setBroadcast(true);
-                    s.setNetworkInterface(findIpv4Interface());
                     s.setLoopbackMode(false);
                     s.setReuseAddress(true);
                     s.joinGroup(address);


### PR DESCRIPTION
This addresses the feature request to add loopback support for UDP transport and hence WS-Discovery.

https://issues.apache.org/jira/browse/CXF-6795

There was some code which was attempting to guess which network interface to use for multicast purposes. I have left the ability to configure a specific interface to use, but I removed the code which tried to guess a default interface since this is best handled by the operating system's routing table. The algorithm was essentially making an arbitrary choice from the available network interfaces, except the loopbacks. However, it is still possible and in many circumstances desirable to run multicast on the loopback adapter. This requires the MulticastSocket to be configured with the setLoopbackMode(false) and setReuseAddress(true) options in order to receive packets which were sent from the local machine.

In some circumstances, this will not be required, but it shouldn't cause a major issue since the WS-D packets are so small. Perhaps someone can comment on impact outside of WS-D for other user of UDPTransport's multicast capability?