### PR TITLE
CVE-2017-3156 backport

### DIFF
--- a/rt/rs/security/oauth-parent/oauth2/src/main/java/org/apache/cxf/rs/security/oauth2/tokens/mac/MacAccessTokenValidator.java
+++ b/rt/rs/security/oauth-parent/oauth2/src/main/java/org/apache/cxf/rs/security/oauth2/tokens/mac/MacAccessTokenValidator.java
@@ -18,6 +18,12 @@
  */
 package org.apache.cxf.rs.security.oauth2.tokens.mac;
 
+import java.security.MessageDigest;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
 import org.apache.cxf.common.util.Base64Exception;
 import org.apache.cxf.common.util.Base64Utility;
 import org.apache.cxf.jaxrs.ext.MessageContext;
@@ -29,12 +35,6 @@ import org.apache.cxf.rs.security.oauth2.provider.OAuthDataProvider;
 import org.apache.cxf.rs.security.oauth2.provider.OAuthServiceException;
 import org.apache.cxf.rs.security.oauth2.utils.AuthorizationUtils;
 import org.apache.cxf.rs.security.oauth2.utils.OAuthConstants;
-
-import java.security.MessageDigest;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
 
 public class MacAccessTokenValidator implements AccessTokenValidator {
     private OAuthDataProvider dataProvider;

--- a/rt/rs/security/oauth-parent/oauth2/src/main/java/org/apache/cxf/rs/security/oauth2/tokens/mac/MacAccessTokenValidator.java
+++ b/rt/rs/security/oauth-parent/oauth2/src/main/java/org/apache/cxf/rs/security/oauth2/tokens/mac/MacAccessTokenValidator.java
@@ -18,12 +18,6 @@
  */
 package org.apache.cxf.rs.security.oauth2.tokens.mac;
 
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
 import org.apache.cxf.common.util.Base64Exception;
 import org.apache.cxf.common.util.Base64Utility;
 import org.apache.cxf.jaxrs.ext.MessageContext;
@@ -35,6 +29,12 @@ import org.apache.cxf.rs.security.oauth2.provider.OAuthDataProvider;
 import org.apache.cxf.rs.security.oauth2.provider.OAuthServiceException;
 import org.apache.cxf.rs.security.oauth2.utils.AuthorizationUtils;
 import org.apache.cxf.rs.security.oauth2.utils.OAuthConstants;
+
+import java.security.MessageDigest;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 public class MacAccessTokenValidator implements AccessTokenValidator {
     private OAuthDataProvider dataProvider;
@@ -92,7 +92,7 @@ public class MacAccessTokenValidator implements AccessTokenValidator {
                 macAccessToken.getMacKey(), hmacAlgo, normalizedString); 
                                                          
             byte[] clientMacData = Base64Utility.decode(clientMacString);
-            boolean validMac = Arrays.equals(serverMacData, clientMacData);
+            boolean validMac = MessageDigest.isEqual(serverMacData, clientMacData);
             if (!validMac) {
                 AuthorizationUtils.throwAuthorizationFailure(Collections
                     .singleton(OAuthConstants.MAC_AUTHORIZATION_SCHEME));


### PR DESCRIPTION
This is a backport of the patch from here: e66ce235 to 2.6.x. Although I'm opening the PR, I do understand that 2.6.x is EOL, and therefore this might not be merged or ultimately released. If anyone does feedback, it will be very gratefully received.