### PR TITLE
When failing to close conduit, distinct read faults from write faults

### DIFF
--- a/core/src/main/java/org/apache/cxf/interceptor/MessageSenderInterceptor.java
+++ b/core/src/main/java/org/apache/cxf/interceptor/MessageSenderInterceptor.java
@@ -20,6 +20,7 @@
 package org.apache.cxf.interceptor;
 
 import java.io.IOException;
+import java.net.SocketTimeoutException;
 import java.util.ResourceBundle;
 
 import org.apache.cxf.common.i18n.BundleUtils;
@@ -60,6 +61,8 @@ public class MessageSenderInterceptor extends AbstractPhaseInterceptor<Message> 
         public void handleMessage(Message message) throws Fault {
             try {
                 getConduit(message).close(message);
+            } catch (SocketTimeoutException e) {
+                throw new Fault(new org.apache.cxf.common.i18n.Message("COULD_NOT_RECEIVE", BUNDLE), e);
             } catch (IOException e) {
                 throw new Fault(new org.apache.cxf.common.i18n.Message("COULD_NOT_SEND", BUNDLE), e);
             }

--- a/core/src/main/java/org/apache/cxf/interceptor/Messages.properties
+++ b/core/src/main/java/org/apache/cxf/interceptor/Messages.properties
@@ -29,6 +29,7 @@ NO_DATAREADER=No DataReader is available for Service: {0}
 NO_DATAWRITER=No DataWriter is available for Service: {0}
 COULD_NOT_UNRWAP=Could not unwrap message parts.
 COULD_NOT_SEND=Could not send Message.
+COULD_NOT_RECEIVE=Could not receive Message.
 NO_PART_FOUND=Message part {0} was not recognized.  (Does it exist in service WSDL?)
 ORDERED_PARAM_REQUIRED=Parameter should be ordered in the following sequence: {0}
 WRITE_ATTACHMENTS=Could not write attachments.


### PR DESCRIPTION
Consider SocketTimeoutExceptions to be incoming message faults while all other
IOExceptions to be outgoing message faults. Each type will have its own error message.