### PR TITLE
Cache URITemplates instead of creating them over and over resulting i…

### DIFF
--- a/rt/frontend/jaxrs/src/main/java/org/apache/cxf/jaxrs/impl/UriBuilderImpl.java
+++ b/rt/frontend/jaxrs/src/main/java/org/apache/cxf/jaxrs/impl/UriBuilderImpl.java
@@ -117,7 +117,7 @@ public class UriBuilderImpl extends UriBuilder implements Cloneable {
             + alreadyResolvedTsPathEnc.size();
 
         String thePath = buildPath();
-        URITemplate pathTempl = new URITemplate(thePath);
+        URITemplate pathTempl = URITemplate.createExactTemplate(thePath);
         thePath = substituteVarargs(pathTempl, alreadyResolvedTs, alreadyResolvedTsPathEnc,
                                     alreadyResolvedEncTs, values, 0, false, fromEncoded,
                                     allowUnresolved, encodePathSlash);
@@ -126,7 +126,7 @@ public class UriBuilderImpl extends UriBuilder implements Cloneable {
         String theQuery = buildQuery();
         int queryTemplateVarsSize = 0;
         if (theQuery != null) {
-            URITemplate queryTempl = new URITemplate(theQuery);
+            URITemplate queryTempl = URITemplate.createExactTemplate(theQuery);
             queryTemplateVarsSize = queryTempl.getVariables().size();
             if (queryTemplateVarsSize > 0) {
                 int lengthDiff = values.length + resolvedTsSize
@@ -140,7 +140,7 @@ public class UriBuilderImpl extends UriBuilder implements Cloneable {
 
         String theFragment = fragment;
         if (theFragment != null) {
-            URITemplate fragmentTempl = new URITemplate(theFragment);
+            URITemplate fragmentTempl = URITemplate.createExactTemplate(theFragment);
             if (fragmentTempl.getVariables().size() > 0) {
                 int lengthDiff = values.length  + resolvedTsSize
                     - alreadyResolvedTs.size() - alreadyResolvedTsPathEnc.size() - alreadyResolvedEncTs.size()
@@ -338,7 +338,7 @@ public class UriBuilderImpl extends UriBuilder implements Cloneable {
                                     boolean fromEncoded,
                                     boolean encodePathSlash) {
     //CHECKSTYLE:ON
-        URITemplate templ = new URITemplate(path);
+        URITemplate templ = URITemplate.createExactTemplate(path);
 
         Set<String> uniqueVars = new HashSet<>(templ.getVariables());
         if (varValueMap.size() + alreadyResolvedTs.size() + alreadyResolvedTsEnc.size()
@@ -522,7 +522,7 @@ public class UriBuilderImpl extends UriBuilder implements Cloneable {
                 this.originalPathEmpty = StringUtils.isEmpty(uri.getPath());
                 uri(uri);
             } catch (IllegalArgumentException ex) {
-                if (!new URITemplate(path).getVariables().isEmpty()) {
+                if (!URITemplate.createExactTemplate(path).getVariables().isEmpty()) {
                     return uriAsTemplate(path);
                 }
                 String pathEncoded = HttpUtils.pathEncode(path);
@@ -662,7 +662,7 @@ public class UriBuilderImpl extends UriBuilder implements Cloneable {
             PathSegment ps = iter.next();
             String p = ps.getPath();
             if (p.length() != 0 || !iter.hasNext()) {
-                p = new URITemplate(p).encodeLiteralCharacters(false);
+                p = URITemplate.createExactTemplate(p).encodeLiteralCharacters(false);
                 if (sb.length() == 0 && leadingSlash) {
                     sb.append('/');
                 } else if (!p.startsWith("/") && sb.length() > 0) {
@@ -848,7 +848,7 @@ public class UriBuilderImpl extends UriBuilder implements Cloneable {
                         val = val.replaceAll("/", "%2F");
                     }
                 } else {
-                    val = new URITemplate(val).encodeLiteralCharacters(isQuery);
+                    val = URITemplate.createExactTemplate(val).encodeLiteralCharacters(isQuery);
                 }
                 b.append(entry.getKey());
                 if (val.length() != 0) {
@@ -890,7 +890,7 @@ public class UriBuilderImpl extends UriBuilder implements Cloneable {
         try {
             return uri(URI.create(uriTemplate));
         } catch (Exception ex) {
-            if (new URITemplate(uriTemplate).getVariables().isEmpty()) {
+            if (URITemplate.createExactTemplate(uriTemplate).getVariables().isEmpty()) {
                 throw new IllegalArgumentException(ex);
             }
             return uriAsTemplate(uriTemplate);

--- a/rt/frontend/jaxrs/src/main/java/org/apache/cxf/jaxrs/model/URITemplate.java
+++ b/rt/frontend/jaxrs/src/main/java/org/apache/cxf/jaxrs/model/URITemplate.java
@@ -25,6 +25,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -44,7 +45,10 @@ public final class URITemplate {
     private static final String CHARACTERS_TO_ESCAPE = ".*+$()";
     private static final String SLASH = "/";
     private static final String SLASH_QUOTE = "/;";
-
+    private static final int MAX_URI_TEMPLATE_CACHE_SIZE = 
+        Integer.getInteger("org.apache.cxf.jaxrs.max_uri_template_cache_size", 2000);
+    private static final Map<String, URITemplate> URI_TEMPLATE_CACHE = new ConcurrentHashMap<>();
+    
     private final String template;
     private final List<String> variables = new ArrayList<>();
     private final List<String> customVariables = new ArrayList<>();
@@ -327,18 +331,26 @@ public final class URITemplate {
     }
 
     public static URITemplate createTemplate(String pathValue) {
-
         if (pathValue == null) {
-            return new URITemplate("/");
-        }
-
-        if (!pathValue.startsWith("/")) {
+            pathValue = "/";
+        } else if (!pathValue.startsWith("/")) {
             pathValue = "/" + pathValue;
         }
-
-        return new URITemplate(pathValue);
+        return createExactTemplate(pathValue);
     }
-
+    
+    public static URITemplate createExactTemplate(String pathValue) {
+        URITemplate template = URI_TEMPLATE_CACHE.get(pathValue);
+        if (template == null) {
+            template = new URITemplate(pathValue);
+            if (URI_TEMPLATE_CACHE.size() >= MAX_URI_TEMPLATE_CACHE_SIZE) {
+                URI_TEMPLATE_CACHE.clear();
+            }
+            URI_TEMPLATE_CACHE.put(pathValue, template);
+        }
+        return template;
+    }
+    
     public static int compareTemplates(URITemplate t1, URITemplate t2) {
         String l1 = t1.getLiteralChars();
         String l2 = t2.getLiteralChars();


### PR DESCRIPTION
…n wasted CPU cycles and GC runs. The cache prevents having to compile java.util.regex.Pattern when the underlying templates seldom change as well as preventing other fairly heavy lifting each time a template is instantiated.

My load tests show approx 10% throughput increase on a basic JAX-RS service with 10 client threads in JMeter. My use case uses a lot of URITemplate instantiation due to calling javax.ws.rs.core.UriInfo.getMatchedURIs() on each sub-resource call.

I checked that URITemplate is thread safe and hence viable to be used in an instance cache without the need for additional locking.