### PR TITLE
Add basic bean-validation (JSR-303) support + Swagger annotation support

### DIFF
--- a/rt/rs/description/src/main/java/org/apache/cxf/jaxrs/model/wadl/WadlGenerator.java
+++ b/rt/rs/description/src/main/java/org/apache/cxf/jaxrs/model/wadl/WadlGenerator.java
@@ -138,6 +138,9 @@ import org.apache.cxf.staxutils.StaxUtils;
 import org.apache.ws.commons.schema.XmlSchema;
 import org.apache.ws.commons.schema.constants.Constants;
 
+
+import io.swagger.annotations.ApiParam;
+
 public class WadlGenerator implements ContainerRequestFilter {
 
     public static final String WADL_QUERY = "_wadl";
@@ -982,9 +985,7 @@ public class WadlGenerator implements ContainerRequestFilter {
     private void addBeanValidationAnnotationsDocs(StringBuilder sb, StringBuffer beanValidationBuffer) {
         // add docs if bean-validations are present for information 
         if (beanValidationBuffer != null && beanValidationBuffer.length() > 0) {
-            sb.append("<doc>");
-            sb.append(beanValidationBuffer);
-            sb.append("</doc>");
+            addDocumentation(sb, beanValidationBuffer.toString());
         }
     }
 
@@ -1030,11 +1031,6 @@ public class WadlGenerator implements ContainerRequestFilter {
             
             beanValidationBuffer.append(" pattern: " + pattern.pattern());
         }
-        
-        
-        // TODO: ask if Swagger annotation support is welcome?
-        // ApiParam apiParam = AnnotationUtils.getAnnotation(anns, ApiParam.class);
-        // also have to check for @Description, see below
         
         // TODO debug output
         System.out.println("*** param: " + ori.getAnnotatedMethod().getName() + " " + paramName);
@@ -1084,10 +1080,20 @@ public class WadlGenerator implements ContainerRequestFilter {
             
             addBeanValidationAnnotationsDocs(sb, beanValidationBuffer);
             
+            ApiParam apiParam = AnnotationUtils.getAnnotation(anns, ApiParam.class);
+            if (apiParam != null && apiParam.value() != null) {
+                addDocumentation(sb, apiParam.value());
+            }
+            
             sb.append("</").append(elementName).append(">");
+            
         } else {
             sb.append("/>");
         }
+    }
+    
+    private void addDocumentation(StringBuilder sb, String doc) {
+        sb.append("<doc>" + doc + "</doc>");
     }
 
     private boolean isDocAvailable(Annotation[] anns) {

--- a/rt/rs/description/src/main/java/org/apache/cxf/jaxrs/model/wadl/WadlGenerator.java
+++ b/rt/rs/description/src/main/java/org/apache/cxf/jaxrs/model/wadl/WadlGenerator.java
@@ -1067,8 +1067,16 @@ public class WadlGenerator implements ContainerRequestFilter {
                                         StringBuffer beanValidationBuffer) {
     //CHECKSTYLE:ON    
         boolean docAnnAvailable = isDocAvailable(anns);
+        
+        boolean apiParamDocsAvailable = false;
+        ApiParam apiParam = AnnotationUtils.getAnnotation(anns, ApiParam.class);
+        if (apiParam != null && apiParam.value() != null) {
+            apiParamDocsAvailable = true;
+        }
+        
         if (docAnnAvailable || (ori != null && !docProviders.isEmpty()) 
-                || (beanValidationBuffer != null && beanValidationBuffer.length() > 0)) {
+                || (beanValidationBuffer != null && beanValidationBuffer.length() > 0)
+                || apiParamDocsAvailable) {
             sb.append(">");
             if (docAnnAvailable) {
                 handleDocs(anns, sb, category, allowDefault, isJson);
@@ -1080,8 +1088,7 @@ public class WadlGenerator implements ContainerRequestFilter {
             
             addBeanValidationAnnotationsDocs(sb, beanValidationBuffer);
             
-            ApiParam apiParam = AnnotationUtils.getAnnotation(anns, ApiParam.class);
-            if (apiParam != null && apiParam.value() != null) {
+            if (apiParamDocsAvailable) {
                 addDocumentation(sb, apiParam.value());
             }
             

--- a/tools/wadlto/jaxrs/pom.xml
+++ b/tools/wadlto/jaxrs/pom.xml
@@ -61,5 +61,9 @@
             <version>0.6.4</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>javax.validation</groupId>
+            <artifactId>validation-api</artifactId>
+        </dependency>
     </dependencies>
 </project>

--- a/tools/wadlto/jaxrs/src/main/java/org/apache/cxf/tools/wadlto/jaxrs/SourceGenerator.java
+++ b/tools/wadlto/jaxrs/src/main/java/org/apache/cxf/tools/wadlto/jaxrs/SourceGenerator.java
@@ -46,6 +46,7 @@ import java.util.TreeSet;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import javax.validation.constraints.NotNull;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.DELETE;
 import javax.ws.rs.DefaultValue;
@@ -1265,6 +1266,15 @@ public class SourceGenerator {
                     writeAnnotation(sbCode, imports, DefaultValue.class, defaultVal, false, false);
                     sbCode.append(" ");    
                 }
+                
+                // Add BeanValidation annotations
+                // @NotNull
+                if ("true".equals(required)) {
+                    writeAnnotation(sbCode, imports, NotNull.class, null, false, false);
+                    sbCode.append(" ");
+                }
+                
+                
             }
             boolean isRepeating = isRepeatingParam(paramEl);
             String type = enumCreated ? getTypicalClassName(name)


### PR DESCRIPTION
Added basic bean-validation and on example for Swagger annotation support to the WadlGenerator for parameters.
# Parameters
## Overview bean-validation support
- [x] @NotNull 
- [x] @Size
- [x] @Min
- [x] @Max
- [x] @Pattern
## Overview Swagger annotation support
- [x] @ApiParam
- [ ] @ApiOperation
- [ ] @ApiResponses / @ApiResponse
- [ ] @ApiModel

Pls let me know if support is desired, then I'll add the others...
## Open questions
- add test cases
- add switch for bean-valdation-support (?)
- extract bean validation methods to separate BeanValidationUtil
# Body Parameters
## Open questions:

They have to be added after the JAXB processing, probably in getSchemaCollection().
How can the annotations of the objects be accessed there?
Or can I hook somehow into the JAXB parsing (JAXBUtils.generateJaxbSchemas?)
