### PR TITLE
[CXF-6869] Add Spring Boot support

### DIFF
--- a/integration/pom.xml
+++ b/integration/pom.xml
@@ -33,5 +33,8 @@
         <module>jca</module>
         <module>cdi</module>
         <module>tracing/tracing-htrace</module>
+        <module>spring-boot/autoconfigure</module>
+        <module>spring-boot/starter-jax-ws</module>
+        <module>spring-boot/starter-jax-rs</module>
     </modules>
 </project>

--- a/integration/spring-boot/autoconfigure/pom.xml
+++ b/integration/spring-boot/autoconfigure/pom.xml
@@ -1,0 +1,97 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements. See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership. The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied. See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <artifactId>cxf-spring-boot-autoconfigure</artifactId>
+    <packaging>bundle</packaging>
+    <name>Apache CXF Spring Boot Autoconfigure</name>
+    <description>Apache CXF Spring Boot Autoconfigure</description>
+    <url>http://cxf.apache.org</url>
+    <parent>
+        <groupId>org.apache.cxf</groupId>
+        <artifactId>cxf-parent</artifactId>
+        <version>3.2.0-SNAPSHOT</version>
+        <relativePath>../../../parent/pom.xml</relativePath>
+    </parent>
+    <dependencies>
+        <!-- Compile -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-autoconfigure</artifactId>
+        </dependency>
+        <!-- Optional -->
+        <dependency>
+            <groupId>org.apache.cxf</groupId>
+            <artifactId>cxf-rt-transports-http</artifactId>
+            <version>${project.version}</version>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.cxf</groupId>
+            <artifactId>cxf-rt-frontend-jaxws</artifactId>
+            <version>${project.version}</version>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.cxf</groupId>
+            <artifactId>cxf-rt-frontend-jaxrs</artifactId>
+            <version>${project.version}</version>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>${cxf.servlet-api.group}</groupId>
+            <artifactId>${cxf.servlet-api.artifact}</artifactId>
+            <version>${cxf.servlet-api.version}</version>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>javax.validation</groupId>
+            <artifactId>validation-api</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <!-- Annotation processing -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-configuration-processor</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <!-- Test -->
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-library</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>${cxf.spring.mock}</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-web</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/integration/spring-boot/autoconfigure/src/main/java/org/apache/cxf/spring/boot/autoconfigure/CxfAutoConfiguration.java
+++ b/integration/spring-boot/autoconfigure/src/main/java/org/apache/cxf/spring/boot/autoconfigure/CxfAutoConfiguration.java
@@ -1,0 +1,75 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.cxf.spring.boot.autoconfigure;
+
+import java.util.Map;
+
+import org.apache.cxf.bus.spring.SpringBus;
+import org.apache.cxf.transport.servlet.CXFServlet;
+import org.springframework.boot.autoconfigure.AutoConfigureAfter;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication;
+import org.springframework.boot.autoconfigure.web.EmbeddedServletContainerAutoConfiguration;
+import org.springframework.boot.context.embedded.ServletRegistrationBean;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.ImportResource;
+
+/**
+ * {@link org.springframework.boot.autoconfigure.EnableAutoConfiguration Auto-configuration} for Apache CXF.
+ *
+ * @author Vedran Pavic
+ */
+@Configuration
+@ConditionalOnWebApplication
+@ConditionalOnClass(CXFServlet.class)
+@ConditionalOnMissingBean(SpringBus.class)
+@EnableConfigurationProperties(CxfProperties.class)
+@AutoConfigureAfter(EmbeddedServletContainerAutoConfiguration.class)
+public class CxfAutoConfiguration {
+
+    private final CxfProperties properties;
+
+    public CxfAutoConfiguration(CxfProperties properties) {
+        this.properties = properties;
+    }
+
+    @Bean
+    public ServletRegistrationBean messageDispatcherServlet() {
+        String path = this.properties.getPath();
+        String urlMapping = path.endsWith("/") ? path + "*" : path + "/*";
+        ServletRegistrationBean registration = new ServletRegistrationBean(
+                new CXFServlet(), urlMapping);
+        CxfProperties.Servlet servletProperties = this.properties.getServlet();
+        registration.setLoadOnStartup(servletProperties.getLoadOnStartup());
+        for (Map.Entry<String, String> entry : servletProperties.getInit().entrySet()) {
+            registration.addInitParameter(entry.getKey(), entry.getValue());
+        }
+        return registration;
+    }
+
+    @Configuration
+    @ImportResource("classpath:META-INF/cxf/cxf.xml")
+    protected static class CxfConfiguration {
+
+    }
+
+}

