### PR TITLE
[CXF-7527] getMatchedURIs to avoid duplicate URIs

### DIFF
--- a/rt/frontend/jaxrs/src/main/java/org/apache/cxf/jaxrs/impl/UriInfoImpl.java
+++ b/rt/frontend/jaxrs/src/main/java/org/apache/cxf/jaxrs/impl/UriInfoImpl.java
@@ -176,7 +176,7 @@ public class UriInfoImpl implements UriInfo {
             List<String> uris = new LinkedList<String>();
             StringBuilder sumPath = new StringBuilder("");
             for (MethodInvocationInfo invocation : stack) {
-                List<String> templateObjects = invocation.getTemplateValues();                
+                List<String> templateObjects = invocation.getTemplateValues();
                 OperationResourceInfo ori = invocation.getMethodInfo();
                 URITemplate[] paths = {
                     ori.getClassResourceInfo().getURITemplate(),
@@ -190,13 +190,15 @@ public class UriInfoImpl implements UriInfo {
                     }
                     uris.add(0, createMatchedPath(paths[0].getValue(), rootObjects, decode));
                 }
-                for (URITemplate t : paths) {
-                    if (t != null) {
-                        sumPath.append("/").append(t.getValue());
+                if (paths[1] != null && paths[1].getValue().length() > 1) {
+                    for (URITemplate t : paths) {
+                        if (t != null) {
+                            sumPath.append("/").append(t.getValue());
+                        }
                     }
+                    objects.addAll(templateObjects);
+                    uris.add(0, createMatchedPath(sumPath.toString(), objects, decode));
                 }
-                objects.addAll(templateObjects);
-                uris.add(0, createMatchedPath(sumPath.toString(), objects, decode));
             }
             return uris;
         }
@@ -206,7 +208,11 @@ public class UriInfoImpl implements UriInfo {
 
     private static String createMatchedPath(String uri, List<? extends Object> vars, boolean decode) {
         String uriPath = UriBuilder.fromPath(uri).buildFromEncoded(vars.toArray()).getRawPath();
-        return decode ? HttpUtils.pathDecode(uriPath) : uriPath;
+        uriPath = decode ? HttpUtils.pathDecode(uriPath) : uriPath;
+        if (uriPath.startsWith("/")) {
+            uriPath = uriPath.substring(1);
+        }
+        return uriPath;
     }
     private String doGetPath(boolean decode, boolean addSlash) {
         String path = HttpUtils.getPathToMatch(message, addSlash);

--- a/systests/jaxrs/src/test/java/org/apache/cxf/systest/jaxrs/JAXRSClientServerBookTest.java
+++ b/systests/jaxrs/src/test/java/org/apache/cxf/systest/jaxrs/JAXRSClientServerBookTest.java
@@ -2598,10 +2598,10 @@ public class JAXRSClientServerBookTest extends AbstractBusClientServerTestBase {
 
     @Test
     public void testUriInfoMatchedUrisDecode() throws Exception {
-        String expected = "[/bookstore/booksubresource/123/chapters/sub/1/matched!uris, "
-                          + "/bookstore/booksubresource/123/chapters/sub/1/, "
-                          + "/bookstore/booksubresource/123/, "
-                          + "/bookstore]";
+        String expected = "[bookstore/booksubresource/123/chapters/sub/1/matched!uris, "
+                          + "bookstore/booksubresource/123/chapters/sub/1/, "
+                          + "bookstore/booksubresource/123/, "
+                          + "bookstore]";
         getAndCompare("http://localhost:" + PORT + "/bookstore/"
                       + "booksubresource/123/chapters/sub/1/matched%21uris?decode=true", 
                       expected, "text/plain", "text/plain", 200);
@@ -2610,10 +2610,10 @@ public class JAXRSClientServerBookTest extends AbstractBusClientServerTestBase {
     @Test
     public void testUriInfoMatchedUrisNoDecode() throws Exception {
         //note '%21' instead of '!'
-        String expected = "[/bookstore/booksubresource/123/chapters/sub/1/matched%21uris, "
-            + "/bookstore/booksubresource/123/chapters/sub/1/, "
-            + "/bookstore/booksubresource/123/, "
-            + "/bookstore]";
+        String expected = "[bookstore/booksubresource/123/chapters/sub/1/matched%21uris, "
+            + "bookstore/booksubresource/123/chapters/sub/1/, "
+            + "bookstore/booksubresource/123/, "
+            + "bookstore]";
         getAndCompare("http://localhost:" + PORT + "/bookstore/"
                       + "booksubresource/123/chapters/sub/1/matched%21uris?decode=false", 
                       expected,

--- a/systests/jaxrs/src/test/java/org/apache/cxf/systest/jaxrs/JAXRSUriInfoMatchTest.java
+++ b/systests/jaxrs/src/test/java/org/apache/cxf/systest/jaxrs/JAXRSUriInfoMatchTest.java
@@ -60,7 +60,7 @@ public class JAXRSUriInfoMatchTest extends AbstractClientServerTestBase {
         WebClient.getConfig(wc).getHttpConduit().getClient().setReceiveTimeout(100000000L);
         wc.accept("text/plain");
         String data = wc.get(String.class);
-        assertEquals("/my/resource/1/matched/uris,/my/resource/1", data);
+        assertEquals("my/resource/1/matched/uris,my/resource/1", data);
     }
     @Test
     public void testMatchedUrisParam() throws Exception {
@@ -69,7 +69,7 @@ public class JAXRSUriInfoMatchTest extends AbstractClientServerTestBase {
         WebClient.getConfig(wc).getHttpConduit().getClient().setReceiveTimeout(100000000L);
         wc.accept("text/plain");
         String data = wc.get(String.class);
-        assertEquals("/my/resource/1/matched/uris/param,/my/resource/1", data);
+        assertEquals("my/resource/1/matched/uris/param,my/resource/1", data);
     }
     @Test
     public void testMatchedUrisParam2() throws Exception {
@@ -78,7 +78,7 @@ public class JAXRSUriInfoMatchTest extends AbstractClientServerTestBase {
         WebClient.getConfig(wc).getHttpConduit().getClient().setReceiveTimeout(100000000L);
         wc.accept("text/plain");
         String data = wc.get(String.class);
-        assertEquals("/my/resource/1/matched/uris/param/2,/my/resource/1", data);
+        assertEquals("my/resource/1/matched/uris/param/2,my/resource/1", data);
     }
     @Test
     public void testMatchedResources() throws Exception {


### PR DESCRIPTION
The UriInfo.getMatchedURIs method currently returns "duplicate" URI
entries when called from a method that is not annotated with an
@Path annotation. The "duplicate" URI is basically the same URI but
with a trailing slash. This was first discovered when using sub
resource locators, but could also occur in simpler scenarios (like
a resource method annotated with @GET but not @Path). 

When comparing against the javadoc and the RI, it looks like the
URIs we were returning started with a slash, where the RI and
javadoc examples do not. This commit removes the starting slash as
well.