### PR TITLE
CXF-5436: Properly handle SOAP responses whose Content-Type is missin…

### DIFF
--- a/core/src/main/java/org/apache/cxf/interceptor/StaxInInterceptor.java
+++ b/core/src/main/java/org/apache/cxf/interceptor/StaxInInterceptor.java
@@ -104,8 +104,12 @@ public class StaxInInterceptor extends AbstractPhaseInterceptor<Message> {
                     .getHeader(m, HttpHeaderHelper.CONTENT_LENGTH);
                 List<String> contentTE = HttpHeaderHelper
                     .getHeader(m, HttpHeaderHelper.CONTENT_TRANSFER_ENCODING);
+                List<String> transferEncoding = HttpHeaderHelper
+                    .getHeader(m, HttpHeaderHelper.TRANSFER_ENCODING);
                 if ((StringUtils.isEmpty(contentLen) || "0".equals(contentLen.get(0)))
-                    && StringUtils.isEmpty(contentTE)) {
+                    && StringUtils.isEmpty(contentTE)
+                    && (StringUtils.isEmpty(transferEncoding) 
+                    || !"chunked".equalsIgnoreCase(transferEncoding.get(0)))) {
                     return;
                 }
             }


### PR DESCRIPTION
…g, even if

the response is chunked.
This code already tests for 'Content-Length:0' to fast track empty responses, but
chunked responses don't set this header, so test also for 'Transfer-Encoding:chunked'.

Signed-off-by: Arnaud Jeansen <arnaud.jeansen@ncr.com>