### PR TITLE
[CXF-7000] Allow logging to be enabled on-the-fly

### DIFF
--- a/core/src/main/java/org/apache/cxf/bus/extension/ExtensionManagerBus.java
+++ b/core/src/main/java/org/apache/cxf/bus/extension/ExtensionManagerBus.java
@@ -40,6 +40,7 @@ import org.apache.cxf.configuration.ConfiguredBeanLocator;
 import org.apache.cxf.configuration.Configurer;
 import org.apache.cxf.configuration.NullConfigurer;
 import org.apache.cxf.feature.Feature;
+import org.apache.cxf.feature.LiveLoggingFeature;
 import org.apache.cxf.feature.LoggingFeature;
 import org.apache.cxf.interceptor.AbstractBasicInterceptorProvider;
 import org.apache.cxf.resource.DefaultResourceManager;
@@ -411,5 +412,29 @@ public class ExtensionManagerBus extends AbstractBasicInterceptorProvider implem
 
         // otherwise use null so the default will be used
         return null;
+    }
+
+    public void enableLiveLogging(boolean enable) {
+        enableLiveLogging(enable, false);
+    }
+
+    public void enableLiveLogging(boolean enable, boolean pretty) {
+        LiveLoggingFeature liveLoggingFeature;
+        if (enable) {
+            liveLoggingFeature = new LiveLoggingFeature();
+            liveLoggingFeature.setPrettyLogging(pretty);
+            this.features.add(liveLoggingFeature);
+            if (state == BusState.RUNNING || state == BusState.INITIAL) {
+                liveLoggingFeature.initialize(this);
+            }
+        } else {
+            for (Feature feature : this.features) {
+                if ("org.apache.cxf.feature.LiveLoggingFeature".contains(feature.getClass().getName())) {
+                    liveLoggingFeature = (LiveLoggingFeature) feature;
+                    liveLoggingFeature.removeLiveLogging(this);
+                    this.features.remove(feature);
+                }
+            }
+        }
     }
 }

--- a/core/src/main/java/org/apache/cxf/feature/LiveLoggingFeature.java
+++ b/core/src/main/java/org/apache/cxf/feature/LiveLoggingFeature.java
@@ -1,0 +1,90 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.cxf.feature;
+
+import org.apache.cxf.Bus;
+import org.apache.cxf.annotations.Provider;
+import org.apache.cxf.common.injection.NoJSR250Annotations;
+import org.apache.cxf.interceptor.AbstractLoggingInterceptor;
+import org.apache.cxf.interceptor.Interceptor;
+import org.apache.cxf.interceptor.InterceptorProvider;
+import org.apache.cxf.interceptor.LiveLoggingInInterceptor;
+import org.apache.cxf.interceptor.LiveLoggingOutInterceptor;
+import org.apache.cxf.message.Message;
+
+/**
+ * This class is used to enable message-on-the-wire logging on a running bus.
+ */
+@NoJSR250Annotations
+@Provider(value = Provider.Type.Feature)
+public class LiveLoggingFeature extends LoggingFeature {
+    private static final int DEFAULT_LIMIT = AbstractLoggingInterceptor.DEFAULT_LIMIT;
+    private static final LiveLoggingInInterceptor IN = new LiveLoggingInInterceptor(DEFAULT_LIMIT);
+    private static final LiveLoggingOutInterceptor OUT = new LiveLoggingOutInterceptor(DEFAULT_LIMIT);
+
+    public LiveLoggingFeature() {
+    }
+
+    @Override
+    protected void initializeProvider(InterceptorProvider provider, Bus bus) {
+        if (limit == DEFAULT_LIMIT && inLocation == null
+                && outLocation == null && !prettyLogging) {
+            provider.getInInterceptors().add(IN);
+            provider.getInFaultInterceptors().add(IN);
+            provider.getOutInterceptors().add(OUT);
+            provider.getOutFaultInterceptors().add(OUT);
+        } else {
+            LiveLoggingInInterceptor in = new LiveLoggingInInterceptor(limit);
+            in.setOutputLocation(inLocation);
+            in.setPrettyLogging(prettyLogging);
+            in.setShowBinaryContent(showBinary);
+            LiveLoggingOutInterceptor out = new LiveLoggingOutInterceptor(limit);
+            out.setOutputLocation(outLocation);
+            out.setPrettyLogging(prettyLogging);
+            out.setShowBinaryContent(showBinary);
+
+            provider.getInInterceptors().add(in);
+            provider.getInFaultInterceptors().add(in);
+            provider.getOutInterceptors().add(out);
+            provider.getOutFaultInterceptors().add(out);
+        }
+    }
+
+    public synchronized void removeLiveLogging(Bus bus) {
+        if (bus == null) {
+            return;
+        }
+
+        while (bus.getInInterceptors().iterator().hasNext()) {
+            Interceptor<? extends Message> in = bus.getInFaultInterceptors().iterator().next();
+            if (in instanceof LiveLoggingInInterceptor) {
+                bus.getInInterceptors().remove(in);
+                bus.getInFaultInterceptors().remove(in);
+            }
+        }
+
+        while (bus.getOutInterceptors().iterator().hasNext()) {
+            Interceptor<? extends Message> out = bus.getOutFaultInterceptors().iterator().next();
+            if (out instanceof LiveLoggingOutInterceptor) {
+                bus.getOutInterceptors().remove(out);
+                bus.getOutFaultInterceptors().remove(out);
+            }
+        }
+    }
+}

