### PR TITLE
lock RefreshToken entity with pissimistic locking to avoid concurrent updates

### DIFF
--- a/rt/rs/security/oauth-parent/oauth2/src/test/java/org/apache/cxf/rs/security/oauth2/grants/code/JPACMTOAuthDataProviderTest.java
+++ b/rt/rs/security/oauth-parent/oauth2/src/test/java/org/apache/cxf/rs/security/oauth2/grants/code/JPACMTOAuthDataProviderTest.java
@@ -18,13 +18,23 @@
  */
 package org.apache.cxf.rs.security.oauth2.grants.code;
 
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.apache.cxf.rs.security.oauth2.common.AccessTokenRegistration;
+import org.apache.cxf.rs.security.oauth2.common.Client;
+import org.apache.cxf.rs.security.oauth2.common.ServerAccessToken;
 import org.apache.cxf.rs.security.oauth2.provider.JPAOAuthDataProvider;
 import org.apache.cxf.rs.security.oauth2.provider.JPAOAuthDataProviderTest;
+import org.apache.cxf.rs.security.oauth2.tokens.refresh.RefreshToken;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.annotation.DirtiesContext.ClassMode;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
@@ -42,7 +52,7 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
  */
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration("JPACMTCodeDataProvider.xml")
-@DirtiesContext
+@DirtiesContext(classMode = ClassMode.AFTER_EACH_TEST_METHOD)
 @ActiveProfiles("hibernate")
 public class JPACMTOAuthDataProviderTest extends JPAOAuthDataProviderTest {
 
@@ -63,5 +73,48 @@ public class JPACMTOAuthDataProviderTest extends JPAOAuthDataProviderTest {
     @After
     @Override
     public void tearDown() {
+    }
+
+    @Test
+    public void testRefreshAccessTokenConcurrently() throws Exception {
+        getProvider().setRecycleRefreshTokens(false);
+
+        Client c = addClient("101", "bob");
+
+        AccessTokenRegistration atr = new AccessTokenRegistration();
+        atr.setClient(c);
+        atr.setApprovedScope(Arrays.asList("a", "refreshToken"));
+        atr.setSubject(null);
+        final ServerAccessToken at = getProvider().createAccessToken(atr);
+
+        Runnable task = new Runnable() {
+
+            @Override
+            public void run() {
+                getProvider().refreshAccessToken(c, at.getRefreshToken(), Collections.emptyList());
+            }
+        };
+
+        Thread th1 = new Thread(task);
+        Thread th2 = new Thread(task);
+        Thread th3 = new Thread(task);
+
+        th1.start();
+        th2.start();
+        th3.start();
+
+        th1.join();
+        th2.join();
+        th3.join();
+
+        assertNotNull(getProvider().getAccessToken(at.getTokenKey()));
+        List<RefreshToken> rtl = getProvider().getRefreshTokens(c, null);
+        assertNotNull(rtl);
+        assertEquals(1, rtl.size());
+        List<String> atl = rtl.get(0).getAccessTokens();
+        assertNotNull(atl);
+
+        // after 3 parallel refreshes we should have 4 AccessTokens
+        assertEquals(4, atl.size());
     }
 }

--- a/rt/rs/security/oauth-parent/oauth2/src/test/java/org/apache/cxf/rs/security/oauth2/provider/JPAOAuthDataProviderTest.java
+++ b/rt/rs/security/oauth-parent/oauth2/src/test/java/org/apache/cxf/rs/security/oauth2/provider/JPAOAuthDataProviderTest.java
@@ -263,7 +263,7 @@ public class JPAOAuthDataProviderTest extends Assert {
         assertNull(getProvider().getRefreshToken(rt.getTokenKey()));
     }
 
-    private Client addClient(String clientId, String userLogin) {
+    protected Client addClient(String clientId, String userLogin) {
         Client c = new Client();
         c.setRedirectUris(Collections.singletonList("http://client/redirect"));
         c.setClientId(clientId);


### PR DESCRIPTION
issue: https://issues.apache.org/jira/browse/CXF-7374
orig issue: https://jira.talendforge.org/browse/TPSVC-2439