### PR TITLE
3.1.x fixes - CXF-6454

### DIFF
--- a/core/src/main/java/org/apache/cxf/endpoint/ClientImpl.java
+++ b/core/src/main/java/org/apache/cxf/endpoint/ClientImpl.java
@@ -173,20 +173,7 @@ public class ClientImpl
             } else {
                 getConduit().close();
             }
-        }
-        
-        bus = null;
-        conduitSelector = null;
-        outFaultObserver = null;
-        outboundChainCache = null;
-        inboundChainCache = null;
-
-        currentRequestContext = null;
-        requestContext.clear();
-        requestContext = null;
-        responseContext.clear();
-        responseContext = null;
-        executor = null;            
+        }       
     }
 
     private void notifyLifecycleManager() {

--- a/rt/transports/jms/src/main/java/org/apache/cxf/transport/jms/JMSConfigFactory.java
+++ b/rt/transports/jms/src/main/java/org/apache/cxf/transport/jms/JMSConfigFactory.java
@@ -129,7 +129,8 @@ public final class JMSConfigFactory {
         
         String targetService = endpoint.getTargetService();
         jmsConfig.setTargetService(targetService);
-        jmsConfig.setMaxNoOfRetries(endpoint.getMaxNoOfRetries());
+        int maxNoOfRetry = endpoint.getMaxNoOfRetries();
+        jmsConfig.setMaxNoOfRetries(maxNoOfRetry);
         jmsConfig.setRetryInterval(endpoint.getRetryInterval());
         return jmsConfig;
     }

--- a/rt/transports/jms/src/main/java/org/apache/cxf/transport/jms/JMSConfigFactory.java
+++ b/rt/transports/jms/src/main/java/org/apache/cxf/transport/jms/JMSConfigFactory.java
@@ -129,8 +129,10 @@ public final class JMSConfigFactory {
         
         String targetService = endpoint.getTargetService();
         jmsConfig.setTargetService(targetService);
-        jmsConfig.setMaxNoOfRetries(endpoint.getMaxNoOfRetries());
-        jmsConfig.setRetryInterval(endpoint.getRetryInterval());
+        int maxNoOfRetries = endpoint.getMaxNoOfRetries();
+        jmsConfig.setMaxNoOfRetries(maxNoOfRetries);
+        long retryInterval = endpoint.getRetryInterval();
+        jmsConfig.setRetryInterval(retryInterval);
         return jmsConfig;
     }
 

--- a/rt/transports/jms/src/main/java/org/apache/cxf/transport/jms/JMSConfigFactory.java
+++ b/rt/transports/jms/src/main/java/org/apache/cxf/transport/jms/JMSConfigFactory.java
@@ -129,6 +129,8 @@ public final class JMSConfigFactory {
         
         String targetService = endpoint.getTargetService();
         jmsConfig.setTargetService(targetService);
+        jmsConfig.setMaxNoOfRetries(endpoint.getMaxNoOfRetries());
+        jmsConfig.setRetryInterval(endpoint.getRetryInterval());
         return jmsConfig;
     }
 

--- a/rt/transports/jms/src/main/java/org/apache/cxf/transport/jms/JMSConfigFactory.java
+++ b/rt/transports/jms/src/main/java/org/apache/cxf/transport/jms/JMSConfigFactory.java
@@ -129,10 +129,8 @@ public final class JMSConfigFactory {
         
         String targetService = endpoint.getTargetService();
         jmsConfig.setTargetService(targetService);
-        int maxNoOfRetries = endpoint.getMaxNoOfRetries();
-        jmsConfig.setMaxNoOfRetries(maxNoOfRetries);
-        long retryInterval = endpoint.getRetryInterval();
-        jmsConfig.setRetryInterval(retryInterval);
+        jmsConfig.setMaxNoOfRetries(endpoint.getMaxNoOfRetries());
+        jmsConfig.setRetryInterval(endpoint.getRetryInterval());
         return jmsConfig;
     }
 

--- a/rt/transports/jms/src/main/java/org/apache/cxf/transport/jms/JMSConfiguration.java
+++ b/rt/transports/jms/src/main/java/org/apache/cxf/transport/jms/JMSConfiguration.java
@@ -94,8 +94,8 @@ public class JMSConfiguration {
     private String targetService;
     private String requestURI;
     
-    private int maxNoOfRetries ;
-    private long retryInterval ;
+    private int maxNoOfRetries;
+    private long retryInterval;
 
 
 
@@ -462,16 +462,16 @@ public class JMSConfiguration {
     }
     
     public int getMaxNoOfRetries() {
-		return maxNoOfRetries;
-	}
-	public void setMaxNoOfRetries(int maxNoOfRetries) {
-		this.maxNoOfRetries = maxNoOfRetries;
-	}
-	public long getRetryInterval() {
-		return retryInterval;
-	}
-	public void setRetryInterval(long retryInterval) {
-		this.retryInterval = retryInterval;
-	}
+	return this.maxNoOfRetries;
+    }
+    public void setMaxNoOfRetries(int maxNoOfRetries) {
+	this.maxNoOfRetries = maxNoOfRetries;
+    }
+    public long getRetryInterval() {
+	return this.retryInterval;
+    }
+    public void setRetryInterval(long retryInterval) {
+	this.retryInterval = retryInterval;
+    }
 
 }

