### PR TITLE
Allow netbeans to recognize files generated by cxf-xjc-plugin

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -277,7 +277,7 @@
                                 <extension>org.apache.cxf.xjcplugins:cxf-xjc-javadoc:${cxf.xjc-utils.version}</extension>
                                 <extension>org.apache.cxf.xjcplugins:cxf-xjc-dv:${cxf.xjc-utils.version}</extension>
                             </extensions>
-                            <sourceRoot>${basedir}/target/generated/src/main/java</sourceRoot>
+                            <sourceRoot>${basedir}/target/generated-sources/cxf-xjc-plugin</sourceRoot>
                             <xsdOptions>
                                 <xsdOption>
                                     <xsd>${basedir}/src/main/resources/schemas/wsdl/http.xsd</xsd>


### PR DESCRIPTION
Netbeans expects generated sources to be placed in folder `target/generated-sources/some-folder`, and recommends using the plugin-name for the leaf folder (which appears in the IDE's source tree as a hint to which plugin generated those sources).

The real fix here is that after opening the CXF sources in Netbeans, all projects having CXF as maven dependency are no longer linked to the jars in the maven repository, but to the CXF source tree. If generated sources are not recognized by the IDE within CXF's source tree, uses of generated classes (such as AuthenticationPolicy) generate an annoying false error alert.
