### PR TITLE
[CXF-7043] Fix JAXRSCxfContinuationsServlet3Test for 3.0.x

### DIFF
--- a/systests/jaxrs/src/test/java/org/apache/cxf/systest/jaxrs/BookCxfContinuationServlet3Server.java
+++ b/systests/jaxrs/src/test/java/org/apache/cxf/systest/jaxrs/BookCxfContinuationServlet3Server.java
@@ -26,7 +26,7 @@ import org.apache.cxf.jaxrs.lifecycle.SingletonResourceProvider;
 import org.apache.cxf.testutil.common.AbstractBusTestServerBase;
 import org.apache.cxf.transport.servlet.CXFNonSpringServlet;
 import org.eclipse.jetty.server.Server;
-import org.eclipse.jetty.servlet.ServletHandler;
+import org.eclipse.jetty.servlet.ServletContextHandler;
 import org.eclipse.jetty.servlet.ServletHolder;
 
 public class BookCxfContinuationServlet3Server extends AbstractBusTestServerBase {
@@ -52,9 +52,10 @@ public class BookCxfContinuationServlet3Server extends AbstractBusTestServerBase
 
     private Server httpServer(CXFNonSpringServlet cxf) {
         Server server = new Server(Integer.parseInt(PORT));
-        ServletHandler handler = new ServletHandler();
-        server.setHandler(handler);
-        handler.addServletWithMapping(new ServletHolder(cxf), "/*");
+        ServletContextHandler context = new ServletContextHandler(ServletContextHandler.SESSIONS);
+        context.setContextPath("/");
+        context.addServlet(new ServletHolder(cxf), "/*");
+        server.setHandler(context);
         return server;
     }
 


### PR DESCRIPTION
https://issues.apache.org/jira/browse/CXF-7043

`JAXRSCxfContinuationsServlet3Test` in the pull req #164 didn't work for 3.0.x branch, because a servlet context was needed to set up explicitly for 3.0.x and otherwise it threw NPE.

```
Caused by: java.lang.NullPointerException
    at org.apache.cxf.transport.servlet.ServletContextResourceResolver.getAsStream(ServletContextResourceResolver.java:54)
    at org.apache.cxf.transport.servlet.ServletContextResourceResolver.resolve(ServletContextResourceResolver.java:114)
    at org.apache.cxf.resource.DefaultResourceManager.findResource(DefaultResourceManager.java:113)
    at org.apache.cxf.resource.DefaultResourceManager.resolveResource(DefaultResourceManager.java:58)
    at org.apache.cxf.transport.servlet.AbstractHTTPServlet.getResourceAsStream(AbstractHTTPServlet.java:153)
    at org.apache.cxf.transport.servlet.AbstractHTTPServlet.finalizeServletInit(AbstractHTTPServlet.java:128)
    at org.apache.cxf.transport.servlet.CXFNonSpringServlet.init(CXFNonSpringServlet.java:88)
    at org.eclipse.jetty.servlet.ServletHolder.initServlet(ServletHolder.java:532)
    ... 30 more 
```
