### PR TITLE
Upgrade to spring-boot 1.5.1.RELEASE

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -147,7 +147,7 @@
         <cxf.slf4j.version>1.7.22</cxf.slf4j.version>
         <cxf.specs.jaxws.api.version>1.2</cxf.specs.jaxws.api.version>
         <cxf.spring.version>4.2.9.RELEASE</cxf.spring.version>
-        <cxf.spring.boot.version>1.4.3.RELEASE</cxf.spring.boot.version>
+        <cxf.spring.boot.version>1.5.1.RELEASE</cxf.spring.boot.version>
         <cxf.spring.security.version>4.2.0.RELEASE</cxf.spring.security.version>
         <cxf.spring.osgi.version>1.2.1</cxf.spring.osgi.version>
         <cxf.spring.ldap.version>2.2.1.RELEASE</cxf.spring.ldap.version>


### PR DESCRIPTION
Spring boot 1.5.1.RELEASE was released yesterday and we can use the same in cxf-spring-boot-starters. so that we can seamlessly integrate in cxf 3.2.0