### PR TITLE
CXF-6942 - Fix to resolve problem finding wsdl with classifier

### DIFF
--- a/maven-plugins/codegen-plugin/src/main/java/org/apache/cxf/maven_plugin/AbstractCodegenMoho.java
+++ b/maven-plugins/codegen-plugin/src/main/java/org/apache/cxf/maven_plugin/AbstractCodegenMoho.java
@@ -869,11 +869,14 @@ public abstract class AbstractCodegenMoho extends AbstractMojo {
         if (artifactSet != null && !artifactSet.isEmpty()) {
             for (Artifact pArtifact : artifactSet) {
                 if (targetArtifact.getGroupId().equals(pArtifact.getGroupId())
-                    && targetArtifact.getArtifactId().equals(pArtifact.getArtifactId())
-                    && targetArtifact.getVersion().equals(pArtifact.getVersion())
-                    && "wsdl".equals(pArtifact.getType())) {
-                    getLog().info(String.format("%s resolved to %s", pArtifact.toString(), pArtifact
-                                      .getFile().getAbsolutePath()));
+                        && targetArtifact.getArtifactId().equals(pArtifact.getArtifactId())
+                        && targetArtifact.getVersion().equals(pArtifact.getVersion()) 
+                        && ("wsdl".equals(pArtifact.getType()) 
+                        || (
+                                targetArtifact.getClassifier() != null
+                                        && pArtifact.getType() != null
+                                        && (targetArtifact.getClassifier() + ".wsdl").equals(pArtifact.getType())
+                        ))) {
                     return pArtifact;
                 }
             }


### PR DESCRIPTION
When using <attachWsdl>true<attachWsdl> when generating a wsdl
an ealier fix added the classifier to the artifact. This
classifier is not used correctly by cxf-codegen-plugin when
<wsdlArtifact> is used to locate the wsdl-file. This fix adds
an extra check to see if an artifact with exists with type
containing the classifier.
