### PR TITLE
Added tests for DefaultResourceManager, fixed a bug, and improved a comment

### DIFF
--- a/core/src/main/java/org/apache/cxf/resource/DefaultResourceManager.java
+++ b/core/src/main/java/org/apache/cxf/resource/DefaultResourceManager.java
@@ -73,8 +73,15 @@ public class DefaultResourceManager implements ResourceManager {
         }
     }
     public final void addResourceResolvers(Collection<? extends ResourceResolver> resolvers) {
+        int i = 0;
         for (ResourceResolver r : resolvers) {
-            addResourceResolver(r);
+            while (!registeredResolvers.contains(r)) {
+                try {
+                    registeredResolvers.add(i++, r);
+                } catch (IndexOutOfBoundsException e) {
+                    i = registeredResolvers.size();
+                }
+            }
         }
     }
 

--- a/core/src/main/java/org/apache/cxf/resource/ResourceManager.java
+++ b/core/src/main/java/org/apache/cxf/resource/ResourceManager.java
@@ -81,8 +81,8 @@ public interface ResourceManager {
 
     /**
      * Get all the currently registered resolvers.  This method should return
-     * a copy of the list of resolvers so that resolvers added after this method
-     * has been called will alter the list returned.
+     * an unmodifiable view of the list of resolvers so that resolvers added
+     * after this method has been called will alter the list returned.
      */
     List<ResourceResolver> getResourceResolvers();
 }

--- a/core/src/test/java/org/apache/cxf/resource/DefaultResourceManagerTest.java
+++ b/core/src/test/java/org/apache/cxf/resource/DefaultResourceManagerTest.java
@@ -1,0 +1,178 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.cxf.resource;
+
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+public class DefaultResourceManagerTest extends Assert {
+
+    private DefaultResourceManager manager;
+    private DummyResolver[] resolvers;
+
+    @Before
+    public void setUp() {
+        AtomicInteger ordering = new AtomicInteger(0);
+
+        resolvers = new DummyResolver[4];
+        for (int i = 0; i < resolvers.length; i++) {
+            resolvers[i] = new DummyResolver(ordering);
+        }
+
+        manager = new DefaultResourceManager(resolvers[resolvers.length - 1]);
+
+        for (int i = resolvers.length - 2; i >= 0; i--) {
+            manager.addResourceResolver(resolvers[i]);
+        }
+    }
+
+    @After
+    public void tearDown() {
+        manager = null;
+        resolvers = null;
+    }
+
+    @Test
+    public void testResolverOrder() {
+        assertArrayEquals(resolvers, getResolvers(manager));
+
+        checkCallOrder(resolvers);
+    }
+
+    @Test
+    public void testCopiedResolverOrder() {
+        ResourceManager newManager = new DefaultResourceManager(manager.getResourceResolvers());
+
+        assertArrayEquals(resolvers, getResolvers(newManager));
+
+        checkCallOrder(resolvers);
+    }
+
+    @Test
+    public void testAddResolverList() {
+        List<ResourceResolver> addedResolvers = new ArrayList<>();
+        for (int i = 0; i < 4; i++) {
+            addedResolvers.add(new DummyResolver(resolvers[0].source));
+        }
+
+        manager.addResourceResolvers(addedResolvers);
+
+        DummyResolver[] expected = new DummyResolver[addedResolvers.size() + resolvers.length];
+        addedResolvers.toArray(expected);
+        System.arraycopy(resolvers, 0, expected, addedResolvers.size(), resolvers.length);
+
+        assertArrayEquals(expected, getResolvers(manager));
+
+        checkCallOrder(expected);
+    }
+
+    @Test
+    public void testAddDuplicateResolver() {
+        manager.addResourceResolver(resolvers[1]);
+
+        assertArrayEquals(resolvers, getResolvers(manager));
+
+        checkCallOrder(resolvers);
+    }
+
+    @Test
+    public void testAddDuplicateResolverList() {
+        manager.addResourceResolvers(new ArrayList<>(manager.getResourceResolvers()));
+
+        assertArrayEquals(resolvers, getResolvers(manager));
+
+        checkCallOrder(resolvers);
+    }
+
+    @Test
+    public void testRemoveResolver() {
+        manager.removeResourceResolver(resolvers[1]);
+
+        DummyResolver[] expected = new DummyResolver[resolvers.length - 1];
+        expected[0] = resolvers[0];
+        System.arraycopy(resolvers, 2, expected, 1, expected.length - 1);
+
+        assertArrayEquals(expected, getResolvers(manager));
+
+        checkCallOrder(expected);
+
+        assertEquals(-1, resolvers[1].order);
+    }
+
+    @Test
+    public void testLiveResolverList() {
+        List<ResourceResolver> currentResolvers = manager.getResourceResolvers();
+        DummyResolver newResolver = new DummyResolver(resolvers[0].source);
+
+        assertFalse(currentResolvers.contains(newResolver));
+        manager.addResourceResolver(newResolver);
+        assertTrue(currentResolvers.contains(newResolver));
+
+        assertTrue(currentResolvers.contains(resolvers[1]));
+        manager.removeResourceResolver(resolvers[1]);
+        assertFalse(currentResolvers.contains(resolvers[1]));
+    }
+
+    private ResourceResolver[] getResolvers(ResourceManager resourceManager) {
+        List<ResourceResolver> list = resourceManager.getResourceResolvers();
+        ResourceResolver[] actual = new ResourceResolver[list.size()];
+        return list.toArray(actual);
+    }
+
+    private void checkCallOrder(DummyResolver[] usedResolvers) {
+        manager.resolveResource(null, Void.class);
+
+        int[] expected = new int[usedResolvers.length];
+        int[] actual = new int[usedResolvers.length];
+        for (int i = 0; i < usedResolvers.length; i++) {
+            expected[i] = i;
+            actual[i] = usedResolvers[i].order;
+        }
+
+        assertArrayEquals(expected, actual);
+    }
+
+    private static class DummyResolver implements ResourceResolver {
+        AtomicInteger source;
+        int order = -1;
+
+        DummyResolver(AtomicInteger source) {
+            this.source = source;
+        }
+
+        @Override
+        public <T> T resolve(String resourceName, Class<T> resourceType) {
+            order = source.getAndIncrement();
+            return null;
+        }
+
+        @Override
+        public InputStream getAsStream(String name) {
+            return null;
+        }
+    }
+}


### PR DESCRIPTION
I noticed that my resource resolvers were sometimes called out of (expected) order, which for me was significant.

I tracked it down to some code in JaxWsServerFactoryBean that creates a new DefaultResourceManager with a copy of the resolvers from the original manager - while the code in DefaultResourceManager for adding a list of resolvers adds them in reverse order.

I think this is wrong, even if only due to the principle of least astonishment, so went ahead and fixed it, after adding some tests that show the problem (and also tests other parts of the class).

I also changed a comment on the ResourceManager interface that I thought was rather unclear (resolving the seeming self-contradiction based on the actual behavior of the code).

I'll note that this was only tested on top of the 3.1.x-fixes branch, since I'm having trouble getting master to compile (even without any changes). However, as far as I can tell only the whitespace is different in these files between those versions. (If you want the 3.1.x version, there's a branch for it in my fork on github.)