### PR TITLE
[CXF-7043] JAX-RS endpoints cannot handle encoded URL when used with continuation and servlet transport

### DIFF
--- a/rt/transports/http/src/main/java/org/apache/cxf/transport/http/AbstractHTTPDestination.java
+++ b/rt/transports/http/src/main/java/org/apache/cxf/transport/http/AbstractHTTPDestination.java
@@ -409,7 +409,7 @@ public abstract class AbstractHTTPDestination
      * Propogate in the message a TLSSessionInfo instance representative  
      * of the TLS-specific information in the HTTP request.
      * 
-     * @param req the Jetty request
+     * @param request the Jetty request
      * @param message the Message
      */
     private static void propogateSecureSession(HttpServletRequest request,

--- a/rt/transports/http/src/main/java/org/apache/cxf/transport/http/Servlet3ContinuationProvider.java
+++ b/rt/transports/http/src/main/java/org/apache/cxf/transport/http/Servlet3ContinuationProvider.java
@@ -87,7 +87,7 @@ public class Servlet3ContinuationProvider implements ContinuationProvider {
                              inMessage.getExchange().getInMessage());
             callback = inMessage.getExchange().get(ContinuationCallback.class);
             blockRestart = PropertyUtils.isTrue(inMessage.getContextualProperty(BLOCK_RESTART));
-            context = req.startAsync(req, resp);
+            context = req.startAsync();
             context.addListener(this);
         }
 

--- a/rt/transports/http/src/main/java/org/apache/cxf/transport/servlet/BaseUrlHelper.java
+++ b/rt/transports/http/src/main/java/org/apache/cxf/transport/servlet/BaseUrlHelper.java
@@ -47,7 +47,12 @@ public final class BaseUrlHelper {
             
             URI uri = URI.create(reqPrefix);
             sb.append(uri.getScheme()).append("://").append(uri.getRawAuthority());
-            sb.append(request.getContextPath()).append(request.getServletPath());
+            if (request.getContextPath() != null) {
+                sb.append(request.getContextPath());
+            }
+            if (request.getServletPath() != null) {
+                sb.append(request.getServletPath());
+            }
             
             reqPrefix = sb.toString();
         }

--- a/rt/transports/http/src/test/java/org/apache/cxf/transport/servlet/BaseUrlHelperTest.java
+++ b/rt/transports/http/src/test/java/org/apache/cxf/transport/servlet/BaseUrlHelperTest.java
@@ -16,11 +16,10 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.cxf.transport.servlet.servicelist;
+package org.apache.cxf.transport.servlet;
 
 import javax.servlet.http.HttpServletRequest;
 
-import org.apache.cxf.transport.servlet.BaseUrlHelper;
 import org.easymock.EasyMock;
 
 import org.junit.Assert;
