### PR TITLE
CXF-7501: Cannot inject field in ContainerRequestFilter (and generally, into any providers registered using FeatureContext)

### DIFF
--- a/integration/cdi/src/main/java/org/apache/cxf/cdi/CdiServerConfigurableFactory.java
+++ b/integration/cdi/src/main/java/org/apache/cxf/cdi/CdiServerConfigurableFactory.java
@@ -1,0 +1,85 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.cxf.cdi;
+
+import javax.enterprise.context.spi.CreationalContext;
+import javax.enterprise.inject.spi.AnnotatedType;
+import javax.enterprise.inject.spi.Bean;
+import javax.enterprise.inject.spi.BeanAttributes;
+import javax.enterprise.inject.spi.BeanManager;
+import javax.enterprise.inject.spi.InjectionTargetFactory;
+import javax.ws.rs.RuntimeType;
+import javax.ws.rs.core.Configurable;
+import javax.ws.rs.core.FeatureContext;
+
+import org.apache.cxf.jaxrs.impl.ConfigurableImpl;
+import org.apache.cxf.jaxrs.impl.ConfigurableImpl.Instantiator;
+import org.apache.cxf.jaxrs.provider.ServerConfigurableFactory;
+
+/** 
+ * Creates the instance of Configurable<?> suitable for CDI-managed runtime.
+ */
+public class CdiServerConfigurableFactory implements ServerConfigurableFactory {
+    private final BeanManager beanManager;
+    
+    CdiServerConfigurableFactory(final BeanManager beanManager) {
+        this.beanManager = beanManager;
+    }
+    
+    @Override
+    public Configurable<FeatureContext> create(FeatureContext context) {
+        return new CdiServerFeatureContextConfigurable(context, beanManager);
+    }
+    
+    /** 
+     * Instantiates the instance of the provider using CDI/BeanManager 
+     */
+    private static class CdiInstantiator implements Instantiator {
+        private final BeanManager beanManager;
+        
+        CdiInstantiator(final BeanManager beanManager) {
+            this.beanManager = beanManager;
+        }
+        
+        @Override
+        public <T> Object create(Class<T> cls) {
+            final AnnotatedType<T> annotatedType = beanManager.createAnnotatedType(cls);
+            final InjectionTargetFactory<T> injectionTargetFactory = 
+                beanManager.getInjectionTargetFactory(annotatedType);
+            final BeanAttributes<T> attributes = beanManager.createBeanAttributes(annotatedType);
+            final Bean<T> bean = beanManager.createBean(attributes, cls, injectionTargetFactory);
+            final CreationalContext<?> context = beanManager.createCreationalContext(bean);
+            return beanManager.getReference(bean, cls, context);
+        }
+    }
+    
+    private static class CdiServerFeatureContextConfigurable extends ConfigurableImpl<FeatureContext> {
+        private final Instantiator instantiator;
+        
+        CdiServerFeatureContextConfigurable(FeatureContext mc, BeanManager beanManager) {
+            super(mc, RuntimeType.SERVER, SERVER_FILTER_INTERCEPTOR_CLASSES);
+            this.instantiator = new CdiInstantiator(beanManager);
+        }
+        
+        @Override
+        protected Instantiator getInstantiator() {
+            return instantiator;
+        }
+    }
+}

--- a/integration/cdi/src/main/java/org/apache/cxf/cdi/CdiServerConfigurableFactory.java
+++ b/integration/cdi/src/main/java/org/apache/cxf/cdi/CdiServerConfigurableFactory.java
@@ -28,6 +28,7 @@ import javax.ws.rs.RuntimeType;
 import javax.ws.rs.core.Configurable;
 import javax.ws.rs.core.FeatureContext;
 
+import org.apache.cxf.cdi.event.DisposableCreationalContext;
 import org.apache.cxf.jaxrs.impl.ConfigurableImpl;
 import org.apache.cxf.jaxrs.impl.ConfigurableImpl.Instantiator;
 import org.apache.cxf.jaxrs.provider.ServerConfigurableFactory;
@@ -65,6 +66,11 @@ public class CdiServerConfigurableFactory implements ServerConfigurableFactory {
             final BeanAttributes<T> attributes = beanManager.createBeanAttributes(annotatedType);
             final Bean<T> bean = beanManager.createBean(attributes, cls, injectionTargetFactory);
             final CreationalContext<?> context = beanManager.createCreationalContext(bean);
+            
+            if (!beanManager.isNormalScope(bean.getScope())) {
+                beanManager.fireEvent(new DisposableCreationalContext(context));
+            }
+            
             return beanManager.getReference(bean, cls, context);
         }
     }

