### PR TITLE
CXF-7086 Add a Map with KeyNames and aliases to configure xmlsec

### DIFF
--- a/rt/rs/security/xml/src/main/java/org/apache/cxf/rs/security/common/RSSecurityUtils.java
+++ b/rt/rs/security/xml/src/main/java/org/apache/cxf/rs/security/common/RSSecurityUtils.java
@@ -23,6 +23,7 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.math.BigInteger;
 import java.security.cert.X509Certificate;
+import java.util.Map;
 
 import javax.security.auth.callback.CallbackHandler;
 
@@ -164,6 +165,32 @@ public final class RSSecurityUtils {
         } catch (Exception ex) {
             throw new WSSecurityException(WSSecurityException.ErrorCode.FAILURE, ex);
         }
+    }
+
+    public static String getAliasForKeyName(Message message, String keyName) throws WSSecurityException {
+        Object o = SecurityUtils.getSecurityPropertyValue(SecurityConstants.KEYNAME_LOOKUP_MAP, message);
+        if (o == null) {
+            throw new WSSecurityException(WSSecurityException.ErrorCode.FAILURE, "stax.keyNotFoundForName",
+                    new Object[] {keyName});
+        }
+
+        Map<String, String> lookupMap = (Map<String, String>)o;
+        String keyAlias = null;
+        if (lookupMap.containsKey(keyName)) {
+            keyAlias = lookupMap.get(keyName);
+        }
+
+        if (keyAlias == null) {
+            throw new WSSecurityException(WSSecurityException.ErrorCode.FAILURE, "stax.keyNotFoundForName",
+                    new Object[] {keyName});
+        }
+
+        return keyAlias;
+    }
+
+    public static Map<String, String> getKeyNameAliasLookupMap(Message message) {
+        return (Map<String, String>)SecurityUtils.
+                getSecurityPropertyValue(SecurityConstants.KEYNAME_LOOKUP_MAP, message);
     }
  
 }

