### PR TITLE
CXF-7084 Add a configurable KeyName value using the properties

### DIFF
--- a/rt/rs/security/xml/src/main/java/org/apache/cxf/rs/security/xml/EncryptionProperties.java
+++ b/rt/rs/security/xml/src/main/java/org/apache/cxf/rs/security/xml/EncryptionProperties.java
@@ -25,6 +25,7 @@ public class EncryptionProperties {
     private String encryptionSymmetricKeyAlgo;
     private String encryptionDigestAlgo;
     private String encryptionKeyIdType;
+    private String encryptionKeyName;
     
     public void setEncryptionKeyTransportAlgo(String encryptionKeyTransportAlgo) {
         this.encryptionKeyTransportAlgo = encryptionKeyTransportAlgo;
@@ -50,5 +51,12 @@ public class EncryptionProperties {
     public String getEncryptionKeyIdType() {
         return encryptionKeyIdType;
     }
-    
+
+    public String getEncryptionKeyName() {
+        return encryptionKeyName;
+    }
+
+    public void setEncryptionKeyName(String encryptionKeyName) {
+        this.encryptionKeyName = encryptionKeyName;
+    }
 }

--- a/rt/rs/security/xml/src/main/java/org/apache/cxf/rs/security/xml/SignatureProperties.java
+++ b/rt/rs/security/xml/src/main/java/org/apache/cxf/rs/security/xml/SignatureProperties.java
@@ -24,6 +24,7 @@ public class SignatureProperties {
     private String signatureC14nMethod;
     private String signatureC14nTransform;
     private String signatureKeyIdType;
+    private String signatureKeyName;
     
     public void setSignatureAlgo(String signatureAlgo) {
         this.signatureAlgo = signatureAlgo;
@@ -71,5 +72,12 @@ public class SignatureProperties {
     public void setSignatureKeyIdType(String signatureKeyIdType) {
         this.signatureKeyIdType = signatureKeyIdType;
     }
-    
+
+    public String getSignatureKeyName() {
+        return signatureKeyName;
+    }
+
+    public void setSignatureKeyName(String signatureKeyName) {
+        this.signatureKeyName = signatureKeyName;
+    }
 }

--- a/rt/security/src/main/java/org/apache/cxf/rt/security/SecurityConstants.java
+++ b/rt/security/src/main/java/org/apache/cxf/rt/security/SecurityConstants.java
@@ -336,9 +336,25 @@ public class SecurityConstants {
      */
     public static final String STS_TOKEN_IMMINENT_EXPIRY_VALUE =
         "security.sts.token.imminent-expiry-value";
-    
+
+    /**
+     * This is a string that will be passed in the KeyInfo/KeyName field of the security
+     * header identifying the key to use for signature verification. This is a custom string
+     * so it needs to be supplied during configuration or at request time. The definition and
+     * interpretation of the content is a responsibility of higher layers.
+     */
+    public static final String SIGNATURE_KEYNAME = "security.signature.keyname";
+
+    /**
+     * This is a string that will be passed in the KeyInfo/KeyName field of the security
+     * header identifying the key to use for de/encryption. This is a custom string so it
+     * needs to be supplied during configuration or at request time. The definition and
+     * interpretation of the content is a responsibility of higher layers.
+     */
+    public static final String ENCRYPTION_KEYNAME = "security.encryption.keyname";
+
     public static final Set<String> COMMON_PROPERTIES;
-    
+
     static {
         Set<String> s = new HashSet<>(Arrays.asList(new String[] {
             USERNAME, PASSWORD, SIGNATURE_USERNAME, ENCRYPT_USERNAME,
@@ -351,7 +367,7 @@ public class SecurityConstants {
             DISABLE_STS_CLIENT_WSMEX_CALL_USING_EPR_ADDRESS, STS_TOKEN_CRYPTO,
             STS_TOKEN_PROPERTIES, STS_TOKEN_USERNAME, STS_TOKEN_ACT_AS, STS_TOKEN_ON_BEHALF_OF,
             STS_CLIENT, STS_APPLIES_TO, CACHE_ISSUED_TOKEN_IN_ENDPOINT, PREFER_WSMEX_OVER_STS_CLIENT_CONFIG,
-            STS_TOKEN_IMMINENT_EXPIRY_VALUE
+            STS_TOKEN_IMMINENT_EXPIRY_VALUE, SIGNATURE_KEYNAME, ENCRYPTION_KEYNAME
         }));
         COMMON_PROPERTIES = Collections.unmodifiableSet(s);
     }


### PR DESCRIPTION
I've added properties to EncryptionProperties and SignatureProperties and also two new SecurityConstants.

This way a KeyName can be directly configured from the *Properties but also configured per message using a property. The Message configuration has a higher preference if both are set.
