### PR TITLE
Fixes a NPE if Bus is not registered

### DIFF
--- a/rt/transports/http-hc/src/main/java/org/apache/cxf/transport/http/asyncclient/Activator.java
+++ b/rt/transports/http-hc/src/main/java/org/apache/cxf/transport/http/asyncclient/Activator.java
@@ -18,6 +18,7 @@
  */
 package org.apache.cxf.transport.http.asyncclient;
 
+import java.io.IOException;
 import java.util.Dictionary;
 import java.util.Enumeration;
 import java.util.HashMap;
@@ -29,21 +30,32 @@ import org.apache.cxf.transport.http.HTTPConduitFactory;
 import org.osgi.framework.BundleActivator;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.Constants;
+import org.osgi.framework.ServiceReference;
 import org.osgi.framework.ServiceRegistration;
+import org.osgi.service.cm.Configuration;
+import org.osgi.service.cm.ConfigurationAdmin;
 import org.osgi.service.cm.ConfigurationException;
 import org.osgi.service.cm.ManagedService;
 import org.osgi.util.tracker.ServiceTracker;
+import org.osgi.util.tracker.ServiceTrackerCustomizer;
 
 public class Activator implements BundleActivator {
 
+    private static final String ASYNC_CLIENT_PID = "org.apache.cxf.transport.http.async";
+
     private ServiceTracker tracker;
+
+    private BundleContext bundleContext;
+    private AsyncHTTPConduitFactory conduitFactory;
+    private ServiceRegistration reg;
 
     @Override
     public void start(BundleContext context) throws Exception {
-        tracker = new ServiceTracker(context, Bus.class.getName(), null);
+        this.bundleContext = context;
+        tracker = new ServiceTracker(context, Bus.class.getName(), new BusTracker());
         tracker.open();
-        ConduitConfigurer conduitConfigurer = new ConduitConfigurer(context, tracker);
-        registerManagedService(context, conduitConfigurer, "org.apache.cxf.transport.http.async");
+        ConduitConfigurer conduitConfigurer = new ConduitConfigurer();
+        registerManagedService(context, conduitConfigurer, ASYNC_CLIENT_PID);
     }
 
     private void registerManagedService(BundleContext context, ConduitConfigurer conduitConfigurer, String servicePid) {
@@ -57,42 +69,86 @@ public class Activator implements BundleActivator {
         tracker.close();
     }
 
-    class ConduitConfigurer implements ManagedService {
-        private AsyncHTTPConduitFactory conduitFactory;
-        private ServiceTracker busTracker;
-        private BundleContext context;
-        private ServiceRegistration reg;
-        
-        ConduitConfigurer(BundleContext context, ServiceTracker busTracker) {
-            this.context = context;
-            this.busTracker = busTracker;
-        }
-
-        @SuppressWarnings({
-            "rawtypes", "unchecked"
-        })
-        @Override
-        public void updated(Dictionary properties) throws ConfigurationException {
-            if (reg != null) {
-                reg.unregister();
-            }
-            conduitFactory = new AsyncHTTPConduitFactory((Bus)this.busTracker.getService());
+    @SuppressWarnings({
+        "rawtypes", "unchecked"
+    })
+    private void registerConduitFactory(Bus bus, Dictionary properties) {
+        unregisterConduitFactory();
+        if (bus != null) {
+            conduitFactory = new AsyncHTTPConduitFactory(bus);
             conduitFactory.update(toMap(properties));
-            reg = context.registerService(HTTPConduitFactory.class.getName(), conduitFactory, null);
+            reg = bundleContext.registerService(HTTPConduitFactory.class.getName(), conduitFactory, null);
         }
-        
-        private Map<String, Object> toMap(Dictionary<String, ?> properties) {
-            Map<String, Object> props = new HashMap<String, Object>();
-            if (properties == null) {
-                return props;
-            }
-            Enumeration<String> keys = properties.keys();
-            while (keys.hasMoreElements()) {
-                String key = keys.nextElement();
-                props.put(key, properties.get(key));
-            }
+    }
+    
+    private void unregisterConduitFactory() {
+        if (reg != null) {
+            reg.unregister();
+            reg = null;
+        }
+    }
+    
+    private Map<String, Object> toMap(Dictionary<String, ?> properties) {
+        Map<String, Object> props = new HashMap<String, Object>();
+        if (properties == null) {
             return props;
         }
+        Enumeration<String> keys = properties.keys();
+        while (keys.hasMoreElements()) {
+            String key = keys.nextElement();
+            props.put(key, properties.get(key));
+        }
+        return props;
+    }
+    
+    class BusTracker implements ServiceTrackerCustomizer {
+
+        @Override
+        public Object addingService(ServiceReference reference) {
+            Bus bus = (Bus)bundleContext.getService(reference);
+            registerConduitFactory(bus, getConfig());
+            return bus;
+        }
         
+        private Dictionary<?, ?> getConfig() {
+            ServiceReference configurationAdminReference = 
+                    bundleContext.getServiceReference(ConfigurationAdmin.class.getName());
+
+            if (configurationAdminReference != null) {
+                ConfigurationAdmin confAdmin =
+                        (ConfigurationAdmin) bundleContext.getService(configurationAdminReference);
+
+                Configuration configuration;
+                try {
+                    configuration = confAdmin.getConfiguration(ASYNC_CLIENT_PID, null);
+                } catch (IOException e) {
+                    throw new IllegalStateException("Couldn't retreive configuration for PID " + ASYNC_CLIENT_PID, e);
+                }
+                if (configuration != null) {
+                    return configuration.getProperties();
+                }
+            }
+            return null;
+        }
+
+        @Override
+        public void modifiedService(ServiceReference reference, Object service) { }
+
+        @Override
+        public void removedService(ServiceReference reference, Object service) {
+            unregisterConduitFactory();
+            bundleContext.ungetService(reference);
+        }
+
+    }
+
+    class ConduitConfigurer implements ManagedService {
+
+        @Override
+        public void updated(@SuppressWarnings("rawtypes") Dictionary properties) throws ConfigurationException {
+            Bus bus = (Bus)tracker.getService();
+            registerConduitFactory(bus, properties);
+        }
+
     }
 }


### PR DESCRIPTION
Just adding the bundle in an OSGi container causes a NPE in the logs because the Activator is called, but no Bus service is available. Even if there's a bundle providing the Bus service it could be registered after the asyncclient Activator executes so the `HTTPConduitFactory` service will be registered indeterministically. The changes will wait for the Bus service to become available and register the `HTTPConduitFactory` service.

Here's the stack trace of the exception:
```
2016-03-09 18:41:49,298 | ERROR | ort.http.async]) | configadmin                      | 3 - org.apache.felix.configadmin - 1.8.8 | [org.osgi.service.cm.ManagedService, id=146, bundle=84/mvn:org.apache.cxf/cxf-rt-transports-http-hc/3.1.4]: Unexpected problem updating configuration org.apache.cxf.transport.http.async
java.lang.NullPointerException
    at org.apache.cxf.transport.http.asyncclient.AsyncHTTPConduitFactory.addListener(AsyncHTTPConduitFactory.java:285)[84:org.apache.cxf.cxf-rt-transports-http-hc:3.1.4]
    at org.apache.cxf.transport.http.asyncclient.AsyncHTTPConduitFactory.<init>(AsyncHTTPConduitFactory.java:144)[84:org.apache.cxf.cxf-rt-transports-http-hc:3.1.4]
    at org.apache.cxf.transport.http.asyncclient.Activator$ConduitConfigurer.updated(Activator.java:79)[84:org.apache.cxf.cxf-rt-transports-http-hc:3.1.4]
    at org.apache.felix.cm.impl.helper.ManagedServiceTracker.updated(ManagedServiceTracker.java:189)[3:org.apache.felix.configadmin:1.8.8]
    at org.apache.felix.cm.impl.helper.ManagedServiceTracker.updateService(ManagedServiceTracker.java:152)[3:org.apache.felix.configadmin:1.8.8]
    at org.apache.felix.cm.impl.helper.ManagedServiceTracker.provideConfiguration(ManagedServiceTracker.java:85)[3:org.apache.felix.configadmin:1.8.8]
    at org.apache.felix.cm.impl.ConfigurationManager$ManagedServiceUpdate.provide(ConfigurationManager.java:1444)[3:org.apache.felix.configadmin:1.8.8]
    at org.apache.felix.cm.impl.ConfigurationManager$ManagedServiceUpdate.run(ConfigurationManager.java:1400)[3:org.apache.felix.configadmin:1.8.8]
    at org.apache.felix.cm.impl.UpdateThread.run0(UpdateThread.java:143)[3:org.apache.felix.configadmin:1.8.8]
    at org.apache.felix.cm.impl.UpdateThread.run(UpdateThread.java:110)[3:org.apache.felix.configadmin:1.8.8]
    at java.lang.Thread.run(Thread.java:745)[:1.7.0_80]
```