### PR TITLE
AccessTokenIntrospectionClient throws NPE

### DIFF
--- a/rt/rs/security/oauth-parent/oauth2/src/main/java/org/apache/cxf/rs/security/oauth2/filters/AccessTokenIntrospectionClient.java
+++ b/rt/rs/security/oauth-parent/oauth2/src/main/java/org/apache/cxf/rs/security/oauth2/filters/AccessTokenIntrospectionClient.java
@@ -19,6 +19,7 @@
 package org.apache.cxf.rs.security.oauth2.filters;
 
 import java.util.Collections;
+import java.util.Date;
 import java.util.LinkedList;
 import java.util.List;
 
@@ -68,9 +69,11 @@ public class AccessTokenIntrospectionClient implements AccessTokenValidator {
         }
         if (response.getIat() != null) {
             atv.setTokenIssuedAt(response.getIat());
+        } else {
+            atv.setTokenIssuedAt(new Date().getTime());
         }
         if (response.getExp() != null) {
-            atv.setTokenLifetime(response.getExp() - response.getIat());
+            atv.setTokenLifetime(response.getExp() - atv.getTokenIssuedAt());
         }
         if (!StringUtils.isEmpty(response.getAud())) {
             atv.setAudiences(response.getAud());


### PR DESCRIPTION
AccessTokenIntrospectionClient throws NPE when introspection result contains expiration timestamp but "issued at" timestamp.