### PR TITLE
[CXF-7162] Inconsistent reading of formatted xml when validating schema

### DIFF
--- a/core/src/main/java/org/apache/cxf/staxutils/StaxUtils.java
+++ b/core/src/main/java/org/apache/cxf/staxutils/StaxUtils.java
@@ -772,6 +772,7 @@ public final class StaxUtils {
                 }
                 break;
             case XMLStreamConstants.CHARACTERS:
+            case XMLStreamConstants.SPACE:
                 String s = reader.getText();
                 if (s != null) {
                     writer.writeCharacters(s);


### PR DESCRIPTION
When calling `StaxUtils.copy()` with a source reader that is validating schema, the spaces between tags used for formatting the XML are not copied to the output.
This causes, when used, the soap body signature validation to fail when using schema validation.
I have already reported this to woodstox (https://github.com/FasterXML/woodstox/issues/29) but anyway, `StaxUtils.copy()` should be aware of both situations (CHARACTERS AND SPACES).