@@ -34,9 +33,9 @@ public class BaseUrlHelperTest {
         EasyMock.expectLastCall().andReturn(new StringBuffer(requestUrl));
 
         req.getContextPath();
-        EasyMock.expectLastCall().andReturn(contextPath);
+        EasyMock.expectLastCall().andReturn(contextPath).anyTimes();
         req.getServletPath();
-        EasyMock.expectLastCall().andReturn(servletPath);
+        EasyMock.expectLastCall().andReturn(servletPath).anyTimes();
 
         req.getPathInfo();
         EasyMock.expectLastCall().andReturn(pathInfo).times(2);

--- a/rt/transports/http/src/test/java/org/apache/cxf/transport/servlet/ServletControllerTest.java
+++ b/rt/transports/http/src/test/java/org/apache/cxf/transport/servlet/ServletControllerTest.java
@@ -55,9 +55,9 @@ public class ServletControllerTest extends Assert {
         req.getPathInfo();
         EasyMock.expectLastCall().andReturn(pathInfo).anyTimes();
         req.getContextPath();
-        EasyMock.expectLastCall().andReturn("");
+        EasyMock.expectLastCall().andReturn("").anyTimes();
         req.getServletPath();
-        EasyMock.expectLastCall().andReturn("");
+        EasyMock.expectLastCall().andReturn("").anyTimes();
         req.setAttribute(Message.BASE_PATH, "http://localhost:8080");
         EasyMock.expectLastCall().anyTimes();
         req.getRequestURI();
@@ -98,9 +98,9 @@ public class ServletControllerTest extends Assert {
         req.getPathInfo();
         EasyMock.expectLastCall().andReturn(null).anyTimes();
         req.getContextPath();
-        EasyMock.expectLastCall().andReturn("");
+        EasyMock.expectLastCall().andReturn("").anyTimes();
         req.getServletPath();
-        EasyMock.expectLastCall().andReturn("");
+        EasyMock.expectLastCall().andReturn("").anyTimes();
         req.getRequestURI();
         EasyMock.expectLastCall().andReturn("/services").times(2);
         

--- a/systests/jaxrs/src/test/java/org/apache/cxf/systest/jaxrs/BookCxfContinuationServlet3Server.java
+++ b/systests/jaxrs/src/test/java/org/apache/cxf/systest/jaxrs/BookCxfContinuationServlet3Server.java
@@ -1,0 +1,82 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.cxf.systest.jaxrs;
+
+import org.apache.cxf.Bus;
+import org.apache.cxf.BusFactory;
+import org.apache.cxf.jaxrs.JAXRSServerFactoryBean;
+import org.apache.cxf.jaxrs.lifecycle.SingletonResourceProvider;
+import org.apache.cxf.testutil.common.AbstractBusTestServerBase;
+import org.apache.cxf.transport.servlet.CXFNonSpringServlet;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.servlet.ServletHandler;
+import org.eclipse.jetty.servlet.ServletHolder;
+
+public class BookCxfContinuationServlet3Server extends AbstractBusTestServerBase {
+    public static final String PORT = allocatePort(BookCxfContinuationServlet3Server.class);
+
+    protected void run() {
+        String busFactory = System.getProperty(BusFactory.BUS_FACTORY_PROPERTY_NAME);
+        System.setProperty(BusFactory.BUS_FACTORY_PROPERTY_NAME, "org.apache.cxf.bus.CXFBusFactory");
+        try {
+            CXFNonSpringServlet cxf = new CXFNonSpringServlet();
+            httpServer(cxf).start();
+            serverFactory(cxf.getBus()).create();
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        } finally {
+            if (busFactory != null) {
+                System.setProperty(BusFactory.BUS_FACTORY_PROPERTY_NAME, busFactory);
+            } else {
+                System.clearProperty(BusFactory.BUS_FACTORY_PROPERTY_NAME);
+            }
+        }
+    }
+
+    private Server httpServer(CXFNonSpringServlet cxf) {
+        Server server = new Server(Integer.parseInt(PORT));
+        ServletHandler handler = new ServletHandler();
+        server.setHandler(handler);
+        handler.addServletWithMapping(new ServletHolder(cxf), "/*");
+        return server;
+    }
+
+    private JAXRSServerFactoryBean serverFactory(Bus bus) {
+        JAXRSServerFactoryBean sf = new JAXRSServerFactoryBean();
+        sf.setBus(bus);
+        sf.setResourceClasses(BookCxfContinuationStore.class);
+        sf.setResourceProvider(BookCxfContinuationStore.class,
+                               new SingletonResourceProvider(new BookCxfContinuationStore()));
+        sf.setAddress("/");
+        return sf;
+    }
+
+    public static void main(String[] args) {
+        try {
+            BookCxfContinuationServlet3Server s = new BookCxfContinuationServlet3Server();
+            s.start();
+        } catch (Exception ex) {
+            ex.printStackTrace();
+            System.exit(-1);
+        } finally {
+            System.out.println("done!");
+        }
+    }
+}

--- a/systests/jaxrs/src/test/java/org/apache/cxf/systest/jaxrs/BookCxfContinuationStore.java
+++ b/systests/jaxrs/src/test/java/org/apache/cxf/systest/jaxrs/BookCxfContinuationStore.java
@@ -169,6 +169,7 @@ public class BookCxfContinuationStore {
         books.put("3", "CXF in Action3");
         books.put("4", "CXF in Action4");
         books.put("5", "CXF in Action5");
+        books.put("A B C", "CXF in Action A B C");
     }
      
 }

--- a/systests/jaxrs/src/test/java/org/apache/cxf/systest/jaxrs/JAXRSCxfContinuationsServlet3Test.java
+++ b/systests/jaxrs/src/test/java/org/apache/cxf/systest/jaxrs/JAXRSCxfContinuationsServlet3Test.java
@@ -1,0 +1,57 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.cxf.systest.jaxrs;
+
+import org.apache.commons.httpclient.HttpClient;
+import org.apache.commons.httpclient.methods.GetMethod;
+import org.apache.cxf.jaxrs.model.AbstractResourceInfo;
+import org.apache.cxf.testutil.common.AbstractBusClientServerTestBase;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class JAXRSCxfContinuationsServlet3Test extends AbstractBusClientServerTestBase {
+    public static final String PORT = BookCxfContinuationServlet3Server.PORT;
+
+    @BeforeClass
+    public static void startServers() throws Exception {
+        AbstractResourceInfo.clearAllMaps();
+        createStaticBus();
+        assertTrue("server did not launch correctly",
+                   launchServer(BookCxfContinuationServlet3Server.class));
+    }
+
+    @Test
+    public void testEncodedURL() throws Exception {
+        String id = "A%20B%20C"; // "A B C"
+        GetMethod get = new GetMethod("http://localhost:" + PORT + "/bookstore/books/" + id);
+        HttpClient httpclient = new HttpClient();
+
+        try {
+            int result = httpclient.executeMethod(get);
+            assertEquals("Encoded path '/" + id + "' is not handled successfully",
+                         200, result);
+            assertEquals("Book description for id " + id + " is wrong",
+                         "CXF in Action A B C", get.getResponseBodyAsString());
+        } finally {
+            // Release current connection to the connection pool once you are done
+            get.releaseConnection();
+        }
+    }
+}

--- a/systests/jaxrs/src/test/java/org/apache/cxf/systest/jaxrs/JAXRSCxfContinuationsTest.java
+++ b/systests/jaxrs/src/test/java/org/apache/cxf/systest/jaxrs/JAXRSCxfContinuationsTest.java
@@ -124,4 +124,22 @@ public class JAXRSCxfContinuationsTest extends AbstractBusClientServerTestBase {
         }
         
     }
+
+    @Test
+    public void testEncodedURL() throws Exception {
+        String id = "A%20B%20C"; // "A B C"
+        GetMethod get = new GetMethod("http://localhost:" + PORT + "/bookstore/books/" + id);
+        HttpClient httpclient = new HttpClient();
+
+        try {
+            int result = httpclient.executeMethod(get);
+            assertEquals("Encoded path '/" + id + "' is not handled successfully",
+                         200, result);
+            assertEquals("Book description for id " + id + " is wrong",
+                         "CXF in Action A B C", get.getResponseBodyAsString());
+        } finally {
+            // Release current connection to the connection pool once you are done
+            get.releaseConnection();
+        }
+    }
 }


### PR DESCRIPTION
See: https://issues.apache.org/jira/browse/CXF-7043