--- a/rt/rs/security/xml/src/main/java/org/apache/cxf/rs/security/xml/EncryptionProperties.java
+++ b/rt/rs/security/xml/src/main/java/org/apache/cxf/rs/security/xml/EncryptionProperties.java
@@ -25,6 +25,7 @@ public class EncryptionProperties {
     private String encryptionSymmetricKeyAlgo;
     private String encryptionDigestAlgo;
     private String encryptionKeyIdType;
+    private String encryptionKeyName;
     
     public void setEncryptionKeyTransportAlgo(String encryptionKeyTransportAlgo) {
         this.encryptionKeyTransportAlgo = encryptionKeyTransportAlgo;
@@ -50,5 +51,12 @@ public class EncryptionProperties {
     public String getEncryptionKeyIdType() {
         return encryptionKeyIdType;
     }
-    
+
+    public String getEncryptionKeyName() {
+        return encryptionKeyName;
+    }
+
+    public void setEncryptionKeyName(String encryptionKeyName) {
+        this.encryptionKeyName = encryptionKeyName;
+    }
 }

--- a/rt/rs/security/xml/src/main/java/org/apache/cxf/rs/security/xml/SignatureProperties.java
+++ b/rt/rs/security/xml/src/main/java/org/apache/cxf/rs/security/xml/SignatureProperties.java
@@ -24,6 +24,7 @@ public class SignatureProperties {
     private String signatureC14nMethod;
     private String signatureC14nTransform;
     private String signatureKeyIdType;
+    private String signatureKeyName;
     
     public void setSignatureAlgo(String signatureAlgo) {
         this.signatureAlgo = signatureAlgo;
@@ -71,5 +72,12 @@ public class SignatureProperties {
     public void setSignatureKeyIdType(String signatureKeyIdType) {
         this.signatureKeyIdType = signatureKeyIdType;
     }
-    
+
+    public String getSignatureKeyName() {
+        return signatureKeyName;
+    }
+
+    public void setSignatureKeyName(String signatureKeyName) {
+        this.signatureKeyName = signatureKeyName;
+    }
 }

--- a/rt/security/src/main/java/org/apache/cxf/rt/security/SecurityConstants.java
+++ b/rt/security/src/main/java/org/apache/cxf/rt/security/SecurityConstants.java
@@ -336,9 +336,25 @@ public class SecurityConstants {
      */
     public static final String STS_TOKEN_IMMINENT_EXPIRY_VALUE =
         "security.sts.token.imminent-expiry-value";
-    
+
+    /**
+     * This is a string that will be passed in the KeyInfo/KeyName field of the security
+     * header identifying the key to use for signature verification. This is a custom string
+     * so it needs to be supplied during configuration or at request time. The definition and
+     * interpretation of the content is a responsibility of higher layers.
+     */
+    public static final String SIGNATURE_KEYNAME = "security.signature.keyname";
+
+    /**
+     * This is a string that will be passed in the KeyInfo/KeyName field of the security
+     * header identifying the key to use for de/encryption. This is a custom string so it
+     * needs to be supplied during configuration or at request time. The definition and
+     * interpretation of the content is a responsibility of higher layers.
+     */
+    public static final String ENCRYPTION_KEYNAME = "security.encryption.keyname";
+
     public static final Set<String> COMMON_PROPERTIES;
-    
+
     static {
         Set<String> s = new HashSet<>(Arrays.asList(new String[] {
             USERNAME, PASSWORD, SIGNATURE_USERNAME, ENCRYPT_USERNAME,
@@ -351,7 +367,7 @@ public class SecurityConstants {
             DISABLE_STS_CLIENT_WSMEX_CALL_USING_EPR_ADDRESS, STS_TOKEN_CRYPTO,
             STS_TOKEN_PROPERTIES, STS_TOKEN_USERNAME, STS_TOKEN_ACT_AS, STS_TOKEN_ON_BEHALF_OF,
             STS_CLIENT, STS_APPLIES_TO, CACHE_ISSUED_TOKEN_IN_ENDPOINT, PREFER_WSMEX_OVER_STS_CLIENT_CONFIG,
-            STS_TOKEN_IMMINENT_EXPIRY_VALUE
+            STS_TOKEN_IMMINENT_EXPIRY_VALUE, SIGNATURE_KEYNAME, ENCRYPTION_KEYNAME
         }));
         COMMON_PROPERTIES = Collections.unmodifiableSet(s);
     }

--- a/rt/security/src/main/java/org/apache/cxf/rt/security/SecurityConstants.java
+++ b/rt/security/src/main/java/org/apache/cxf/rt/security/SecurityConstants.java
@@ -353,6 +353,14 @@ public class SecurityConstants {
      */
     public static final String ENCRYPTION_KEYNAME = "security.encryption.keyname";
 
+    /**
+     * This is a map containing mappings from KeyName to alias. This needs to be used
+     * then KeyInfo/KeyName is used so the inbound handler can determine which key to use
+     * for signature verification or decryption.
+     */
+    public static final String KEYNAME_LOOKUP_MAP = "security.keyname.mapping";
+
+
     public static final Set<String> COMMON_PROPERTIES;
 
     static {
@@ -367,7 +375,7 @@ public class SecurityConstants {
             DISABLE_STS_CLIENT_WSMEX_CALL_USING_EPR_ADDRESS, STS_TOKEN_CRYPTO,
             STS_TOKEN_PROPERTIES, STS_TOKEN_USERNAME, STS_TOKEN_ACT_AS, STS_TOKEN_ON_BEHALF_OF,
             STS_CLIENT, STS_APPLIES_TO, CACHE_ISSUED_TOKEN_IN_ENDPOINT, PREFER_WSMEX_OVER_STS_CLIENT_CONFIG,
-            STS_TOKEN_IMMINENT_EXPIRY_VALUE, SIGNATURE_KEYNAME, ENCRYPTION_KEYNAME
+            STS_TOKEN_IMMINENT_EXPIRY_VALUE, SIGNATURE_KEYNAME, ENCRYPTION_KEYNAME, KEYNAME_LOOKUP_MAP
         }));
         COMMON_PROPERTIES = Collections.unmodifiableSet(s);
     }


### PR DESCRIPTION
This patch is related to https://github.com/apache/santuario-java/pull/8

The goal is to have a solution where the "user" of the XmlSecInInterceptor can specify a map of KeyNames and the keystore aliases that contain the keys to use during the signature validation.

(and possibly also decryption, but that i haven't looked at yet)

Looking for feedback
