### PR TITLE
[CXF-7112,CXF-7109] Make sure to remove ClientCallback from exchange when invoking handleException()

### DIFF
--- a/rt/transports/http-hc/src/main/java/org/apache/cxf/transport/http/asyncclient/AsyncHTTPConduit.java
+++ b/rt/transports/http-hc/src/main/java/org/apache/cxf/transport/http/asyncclient/AsyncHTTPConduit.java
@@ -872,7 +872,8 @@ public class AsyncHTTPConduit extends URLConnectionHTTPConduit {
                     }
 
                     Exchange exchange = outMessage.getExchange();
-                    ClientCallback cc = exchange.get(ClientCallback.class);
+                    // remove callback so that it won't be invoked twice
+                    ClientCallback cc = exchange.remove(ClientCallback.class);
                     if (cc != null) {
                         cc.handleException(null, new SocketTimeoutException());
                     }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/CXF-7112
https://issues.apache.org/jira/browse/CXF-7109

If a client callback is not removed from exchange, there still remains a possibility for some other thread somewhere else to invoke the same callback again, according to [CXF-7109](https://issues.apache.org/jira/browse/CXF-7109).