### PR TITLE
[CXF-7201] Correctly format UserInfo response when no signature or encryption is used.

### DIFF
--- a/rt/rs/security/sso/oidc/src/main/java/org/apache/cxf/rs/security/oidc/idp/UserInfoService.java
+++ b/rt/rs/security/sso/oidc/src/main/java/org/apache/cxf/rs/security/oidc/idp/UserInfoService.java
@@ -29,6 +29,7 @@ import javax.ws.rs.core.Response;
 
 import org.apache.cxf.jaxrs.ext.MessageContext;
 import org.apache.cxf.rs.security.jose.jwt.JwtToken;
+import org.apache.cxf.rs.security.jose.jwt.JwtUtils;
 import org.apache.cxf.rs.security.oauth2.common.Client;
 import org.apache.cxf.rs.security.oauth2.common.OAuthContext;
 import org.apache.cxf.rs.security.oauth2.provider.OAuthDataProvider;
@@ -66,14 +67,17 @@ public class UserInfoService extends OAuthServerJoseJwtProducer {
             return Response.serverError().build();
         }
         
-        Object responseEntity = userInfo;
+        Object responseEntity;
+        JwtToken jwtToken = new JwtToken(userInfo);
         // UserInfo may be returned in a clear form as JSON
         if (super.isJwsRequired() || super.isJweRequired()) {
             Client client = null;
             if (oauthDataProvider != null) {
                 client = oauthDataProvider.getClient(oauth.getClientId());
             }
-            responseEntity = super.processJwt(new JwtToken(userInfo), client);
+            responseEntity = super.processJwt(jwtToken, client);
+        } else {
+            responseEntity = JwtUtils.claimsToJson(jwtToken.getClaims(), null);
         }
         return Response.ok(responseEntity).build();
         


### PR DESCRIPTION
Create Json UserInfo with JwtUtils.claimsToJson when no signature or encryption is Used.