### PR TITLE
Fix Swagger UI work with CXF in Karaf

### DIFF
--- a/rt/rs/description-swagger/src/main/java/org/apache/cxf/jaxrs/swagger/OsgiSwaggerUiResolver.java
+++ b/rt/rs/description-swagger/src/main/java/org/apache/cxf/jaxrs/swagger/OsgiSwaggerUiResolver.java
@@ -40,11 +40,11 @@ public class OsgiSwaggerUiResolver extends SwaggerUiResolver {
             for (Bundle b : bundle.getBundleContext().getBundles()) {
                 String location = b.getLocation();
                 if (swaggerUiVersion != null) {
-                    if (location.equals(LOCATION + swaggerUiVersion)) {
+                    if (location.endsWith(LOCATION + swaggerUiVersion)) {
                         return getSwaggerUiRoot(b, swaggerUiVersion);
                     }
-                } else if (location.startsWith(LOCATION)) {
-                    swaggerUiVersion = location.substring(LOCATION.length());
+                } else if (location.contains(LOCATION)) {
+                    swaggerUiVersion = location.substring(location.indexOf(LOCATION) + LOCATION.length());
                     return getSwaggerUiRoot(b, swaggerUiVersion);
                 }
             }


### PR DESCRIPTION
This pr is inteneded to fix it in Karaf, in case when  org.webjars/swagger-ui is installed using "wrap" protocol, as swagger-ui library is a plain jar. When swagger-ui is installed using command line, like 

bundle:install mvn:org.webjars/swagger-ui/VERSION  

it works just fine, because despite  the installation was done by implicitly using "wrap", the location attribute of a swagger-ui bundle is mvn:org.webjars... 


However, when there is a need to install swagger using custom Karaf feature, e.g. 

```xml
     <feature name="my-feature" version='1.2.3'>
         <feature version='3.1.9'>cxf</feature>
         <feature version='3.1.9'>cxf-rs-description-swagger2</feature>
         <bundle>wrap:mvn:org.webjars/swagger-ui/2.1.8-M1</bundle>
     </feature>
```

the location attribute of a swagger-ui bundle becomes like  wrap:mvn:org.webjars/swagger-ui/VERSION, so that CXF fails to find the bundle.