### PR TITLE
[STS] Added switch to disable the generation of a Lifetime element in a cla…

### DIFF
--- a/services/sts/sts-core/src/main/java/org/apache/cxf/sts/operation/AbstractOperation.java
+++ b/services/sts/sts-core/src/main/java/org/apache/cxf/sts/operation/AbstractOperation.java
@@ -106,6 +106,7 @@ public abstract class AbstractOperation {
     protected List<TokenDelegationHandler> delegationHandlers = new ArrayList<>();
     protected TokenWrapper tokenWrapper = new DefaultTokenWrapper();
     protected boolean allowCustomContent;
+    protected boolean includeLifetimeElement = true;
 
     public boolean isAllowCustomContent() {
         return allowCustomContent;
@@ -182,6 +183,15 @@ public abstract class AbstractOperation {
     public void setClaimsManager(ClaimsManager claimsManager) {
         this.claimsManager = claimsManager;
     }
+
+    public void setIncludeLifetimeElement(boolean value) {
+        this.includeLifetimeElement = value;
+    }
+
+    public boolean getIncludeLifetimeElement() {
+        return this.includeLifetimeElement;
+    }
+    
 
     /**
      * Check the arguments from the STSProvider and parse the request.

--- a/services/sts/sts-core/src/main/java/org/apache/cxf/sts/operation/TokenIssueOperation.java
+++ b/services/sts/sts-core/src/main/java/org/apache/cxf/sts/operation/TokenIssueOperation.java
@@ -75,7 +75,7 @@ import org.apache.xml.security.exceptions.XMLSecurityException;
 public class TokenIssueOperation extends AbstractOperation implements IssueOperation, IssueSingleOperation {
 
     static final Logger LOG = LogUtils.getL7dLogger(TokenIssueOperation.class);
-
+    
 
     public RequestSecurityTokenResponseCollectionType issue(
             RequestSecurityTokenType request,
@@ -89,6 +89,7 @@ public class TokenIssueOperation extends AbstractOperation implements IssueOpera
         return responseCollection;
     }
 
+    
     public RequestSecurityTokenResponseCollectionType issue(
             RequestSecurityTokenCollectionType requestCollection,
             Principal principal,
@@ -354,10 +355,13 @@ public class TokenIssueOperation extends AbstractOperation implements IssueOpera
         }
 
         // Lifetime
-        LifetimeType lifetime =
-            createLifetime(tokenResponse.getCreated(), tokenResponse.getExpires());
-        JAXBElement<LifetimeType> lifetimeType = QNameConstants.WS_TRUST_FACTORY.createLifetime(lifetime);
-        response.getAny().add(lifetimeType);
+        if (includeLifetimeElement) {
+            LifetimeType lifetime =
+                createLifetime(tokenResponse.getCreated(), tokenResponse.getExpires());
+            JAXBElement<LifetimeType> lifetimeType =
+                QNameConstants.WS_TRUST_FACTORY.createLifetime(lifetime);
+            response.getAny().add(lifetimeType);
+        }
 
         // KeySize
         long keySize = tokenResponse.getKeySize();

--- a/services/sts/sts-core/src/main/java/org/apache/cxf/sts/operation/TokenRenewOperation.java
+++ b/services/sts/sts-core/src/main/java/org/apache/cxf/sts/operation/TokenRenewOperation.java
@@ -270,10 +270,12 @@ public class TokenRenewOperation extends AbstractOperation implements RenewOpera
         response.getAny().add(tokenRequirements.getAppliesTo());
 
         // Lifetime
-        LifetimeType lifetime =
-            createLifetime(tokenRenewerResponse.getCreated(), tokenRenewerResponse.getExpires());
-        JAXBElement<LifetimeType> lifetimeType = QNameConstants.WS_TRUST_FACTORY.createLifetime(lifetime);
-        response.getAny().add(lifetimeType);
+        if (includeLifetimeElement) {
+            LifetimeType lifetime =
+                createLifetime(tokenRenewerResponse.getCreated(), tokenRenewerResponse.getExpires());
+            JAXBElement<LifetimeType> lifetimeType = QNameConstants.WS_TRUST_FACTORY.createLifetime(lifetime);
+            response.getAny().add(lifetimeType);
+        }
 
         return response;
     }

--- a/services/sts/sts-core/src/main/java/org/apache/cxf/sts/operation/TokenValidateOperation.java
+++ b/services/sts/sts-core/src/main/java/org/apache/cxf/sts/operation/TokenValidateOperation.java
@@ -229,11 +229,13 @@ public class TokenValidateOperation extends AbstractOperation implements Validat
             response.getAny().add(requestedToken);
 
             // Lifetime
-            LifetimeType lifetime =
-                createLifetime(tokenProviderResponse.getCreated(), tokenProviderResponse.getExpires());
-            JAXBElement<LifetimeType> lifetimeType =
-                QNameConstants.WS_TRUST_FACTORY.createLifetime(lifetime);
-            response.getAny().add(lifetimeType);
+            if (includeLifetimeElement) {
+                LifetimeType lifetime =
+                    createLifetime(tokenProviderResponse.getCreated(), tokenProviderResponse.getExpires());
+                JAXBElement<LifetimeType> lifetimeType =
+                    QNameConstants.WS_TRUST_FACTORY.createLifetime(lifetime);
+                response.getAny().add(lifetimeType);
+            }
 
             if (returnReferences) {
                 // RequestedAttachedReference


### PR DESCRIPTION
Added a boolean to disable the generation of the Lifetime element in the STS response.  Default is true (don't disable) to match existing behaviour.

Discussed here by a team member: http://cxf.547215.n5.nabble.com/STS-removing-Lifetime-from-response-tc5782461.html

