### PR TITLE
Fix Swagger-UI for Karaf wrap feature with parameters

### DIFF
--- a/rt/rs/description-swagger/src/main/java/org/apache/cxf/jaxrs/swagger/OsgiSwaggerUiResolver.java
+++ b/rt/rs/description-swagger/src/main/java/org/apache/cxf/jaxrs/swagger/OsgiSwaggerUiResolver.java
@@ -50,7 +50,9 @@ public class OsgiSwaggerUiResolver extends SwaggerUiResolver {
                             return getSwaggerUiRoot(b, swaggerUiVersion);
                         }
                     } else  if (location.startsWith(pattern)) {
-                        swaggerUiVersion = location.substring(pattern.length());
+                        int dollarIndex = location.indexOf("$");
+                        swaggerUiVersion = location.substring(pattern.length(),
+                                dollarIndex > pattern.length() ? dollarIndex : location.length());
                         return getSwaggerUiRoot(b, swaggerUiVersion);
                     }
                 }


### PR DESCRIPTION
In addition to https://github.com/apache/cxf/pull/220 
Karaf wrap allows some parameters within the `feature.xml`

So it may look like
```
     <feature name="my-feature" version='1.2.3'>
         <feature version='3.1.9'>cxf</feature>
         <feature version='3.1.9'>cxf-rs-description-swagger2</feature>
         <bundle>wrap:mvn:org.webjars/swagger-ui/2.1.8-M1$Bundle-SymbolicName=swaggerUI&Bundle-Version=2.1.8-M1</bundle>
     </feature>
```

This pull request will ignore everything added after the first dollar sign larger then the `pattern.length`