### PR TITLE
CXF-7161: OIDC dynreg : NPE for implicit grant

### DIFF
--- a/rt/rs/security/oauth-parent/oauth2/src/main/java/org/apache/cxf/rs/security/oauth2/services/DynamicRegistrationService.java
+++ b/rt/rs/security/oauth-parent/oauth2/src/main/java/org/apache/cxf/rs/security/oauth2/services/DynamicRegistrationService.java
@@ -125,10 +125,12 @@ public class DynamicRegistrationService {
     protected ClientRegistrationResponse fromClientToRegistrationResponse(Client client) {
         ClientRegistrationResponse response = new ClientRegistrationResponse();
         response.setClientId(client.getClientId());
-        response.setClientSecret(client.getClientSecret());
+        if (client.getClientSecret() != null) {
+            response.setClientSecret(client.getClientSecret());
+            // TODO: consider making Client secret time limited
+            response.setClientSecretExpiresAt(Long.valueOf(0));
+        }
         response.setClientIdIssuedAt(client.getRegisteredAt());
-        // TODO: consider making Client secret time limited
-        response.setClientSecretExpiresAt(Long.valueOf(0));
         UriBuilder ub = getMessageContext().getUriInfo().getAbsolutePathBuilder();
         
         if (supportRegistrationAccessTokens) {


### PR DESCRIPTION
When clientSecret is null, we don't return anymore
clientSecret JSON node in the response (it's marked
as OPTIONAL in OIDC Connect Registration 1.0 specs).