### PR TITLE
CXF-7501: Cannot inject field in ContainerRequestFilter (and generally, into any providers registered using FeatureContext)

### DIFF
--- a/integration/cdi/src/main/java/org/apache/cxf/cdi/CdiServerConfigurableFactory.java
+++ b/integration/cdi/src/main/java/org/apache/cxf/cdi/CdiServerConfigurableFactory.java
@@ -49,7 +49,8 @@ public class CdiServerConfigurableFactory implements ServerConfigurableFactory {
     }
     
     /** 
-     * Instantiates the instance of the provider using CDI/BeanManager 
+     * Instantiates the instance of the provider using CDI/BeanManager (or fall back
+     * to default strategy of CDI bean is not available).
      */
     private static class CdiInstantiator implements Instantiator {
         private final BeanManager beanManager;
@@ -58,11 +59,10 @@ public class CdiServerConfigurableFactory implements ServerConfigurableFactory {
             this.beanManager = beanManager;
         }
         
-        @SuppressWarnings("unchecked")
         @Override
         public <T> Object create(Class<T> cls) {
             final Set<Bean<?>> candidates = beanManager.getBeans(cls);
-            final Bean<T> bean = (Bean<T>)beanManager.resolve(candidates);
+            final Bean<?> bean = beanManager.resolve(candidates);
 
             if (bean != null) {
                 final CreationalContext<?> context = beanManager.createCreationalContext(bean);

--- a/systests/cdi/base/src/main/java/org/apache/cxf/systests/cdi/base/BookStoreRequestFilter.java
+++ b/systests/cdi/base/src/main/java/org/apache/cxf/systests/cdi/base/BookStoreRequestFilter.java
@@ -24,14 +24,22 @@ import java.io.IOException;
 import javax.inject.Inject;
 import javax.ws.rs.container.ContainerRequestContext;
 import javax.ws.rs.container.ContainerRequestFilter;
+import javax.ws.rs.container.ResourceInfo;
+import javax.ws.rs.core.Context;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
 
 public class BookStoreRequestFilter implements ContainerRequestFilter {
     @Inject private BookStoreAuthenticator authenticator;
+    @Context private ResourceInfo resourceInfo;
     
     @Override
     public void filter(ContainerRequestContext requestContext) throws IOException {
+        // Contextual instances should be injected independently
+        if (resourceInfo == null || resourceInfo.getResourceMethod() == null) {
+            requestContext.abortWith(Response.serverError().build());
+        }
+        
         if (!authenticator.authenticated()) {
             requestContext.abortWith(Response.status(Status.UNAUTHORIZED).build());
         }

--- a/systests/cdi/base/src/main/java/org/apache/cxf/systests/cdi/base/BookStoreResponseFilter.java
+++ b/systests/cdi/base/src/main/java/org/apache/cxf/systests/cdi/base/BookStoreResponseFilter.java
@@ -1,0 +1,44 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.cxf.systests.cdi.base;
+
+import java.io.IOException;
+
+import javax.enterprise.inject.Vetoed;
+import javax.inject.Inject;
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ContainerResponseContext;
+import javax.ws.rs.container.ContainerResponseFilter;
+import javax.ws.rs.core.Response;
+
+@Vetoed
+public class BookStoreResponseFilter implements ContainerResponseFilter {
+    @Inject private BookStoreAuthenticator authenticator;
+    
+    @Override
+    public void filter(ContainerRequestContext requestContext,
+            ContainerResponseContext responseContext) throws IOException {
+        if (authenticator != null) {
+            // This filter should not be created using CDI runtime (it is vetoed) as 
+            // such the injection should not be performed.
+            responseContext.setStatus(Response.Status.INTERNAL_SERVER_ERROR.getStatusCode());
+        }
+    }
+}

--- a/systests/cdi/cdi-owb/cdi-producers-owb/src/test/java/org/apache/cxf/systest/jaxrs/cdi/SampleFeature.java
+++ b/systests/cdi/cdi-owb/cdi-producers-owb/src/test/java/org/apache/cxf/systest/jaxrs/cdi/SampleFeature.java
@@ -24,12 +24,14 @@ import javax.ws.rs.core.FeatureContext;
 
 import org.apache.cxf.jaxrs.provider.atom.AtomFeedProvider;
 import org.apache.cxf.systests.cdi.base.BookStoreRequestFilter;
+import org.apache.cxf.systests.cdi.base.BookStoreResponseFilter;
 
 public class SampleFeature implements Feature {
     @Override
     public boolean configure(FeatureContext context) {
         context.register(AtomFeedProvider.class);
         context.register(BookStoreRequestFilter.class);
+        context.register(BookStoreResponseFilter.class);
         return false;
     }
 }

--- a/systests/cdi/cdi-weld/cdi-producers-weld/src/test/java/org/apache/cxf/systest/jaxrs/cdi/SampleFeature.java
+++ b/systests/cdi/cdi-weld/cdi-producers-weld/src/test/java/org/apache/cxf/systest/jaxrs/cdi/SampleFeature.java
@@ -24,12 +24,14 @@ import javax.ws.rs.core.FeatureContext;
 
 import org.apache.cxf.jaxrs.provider.atom.AtomFeedProvider;
 import org.apache.cxf.systests.cdi.base.BookStoreRequestFilter;
+import org.apache.cxf.systests.cdi.base.BookStoreResponseFilter;
 
 public class SampleFeature implements Feature {
     @Override
     public boolean configure(FeatureContext context) {
         context.register(AtomFeedProvider.class);
         context.register(BookStoreRequestFilter.class);
+        context.register(BookStoreResponseFilter.class);
         return false;
     }
 }


### PR DESCRIPTION
Using proper CDI bean resolution with fallback to default strategy. The `@Vetoed` presented an edge case when CDI runtime won't resolve the bean but we have to go over manual instantiation. 

CC @rmannibucau @johnament 