### PR TITLE
[CXF-7015] Capture invalid escapes and throw IllegalArgumentException

### DIFF
--- a/core/src/main/java/org/apache/cxf/common/util/UrlUtils.java
+++ b/core/src/main/java/org/apache/cxf/common/util/UrlUtils.java
@@ -21,6 +21,7 @@ package org.apache.cxf.common.util;
 
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
+import java.nio.BufferUnderflowException;
 import java.nio.ByteBuffer;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
@@ -96,8 +97,9 @@ public final class UrlUtils {
                         final int u = digit16((byte) in.get());
                         final int l = digit16((byte) in.get());
                         out.put((byte) ((u << 4) + l));
-                    } catch (final ArrayIndexOutOfBoundsException e) {
-                        throw new RuntimeException("Invalid URL encoding: ", e);
+                    } catch (final BufferUnderflowException e) {
+                        throw new IllegalArgumentException(
+                                "Invalid URL encoding: Incomplete trailing escape (%) pattern");
                     }
                 } else {
                     out.put((byte) b);
@@ -113,7 +115,7 @@ public final class UrlUtils {
     private static int digit16(final byte b) {
         final int i = Character.digit((char) b, RADIX);
         if (i == -1) {
-            throw new RuntimeException("Invalid URL encoding: not a valid digit (radix " + RADIX + "): " + b);
+            throw new IllegalArgumentException("Invalid URL encoding: not a valid digit (radix " + RADIX + "): " + b);
         }
         return i;
     }

--- a/core/src/test/java/org/apache/cxf/common/util/UrlUtilsTest.java
+++ b/core/src/test/java/org/apache/cxf/common/util/UrlUtilsTest.java
@@ -41,6 +41,16 @@ public class UrlUtilsTest extends Assert {
     public void testUrlDecodeReserved() {
         assertEquals("!$&'()*,;=", UrlUtils.urlDecode("!$&'()*,;="));
     }
+
+    @Test (expected = IllegalArgumentException.class)
+    public void testUrlDecodeIncompleteEscape() {
+        UrlUtils.urlDecode("%2");
+    }
+
+    @Test (expected = IllegalArgumentException.class)
+    public void testUrlDecodeInvalidEscape() {
+        UrlUtils.urlDecode("%2$");
+    }
     
     @Test
     public void testPathDecode() {


### PR DESCRIPTION
The changes for CXF-6189 allow a BufferUnderflowException to be thrown when an invalid escape value is provided. 

Fixed to catch the correct exception type from the try block. Also updated the exception thrown from a RuntimeException to a more useful IllegalArgumentException