### PR TITLE
CXF-7137: extended unittest to show non working security definitions

### DIFF
--- a/systests/jaxrs/src/test/java/org/apache/cxf/systest/jaxrs/description/AbstractSwagger2ServiceDescriptionTest.java
+++ b/systests/jaxrs/src/test/java/org/apache/cxf/systest/jaxrs/description/AbstractSwagger2ServiceDescriptionTest.java
@@ -49,12 +49,15 @@ import org.apache.cxf.jaxrs.swagger.SwaggerUtils;
 import org.apache.cxf.testutil.common.AbstractBusClientServerTestBase;
 import org.apache.cxf.testutil.common.AbstractBusTestServerBase;
 
+import org.hamcrest.CoreMatchers;
 import org.junit.Ignore;
 import org.junit.Test;
 
 import org.yaml.snakeyaml.Yaml;
 
 public abstract class AbstractSwagger2ServiceDescriptionTest extends AbstractBusClientServerTestBase {
+    private static final String CONTACT = "CXF unittest";
+    private static final String SECURITY_DEFINITION_NAME = "basicAuth";
 
     @Ignore
     public abstract static class Server extends AbstractBusTestServerBase {
@@ -75,6 +78,9 @@ public abstract class AbstractSwagger2ServiceDescriptionTest extends AbstractBus
             sf.setProvider(new JacksonJsonProvider());
             final Swagger2Feature feature = new Swagger2Feature();
             feature.setRunAsFilter(runAsFilter);
+            feature.setContact(CONTACT);
+            feature.setSecurityDefinitions(Collections.singletonMap(SECURITY_DEFINITION_NAME,
+               new io.swagger.models.auth.BasicAuthDefinition()));
             sf.setFeatures(Arrays.asList(feature));
             sf.setAddress("http://localhost:" + port + "/");
             sf.setExtensionMappings(
@@ -140,6 +146,8 @@ public abstract class AbstractSwagger2ServiceDescriptionTest extends AbstractBus
             assertEquals(1, delOpParams.size());
             assertEquals(ParameterType.PATH, delOpParams.get(0).getType());
 
+            assertThat(swaggerJson, CoreMatchers.containsString(CONTACT));
+            assertThat(swaggerJson, CoreMatchers.containsString(SECURITY_DEFINITION_NAME));
         } finally {
             client.close();
         }


### PR DESCRIPTION
I've extended the unittest to show that the implementation from CXF-7137 isn't working at the moment. While contact is part of the BeanConfig and correctly serialized, the SecurityDefinitions are not shown in the swagger.json as Swagger's BaseApiListingResource handles only the attributes from BeanConfig.

I'm not sure if this can be fixed without changes in Swagger, please have a look.