### PR TITLE
[CXF-7109] ClientCallback may be invoked twice when Async HTTP Transport is used

### DIFF
--- a/core/src/main/java/org/apache/cxf/interceptor/ClientOutFaultObserver.java
+++ b/core/src/main/java/org/apache/cxf/interceptor/ClientOutFaultObserver.java
@@ -50,7 +50,8 @@ public class ClientOutFaultObserver extends AbstractFaultChainInitiatorObserver 
             return;
         }
         Exception ex = m.getContent(Exception.class);
-        ClientCallback callback = m.getExchange().get(ClientCallback.class);
+        // remove callback so that it won't be invoked twice
+        ClientCallback callback = m.getExchange().remove(ClientCallback.class);
 
         if (callback != null) {
             Map<String, Object> resCtx = CastUtils.cast((Map<?, ?>) m.getExchange().getOutMessage().get(

--- a/core/src/main/java/org/apache/cxf/message/AbstractWrappedMessage.java
+++ b/core/src/main/java/org/apache/cxf/message/AbstractWrappedMessage.java
@@ -157,6 +157,9 @@ public abstract class AbstractWrappedMessage implements Message {
     public <T> void put(Class<T> key, T value) {
         message.put(key, value);
     }
+    public <T> T remove(Class<T> key) {
+        return message.remove(key);
+    }
 
     public Object getContextualProperty(String key) {
         return message.getContextualProperty(key);

--- a/core/src/main/java/org/apache/cxf/message/ExchangeImpl.java
+++ b/core/src/main/java/org/apache/cxf/message/ExchangeImpl.java
@@ -159,6 +159,10 @@ public class ExchangeImpl extends ConcurrentHashMap<String, Object>  implements 
         return super.put(key, value);
     }
 
+    public <T> T remove(Class<T> key) {
+        return key.cast(super.remove(key.getName()));
+    }
+
     private void setMessageContextProperty(Message m, String key, Object value) {
         if (m == null) {
             return;

--- a/core/src/main/java/org/apache/cxf/message/StringMap.java
+++ b/core/src/main/java/org/apache/cxf/message/StringMap.java
@@ -38,4 +38,11 @@ public interface StringMap extends Map<String, Object> {
      * @param value the value
      */
     <T> void put(Class<T> key, T value);
+
+    /**
+     * Convenience method for removing typed objects from the map.
+     * equivalent to:  (T)remove(key.getName());
+     * @param key the key
+     */
+    <T> T remove(Class<T> key);
 }

--- a/core/src/main/java/org/apache/cxf/message/StringMapImpl.java
+++ b/core/src/main/java/org/apache/cxf/message/StringMapImpl.java
@@ -46,4 +46,8 @@ public class StringMapImpl
     public <T> void put(Class<T> key, T value) {
         put(key.getName(), value);
     }
+
+    public <T> T remove(Class<T> key) {
+        return key.cast(remove(key.getName()));
+    }
 }

--- a/rt/transports/http-hc/src/test/java/org/apache/cxf/transport/http/asyncclient/AsyncHTTPConduitTest.java
+++ b/rt/transports/http-hc/src/test/java/org/apache/cxf/transport/http/asyncclient/AsyncHTTPConduitTest.java
@@ -23,6 +23,7 @@ import java.net.URL;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import javax.xml.ws.AsyncHandler;
 import javax.xml.ws.Endpoint;
@@ -196,6 +197,26 @@ public class AsyncHTTPConduitTest extends AbstractBusClientServerTestBase {
             public void handleResponse(Response<GreetMeLaterResponse> res) {
             }
         }).get();
+    }
+
+    @Test
+    public void testCallAsyncCallbackInvokedOnlyOnce() throws Exception {
+        // This test is especially targeted for RHEL 6.8
+        updateAddressPort(g, PORT_INV);
+        int repeat = 100;
+        final AtomicInteger count = new AtomicInteger(0);
+        for (int i = 0; i < repeat; i++) {
+            try {
+                g.greetMeAsync(request, new AsyncHandler<GreetMeResponse>() {
+                    public void handleResponse(Response<GreetMeResponse> res) {
+                        count.incrementAndGet();
+                    }
+                }).get();
+            } catch (Exception e) {
+            }
+        }
+        Thread.sleep(1000);
+        assertEquals("Callback should be invoked only once per request", repeat, count.intValue());
     }
         
     @Test

--- a/rt/transports/http/src/main/java/org/apache/cxf/transport/http/HTTPConduit.java
+++ b/rt/transports/http/src/main/java/org/apache/cxf/transport/http/HTTPConduit.java
@@ -1626,12 +1626,13 @@ public abstract class HTTPConduit
                     if (isOneway(exchange) && responseCode > 300) {
                         throw new HTTPException(responseCode, getResponseMessage(), url.toURL());
                     }
-                    ClientCallback cc = exchange.get(ClientCallback.class);
-                    if (null != cc) {
-                        //REVISIT move the decoupled destination property name into api
-                        Endpoint ep = exchange.getEndpoint();
-                        if (null != ep && null != ep.getEndpointInfo() && null == ep.getEndpointInfo().
+                    //REVISIT move the decoupled destination property name into api
+                    Endpoint ep = exchange.getEndpoint();
+                    if (null != ep && null != ep.getEndpointInfo() && null == ep.getEndpointInfo().
                             getProperty("org.apache.cxf.ws.addressing.MAPAggregator.decoupledDestination")) {
+                        // remove callback so that it won't be invoked twice
+                        ClientCallback cc = exchange.remove(ClientCallback.class);
+                        if (null != cc) {
                             cc.handleResponse(null, null);
                         }
                     }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/CXF-7109
https://issues.jboss.org/browse/ENTESB-6136

I think the best way to make a client callback invoked once and only once is to remove from the exchange immediately after its `handle***()` method is invoked once. It should prevent a client callback from being called more than once not only for the [CXF-7109](https://issues.apache.org/jira/browse/CXF-7109) case but also for any other potential cases where the callback may be invoked more than once accidentally.

I added `remove(Class<T>)` to `Exchange` (`StringMap`) for convenience and symmetry. It is necessary to remove the callback right before calling its `handle***()`, as otherwise some other thread may grab it concurrently before the current thread invokes `handle***()`.

I also added a test case `AsyncHTTPConduitTest#testCallAsyncCallbackInvokedOnlyOnce()`, but please note this test fails only on RHEL 6.8 even without this fix. In order to check if this fix is really effective, you need to run the test on RHEL 6.8 to compare the results.