### PR TITLE
[CXF-7241]: JAX-RS ContainerRequestContext#setRequestUri() will cause a 404 when Uri contains a query string

### DIFF
--- a/rt/frontend/jaxrs/src/main/java/org/apache/cxf/jaxrs/impl/ContainerRequestContextImpl.java
+++ b/rt/frontend/jaxrs/src/main/java/org/apache/cxf/jaxrs/impl/ContainerRequestContextImpl.java
@@ -113,11 +113,16 @@ public class ContainerRequestContextImpl extends AbstractRequestContextImpl
                 
         }
         doSetRequestUri(requestUri);
+        doSetQueryString(requestUri);
     }
     
     public void doSetRequestUri(URI requestUri) throws IllegalStateException {
         checkNotPreMatch();
-        HttpUtils.resetRequestURI(m, requestUri.toString());
+        HttpUtils.resetRequestURI(m, requestUri.getPath());
+    }
+
+    public void doSetQueryString(URI requestUri) {
+        m.put(Message.QUERY_STRING, requestUri.getQuery());
     }
 
     @Override


### PR DESCRIPTION
Replace requestUri#toString() with requestUri#getPath() when setting Message.REQUEST_URI
Add new method to set Message.QUERY_STRING based on requestUri.getQuery()