### PR TITLE
[CXF-7248]: JAX-RS @Context injected fields cause a NPE in re-used providers from OSGI

### DIFF
--- a/rt/frontend/jaxrs/src/main/java/org/apache/cxf/jaxrs/utils/InjectionUtils.java
+++ b/rt/frontend/jaxrs/src/main/java/org/apache/cxf/jaxrs/utils/InjectionUtils.java
@@ -1076,7 +1076,7 @@ public final class InjectionUtils {
     }
     
     public static Method getGetterFromSetter(Method setter) throws Exception {
-        return setter.getClass().getMethod("get" + setter.getName().substring(3), new Class[]{});
+        return setter.getDeclaringClass().getMethod("get" + setter.getName().substring(3));
     }
     
     public static void injectContextProxiesAndApplication(AbstractResourceInfo cri, 


### PR DESCRIPTION
InjectionUtils#getGetterFromSetter was trying to obtain getter method in the java.lang.reflect.Method class instead of the class where the setter is coming from.

This change is also relevant for the other fix branches. Should I make other PRs?