### PR TITLE
fix StringBuilder.toString(), add invalidValue in message

### DIFF
--- a/rt/frontend/jaxrs/src/main/java/org/apache/cxf/jaxrs/validation/ValidationExceptionMapper.java
+++ b/rt/frontend/jaxrs/src/main/java/org/apache/cxf/jaxrs/validation/ValidationExceptionMapper.java
@@ -60,7 +60,7 @@ public class ValidationExceptionMapper implements ExceptionMapper< ValidationExc
             }
             ResponseBuilder rb = JAXRSUtils.toResponseBuilder(errorStatus);
             if (responseBody != null) {
-                rb.entity(responseBody);
+                rb.entity(responseBody.toString());
             }
             return rb.build();
         } else {
@@ -68,8 +68,10 @@ public class ValidationExceptionMapper implements ExceptionMapper< ValidationExc
         }
     }
     private String getMessage(ConstraintViolation<?> violation) {
-        return violation.getRootBeanClass().getSimpleName() 
-            + "." + violation.getPropertyPath() 
+        return "Value " 
+            + (violation.getInvalidValue() != null ? "'" + violation.getInvalidValue().toString() + "'" : "(null)")
+            + " of " + violation.getRootBeanClass().getSimpleName()
+            + "." + violation.getPropertyPath()
             + ": " + violation.getMessage();
     }
     /**


### PR DESCRIPTION
- fix No message body writer has been found for class java.lang.StringBuilder, ContentType: text/plain
- add invalidValue in message

Example messages:

Value 'Desctiption follows' of DocumentResourceImpl.create.arg0.description: size must be between 36 and 36
Value (null) of DocumentResourceImpl.create.arg0.displayName: may not be null
Value 'Desctiption follows' of DocumentResourceImpl.create.arg0.description: must match "[\da-fA-F]{8}-[\da-fA-F]{4}-[\da-fA-F]{4}-[\da-fA-F]{4}-[\da-fA-F]{12}"
Value '      ' of DocumentResourceImpl.create.arg0.displayName: must match ".*[^\s ].*"
Value 'Desctiption follows' of DocumentResourceImpl.create.arg0.description: must match "[\da-fA-F]{8}-[\da-fA-F]{4}-[\da-fA-F]{4}-[\da-fA-F]{4}-[\da-fA-F]{12}"
Value 'Desctiption follows' of DocumentResourceImpl.create.arg0.description: size must be between 36 and 36

Compare to xsd validation message:
Internal Exception: org.xml.sax.SAXParseException; cvc-pattern-valid: Value '' is not facet-valid with respect to pattern '[\da-fA-F]{8}-[\da-fA-F]{4}-[\da-fA-F]{4}-[\da-fA-F]{4}-[\da-fA-F]{12}' for type 'UUID'.
Internal Exception: org.xml.sax.SAXParseException; cvc-pattern-valid: Value '' is not facet-valid with respect to pattern '.*[^\s ].*' for type 'notEmptyString'.