### PR TITLE
[CXF-7210] Fix StringIndexOutOfBoundsException

### DIFF
--- a/rt/rs/client/src/main/java/org/apache/cxf/jaxrs/client/AbstractClient.java
+++ b/rt/rs/client/src/main/java/org/apache/cxf/jaxrs/client/AbstractClient.java
@@ -648,8 +648,10 @@ public abstract class AbstractClient implements Client {
         String reqURIPath = requestURI.getRawPath();
         
         UriBuilder builder = new UriBuilderImpl().uri(newBaseURI);
-        String basePath = reqURIPath.startsWith(baseURIPath) ? baseURIPath : getBaseURI().getRawPath(); 
-        builder.path(reqURIPath.equals(basePath) ? "" : reqURIPath.substring(basePath.length()));
+        String basePath = reqURIPath.startsWith(baseURIPath) ? baseURIPath : getBaseURI().getRawPath();
+        String relativePath = reqURIPath.equals(basePath) ? ""
+                : reqURIPath.startsWith(basePath) ? reqURIPath.substring(basePath.length()) : reqURIPath;
+        builder.path(relativePath);
         
         String newQuery = newBaseURI.getRawQuery();
         if (newQuery == null) {


### PR DESCRIPTION
The logic goes as follows:

1) Base- & request-URI are the same, then only add base-URI.
2) If request-URI starts with base-URI, only add the parts from request-URI that are not already included in base-URI
3) Otherwise add both base-URI and request-URI