### PR TITLE
Handle @Priority on ExceptionMappers

### DIFF
--- a/rt/frontend/jaxrs/src/main/java/org/apache/cxf/jaxrs/provider/ProviderFactory.java
+++ b/rt/frontend/jaxrs/src/main/java/org/apache/cxf/jaxrs/provider/ProviderFactory.java
@@ -858,7 +858,7 @@ public abstract class ProviderFactory {
         return result;
     }
 
-    private static int comparePriorityStatus(Class<?> cl1, Class<?> cl2) {
+    static int comparePriorityStatus(Class<?> cl1, Class<?> cl2) {
         Integer value1 = AnnotationUtils.getBindingPriority(cl1);
         Integer value2 = AnnotationUtils.getBindingPriority(cl2);
         return value1.compareTo(value2);

--- a/rt/frontend/jaxrs/src/main/java/org/apache/cxf/jaxrs/provider/ServerProviderFactory.java
+++ b/rt/frontend/jaxrs/src/main/java/org/apache/cxf/jaxrs/provider/ServerProviderFactory.java
@@ -598,7 +598,11 @@ public final class ServerProviderFactory extends ProviderFactory {
                     return -1;
                 }
             }
-            return super.compare(p1, p2);
+            int result = super.compare(p1, p2);
+            if (result == 0) {
+                result = comparePriorityStatus(p1.getProvider().getClass(), p2.getProvider().getClass());
+            }
+            return result;
         }
     }
 

--- a/rt/frontend/jaxrs/src/test/java/org/apache/cxf/jaxrs/provider/ProviderFactoryTest.java
+++ b/rt/frontend/jaxrs/src/test/java/org/apache/cxf/jaxrs/provider/ProviderFactoryTest.java
@@ -886,6 +886,52 @@ public class ProviderFactoryTest extends Assert {
                    pf.createContextResolver(String.class, m, MediaType.TEXT_PLAIN_TYPE).getContext(null));
     }
 
+    @Test
+    public void testSortExceptionMapperByPriority() {
+        ServerProviderFactory pf = ServerProviderFactory.getInstance();
+        List<Object> providers = new ArrayList<>();
+        LowPriorityExceptionMapper lowMapper = new LowPriorityExceptionMapper();
+        providers.add(lowMapper);
+        HighPriorityExceptionMapper highMapper = new HighPriorityExceptionMapper();
+        providers.add(highMapper);
+        pf.setUserProviders(providers);
+        Message m = new MessageImpl();
+        assertEquals(Response.ok().build().getStatus(),
+                     pf.createExceptionMapper(RuntimeException.class, m).toResponse(null).getStatus());
+    }
+
+    @Test
+    public void testSortExceptionMapperByPriorityReversed() {
+        ServerProviderFactory pf = ServerProviderFactory.getInstance();
+        List<Object> providers = new ArrayList<>();
+        HighPriorityExceptionMapper highMapper = new HighPriorityExceptionMapper();
+        providers.add(highMapper);
+        LowPriorityExceptionMapper lowMapper = new LowPriorityExceptionMapper();
+        providers.add(lowMapper);
+        pf.setUserProviders(providers);
+        Message m = new MessageImpl();
+        assertEquals(Response.ok().build().getStatus(),
+                   pf.createExceptionMapper(RuntimeException.class, m).toResponse(null).getStatus());
+    }
+
+    @Priority(1001)
+    private static class HighPriorityExceptionMapper implements ExceptionMapper<Exception> {
+
+        @Override
+        public Response toResponse(Exception exception) {
+            return Response.ok().build();
+        }
+    }
+
+    @Priority(2001)
+    private static class LowPriorityExceptionMapper implements ExceptionMapper<Exception> {
+
+        @Override
+        public Response toResponse(Exception exception) {
+            return Response.noContent().build();
+        }
+    }
+
     private static class TestRuntimeExceptionMapper implements ExceptionMapper<RuntimeException> {
 
         public Response toResponse(RuntimeException exception) {


### PR DESCRIPTION
Like PR #321, we need to handle the `@Priority` annotation on exception mappers.