--- a/rt/transports/jms/src/main/java/org/apache/cxf/transport/jms/JMSConfiguration.java
+++ b/rt/transports/jms/src/main/java/org/apache/cxf/transport/jms/JMSConfiguration.java
@@ -462,16 +462,16 @@ public class JMSConfiguration {
     }
     
     public int getMaxNoOfRetries() {
-	return this.maxNoOfRetries;
+    	return this.maxNoOfRetries;
     }
     public void setMaxNoOfRetries(int maxNoOfRetries) {
-	this.maxNoOfRetries = maxNoOfRetries;
+    	this.maxNoOfRetries = maxNoOfRetries;
     }
     public long getRetryInterval() {
-	return this.retryInterval;
+    	return this.retryInterval;
     }
     public void setRetryInterval(long retryInterval) {
-	this.retryInterval = retryInterval;
+    	this.retryInterval = retryInterval;
     }
 
 }

--- a/rt/transports/jms/src/main/java/org/apache/cxf/transport/jms/JMSConfiguration.java
+++ b/rt/transports/jms/src/main/java/org/apache/cxf/transport/jms/JMSConfiguration.java
@@ -462,16 +462,16 @@ public class JMSConfiguration {
     }
     
     public int getMaxNoOfRetries() {
-    	return this.maxNoOfRetries;
+        return this.maxNoOfRetries;
     }
     public void setMaxNoOfRetries(int maxNoOfRetries) {
-    	this.maxNoOfRetries = maxNoOfRetries;
+        this.maxNoOfRetries = maxNoOfRetries;
     }
     public long getRetryInterval() {
-    	return this.retryInterval;
+        return this.retryInterval;
     }
     public void setRetryInterval(long retryInterval) {
-    	this.retryInterval = retryInterval;
+        this.retryInterval = retryInterval;
     }
 
 }

--- a/rt/transports/jms/src/main/java/org/apache/cxf/transport/jms/JMSConfiguration.java
+++ b/rt/transports/jms/src/main/java/org/apache/cxf/transport/jms/JMSConfiguration.java
@@ -93,6 +93,9 @@ public class JMSConfiguration {
     // For jms spec. Do not configure manually
     private String targetService;
     private String requestURI;
+    
+    private int maxNoOfRetries ;
+    private long retryInterval ;
 
 
 
@@ -457,5 +460,18 @@ public class JMSConfiguration {
     public void setTransactionManager(TransactionManager transactionManager) {
         this.transactionManager = transactionManager;
     }
+    
+    public int getMaxNoOfRetries() {
+		return maxNoOfRetries;
+	}
+	public void setMaxNoOfRetries(int maxNoOfRetries) {
+		this.maxNoOfRetries = maxNoOfRetries;
+	}
+	public long getRetryInterval() {
+		return retryInterval;
+	}
+	public void setRetryInterval(long retryInterval) {
+		this.retryInterval = retryInterval;
+	}
 
 }

--- a/rt/transports/jms/src/main/java/org/apache/cxf/transport/jms/JMSDestination.java
+++ b/rt/transports/jms/src/main/java/org/apache/cxf/transport/jms/JMSDestination.java
@@ -167,7 +167,7 @@ public class JMSDestination extends AbstractMultiplexDestination implements Mess
                 this.jmsListener = createTargetDestinationListener();
                 LOG.log(Level.INFO, "Established JMS connection");
             } catch (InterruptedException ie) {
-    			break;
+                break;
             } catch (Exception e1) {
                 jmsListener = null;
                 String message = "Exception on reconnect. Attempt num was " + tries;
@@ -179,9 +179,10 @@ public class JMSDestination extends AbstractMultiplexDestination implements Mess
             }
         } while (jmsListener == null && !shutdown && tries < maxNoOfRetries);
         //Cleanup the connection if Listener wasn't created after all the retries
