### PR TITLE
[CXF-7470] Cannot set target for recovered source sequence

### DIFF
--- a/rt/ws/rm/src/main/java/org/apache/cxf/ws/rm/SourceSequence.java
+++ b/rt/ws/rm/src/main/java/org/apache/cxf/ws/rm/SourceSequence.java
@@ -271,13 +271,13 @@ public class SourceSequence extends AbstractSequence {
      *
      * @param to
      */
-    synchronized void setTarget(EndpointReferenceType to) {
+    public synchronized void setTarget(EndpointReferenceType to) {
         if (target == null && !ContextUtils.isGenericAddress(to)) {
             target = to;
         }
     }
 
-    synchronized EndpointReferenceType getTarget() {
+    public synchronized EndpointReferenceType getTarget() {
         return target;
     }
 


### PR DESCRIPTION
This fixes https://issues.apache.org/jira/browse/CXF-7470 by making the setTarget method public.