--- a/core/src/main/java/org/apache/cxf/feature/LoggingFeature.java
+++ b/core/src/main/java/org/apache/cxf/feature/LoggingFeature.java
@@ -49,8 +49,7 @@ public class LoggingFeature extends AbstractFeature {
     private static final int DEFAULT_LIMIT = AbstractLoggingInterceptor.DEFAULT_LIMIT;
     private static final LoggingInInterceptor IN = new LoggingInInterceptor(DEFAULT_LIMIT);
     private static final LoggingOutInterceptor OUT = new LoggingOutInterceptor(DEFAULT_LIMIT);
-    
-    
+
     String inLocation;
     String outLocation;
     boolean prettyLogging;

--- a/core/src/main/java/org/apache/cxf/interceptor/LiveLoggingInInterceptor.java
+++ b/core/src/main/java/org/apache/cxf/interceptor/LiveLoggingInInterceptor.java
@@ -1,0 +1,25 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.cxf.interceptor;
+
+public class LiveLoggingInInterceptor extends LoggingInInterceptor {
+    public LiveLoggingInInterceptor(int lim) {
+        super(lim);
+    }
+}

--- a/core/src/main/java/org/apache/cxf/interceptor/LiveLoggingOutInterceptor.java
+++ b/core/src/main/java/org/apache/cxf/interceptor/LiveLoggingOutInterceptor.java
@@ -1,0 +1,25 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.cxf.interceptor;
+
+public class LiveLoggingOutInterceptor extends LoggingOutInterceptor {
+    public LiveLoggingOutInterceptor(int lim) {
+        super(lim);
+    }
+}

--- a/core/src/test/java/org/apache/cxf/endpoint/EndpointImplTest.java
+++ b/core/src/test/java/org/apache/cxf/endpoint/EndpointImplTest.java
@@ -19,8 +19,14 @@
 
 package org.apache.cxf.endpoint;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.apache.cxf.Bus;
 import org.apache.cxf.bus.extension.ExtensionManagerBus;
+import org.apache.cxf.feature.Feature;
+import org.apache.cxf.interceptor.LiveLoggingInInterceptor;
+import org.apache.cxf.interceptor.LiveLoggingOutInterceptor;
 import org.apache.cxf.service.Service;
 import org.apache.cxf.service.ServiceImpl;
 import org.apache.cxf.service.model.EndpointInfo;
@@ -63,4 +69,33 @@ public class EndpointImplTest extends Assert {
     }
     
     //TODO add other tests
+
+    @Test
+    public void testLiveLoggingFeature() throws Exception {
+        ExtensionManagerBus bus = new ExtensionManagerBus();
+        bus.enableLiveLogging(true, true);
+
+        List<String> featureList = new ArrayList<>();
+        for (Feature feature : bus.getFeatures()) {
+            featureList.add(feature.getClass().getSimpleName());
+        }
+
+        assertEquals(true, featureList.contains("LiveLoggingFeature"));
+        Object inInterceptor = bus.getInInterceptors().get(0);
+        Object inFaultInterceptor = bus.getInFaultInterceptors().get(0);
+        Object outInterceptor = bus.getOutInterceptors().get(0);
+        Object outFaultInterceptor = bus.getOutFaultInterceptors().get(0);
+
+        assertTrue(inInterceptor instanceof LiveLoggingInInterceptor);
+        assertTrue(outInterceptor instanceof LiveLoggingOutInterceptor);
+        assertTrue(inFaultInterceptor instanceof LiveLoggingInInterceptor);
+        assertTrue(outFaultInterceptor instanceof LiveLoggingOutInterceptor);
+
+        bus.enableLiveLogging(false);
+        assertEquals(0, bus.getFeatures().size());
+        assertEquals(0, bus.getInInterceptors().size());
+        assertEquals(0, bus.getInFaultInterceptors().size());
+        assertEquals(0, bus.getOutInterceptors().size());
+        assertEquals(0, bus.getOutFaultInterceptors().size());
+    }
 }


### PR DESCRIPTION
The purpose of LiveLoggingInInterceptor/LiveLoggingOutInterceptor is to work as a marker and avoid removing any user's LoggingInInterceptor/LoggingOutInterceptor implementations.
