### PR TITLE
[CXF-7400] Add dots to SwaggerUIResourceFilter regex

### DIFF
--- a/rt/rs/description-swagger/src/main/java/org/apache/cxf/jaxrs/swagger/Swagger2Feature.java
+++ b/rt/rs/description-swagger/src/main/java/org/apache/cxf/jaxrs/swagger/Swagger2Feature.java
@@ -472,7 +472,7 @@ public class Swagger2Feature extends AbstractSwaggerFeature {
     protected static class SwaggerUIResourceFilter implements ContainerRequestFilter {
         private static final Pattern PATTERN =
             Pattern.compile(
-                  ".*js|.*gz|.*map|oauth2*[.]html|.*png|.*css|.*ico|"
+                  ".*[.]js|.*[.]gz|.*[.]map|oauth2*[.]html|.*[.]png|.*[.]css|.*[.]ico|"
                   + "/css/.*|/images/.*|/lib/.*|/fonts/.*"
             );
 


### PR DESCRIPTION
When using the Swagger2Feature with Swagger UI, requests to paths ending in "ico" (such as /magnifico) are caught by this regular expression and modified, this change should only catch paths that end with ".ico" (same deal for other extensions)