### PR TITLE
Prevent NPE thrown in getAuthorizationPolicyFromMessage for authorization header values with lenght less than 4

### DIFF
--- a/rt/transports/http/src/main/java/org/apache/cxf/transport/http/AbstractHTTPDestination.java
+++ b/rt/transports/http/src/main/java/org/apache/cxf/transport/http/AbstractHTTPDestination.java
@@ -173,7 +173,9 @@ public abstract class AbstractHTTPDestination
             String authEncoded = creds.get(1);
             try {
                 byte[] authBytes = Base64Utility.decode(authEncoded);
-
+                if (authBytes == null) {
+                    throw new Base64Exception(new Throwable("invalid Base64 data."));
+                }
                 String authDecoded = decodeBasicAuthWithIso8859
                     ? new String(authBytes, StandardCharsets.ISO_8859_1) : new String(authBytes);
 


### PR DESCRIPTION
This PR fixes the following issue. 
In the getAuthorizationPolicyFromMessage() method in AbstractHTTPDestination class, the following line of code returns null when we provide an encoded string with character length less than 4(invalid base64 data) as the value for basic authorization headers.
eg: curl -k -d "grant_type=password&username=Username&password=Password" -H "Authorization : Basic som" http://localhost:8280/token

byte[] authBytes = Base64Utility.decode(authEncoded) (line 175)

Since this is obtained as null the following line of code throws the NPE.

String authDecoded = decodeBasicAuthWithIso8859 ? new String(authBytes, StandardCharsets.ISO_8859_1) : new String(authBytes)       
           