### PR TITLE
CXF-7544: Support @Context-based injection into proxied CDI beans

### DIFF
--- a/integration/cdi/src/main/java/org/apache/cxf/cdi/CdiClassUnwrapper.java
+++ b/integration/cdi/src/main/java/org/apache/cxf/cdi/CdiClassUnwrapper.java
@@ -22,8 +22,18 @@ import java.util.regex.Pattern;
 
 import org.apache.cxf.common.util.ClassUnwrapper;
 
+/**
+ * Unwraps the CDI proxy classes into real classes.
+ */
 class CdiClassUnwrapper implements ClassUnwrapper {
-    private static final Pattern PROXY_PATTERN = Pattern.compile(".+\\$\\$.+Proxy");
+    /**
+     * Known proxy patterns for OWB and Weld:
+     * 
+     *  Xxx$$OwbNormalScopeProxy0
+     *  Xxx$Proxy$_$$_WeldClientProxy
+     *  
+     */
+    private static final Pattern PROXY_PATTERN = Pattern.compile(".+\\$\\$.+Proxy\\d*");
 
     CdiClassUnwrapper() {
 

--- a/integration/cdi/src/main/java/org/apache/cxf/cdi/inject/ContextInjectionTarget.java
+++ b/integration/cdi/src/main/java/org/apache/cxf/cdi/inject/ContextInjectionTarget.java
@@ -1,0 +1,76 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.cxf.cdi.inject;
+
+import java.util.Set;
+
+import javax.enterprise.context.spi.CreationalContext;
+import javax.enterprise.inject.spi.InjectionPoint;
+import javax.enterprise.inject.spi.InjectionTarget;
+
+import org.apache.cxf.jaxrs.provider.ServerProviderFactory;
+import org.apache.cxf.message.Message;
+import org.apache.cxf.phase.PhaseInterceptorChain;
+
+public final class ContextInjectionTarget<X> implements InjectionTarget<X> {
+    private final InjectionTarget<X> delegate;
+    private final Class<?> providerClass;
+    
+    public ContextInjectionTarget(final InjectionTarget<X> delegate, final Class<?> providerClass) {
+        this.delegate = delegate;
+        this.providerClass = providerClass;
+    }
+    
+    @Override
+    public void inject(X instance, CreationalContext<X> ctx) {
+        delegate.inject(instance, ctx);
+        
+        final Message message = PhaseInterceptorChain.getCurrentMessage();
+        if (message != null) {
+            final ServerProviderFactory factory = ServerProviderFactory.getInstance(message);
+            factory.injectContextProxiesIntoProvider(providerClass, instance);
+        }
+    }
+
+    @Override
+    public void postConstruct(X instance) {
+        delegate.postConstruct(instance);
+    }
+
+    @Override
+    public void preDestroy(X instance) {
+        delegate.dispose(instance);
+    }
+
+    @Override
+    public void dispose(X instance) {
+        delegate.dispose(instance);
+    }
+
+    @Override
+    public Set<InjectionPoint> getInjectionPoints() {
+        return delegate.getInjectionPoints();
+    }
+
+    @Override
+    public X produce(CreationalContext<X> ctx) {
+        return delegate.produce(ctx);
+    }
+}

--- a/systests/cdi/base/src/main/java/org/apache/cxf/systests/cdi/base/BookStorePreMatchingRequestFilter.java
+++ b/systests/cdi/base/src/main/java/org/apache/cxf/systests/cdi/base/BookStorePreMatchingRequestFilter.java
@@ -1,0 +1,43 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.cxf.systests.cdi.base;
+
+import java.io.IOException;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ContainerRequestFilter;
+import javax.ws.rs.container.PreMatching;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.UriInfo;
+
+@ApplicationScoped @PreMatching
+public class BookStorePreMatchingRequestFilter implements ContainerRequestFilter {
+    @Context private UriInfo uriInfo;
+    
+    @Override
+    public void filter(ContainerRequestContext requestContext) throws IOException {
+        // Contextual instances should be injected independently
+        if (uriInfo == null || uriInfo.getBaseUri() == null) {
+            requestContext.abortWith(Response.serverError().entity("uriInfo is not set").build());
+        }
+    }
+}

--- a/systests/cdi/cdi-owb/cdi-producers-owb/src/test/java/org/apache/cxf/systest/jaxrs/cdi/SampleNestedFeature.java
+++ b/systests/cdi/cdi-owb/cdi-producers-owb/src/test/java/org/apache/cxf/systest/jaxrs/cdi/SampleNestedFeature.java
@@ -22,17 +22,12 @@ package org.apache.cxf.systest.jaxrs.cdi;
 import javax.ws.rs.core.Feature;
 import javax.ws.rs.core.FeatureContext;
 
-import org.apache.cxf.jaxrs.provider.atom.AtomFeedProvider;
-import org.apache.cxf.systests.cdi.base.BookStoreRequestFilter;
-import org.apache.cxf.systests.cdi.base.BookStoreResponseFilter;
+import org.apache.cxf.systests.cdi.base.BookStorePreMatchingRequestFilter;
 
-public class SampleFeature implements Feature {
+public class SampleNestedFeature implements Feature {
     @Override
     public boolean configure(FeatureContext context) {
-        context.register(AtomFeedProvider.class);
-        context.register(BookStoreRequestFilter.class);
-        context.register(BookStoreResponseFilter.class);
-        context.register(SampleNestedFeature.class);
+        context.register(BookStorePreMatchingRequestFilter.class);
         return false;
     }
 }

--- a/systests/cdi/cdi-weld/cdi-producers-weld/src/test/java/org/apache/cxf/systest/jaxrs/cdi/SampleFeature.java
+++ b/systests/cdi/cdi-weld/cdi-producers-weld/src/test/java/org/apache/cxf/systest/jaxrs/cdi/SampleFeature.java
@@ -32,6 +32,7 @@ public class SampleFeature implements Feature {
         context.register(AtomFeedProvider.class);
         context.register(BookStoreRequestFilter.class);
         context.register(BookStoreResponseFilter.class);
+        context.register(SampleNestedFeature.class);
         return false;
     }
 }

--- a/systests/cdi/cdi-weld/cdi-producers-weld/src/test/java/org/apache/cxf/systest/jaxrs/cdi/SampleNestedFeature.java
+++ b/systests/cdi/cdi-weld/cdi-producers-weld/src/test/java/org/apache/cxf/systest/jaxrs/cdi/SampleNestedFeature.java
@@ -22,17 +22,12 @@ package org.apache.cxf.systest.jaxrs.cdi;
 import javax.ws.rs.core.Feature;
 import javax.ws.rs.core.FeatureContext;
 
-import org.apache.cxf.jaxrs.provider.atom.AtomFeedProvider;
-import org.apache.cxf.systests.cdi.base.BookStoreRequestFilter;
-import org.apache.cxf.systests.cdi.base.BookStoreResponseFilter;
+import org.apache.cxf.systests.cdi.base.BookStorePreMatchingRequestFilter;
 
-public class SampleFeature implements Feature {
+public class SampleNestedFeature implements Feature {
     @Override
     public boolean configure(FeatureContext context) {
-        context.register(AtomFeedProvider.class);
-        context.register(BookStoreRequestFilter.class);
-        context.register(BookStoreResponseFilter.class);
-        context.register(SampleNestedFeature.class);
+        context.register(BookStorePreMatchingRequestFilter.class);
         return false;
     }
 }


### PR DESCRIPTION
The issue pop up as part of https://github.com/apache/cxf/pull/330 discussion. In case when provider / feature / resource is a proxied CDI bean, the contextual class members (annotated with @Context) are not injected.

More broadly,iIn some circumstances (like using `@ApplicationScoped` annotation for example) the CDI runtime will create a proxy class for a particular bean. As the result, the CXF side is going to bind the particular provider metadata to this proxy instance. It looks logical and unambiguous.

However, the interesting things are happening when CXF will try to inject contextual proxies (`@Context` annotations) into the provider instance. The injections are successful but the target object for them will be the proxy instance (not the real instance behind it). Consequently, at runtime, when the proxy delegates the call to a backing instance, all contextual proxies are null in there (simply put, not set).