### PR TITLE
[CXF-7447] Add doPrivs to avoid AccessControlExceptions

### DIFF
--- a/rt/frontend/jaxrs/src/main/java/org/apache/cxf/jaxrs/provider/ProviderCache.java
+++ b/rt/frontend/jaxrs/src/main/java/org/apache/cxf/jaxrs/provider/ProviderCache.java
@@ -19,6 +19,8 @@
 
 package org.apache.cxf.jaxrs.provider;
 
+import java.security.AccessController;
+import java.security.PrivilegedAction;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -32,7 +34,12 @@ import org.apache.cxf.jaxrs.model.ProviderInfo;
 
 public class ProviderCache {
     private static final int MAX_PROVIDER_CACHE_SIZE =
-        Integer.getInteger("org.apache.cxf.jaxrs.max_provider_cache_size", 100);
+        AccessController.doPrivileged(new PrivilegedAction<Integer>() {
+            @Override
+            public Integer run() {
+                return Integer.getInteger("org.apache.cxf.jaxrs.max_provider_cache_size", 100);
+            } }).intValue();
+
     private final Map<String, List<ProviderInfo<MessageBodyReader<?>>>>
         readerProviderCache = new ConcurrentHashMap<String, List<ProviderInfo<MessageBodyReader<?>>>>();
 

--- a/rt/transports/http/src/main/java/org/apache/cxf/transport/http/URLConnectionHTTPConduit.java
+++ b/rt/transports/http/src/main/java/org/apache/cxf/transport/http/URLConnectionHTTPConduit.java
@@ -367,7 +367,20 @@ public class URLConnectionHTTPConduit extends HTTPConduit {
             }
         }
         protected int getResponseCode() throws IOException {
-            return connection.getResponseCode();
+            try {
+                return AccessController.doPrivileged(new PrivilegedExceptionAction<Integer>() {
+
+                    @Override
+                    public Integer run() throws IOException {
+                        return connection.getResponseCode();
+                    } });
+            } catch (PrivilegedActionException e) {
+                Throwable t = e.getCause();
+                if (t instanceof IOException) {
+                    throw (IOException) t;
+                }
+                throw new RuntimeException(t);
+            }
         }
         protected String getResponseMessage() throws IOException {
             return connection.getResponseMessage();


### PR DESCRIPTION
We found a few places in JAX-RS code where AccessControlExceptions were being thrown when using a security manager.  This suggested fix adds doPriv blocks around the offending code. 