### PR TITLE
[CXF-6967] Make content-disposition case insensitive and add some ini…

### DIFF
--- a/core/src/main/java/org/apache/cxf/attachment/ContentDisposition.java
+++ b/core/src/main/java/org/apache/cxf/attachment/ContentDisposition.java
@@ -33,7 +33,7 @@ public class ContentDisposition {
             Pattern.compile(CD_HEADER_PARAMS_EXPRESSION);
 
     private static final String CD_HEADER_EXT_PARAMS_EXPRESSION =
-            "(UTF-8|ISO-8859-1)''((?:%[0-9a-f]{2}|\\S)+)";
+            "(?i)(UTF-8|ISO-8859-1)''((?:%[0-9a-f]{2}|\\S)+)";
     private static final Pattern CD_HEADER_EXT_PARAMS_PATTERN =
             Pattern.compile(CD_HEADER_EXT_PARAMS_EXPRESSION);
     private static final Pattern CODEPOINT_ENCODED_VALUE_PATTERN = Pattern.compile("&#[0-9]{4};|\\S");
@@ -60,7 +60,7 @@ public class ContentDisposition {
             String paramName = pair[0].trim();
             String paramValue = pair.length == 2 ? pair[1].trim().replace("\"", "") : "";
             // filename* looks like the only CD param that is human readable
-            // and worthy of the extended encoding support. Other parameters 
+            // and worthy of the extended encoding support. Other parameters
             // can be supported if needed, see the complete list below
             /*
                 http://www.iana.org/assignments/cont-disp/cont-disp.xhtml#cont-disp-2
@@ -74,7 +74,7 @@ public class ContentDisposition {
                 voice               type or use of audio content [RFC2421]
                 handling            whether or not processing is required [RFC3204]
              */
-            if ("filename*".equals(paramName)) {
+            if ("filename*".equalsIgnoreCase(paramName)) {
                 // try to decode the value if it matches the spec
                 try {
                     Matcher matcher = CD_HEADER_EXT_PARAMS_PATTERN.matcher(paramValue);
@@ -87,7 +87,7 @@ public class ContentDisposition {
                 } catch (UnsupportedEncodingException e) {
                     // would be odd not to support UTF-8 or 8859-1
                 }
-            } else if ("filename".equals(paramName) && paramValue.contains("&#")) {
+            } else if ("filename".equalsIgnoreCase(paramName) && paramValue.contains("&#")) {
                 Matcher matcher = CODEPOINT_ENCODED_VALUE_PATTERN.matcher(paramValue);
                 StringBuilder sb = new StringBuilder();
                 while (matcher.find()) {
@@ -117,7 +117,7 @@ public class ContentDisposition {
     public String getFilename() {
         return params.get("filename");
     }
-    
+
     public String getParameter(String name) {
         return params.get(name);
     }

--- a/core/src/main/java/org/apache/cxf/attachment/ContentDisposition.java
+++ b/core/src/main/java/org/apache/cxf/attachment/ContentDisposition.java
@@ -103,7 +103,7 @@ public class ContentDisposition {
                     paramValue = sb.toString();
                 }
             }
-            params.put(paramName, paramValue);
+            params.put(paramName.toLowerCase(), paramValue);
         }
         if (extendedFilename != null) {
             params.put("filename", extendedFilename);

--- a/core/src/test/java/org/apache/cxf/attachment/AttachmentUtilTest.java
+++ b/core/src/test/java/org/apache/cxf/attachment/AttachmentUtilTest.java
@@ -22,53 +22,65 @@ import org.junit.Assert;
 import org.junit.Test;
 
 public class AttachmentUtilTest extends Assert {
-    
+
     @Test
     public void testContendDispositionFileNameNoQuotes() {
-        assertEquals("a.txt", 
+        assertEquals("a.txt",
                      AttachmentUtil.getContentDispositionFileName("form-data; filename=a.txt"));
     }
-    
+
     @Test
     public void testContendDispositionFileNameNoQuotesAndType() {
-        assertEquals("a.txt", 
+        assertEquals("a.txt",
                      AttachmentUtil.getContentDispositionFileName("filename=a.txt"));
     }
-    
+
     @Test
     public void testContendDispositionFileNameNoQuotesAndType2() {
-        assertEquals("a.txt", 
+        assertEquals("a.txt",
                      AttachmentUtil.getContentDispositionFileName("name=files; filename=a.txt"));
     }
-    
+
     @Test
     public void testContendDispositionFileNameSpacesNoQuotes() {
-        assertEquals("a.txt", 
+        assertEquals("a.txt",
                      AttachmentUtil.getContentDispositionFileName("form-data; filename = a.txt"));
     }
-    
+
     @Test
     public void testContendDispositionFileNameWithQuotes() {
-        assertEquals("a.txt", 
+        assertEquals("a.txt",
                      AttachmentUtil.getContentDispositionFileName("form-data; filename=\"a.txt\""));
     }
-    
+
     @Test
     public void testContendDispositionFileNameWithQuotesAndSemicolon() {
-        assertEquals("a;txt", 
+        assertEquals("a;txt",
                      AttachmentUtil.getContentDispositionFileName("form-data; filename=\"a;txt\""));
     }
-    
+
     @Test
     public void testContendDispositionFileNameWithQuotesAndSemicolon2() {
-        assertEquals("a;txt", 
+        assertEquals("a;txt",
                      AttachmentUtil.getContentDispositionFileName("filename=\"a;txt\""));
     }
-    
+
     @Test
     public void testContendDispositionFileNameWithQuotesAndSemicolon3() {
-        assertEquals("a;txt", 
+        assertEquals("a;txt",
                      AttachmentUtil.getContentDispositionFileName("name=\"a\";filename=\"a;txt\""));
+    }
+
+    @Test
+    public void testContentDispositionAsterickMode() {
+        assertEquals("a b;txt",
+                   AttachmentUtil.getContentDispositionFileName("name=\"a b\";filename*=UTF-8''a%20btxt"));
+    }
+
+    @Test
+    public void testContentDispositionAsterickModeLowercase() {
+        assertEquals("a b;txt",
+                   AttachmentUtil.getContentDispositionFileName("name=\"a b\";filename*=utf-8''a%20btxt"));
     }
 
     @Test
@@ -77,7 +89,7 @@ public class AttachmentUtilTest extends Assert {
                 AttachmentUtil.getContentDispositionFileName(
                         "filename*=UTF-8''%e4%b8%96%e7%95%8c%e3%83%bc%e3%83%95%e3%82%a1%e3%82%a4%e3%83%ab.txt"));
     }
-    
+
     @Test
     public void testContendDispositionFileNameNoRfc5987() {
         assertEquals("демо-сервис.zip",
@@ -86,4 +98,3 @@ public class AttachmentUtilTest extends Assert {
     }
 
 }
-

--- a/core/src/test/java/org/apache/cxf/attachment/AttachmentUtilTest.java
+++ b/core/src/test/java/org/apache/cxf/attachment/AttachmentUtilTest.java
@@ -73,14 +73,26 @@ public class AttachmentUtilTest extends Assert {
 
     @Test
     public void testContentDispositionAsterickMode() {
-        assertEquals("a b;txt",
-                   AttachmentUtil.getContentDispositionFileName("name=\"a b\";filename*=UTF-8''a%20btxt"));
+        assertEquals("a b.txt",
+                   AttachmentUtil.getContentDispositionFileName("filename=\"bad.txt\"; filename*=UTF-8''a%20b.txt"));
     }
 
     @Test
     public void testContentDispositionAsterickModeLowercase() {
-        assertEquals("a b;txt",
-                   AttachmentUtil.getContentDispositionFileName("name=\"a b\";filename*=utf-8''a%20btxt"));
+        assertEquals("a b.txt",
+                   AttachmentUtil.getContentDispositionFileName("filename*=utf-8''a%20b.txt"));
+    }
+
+    @Test
+    public void testContentDispositionAsterickModeFnUppercase() {
+        assertEquals("a b.txt",
+                   AttachmentUtil.getContentDispositionFileName("FILENAME*=utf-8''a%20b.txt"));
+    }
+
+    @Test
+    public void testContentDispositionFnUppercase() {
+        assertEquals("a b.txt",
+                   AttachmentUtil.getContentDispositionFileName("FILENAME=\"a b.txt\""));
     }
 
     @Test


### PR DESCRIPTION
This pull request makes the content-encoding case insensitive as well as the filename fields. The specs say that these fields should be insensitive. I also added some unit tests to verify functionality.