--- a/integration/cdi/src/main/java/org/apache/cxf/cdi/JAXRSCdiResourceExtension.java
+++ b/integration/cdi/src/main/java/org/apache/cxf/cdi/JAXRSCdiResourceExtension.java
@@ -49,6 +49,7 @@ import javax.ws.rs.ext.Provider;
 
 import org.apache.cxf.Bus;
 import org.apache.cxf.bus.extension.ExtensionManagerBus;
+import org.apache.cxf.cdi.event.DisposableCreationalContext;
 import org.apache.cxf.cdi.extension.JAXRSServerFactoryCustomizationExtension;
 import org.apache.cxf.feature.Feature;
 import org.apache.cxf.jaxrs.JAXRSServerFactoryBean;
@@ -188,11 +189,22 @@ public class JAXRSCdiResourceExtension implements Extension {
     }
 
     /**
+     * Registers created CreationalContext instances for disposal
+     */
+    public void registerCreationalContextForDisposal(@Observes final DisposableCreationalContext event) {
+        synchronized (disposableCreationalContexts) {
+            disposableCreationalContexts.add(event.getContext());
+        }
+    }
+    
+    /**
      * Releases created CreationalContext instances
      */
     public void release(@Observes final BeforeShutdown event) {
-        for (final CreationalContext<?> disposableCreationalContext: disposableCreationalContexts) {
-            disposableCreationalContext.release();
+        synchronized (disposableCreationalContexts) {
+            for (final CreationalContext<?> disposableCreationalContext: disposableCreationalContexts) {
+                disposableCreationalContext.release();
+            }
         }
     }
 
@@ -381,9 +393,13 @@ public class JAXRSCdiResourceExtension implements Extension {
      */
     private<T> CreationalContext< T > createCreationalContext(final BeanManager beanManager, Bean< T > bean) {
         final CreationalContext< T > creationalContext = beanManager.createCreationalContext(bean);
+        
         if (!(bean instanceof DefaultApplicationBean)) {
-            disposableCreationalContexts.add(creationalContext);
+            synchronized (disposableCreationalContexts) {
+                disposableCreationalContexts.add(creationalContext);
+            }
         }
+        
         return creationalContext;
     }
 

--- a/integration/cdi/src/main/java/org/apache/cxf/cdi/JAXRSCdiResourceExtension.java
+++ b/integration/cdi/src/main/java/org/apache/cxf/cdi/JAXRSCdiResourceExtension.java
@@ -52,6 +52,7 @@ import org.apache.cxf.bus.extension.ExtensionManagerBus;
 import org.apache.cxf.cdi.extension.JAXRSServerFactoryCustomizationExtension;
 import org.apache.cxf.feature.Feature;
 import org.apache.cxf.jaxrs.JAXRSServerFactoryBean;
+import org.apache.cxf.jaxrs.provider.ServerConfigurableFactory;
 import org.apache.cxf.jaxrs.utils.ResourceUtils;
 
 /**
@@ -138,6 +139,11 @@ public class JAXRSCdiResourceExtension implements Extension {
                 busBean,
                 Bus.class,
                 beanManager.createCreationalContext(busBean));
+        
+        // Adding the extension for dynamic providers registration and instantiation
+        if (bus.getExtension(ServerConfigurableFactory.class) == null) {
+            bus.setExtension(new CdiServerConfigurableFactory(beanManager), ServerConfigurableFactory.class);
+        }
 
         for (final Bean< ? > application: applicationBeans) {
             final Application instance = (Application)beanManager.getReference(

--- a/integration/cdi/src/main/java/org/apache/cxf/cdi/event/DisposableCreationalContext.java
+++ b/integration/cdi/src/main/java/org/apache/cxf/cdi/event/DisposableCreationalContext.java
@@ -1,0 +1,34 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.cxf.cdi.event;
+
+import javax.enterprise.context.spi.CreationalContext;
+
+public class DisposableCreationalContext {
+    private final CreationalContext<?> context;
+    
+    public DisposableCreationalContext(CreationalContext<?> context) {
+        this.context = context;
+    }
+    
+    public CreationalContext<?> getContext() {
+        return context;
+    }
+}

--- a/rt/frontend/jaxrs/src/main/java/org/apache/cxf/jaxrs/provider/ServerConfigurableFactory.java
+++ b/rt/frontend/jaxrs/src/main/java/org/apache/cxf/jaxrs/provider/ServerConfigurableFactory.java
@@ -17,19 +17,26 @@
  * under the License.
  */
 
-package org.apache.cxf.systest.jaxrs.cdi;
+package org.apache.cxf.jaxrs.provider;
 
-import javax.ws.rs.core.Feature;
+import javax.ws.rs.container.ContainerRequestFilter;
+import javax.ws.rs.container.ContainerResponseFilter;
+import javax.ws.rs.core.Configurable;
 import javax.ws.rs.core.FeatureContext;
+import javax.ws.rs.ext.ReaderInterceptor;
+import javax.ws.rs.ext.WriterInterceptor;
 
-import org.apache.cxf.jaxrs.provider.atom.AtomFeedProvider;
-import org.apache.cxf.systests.cdi.base.BookStoreRequestFilter;
-
-public class SampleFeature implements Feature {
-    @Override
-    public boolean configure(FeatureContext context) {
-        context.register(AtomFeedProvider.class);
-        context.register(BookStoreRequestFilter.class);
-        return false;
-    }
+/**
+ * Manages the creation of server-side Configurable<FeatureContext> depending on 
+ * the presence of managed runtime (like CDI f.e.). 
+ */
+public interface ServerConfigurableFactory {
+    Class<?>[] SERVER_FILTER_INTERCEPTOR_CLASSES = new Class<?>[] {
+        ContainerRequestFilter.class,
+        ContainerResponseFilter.class,
+        ReaderInterceptor.class,
+        WriterInterceptor.class 
+    };
+    
+    Configurable<FeatureContext> create(FeatureContext context);
 }

--- a/rt/frontend/jaxrs/src/main/java/org/apache/cxf/jaxrs/provider/ServerProviderFactory.java
+++ b/rt/frontend/jaxrs/src/main/java/org/apache/cxf/jaxrs/provider/ServerProviderFactory.java
@@ -21,11 +21,9 @@ package org.apache.cxf.jaxrs.provider;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.LinkedList;
 import java.util.List;
@@ -40,6 +38,7 @@ import javax.ws.rs.container.ContainerRequestFilter;
 import javax.ws.rs.container.ContainerResponseFilter;
 import javax.ws.rs.container.DynamicFeature;
 import javax.ws.rs.container.PreMatching;
+import javax.ws.rs.core.Configurable;
 import javax.ws.rs.core.Configuration;
 import javax.ws.rs.core.Feature;
 import javax.ws.rs.core.FeatureContext;
@@ -72,12 +71,6 @@ import org.apache.cxf.message.Message;
 import org.apache.cxf.message.MessageUtils;
 
 public final class ServerProviderFactory extends ProviderFactory {
-    private static final Set<Class<?>> SERVER_FILTER_INTERCEPTOR_CLASSES =
-        new HashSet<Class<?>>(Arrays.<Class<?>>asList(ContainerRequestFilter.class,
-                                                      ContainerResponseFilter.class,
-                                                      ReaderInterceptor.class,
-                                                      WriterInterceptor.class));
-
     private static final String WADL_PROVIDER_NAME = "org.apache.cxf.jaxrs.model.wadl.WadlGenerator";
     private static final String MAKE_DEFAULT_WAE_LEAST_SPECIFIC = "default.wae.mapper.least.specific";
     private List<ProviderInfo<ExceptionMapper<?>>> exceptionMappers =
@@ -399,8 +392,11 @@ public final class ServerProviderFactory extends ProviderFactory {
     }
 
     private FeatureContext createServerFeatureContext() {
-        FeatureContextImpl featureContext = new FeatureContextImpl();
-        ServerFeatureContextConfigurable configImpl = new ServerFeatureContextConfigurable(featureContext);
+        final FeatureContextImpl featureContext = new FeatureContextImpl();
+        final ServerConfigurableFactory factory = getBus().getExtension(ServerConfigurableFactory.class);
+        final Configurable<FeatureContext> configImpl = (factory == null) 
+            ? new ServerFeatureContextConfigurable(featureContext) 
+                : factory.create(featureContext);
         featureContext.setConfigurable(configImpl);
 
         if (application != null) {
@@ -418,7 +414,7 @@ public final class ServerProviderFactory extends ProviderFactory {
 
     private static class ServerFeatureContextConfigurable extends ConfigurableImpl<FeatureContext> {
         protected ServerFeatureContextConfigurable(FeatureContext mc) {
-            super(mc, RuntimeType.SERVER, SERVER_FILTER_INTERCEPTOR_CLASSES.toArray(new Class<?>[]{}));
+            super(mc, RuntimeType.SERVER, ServerConfigurableFactory.SERVER_FILTER_INTERCEPTOR_CLASSES);
         }
     }
 

--- a/systests/cdi/base/src/main/java/org/apache/cxf/systests/cdi/base/BookStoreAuthenticator.java
+++ b/systests/cdi/base/src/main/java/org/apache/cxf/systests/cdi/base/BookStoreAuthenticator.java
@@ -16,20 +16,18 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+package org.apache.cxf.systests.cdi.base;
 
-package org.apache.cxf.systest.jaxrs.cdi;
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Named;
 
-import javax.ws.rs.core.Feature;
-import javax.ws.rs.core.FeatureContext;
-
-import org.apache.cxf.jaxrs.provider.atom.AtomFeedProvider;
-import org.apache.cxf.systests.cdi.base.BookStoreRequestFilter;
-
-public class SampleFeature implements Feature {
-    @Override
-    public boolean configure(FeatureContext context) {
-        context.register(AtomFeedProvider.class);
-        context.register(BookStoreRequestFilter.class);
-        return false;
+@Named @ApplicationScoped
+public class BookStoreAuthenticator {
+    public BookStoreAuthenticator() {
+        
+    }
+    
+    public boolean authenticated() {
+        return true;
     }
 }

--- a/systests/cdi/base/src/main/java/org/apache/cxf/systests/cdi/base/BookStoreRequestFilter.java
+++ b/systests/cdi/base/src/main/java/org/apache/cxf/systests/cdi/base/BookStoreRequestFilter.java
@@ -17,19 +17,23 @@
  * under the License.
  */
 
-package org.apache.cxf.systest.jaxrs.cdi;
+package org.apache.cxf.systests.cdi.base;
 
-import javax.ws.rs.core.Feature;
-import javax.ws.rs.core.FeatureContext;
+import java.io.IOException;
 
-import org.apache.cxf.jaxrs.provider.atom.AtomFeedProvider;
-import org.apache.cxf.systests.cdi.base.BookStoreRequestFilter;
+import javax.inject.Inject;
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ContainerRequestFilter;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.Status;
 
-public class SampleFeature implements Feature {
+public class BookStoreRequestFilter implements ContainerRequestFilter {
+    @Inject private BookStoreAuthenticator authenticator;
+    
     @Override
-    public boolean configure(FeatureContext context) {
-        context.register(AtomFeedProvider.class);
-        context.register(BookStoreRequestFilter.class);
-        return false;
+    public void filter(ContainerRequestContext requestContext) throws IOException {
+        if (!authenticator.authenticated()) {
+            requestContext.abortWith(Response.status(Status.UNAUTHORIZED).build());
+        }
     }
 }

--- a/systests/cdi/cdi-weld/cdi-producers-weld/src/test/java/org/apache/cxf/systest/jaxrs/cdi/SampleFeature.java
+++ b/systests/cdi/cdi-weld/cdi-producers-weld/src/test/java/org/apache/cxf/systest/jaxrs/cdi/SampleFeature.java
@@ -23,11 +23,13 @@ import javax.ws.rs.core.Feature;
 import javax.ws.rs.core.FeatureContext;
 
 import org.apache.cxf.jaxrs.provider.atom.AtomFeedProvider;
+import org.apache.cxf.systests.cdi.base.BookStoreRequestFilter;
 
 public class SampleFeature implements Feature {
     @Override
     public boolean configure(FeatureContext context) {
         context.register(AtomFeedProvider.class);
+        context.register(BookStoreRequestFilter.class);
         return false;
     }
 }


### PR DESCRIPTION
Adding the new extension-based customization (`ServerConfigurableFactory`) in order to control the way how providers are created and registered using `FeatureContext::register` methods family. It allows to use proper mechanisms in case of managed runtimes (like CDIs f.e.).

@sberyozkin @johnament Submitting through PR to have some feedback guys you may have. The change is not really complex but touches a bit some internals. 

Thanks.