-    	if(jmsListener == null) {
-    	    deactivate();
-    	}
+        if (jmsListener == null) {
+            deactivate();
+            
+        }
     }
 
     public void deactivate() {

--- a/rt/transports/jms/src/main/java/org/apache/cxf/transport/jms/JMSDestination.java
+++ b/rt/transports/jms/src/main/java/org/apache/cxf/transport/jms/JMSDestination.java
@@ -166,8 +166,7 @@ public class JMSDestination extends AbstractMultiplexDestination implements Mess
                 Thread.sleep(retryInterval);
                 this.jmsListener = createTargetDestinationListener();
                 LOG.log(Level.INFO, "Established JMS connection");
-            }catch(InterruptedException ie){
-    			LOG.log(Level.INFO, "InterruptedException - stopping the retry");
+            } catch (InterruptedException ie) {
     			break;
             } catch (Exception e1) {
                 jmsListener = null;
@@ -178,10 +177,10 @@ public class JMSDestination extends AbstractMultiplexDestination implements Mess
                     LOG.log(Level.WARNING, message);
                 }
             }
-        } while (jmsListener == null && !shutdown && tries<maxNoOfRetries);
+        } while (jmsListener == null && !shutdown && tries < maxNoOfRetries);
         //Cleanup the connection if Listener wasn't created after all the retries
-    	if(jmsListener == null ){
-    		deactivate();
+    	if(jmsListener == null) {
+    	    deactivate();
     	}
     }
 

