### PR TITLE
Fix obvious typo in DEBUG logs.

### DIFF
--- a/core/src/main/java/org/apache/cxf/endpoint/ClientImpl.java
+++ b/core/src/main/java/org/apache/cxf/endpoint/ClientImpl.java
@@ -737,7 +737,7 @@ public class ClientImpl
         if (endpoint.getService().getDataBinding() instanceof InterceptorProvider) {
             InterceptorProvider p = (InterceptorProvider)endpoint.getService().getDataBinding();
             if (LOG.isLoggable(Level.FINE)) {
-                LOG.fine("Interceptors contributed by databinging: " + p.getInInterceptors());
+                LOG.fine("Interceptors contributed by databinding: " + p.getInInterceptors());
             }
             chain = inboundChainCache.get(pm.getInPhases(), i1, i2, i3, i4,
                                           p.getInInterceptors());


### PR DESCRIPTION
Noticed this while debugging something on 3.1.5+, and master still has the typo. 