### PR TITLE
[CXF-7374] Fix for jpa refreshToken writeLock

### DIFF
--- a/rt/rs/security/oauth-parent/oauth2/src/main/java/org/apache/cxf/rs/security/oauth2/grants/code/JPACMTCodeDataProvider.java
+++ b/rt/rs/security/oauth-parent/oauth2/src/main/java/org/apache/cxf/rs/security/oauth2/grants/code/JPACMTCodeDataProvider.java
@@ -18,11 +18,23 @@
  */
 package org.apache.cxf.rs.security.oauth2.grants.code;
 
+import java.util.Collections;
+import java.util.Map;
 import javax.persistence.EntityManager;
 import javax.persistence.EntityTransaction;
+import javax.persistence.LockModeType;
 import javax.persistence.PersistenceContext;
 
+import org.apache.cxf.rs.security.oauth2.common.ServerAccessToken;
+import org.apache.cxf.rs.security.oauth2.tokens.refresh.RefreshToken;
+
 public class JPACMTCodeDataProvider extends JPACodeDataProvider {
+
+    private static final int DEFAULT_PESSIMISTIC_LOCK_TIMEOUT = 10000;
+
+    private int pessimisticLockTimeout = DEFAULT_PESSIMISTIC_LOCK_TIMEOUT;
+
+    private boolean useJpaLockForExistingRefreshToken = true;
 
     @PersistenceContext
     private EntityManager entityManager;
@@ -59,5 +71,38 @@ public class JPACMTCodeDataProvider extends JPACodeDataProvider {
      */
     @Override
     protected void closeIfNeeded(EntityManager em) {
+    }
+
+    protected void lockRefreshTokenForUpdate(final RefreshToken refreshToken) {
+        execute(new EntityManagerOperation<Void>() {
+
+            @Override
+            public Void execute(EntityManager em) {
+                Map<String, Object> options = Collections.emptyMap();
+                if (pessimisticLockTimeout > 0) {
+                    options = Collections.<String, Object> singletonMap("javax.persistence.lock.timeout",
+                            pessimisticLockTimeout);
+                }
+                em.refresh(refreshToken, LockModeType.PESSIMISTIC_WRITE, options);
+                return null;
+            }
+        });
+    }
+
+    @Override
+    protected RefreshToken updateRefreshToken(RefreshToken rt, ServerAccessToken at) {
+        if (useJpaLockForExistingRefreshToken && !isRecycleRefreshTokens() && rt.getAccessTokens().size() != 0) {
+            // lock RT for update
+            lockRefreshTokenForUpdate(rt);
+        }
+        return super.updateRefreshToken(rt, at);
+    }
+
+    public void setPessimisticLockTimeout(int pessimisticLockTimeout) {
+        this.pessimisticLockTimeout = pessimisticLockTimeout;
+    }
+
+    public void setUseJpaLockForExistingRefreshToken(boolean useJpaLockForExistingRefreshToken) {
+        this.useJpaLockForExistingRefreshToken = useJpaLockForExistingRefreshToken;
     }
 }

--- a/rt/rs/security/oauth-parent/oauth2/src/test/java/org/apache/cxf/rs/security/oauth2/grants/code/JPACMTOAuthDataProviderOpenJPATest.java
+++ b/rt/rs/security/oauth-parent/oauth2/src/test/java/org/apache/cxf/rs/security/oauth2/grants/code/JPACMTOAuthDataProviderOpenJPATest.java
@@ -18,7 +18,6 @@
  */
 package org.apache.cxf.rs.security.oauth2.grants.code;
 
-import org.apache.cxf.rs.security.oauth2.provider.JPAOAuthDataProviderTest;
 import org.junit.runner.RunWith;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
@@ -38,7 +37,7 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
  */
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration("JPACMTCodeDataProvider.xml")
-@DirtiesContext
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
 @ActiveProfiles(value = "openJPA", inheritProfiles = false)
-public class JPACMTOAuthDataProviderOpenJPATest extends JPAOAuthDataProviderTest {
+public class JPACMTOAuthDataProviderOpenJPATest extends JPACMTOAuthDataProviderTest {
 }

--- a/rt/rs/security/oauth-parent/oauth2/src/test/java/org/apache/cxf/rs/security/oauth2/grants/code/JPACMTOAuthDataProviderTest.java
+++ b/rt/rs/security/oauth-parent/oauth2/src/test/java/org/apache/cxf/rs/security/oauth2/grants/code/JPACMTOAuthDataProviderTest.java
@@ -74,6 +74,7 @@ public class JPACMTOAuthDataProviderTest extends JPAOAuthDataProviderTest {
     @After
     @Override
     public void tearDown() {
+        tearDownClients();
     }
     
     @Test
@@ -115,7 +116,7 @@ public class JPACMTOAuthDataProviderTest extends JPAOAuthDataProviderTest {
         List<String> atl = rtl.get(0).getAccessTokens();
         assertNotNull(atl);
 
-        assertEquals(2, atl.size());
+        assertEquals(4, atl.size());
     }
 }
 

--- a/rt/rs/security/oauth-parent/oauth2/src/test/java/org/apache/cxf/rs/security/oauth2/provider/JPAOAuthDataProviderTest.java
+++ b/rt/rs/security/oauth-parent/oauth2/src/test/java/org/apache/cxf/rs/security/oauth2/provider/JPAOAuthDataProviderTest.java
@@ -281,9 +281,35 @@ public class JPAOAuthDataProviderTest extends Assert {
         assertEquals(c.getResourceOwnerSubject().getLogin(), c2.getResourceOwnerSubject().getLogin());
     }
 
+    protected void tearDownClient(String clientId) {
+        if (getProvider() == null) {
+            return;
+        }
+        Client client = getProvider().getClient(clientId);
+        if (client != null) {
+            List<RefreshToken> refreshTokens = getProvider().getRefreshTokens(client, null);
+            for (RefreshToken refreshToken : refreshTokens) {
+                getProvider().revokeToken(client, refreshToken.getTokenKey(), refreshToken.getTokenType());
+            }
+            List<ServerAccessToken> accessTokens = getProvider().getAccessTokens(client, null);
+            for (ServerAccessToken accessToken : accessTokens) {
+                getProvider().revokeToken(client, accessToken.getTokenKey(), accessToken.getTokenType());
+            }
+            getProvider().removeClient(clientId);
+        }
+    }
+
+    protected void tearDownClients() {
+        tearDownClient("101");
+        tearDownClient("12345");
+        tearDownClient("56789");
+        tearDownClient("09876");
+    }
+
     @After
     public void tearDown() throws Exception {
         try {
+            tearDownClients();
             if (provider != null) {
                 getProvider().close();
             }

--- a/rt/rs/security/oauth-parent/oauth2/src/test/resources/META-INF/persistence.xml
+++ b/rt/rs/security/oauth-parent/oauth2/src/test/resources/META-INF/persistence.xml
@@ -56,6 +56,7 @@
             <property name="openjpa.jdbc.SynchronizeMappings" value="buildSchema"/>
             <property name="openjpa.jdbc.EagerFetchMode" value="parallel"/>
             <property name="openjpa.MaxFetchDepth" value="20"/>
+            <property name="openjpa.jdbc.DBDictionary" value="SupportsSelectForUpdate=true"/>
             <!--
             <property name="openjpa.Log" value="DefaultLevel=WARN, Runtime=TRACE, Tool=INFO"/>
             -->


### PR DESCRIPTION
Fix for Jpa refreshToken writeLock:
 - writeLock is only called if RT already exist in db
   (rt.accessTokens > 0)
 - writeLock is moved to JPACMTCodeDataProvider
   it can only be used on CMT managed entityManagers
   since the transaction must span all the refreshAccessToken method
   (in non-CMTs, we have multiple tx for this single method).