--- a/integration/spring-boot/autoconfigure/src/main/java/org/apache/cxf/spring/boot/autoconfigure/CxfProperties.java
+++ b/integration/spring-boot/autoconfigure/src/main/java/org/apache/cxf/spring/boot/autoconfigure/CxfProperties.java
@@ -1,0 +1,88 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.cxf.spring.boot.autoconfigure;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Pattern;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * {@link ConfigurationProperties} for Apache CXF.
+ *
+ * @author Vedran Pavic
+ */
+@ConfigurationProperties("cxf")
+public class CxfProperties {
+
+    /**
+     * Path that serves as the base URI for the services.
+     */
+    @NotNull
+    @Pattern(regexp = "/[^?#]*", message = "Path must start with /")
+    private String path = "/services";
+
+    private final Servlet servlet = new Servlet();
+
+    public String getPath() {
+        return this.path;
+    }
+
+    public void setPath(String path) {
+        this.path = path;
+    }
+
+    public Servlet getServlet() {
+        return this.servlet;
+    }
+
+    public static class Servlet {
+
+        /**
+         * Servlet init parameters to pass to Apache CXF.
+         */
+        private Map<String, String> init = new HashMap<String, String>();
+
+        /**
+         * Load on startup priority of the Apache CXF servlet.
+         */
+        private int loadOnStartup = -1;
+
+        public Map<String, String> getInit() {
+            return this.init;
+        }
+
+        public void setInit(Map<String, String> init) {
+            this.init = init;
+        }
+
+        public int getLoadOnStartup() {
+            return this.loadOnStartup;
+        }
+
+        public void setLoadOnStartup(int loadOnStartup) {
+            this.loadOnStartup = loadOnStartup;
+        }
+
+    }
+
+}

--- a/integration/spring-boot/autoconfigure/src/main/java/org/apache/cxf/spring/boot/autoconfigure/package.html
+++ b/integration/spring-boot/autoconfigure/src/main/java/org/apache/cxf/spring/boot/autoconfigure/package.html
@@ -1,0 +1,28 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 3.2 Final//EN">
+<html>
+<head>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements. See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership. The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied. See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+</head>
+<body bgcolor="white">
+
+Auto-configuration for Apache CXF.
+
+</body>
+</html>

--- a/integration/spring-boot/autoconfigure/src/main/resources/META-INF/spring.factories
+++ b/integration/spring-boot/autoconfigure/src/main/resources/META-INF/spring.factories
@@ -1,0 +1,3 @@
+# Auto Configure
+org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
+org.apache.cxf.spring.boot.autoconfigure.CxfAutoConfiguration

