### PR TITLE
CXF-6904 Customize Swagger scan logic so it doesn't hurt in OSGi.

### DIFF
--- a/rt/rs/description-swagger/src/main/java/org/apache/cxf/jaxrs/swagger/CxfBeanConfig.java
+++ b/rt/rs/description-swagger/src/main/java/org/apache/cxf/jaxrs/swagger/CxfBeanConfig.java
@@ -1,0 +1,44 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.cxf.jaxrs.swagger;
+
+import java.util.Set;
+
+import io.swagger.jaxrs.config.BeanConfig;
+
+/**
+ * Dedicated configuration for Swagger which receives list of classes to be used to build swagger descriptor.
+ *
+ * These classes are used to enrich scan result reported by BeanConfig by default.
+ */
+public class CxfBeanConfig extends BeanConfig {
+
+    private final Set<Class<?>> classes;
+
+    public CxfBeanConfig(Set<Class<?>> classes) {
+        this.classes = classes;
+    }
+
+    @Override
+    public Set<Class<?>> classes() {
+        this.classes.addAll(super.classes());
+        return this.classes;
+    }
+
+}

--- a/rt/rs/description-swagger/src/main/java/org/apache/cxf/jaxrs/swagger/Swagger2Feature.java
+++ b/rt/rs/description-swagger/src/main/java/org/apache/cxf/jaxrs/swagger/Swagger2Feature.java
@@ -40,7 +40,6 @@ import javax.ws.rs.PathParam;
 import javax.ws.rs.container.ContainerRequestContext;
 import javax.ws.rs.container.ContainerRequestFilter;
 import javax.ws.rs.container.PreMatching;
-import javax.ws.rs.core.Application;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
@@ -55,7 +54,6 @@ import org.apache.cxf.common.util.StringUtils;
 import org.apache.cxf.endpoint.Server;
 import org.apache.cxf.jaxrs.JAXRSServiceFactoryBean;
 import org.apache.cxf.jaxrs.ext.MessageContext;
-import org.apache.cxf.jaxrs.model.ApplicationInfo;
 import org.apache.cxf.jaxrs.model.ClassResourceInfo;
 import org.apache.cxf.jaxrs.model.doc.DocumentationProvider;
 import org.apache.cxf.jaxrs.model.doc.JavaDocProvider;
@@ -95,17 +93,10 @@ public class Swagger2Feature extends AbstractSwaggerFeature {
     protected void addSwaggerResource(Server server, Bus bus) {
         JAXRSServiceFactoryBean sfb =
             (JAXRSServiceFactoryBean) server.getEndpoint().get(JAXRSServiceFactoryBean.class.getName());
+        Set<Class<?>> classes = new HashSet<>();
         if (!isScan()) {
-            ServerProviderFactory factory = 
-                (ServerProviderFactory)server.getEndpoint().get(ServerProviderFactory.class.getName());
-            ApplicationInfo applicationInfo = factory.getApplicationProvider();
-            if (applicationInfo == null) {
-                Set<Class<?>> serviceClasses = new HashSet<Class<?>>();
-                for (ClassResourceInfo cri : sfb.getClassResourceInfo()) {
-                    serviceClasses.add(cri.getServiceClass());
-                }
-                applicationInfo = new ApplicationInfo(new DefaultApplication(serviceClasses), bus);
-                server.getEndpoint().put(Application.class.getName(), applicationInfo);
+            for (ClassResourceInfo cri : sfb.getClassResourceInfo()) {
+                classes.add(cri.getServiceClass());
             }
         }
         
@@ -145,7 +136,7 @@ public class Swagger2Feature extends AbstractSwaggerFeature {
         ((ServerProviderFactory) server.getEndpoint().get(
                 ServerProviderFactory.class.getName())).setUserProviders(providers);
 
-        BeanConfig beanConfig = new BeanConfig();
+        BeanConfig beanConfig = new CxfBeanConfig(classes);
         beanConfig.setResourcePackage(getResourcePackage());
         beanConfig.setVersion(getVersion());
         String basePath = getBasePath();
@@ -398,16 +389,5 @@ public class Swagger2Feature extends AbstractSwaggerFeature {
             }
         }
     }
-    
-    protected static class DefaultApplication extends Application {
-        Set<Class<?>> serviceClasses;
-        DefaultApplication(Set<Class<?>> serviceClasses) {
-            this.serviceClasses = serviceClasses;
-        }
-        @Override
-        public Set<Class<?>> getClasses() {
-            return serviceClasses;
-        }
-    }
-    
+
 }


### PR DESCRIPTION
This PR overrides bean config and allows to use most of it's code used for swagger configuration. This keeps default behavior of swagger, with some small difference that when scan on Swagger2Feature is disabled it passes classes which are available on endpoint.
