### PR TITLE
[CXF-7430] The method logInputStream of the LoggingInInterceptor class passes txt/plain content type to the writePayload method if the payload content was truncated.

### DIFF
--- a/core/src/main/java/org/apache/cxf/interceptor/LoggingInInterceptor.java
+++ b/core/src/main/java/org/apache/cxf/interceptor/LoggingInInterceptor.java
@@ -219,6 +219,7 @@ public class LoggingInInterceptor extends AbstractLoggingInterceptor {
             }
             if (bos.size() > limit && limit != -1) {
                 buffer.getMessage().append("(message truncated to " + limit + " bytes)\n");
+                ct = "text/plain";
             }
             writePayload(buffer.getPayload(), bos, encoding, ct);
 

--- a/core/src/test/java/org/apache/cxf/interceptor/LoggingInInterceptorTest.java
+++ b/core/src/test/java/org/apache/cxf/interceptor/LoggingInInterceptorTest.java
@@ -29,6 +29,7 @@ import org.apache.cxf.message.Message;
 import org.apache.cxf.message.MessageImpl;
 
 import org.easymock.EasyMock;
+import org.easymock.IAnswer;
 import org.easymock.IMocksControl;
 
 import org.junit.After;
@@ -65,12 +66,14 @@ public class LoggingInInterceptorTest extends Assert {
         message.setContent(Writer.class, sw);
 
         inputStream = control.createMock(InputStream.class);
-        EasyMock.expect(inputStream.read(EasyMock.anyObject(), EasyMock.anyInt(), EasyMock.anyInt()))
-                .andAnswer(() -> {
-                    System.arraycopy(bufferContent.getBytes(), 0,
-                            EasyMock.getCurrentArguments()[0], 0,
-                            bufferLength);
-                    return bufferLength;
+        EasyMock.expect(inputStream.read(EasyMock.anyObject(byte[].class), EasyMock.anyInt(), EasyMock.anyInt()))
+                .andAnswer(new IAnswer<Integer>() {
+                    public Integer answer() {
+                        System.arraycopy(bufferContent.getBytes(), 0,
+                                EasyMock.getCurrentArguments()[0], 0,
+                                bufferLength);
+                        return bufferLength;
+                    }
                 }).andStubReturn(-1);
         control.replay();
     }

--- a/core/src/test/java/org/apache/cxf/interceptor/LoggingInInterceptorTest.java
+++ b/core/src/test/java/org/apache/cxf/interceptor/LoggingInInterceptorTest.java
@@ -1,0 +1,134 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.cxf.interceptor;
+
+import java.io.InputStream;
+import java.io.StringWriter;
+import java.io.Writer;
+
+import org.apache.cxf.io.CachedOutputStream;
+import org.apache.cxf.message.ExchangeImpl;
+import org.apache.cxf.message.Message;
+import org.apache.cxf.message.MessageImpl;
+
+import org.easymock.EasyMock;
+import org.easymock.IMocksControl;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+@SuppressWarnings("deprecation")
+public class LoggingInInterceptorTest extends Assert {
+    static String encoding = "UTF-8";
+    static String inLimitContentType = "text/xml";
+    static String offLimitContentType = "text/plain";
+
+    static String bufferContent = "<today><is><the><eighteenth><of><july><two><thousand><seventeen>"
+            + "</seventeen></thousand></two></july></of></eighteenth></the></is></today>";
+    static int bufferLength = bufferContent.getBytes().length;
+
+    protected IMocksControl control;
+    private Message message;
+    private InputStream inputStream;
+    private LoggingMessage loggingMessage;
+    private LoggingInInterceptorAncestorTester classUnderTest;
+
+    @Before
+    public void setUp() throws Exception {
+        loggingMessage = new LoggingMessage("", "");
+        control = EasyMock.createNiceControl();
+
+        StringWriter sw = new StringWriter();
+        sw.append("<today/>");
+        message = new MessageImpl();
+        message.setExchange(new ExchangeImpl());
+        message.put(Message.CONTENT_TYPE, "application/xml");
+        message.setContent(Writer.class, sw);
+
+        inputStream = control.createMock(InputStream.class);
+        EasyMock.expect(inputStream.read(EasyMock.anyObject(), EasyMock.anyInt(), EasyMock.anyInt()))
+                .andAnswer(() -> {
+                    System.arraycopy(bufferContent.getBytes(), 0,
+                            EasyMock.getCurrentArguments()[0], 0,
+                            bufferLength);
+                    return bufferLength;
+                }).andStubReturn(-1);
+        control.replay();
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        control.verify();
+    }
+
+    @Test
+    public void testLogInputStreamInLimit() throws Exception {
+        //arrange
+        classUnderTest = new LoggingInInterceptorAncestorTester(4098);
+        //act
+        classUnderTest.testLogInputStream(message, inputStream, loggingMessage, encoding, inLimitContentType);
+        //assert
+        assertEquals("The content type should be xml",
+                inLimitContentType,
+                classUnderTest.getContentType());
+    }
+
+    @Test
+    public void testLogInputStreamOffLimit() throws Exception {
+        //arrange
+        classUnderTest = new LoggingInInterceptorAncestorTester(16);
+        //act
+        classUnderTest.testLogInputStream(message, inputStream, loggingMessage, encoding, inLimitContentType);
+        //assert
+        assertEquals("The encoding should become plain text",
+                offLimitContentType,
+                classUnderTest.getContentType());
+    }
+
+    class LoggingInInterceptorAncestorTester extends LoggingInInterceptor {
+        private String contentType;
+
+        LoggingInInterceptorAncestorTester(int limit) {
+            super(limit);
+        }
+
+        public String getContentType() {
+            return contentType;
+        }
+
+        public void testLogInputStream(Message logMessage,
+                                       InputStream is,
+                                       LoggingMessage buffer,
+                                       String contentEncoding,
+                                       String logContentType) {
+            this.logInputStream(logMessage, is, buffer, contentEncoding, logContentType);
+        }
+
+        @Override
+        protected void writePayload(StringBuilder builder,
+                                    CachedOutputStream cos,
+                                    String contentEncoding,
+                                    String logContentType) {
+            this.contentType = logContentType;
+        }
+    }
+}


### PR DESCRIPTION
The method logInputStream of the LoggingInInterceptor class passes txt/plain content type to the writePayload method if the payload content was truncated.