--- a/integration/spring-boot/autoconfigure/src/test/java/org/apache/cxf/spring/boot/autoconfigure/CxfAutoConfigurationTests.java
+++ b/integration/spring-boot/autoconfigure/src/test/java/org/apache/cxf/spring/boot/autoconfigure/CxfAutoConfigurationTests.java
@@ -1,0 +1,114 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.cxf.spring.boot.autoconfigure;
+
+import org.junit.After;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.springframework.beans.factory.BeanCreationException;
+import org.springframework.boot.context.embedded.ServletRegistrationBean;
+import org.springframework.boot.test.EnvironmentTestUtils;
+import org.springframework.mock.web.MockServletContext;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.web.context.support.AnnotationConfigWebApplicationContext;
+
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasEntry;
+import static org.junit.Assert.assertThat;
+
+/**
+ * Tests for {@link CxfAutoConfiguration}.
+ *
+ * @author Vedran Pavic
+ */
+public class CxfAutoConfigurationTests {
+
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
+
+    private AnnotationConfigWebApplicationContext context;
+
+    @After
+    public void close() {
+        if (this.context != null) {
+            this.context.close();
+        }
+    }
+
+    @Test
+    public void defaultConfiguration() {
+        load(CxfAutoConfiguration.class);
+        assertThat(this.context.getBeansOfType(ServletRegistrationBean.class).size(),
+                equalTo(1));
+    }
+
+    @Test
+    public void customPathMustBeginWithASlash() {
+        this.thrown.expect(BeanCreationException.class);
+        this.thrown.expectMessage("Path must start with /");
+        load(CxfAutoConfiguration.class, "spring.cxf.path=invalid");
+    }
+
+    @Test
+    public void customPathWithTrailingSlash() {
+        load(CxfAutoConfiguration.class, "spring.cxf.path=/valid/");
+        assertThat(this.context.getBean(ServletRegistrationBean.class).getUrlMappings(),
+                contains("/valid/*"));
+    }
+
+    @Test
+    public void customPath() {
+        load(CxfAutoConfiguration.class, "spring.cxf.path=/valid");
+        assertThat(this.context.getBeansOfType(ServletRegistrationBean.class).size(),
+                equalTo(1));
+        assertThat(this.context.getBean(ServletRegistrationBean.class).getUrlMappings(),
+                contains("/valid/*"));
+    }
+
+    @Test
+    public void customLoadOnStartup() {
+        load(CxfAutoConfiguration.class, "spring.cxf.servlet.load-on-startup=1");
+        ServletRegistrationBean registrationBean = this.context
+                .getBean(ServletRegistrationBean.class);
+        assertThat(ReflectionTestUtils.getField(registrationBean, "loadOnStartup"),
+                equalTo(1));
+    }
+
+    @Test
+    public void customInitParameters() {
+        load(CxfAutoConfiguration.class, "spring.cxf.servlet.init.key1=value1",
+                "spring.cxf.servlet.init.key2=value2");
+        ServletRegistrationBean registrationBean = this.context
+                .getBean(ServletRegistrationBean.class);
+        assertThat(registrationBean.getInitParameters(), hasEntry("key1", "value1"));
+        assertThat(registrationBean.getInitParameters(), hasEntry("key2", "value2"));
+    }
+
+    private void load(Class<?> config, String... environment) {
+        AnnotationConfigWebApplicationContext ctx = new AnnotationConfigWebApplicationContext();
+        ctx.setServletContext(new MockServletContext());
+        EnvironmentTestUtils.addEnvironment(ctx, environment);
+        ctx.register(config);
+        ctx.refresh();
+        this.context = ctx;
+    }
+
+}