--- a/rt/transports/jms/src/main/java/org/apache/cxf/transport/jms/uri/JMSEndpoint.java
+++ b/rt/transports/jms/src/main/java/org/apache/cxf/transport/jms/uri/JMSEndpoint.java
@@ -44,8 +44,8 @@ public class JMSEndpoint {
     public static final DeliveryModeType DELIVERYMODE_DEFAULT = DeliveryModeType.PERSISTENT;
     public static final long TIMETOLIVE_DEFAULT = Message.DEFAULT_TIME_TO_LIVE;
     public static final int PRIORITY_DEFAULT = Message.DEFAULT_PRIORITY;
-    private static final int DEFAULT_RETRY_COUNT = Integer.MAX_VALUE;
-    private static final long DEFAULT_RETRY_INTERVAL = 5000L;
+    public static final int DEFAULT_RETRY_COUNT = Integer.MAX_VALUE;
+    public static final long DEFAULT_RETRY_INTERVAL = 5000L;
 
     /**
      * All parameters with this prefix will go to jndiParameters and be used

--- a/rt/transports/jms/src/main/java/org/apache/cxf/transport/jms/uri/JMSEndpoint.java
+++ b/rt/transports/jms/src/main/java/org/apache/cxf/transport/jms/uri/JMSEndpoint.java
@@ -44,6 +44,8 @@ public class JMSEndpoint {
     public static final DeliveryModeType DELIVERYMODE_DEFAULT = DeliveryModeType.PERSISTENT;
     public static final long TIMETOLIVE_DEFAULT = Message.DEFAULT_TIME_TO_LIVE;
     public static final int PRIORITY_DEFAULT = Message.DEFAULT_PRIORITY;
+    private static final int DEFAULT_RETRY_COUNT = Integer.MAX_VALUE;
+	private static final long DEFAULT_RETRY_INTERVAL = 5000L;
 
     /**
      * All parameters with this prefix will go to jndiParameters and be used
@@ -85,6 +87,8 @@ public class JMSEndpoint {
     private boolean useConduitIdSelector = true;
     private String username;
     private int concurrentConsumers = 1;
+    private int maxNoOfRetries = DEFAULT_RETRY_COUNT;
+    private long retryInterval = DEFAULT_RETRY_INTERVAL;
 
     /**
      * @param uri
@@ -475,5 +479,23 @@ public class JMSEndpoint {
             throw new IllegalArgumentException(v);
         }
     }
+       public int getMaxNoOfRetries() {
+		return maxNoOfRetries;
+	}
+	public void setMaxNoOfRetries(int maxNoOfRetries) {
+		this.maxNoOfRetries = maxNoOfRetries;
+	}
+	public void setMaxNoOfRetries(String maxNoOfRetries) {
+		this.maxNoOfRetries = Integer.valueOf(maxNoOfRetries);
+	}
+	public long getRetryInterval() {
+		return retryInterval;
+	}
+	public void setRetryInterval(long retryInterval) {
+		this.retryInterval = retryInterval;
+	}
+	public void setRetryInterval(String retryInterval) {
+		this.retryInterval = Long.valueOf(retryInterval);
+	}
     
 }

--- a/rt/transports/jms/src/main/java/org/apache/cxf/transport/jms/uri/JMSEndpoint.java
+++ b/rt/transports/jms/src/main/java/org/apache/cxf/transport/jms/uri/JMSEndpoint.java
@@ -45,7 +45,7 @@ public class JMSEndpoint {
     public static final long TIMETOLIVE_DEFAULT = Message.DEFAULT_TIME_TO_LIVE;
     public static final int PRIORITY_DEFAULT = Message.DEFAULT_PRIORITY;
     private static final int DEFAULT_RETRY_COUNT = Integer.MAX_VALUE;
-	private static final long DEFAULT_RETRY_INTERVAL = 5000L;
+    private static final long DEFAULT_RETRY_INTERVAL = 5000L;
 
     /**
      * All parameters with this prefix will go to jndiParameters and be used
@@ -479,23 +479,23 @@ public class JMSEndpoint {
             throw new IllegalArgumentException(v);
         }
     }
-       public int getMaxNoOfRetries() {
-		return maxNoOfRetries;
-	}
-	public void setMaxNoOfRetries(int maxNoOfRetries) {
-		this.maxNoOfRetries = maxNoOfRetries;
-	}
-	public void setMaxNoOfRetries(String maxNoOfRetries) {
-		this.maxNoOfRetries = Integer.valueOf(maxNoOfRetries);
-	}
-	public long getRetryInterval() {
-		return retryInterval;
-	}
-	public void setRetryInterval(long retryInterval) {
-		this.retryInterval = retryInterval;
-	}
-	public void setRetryInterval(String retryInterval) {
-		this.retryInterval = Long.valueOf(retryInterval);
-	}
+    public int getMaxNoOfRetries() {
+	return maxNoOfRetries;
+    }
+    public void setMaxNoOfRetries(int maxNoOfRetries) {
+	this.maxNoOfRetries = maxNoOfRetries;
+    }
+    public void setMaxNoOfRetries(String maxNoOfRetries) {
+	this.maxNoOfRetries = Integer.valueOf(maxNoOfRetries);
+    }
+    public long getRetryInterval() {
+	return retryInterval;
+    }
+    public void setRetryInterval(long retryInterval) {
+	this.retryInterval = retryInterval;
+    }
+    public void setRetryInterval(String retryInterval) {
+	this.retryInterval = Long.valueOf(retryInterval);
+    }
     
 }

--- a/rt/transports/jms/src/main/java/org/apache/cxf/transport/jms/uri/JMSEndpoint.java
+++ b/rt/transports/jms/src/main/java/org/apache/cxf/transport/jms/uri/JMSEndpoint.java
@@ -480,22 +480,22 @@ public class JMSEndpoint {
         }
     }
     public int getMaxNoOfRetries() {
-	return maxNoOfRetries;
+        return maxNoOfRetries;
     }
     public void setMaxNoOfRetries(int maxNoOfRetries) {
-	this.maxNoOfRetries = maxNoOfRetries;
+        this.maxNoOfRetries = maxNoOfRetries;
     }
     public void setMaxNoOfRetries(String maxNoOfRetries) {
-	this.maxNoOfRetries = Integer.valueOf(maxNoOfRetries);
+        this.maxNoOfRetries = Integer.valueOf(maxNoOfRetries);
     }
     public long getRetryInterval() {
-	return retryInterval;
+        return retryInterval;
     }
     public void setRetryInterval(long retryInterval) {
-	this.retryInterval = retryInterval;
+        this.retryInterval = retryInterval;
     }
     public void setRetryInterval(String retryInterval) {
-	this.retryInterval = Long.valueOf(retryInterval);
+        this.retryInterval = Long.valueOf(retryInterval);
     }
     
 }


### PR DESCRIPTION
CXF-6454 - Orphaned JMS connections created in endless loop
Changing the code to limit the number of retries to a pre-defined value. It can be configured as maxNoOfRetries in JMS Enpoint. 
Adding another property to make the sleep time configurable. We were seeing high CPU consumption because of low sleep interval time. 