--- a/integration/spring-boot/starter-jax-rs/pom.xml
+++ b/integration/spring-boot/starter-jax-rs/pom.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements. See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership. The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied. See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <artifactId>cxf-spring-boot-starter-jax-rs</artifactId>
+    <packaging>bundle</packaging>
+    <name>Apache CXF Spring Boot Starter JAX-RS</name>
+    <description>Apache CXF Spring Boot Starter JAX-RS</description>
+    <url>http://cxf.apache.org</url>
+    <parent>
+        <groupId>org.apache.cxf</groupId>
+        <artifactId>cxf-parent</artifactId>
+        <version>3.2.0-SNAPSHOT</version>
+        <relativePath>../../../parent/pom.xml</relativePath>
+    </parent>
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.cxf</groupId>
+            <artifactId>cxf-spring-boot-autoconfigure</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.cxf</groupId>
+            <artifactId>cxf-rt-transports-http</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.cxf</groupId>
+            <artifactId>cxf-rt-frontend-jaxrs</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>${cxf.servlet-api.group}</groupId>
+            <artifactId>${cxf.servlet-api.artifact}</artifactId>
+            <version>${cxf.servlet-api.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>javax.validation</groupId>
+            <artifactId>validation-api</artifactId>
+        </dependency>
+    </dependencies>
+</project>

--- a/integration/spring-boot/starter-jax-ws/pom.xml
+++ b/integration/spring-boot/starter-jax-ws/pom.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements. See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership. The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied. See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <artifactId>cxf-spring-boot-starter-jax-ws</artifactId>
+    <packaging>bundle</packaging>
+    <name>Apache CXF Spring Boot Starter JAX-WS</name>
+    <description>Apache CXF Spring Boot Starter JAX-WS</description>
+    <url>http://cxf.apache.org</url>
+    <parent>
+        <groupId>org.apache.cxf</groupId>
+        <artifactId>cxf-parent</artifactId>
+        <version>3.2.0-SNAPSHOT</version>
+        <relativePath>../../../parent/pom.xml</relativePath>
+    </parent>
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.cxf</groupId>
+            <artifactId>cxf-spring-boot-autoconfigure</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.cxf</groupId>
+            <artifactId>cxf-rt-transports-http</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.cxf</groupId>
+            <artifactId>cxf-rt-frontend-jaxws</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>${cxf.servlet-api.group}</groupId>
+            <artifactId>${cxf.servlet-api.artifact}</artifactId>
+            <version>${cxf.servlet-api.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>javax.validation</groupId>
+            <artifactId>validation-api</artifactId>
+        </dependency>
+    </dependencies>
+</project>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -144,6 +144,7 @@
         <cxf.slf4j.version>1.7.21</cxf.slf4j.version>
         <cxf.specs.jaxws.api.version>1.2</cxf.specs.jaxws.api.version>
         <cxf.spring.version>4.1.9.RELEASE</cxf.spring.version>
+        <cxf.spring.boot.version>1.3.4.RELEASE</cxf.spring.boot.version>
         <cxf.spring.security.version>3.2.9.RELEASE</cxf.spring.security.version>
         <cxf.spring.osgi.version>1.2.1</cxf.spring.osgi.version>
         <cxf.spring.ldap.version>1.3.1.RELEASE</cxf.spring.ldap.version>
@@ -726,6 +727,12 @@
                 <scope>test</scope>
             </dependency>
             <dependency>
+                <groupId>org.hamcrest</groupId>
+                <artifactId>hamcrest-library</artifactId>
+                <version>1.3</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
                 <groupId>nekohtml</groupId>
                 <artifactId>nekohtml</artifactId>
                 <version>1.9.6.2</version>
@@ -1241,6 +1248,21 @@
                         <artifactId>commons-logging</artifactId>
                     </exclusion>
                 </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot</artifactId>
+                <version>${cxf.spring.boot.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-autoconfigure</artifactId>
+                <version>${cxf.spring.boot.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-configuration-processor</artifactId>
+                <version>${cxf.spring.boot.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.springframework.security</groupId>


### PR DESCRIPTION
This commit adds Spring Boot support which includes:

- Auto-configuration module to provide auto-configuration capabilites for ```CXFServlet``` and ```SpringBus```
- JAX-WS starter module which assembles dependencies required for development of JAX-WS services
- JAX-RS starter module which assembles dependencies required for development of JAX-RS services

@sberyozkin Please review the PR and let me know if everything is OK from the prespective of CXF project.

One question from my side - you mentioned you'd target this at 3.1.7 release, however I've based my PR on the current master, is this an issue?

I still plan to test the integration by creating some sample Spring Boot projects. We can update the existing sample projects to make use of this integration in a separate PR if that's OK with you.