### PR TITLE
CXF-7544: Support @Context-based injection into proxied CDI beans

### DIFF
--- a/integration/cdi/src/main/java/org/apache/cxf/cdi/CdiClassUnwrapper.java
+++ b/integration/cdi/src/main/java/org/apache/cxf/cdi/CdiClassUnwrapper.java
@@ -22,8 +22,18 @@ import java.util.regex.Pattern;
 
 import org.apache.cxf.common.util.ClassUnwrapper;
 
+/**
+ * Unwraps the CDI proxy classes into real classes.
+ */
 class CdiClassUnwrapper implements ClassUnwrapper {
-    private static final Pattern PROXY_PATTERN = Pattern.compile(".+\\$\\$.+Proxy");
+    /**
+     * Known proxy patterns for OWB and Weld:
+     * 
+     *  Xxx$$OwbNormalScopeProxy0
+     *  Xxx$Proxy$_$$_WeldClientProxy
+     *  
+     */
+    private static final Pattern PROXY_PATTERN = Pattern.compile(".+\\$\\$.+Proxy\\d*");
 
     CdiClassUnwrapper() {
 

--- a/rt/frontend/jaxrs/src/main/java/org/apache/cxf/jaxrs/model/FilterProviderInfo.java
+++ b/rt/frontend/jaxrs/src/main/java/org/apache/cxf/jaxrs/model/FilterProviderInfo.java
@@ -32,18 +32,23 @@ public class FilterProviderInfo<T> extends ProviderInfo<T> {
     private Map<Class<?>, Integer> supportedContracts;
     private boolean dynamic;
 
-    public FilterProviderInfo(T provider,
+    public FilterProviderInfo(Class<?> resourceClass, 
+                              Class<?> serviceClass,
+                              T provider,
                               Bus bus,
                               Map<Class<?>, Integer> supportedContracts) {
-        this(provider, bus, ProviderFactory.DEFAULT_FILTER_NAME_BINDING, false, supportedContracts);
+        this(resourceClass, serviceClass, provider, bus, ProviderFactory.DEFAULT_FILTER_NAME_BINDING, 
+            false, supportedContracts);
     }
 
-    public FilterProviderInfo(T provider,
+    public FilterProviderInfo(Class<?> resourceClass, 
+                              Class<?> serviceClass,
+                              T provider,
                               Bus bus,
                               String nameBinding,
                               boolean dynamic,
                               Map<Class<?>, Integer> supportedContracts) {
-        super(provider, bus, true);
+        super(resourceClass, serviceClass, provider, bus, true);
         this.nameBinding = Collections.singleton(nameBinding);
         this.supportedContracts = supportedContracts;
         this.dynamic = dynamic;

--- a/rt/frontend/jaxrs/src/main/java/org/apache/cxf/jaxrs/model/ProviderInfo.java
+++ b/rt/frontend/jaxrs/src/main/java/org/apache/cxf/jaxrs/model/ProviderInfo.java
@@ -35,7 +35,16 @@ public class ProviderInfo<T> extends AbstractResourceInfo {
     }
 
     public ProviderInfo(T provider, Bus bus, boolean checkContexts, boolean custom) {
-        this(provider, null, bus, checkContexts, custom);
+        this(provider.getClass(), provider.getClass(), provider, bus, true, custom);
+    }
+
+    public ProviderInfo(Class<?> resourceClass, Class<?> serviceClass, T provider, Bus bus, boolean custom) {
+        this(resourceClass, serviceClass, provider, bus, true, custom);
+    }
+
+    public ProviderInfo(Class<?> resourceClass, Class<?> serviceClass, T provider, Bus bus, 
+            boolean checkContexts, boolean custom) {
+        this(resourceClass, serviceClass, provider, null, bus, checkContexts, custom);
     }
 
     public ProviderInfo(T provider,
@@ -45,14 +54,24 @@ public class ProviderInfo<T> extends AbstractResourceInfo {
         this(provider, constructorProxies, bus, true, custom);
     }
 
+    public ProviderInfo(Class<?> resourceClass, 
+            Class<?> serviceClass,
+            T provider,
+            Map<Class<?>, ThreadLocalProxy<?>> constructorProxies,
+            Bus bus,
+            boolean checkContexts,
+            boolean custom) {
+        super(resourceClass, serviceClass, true, checkContexts, constructorProxies, bus, provider);
+        this.provider = provider;
+        this.custom = custom;
+    }
+
     public ProviderInfo(T provider,
                         Map<Class<?>, ThreadLocalProxy<?>> constructorProxies,
                         Bus bus,
                         boolean checkContexts,
                         boolean custom) {
-        super(provider.getClass(), provider.getClass(), true, checkContexts, constructorProxies, bus, provider);
-        this.provider = provider;
-        this.custom = custom;
+        this(provider.getClass(), provider.getClass(), provider, constructorProxies, bus, checkContexts, custom);
     }
 
     @Override

--- a/rt/frontend/jaxrs/src/main/java/org/apache/cxf/jaxrs/provider/ServerProviderFactory.java
+++ b/rt/frontend/jaxrs/src/main/java/org/apache/cxf/jaxrs/provider/ServerProviderFactory.java
@@ -211,7 +211,11 @@ public final class ServerProviderFactory extends ProviderFactory {
                 for (Object featureProvider : cfg.getInstances()) {
                     Map<Class<?>, Integer> contracts = cfg.getContracts(featureProvider.getClass());
                     if (contracts != null && !contracts.isEmpty()) {
-                        allProviders.add(new FilterProviderInfo<Object>(featureProvider,
+                        Class<?> providerCls = ClassHelper.getRealClass(getBus(), featureProvider);
+                        
+                        allProviders.add(new FilterProviderInfo<Object>(featureProvider.getClass(),
+                                                                        providerCls,
+                                                                        featureProvider,
                                                                         getBus(),
                                                                         contracts));
                     } else {
@@ -373,7 +377,10 @@ public final class ServerProviderFactory extends ProviderFactory {
                 for (Object provider : cfg.getInstances()) {
                     Map<Class<?>, Integer> contracts = cfg.getContracts(provider.getClass());
                     if (contracts != null && !contracts.isEmpty()) {
-                        registerUserProvider(new FilterProviderInfo<Object>(provider,
+                        Class<?> providerCls = ClassHelper.getRealClass(getBus(), provider);
+                        registerUserProvider(new FilterProviderInfo<Object>(provider.getClass(),
+                            providerCls,
+                            provider,
                             getBus(),
                             nameBinding,
                             true,
@@ -601,5 +608,4 @@ public final class ServerProviderFactory extends ProviderFactory {
             return result;
         }
     }
-
 }

--- a/rt/rs/client/src/main/java/org/apache/cxf/jaxrs/client/spec/ClientImpl.java
+++ b/rt/rs/client/src/main/java/org/apache/cxf/jaxrs/client/spec/ClientImpl.java
@@ -39,6 +39,7 @@ import javax.ws.rs.core.Link;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.UriBuilder;
 
+import org.apache.cxf.common.util.ClassHelper;
 import org.apache.cxf.common.util.SystemPropertyAction;
 import org.apache.cxf.configuration.jsse.TLSClientParameters;
 import org.apache.cxf.jaxrs.client.AbstractClient;
@@ -274,8 +275,9 @@ public class ClientImpl implements Client {
                     if (contracts == null || contracts.isEmpty()) {
                         providers.add(p);
                     } else {
-                        providers.add(
-                            new FilterProviderInfo<Object>(p, pf.getBus(), contracts));
+                        final Class<?> providerCls = ClassHelper.getRealClass(pf.getBus(), p);
+                        providers.add(new FilterProviderInfo<Object>(p.getClass(), 
+                            providerCls, p, pf.getBus(), contracts));
                     }
                 }
             }

--- a/systests/cdi/base/src/main/java/org/apache/cxf/systests/cdi/base/BookStorePreMatchingRequestFilter.java
+++ b/systests/cdi/base/src/main/java/org/apache/cxf/systests/cdi/base/BookStorePreMatchingRequestFilter.java
@@ -1,0 +1,48 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.cxf.systests.cdi.base;
+
+import java.io.IOException;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ContainerRequestFilter;
+import javax.ws.rs.container.PreMatching;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.UriInfo;
+
+@ApplicationScoped @PreMatching
+public class BookStorePreMatchingRequestFilter implements ContainerRequestFilter {
+    private UriInfo uriInfo;
+    
+    @Context 
+    public void setUriInfo(UriInfo uriInfo) {
+        this.uriInfo = uriInfo;
+    }
+    
+    @Override
+    public void filter(ContainerRequestContext requestContext) throws IOException {
+        // Contextual instances should be injected independently
+        if (uriInfo == null || uriInfo.getBaseUri() == null) {
+            requestContext.abortWith(Response.serverError().entity("uriInfo is not set").build());
+        }
+    }
+}

--- a/systests/cdi/cdi-owb/cdi-producers-owb/pom.xml
+++ b/systests/cdi/cdi-owb/cdi-producers-owb/pom.xml
@@ -45,5 +45,11 @@
              <groupId>org.apache.abdera</groupId>
              <artifactId>abdera-parser</artifactId>
         </dependency>
+        <dependency>
+             <groupId>org.mockito</groupId>
+             <artifactId>mockito-core</artifactId>
+             <version>2.7.14</version>
+             <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/systests/cdi/cdi-owb/cdi-producers-owb/src/test/java/org/apache/cxf/systest/jaxrs/cdi/SampleNestedFeature.java
+++ b/systests/cdi/cdi-owb/cdi-producers-owb/src/test/java/org/apache/cxf/systest/jaxrs/cdi/SampleNestedFeature.java
@@ -22,17 +22,12 @@ package org.apache.cxf.systest.jaxrs.cdi;
 import javax.ws.rs.core.Feature;
 import javax.ws.rs.core.FeatureContext;
 
-import org.apache.cxf.jaxrs.provider.atom.AtomFeedProvider;
-import org.apache.cxf.systests.cdi.base.BookStoreRequestFilter;
-import org.apache.cxf.systests.cdi.base.BookStoreResponseFilter;
+import org.apache.cxf.systests.cdi.base.BookStorePreMatchingRequestFilter;
 
-public class SampleFeature implements Feature {
+public class SampleNestedFeature implements Feature {
     @Override
     public boolean configure(FeatureContext context) {
-        context.register(AtomFeedProvider.class);
-        context.register(BookStoreRequestFilter.class);
-        context.register(BookStoreResponseFilter.class);
-        context.register(SampleNestedFeature.class);
+        context.register(BookStorePreMatchingRequestFilter.class);
         return false;
     }
 }

--- a/systests/cdi/cdi-owb/cdi-producers-owb/src/test/java/org/apache/cxf/systest/jaxrs/cdi/unwrapper/ClassUnwrapperTest.java
+++ b/systests/cdi/cdi-owb/cdi-producers-owb/src/test/java/org/apache/cxf/systest/jaxrs/cdi/unwrapper/ClassUnwrapperTest.java
@@ -1,0 +1,90 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.cxf.systest.jaxrs.cdi.unwrapper;
+
+import java.util.Set;
+
+import javax.enterprise.inject.spi.Bean;
+import javax.enterprise.inject.spi.BeanManager;
+import javax.servlet.ServletContext;
+import javax.servlet.ServletContextEvent;
+
+import org.apache.cxf.Bus;
+import org.apache.cxf.common.util.ClassUnwrapper;
+import org.apache.cxf.systests.cdi.base.BookStorePreMatchingRequestFilter;
+import org.apache.cxf.systests.cdi.base.BookStoreRequestFilter;
+import org.apache.webbeans.config.WebBeansContext;
+import org.apache.webbeans.spi.ContainerLifecycle;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
+
+
+public class ClassUnwrapperTest {
+    private Bus bus;
+    private ContainerLifecycle lifecycle;
+    private ServletContextEvent event;
+    
+    @Before
+    public void setUp() {
+        event = new ServletContextEvent(mock(ServletContext.class));
+        lifecycle = WebBeansContext.currentInstance().getService(ContainerLifecycle.class);
+        lifecycle.startApplication(event);
+        bus = getBeanReference(Bus.class);
+    }
+
+    @SuppressWarnings("unchecked")
+    private<T> T getBeanReference(Class<T> clazz) {
+        final BeanManager beanManager = lifecycle.getBeanManager();
+        final Set<Bean<?>> beans = beanManager.getBeans(clazz);
+        final Bean<?> bean = beanManager.resolve(beans);
+        return (T)beanManager.getReference(bean, clazz, beanManager.createCreationalContext(bean));
+    }
+
+    @After
+    public void tearDown() {
+        lifecycle.stopApplication(event);
+    }
+    
+    @Test
+    public void testProxyClassIsProperlyUnwrapped() {
+        final BookStorePreMatchingRequestFilter filter = getBeanReference(BookStorePreMatchingRequestFilter.class);
+        final ClassUnwrapper unwrapper = (ClassUnwrapper)bus.getProperty(ClassUnwrapper.class.getName());
+        
+        assertThat(unwrapper, notNullValue());
+        assertThat(filter.getClass(), not(equalTo(BookStorePreMatchingRequestFilter.class)));
+        assertThat(unwrapper.getRealClass(filter), equalTo(BookStorePreMatchingRequestFilter.class));
+    }
+    
+    @Test
+    public void testRealClassIsProperlyUnwrapped() {
+        final BookStoreRequestFilter filter = getBeanReference(BookStoreRequestFilter.class);
+        final ClassUnwrapper unwrapper = (ClassUnwrapper)bus.getProperty(ClassUnwrapper.class.getName());
+        
+        assertThat(unwrapper, notNullValue());
+        assertThat(filter.getClass(), equalTo(BookStoreRequestFilter.class));
+        assertThat(unwrapper.getRealClass(filter), equalTo(BookStoreRequestFilter.class));
+    }
+}

--- a/systests/cdi/cdi-weld/cdi-producers-weld/pom.xml
+++ b/systests/cdi/cdi-weld/cdi-producers-weld/pom.xml
@@ -45,5 +45,11 @@
              <groupId>org.apache.abdera</groupId>
              <artifactId>abdera-parser</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.jboss.weld.se</groupId>
+            <artifactId>weld-se-core</artifactId>
+            <version>${cxf.jboss.weld.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/systests/cdi/cdi-weld/cdi-producers-weld/src/test/java/org/apache/cxf/systest/jaxrs/cdi/SampleFeature.java
+++ b/systests/cdi/cdi-weld/cdi-producers-weld/src/test/java/org/apache/cxf/systest/jaxrs/cdi/SampleFeature.java
@@ -32,6 +32,7 @@ public class SampleFeature implements Feature {
         context.register(AtomFeedProvider.class);
         context.register(BookStoreRequestFilter.class);
         context.register(BookStoreResponseFilter.class);
+        context.register(SampleNestedFeature.class);
         return false;
     }
 }

--- a/systests/cdi/cdi-weld/cdi-producers-weld/src/test/java/org/apache/cxf/systest/jaxrs/cdi/SampleNestedFeature.java
+++ b/systests/cdi/cdi-weld/cdi-producers-weld/src/test/java/org/apache/cxf/systest/jaxrs/cdi/SampleNestedFeature.java
@@ -22,17 +22,12 @@ package org.apache.cxf.systest.jaxrs.cdi;
 import javax.ws.rs.core.Feature;
 import javax.ws.rs.core.FeatureContext;
 
-import org.apache.cxf.jaxrs.provider.atom.AtomFeedProvider;
-import org.apache.cxf.systests.cdi.base.BookStoreRequestFilter;
-import org.apache.cxf.systests.cdi.base.BookStoreResponseFilter;
+import org.apache.cxf.systests.cdi.base.BookStorePreMatchingRequestFilter;
 
-public class SampleFeature implements Feature {
+public class SampleNestedFeature implements Feature {
     @Override
     public boolean configure(FeatureContext context) {
-        context.register(AtomFeedProvider.class);
-        context.register(BookStoreRequestFilter.class);
-        context.register(BookStoreResponseFilter.class);
-        context.register(SampleNestedFeature.class);
+        context.register(BookStorePreMatchingRequestFilter.class);
         return false;
     }
 }

--- a/systests/cdi/cdi-weld/cdi-producers-weld/src/test/java/org/apache/cxf/systest/jaxrs/cdi/unwrapper/ClassUnwrapperTest.java
+++ b/systests/cdi/cdi-weld/cdi-producers-weld/src/test/java/org/apache/cxf/systest/jaxrs/cdi/unwrapper/ClassUnwrapperTest.java
@@ -1,0 +1,75 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.cxf.systest.jaxrs.cdi.unwrapper;
+
+import org.apache.cxf.Bus;
+import org.apache.cxf.common.util.ClassUnwrapper;
+import org.apache.cxf.systests.cdi.base.BookStorePreMatchingRequestFilter;
+import org.apache.cxf.systests.cdi.base.BookStoreRequestFilter;
+import org.jboss.weld.environment.se.Weld;
+import org.jboss.weld.environment.se.WeldContainer;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.junit.Assert.assertThat;
+
+public class ClassUnwrapperTest {
+    private Bus bus;
+    private WeldContainer container;
+    
+    @Before
+    public void setUp() {
+        final Weld weld = new Weld();
+        container = weld.initialize();
+        bus = getBeanReference(Bus.class);
+    }
+
+    private<T> T getBeanReference(Class<T> clazz) {
+        return container.select(clazz).get();
+    }
+
+    @After
+    public void tearDown() {
+        container.close();
+    }
+    
+    @Test
+    public void testProxyClassIsProperlyUnwrapped() {
+        final BookStorePreMatchingRequestFilter filter = getBeanReference(BookStorePreMatchingRequestFilter.class);
+        final ClassUnwrapper unwrapper = (ClassUnwrapper)bus.getProperty(ClassUnwrapper.class.getName());
+        
+        assertThat(unwrapper, notNullValue());
+        assertThat(filter.getClass(), not(equalTo(BookStorePreMatchingRequestFilter.class)));
+        assertThat(unwrapper.getRealClass(filter), equalTo(BookStorePreMatchingRequestFilter.class));
+    }
+    
+    @Test
+    public void testRealClassIsProperlyUnwrapped() {
+        final BookStoreRequestFilter filter = getBeanReference(BookStoreRequestFilter.class);
+        final ClassUnwrapper unwrapper = (ClassUnwrapper)bus.getProperty(ClassUnwrapper.class.getName());
+        
+        assertThat(unwrapper, notNullValue());
+        assertThat(filter.getClass(), equalTo(BookStoreRequestFilter.class));
+        assertThat(unwrapper.getRealClass(filter), equalTo(BookStoreRequestFilter.class));
+    }
+}


### PR DESCRIPTION
The issue pop up as part of #330 discussion. In case when provider / feature / resource is a proxied CDI bean, the contextual class members (annotated with @context) are not injected.

More broadly, in some circumstances (like using @ApplicationScoped annotation for example) the CDI runtime will create a proxy class for a particular bean. As the result, the CXF side is going to bind the particular provider metadata to this proxy instance. It looks logical and unambiguous.

However, the interesting things are happening when CXF will try to inject contextual proxies (@Context annotations) into the provider instance. The injections are successful but the target object for them will be the proxy instance (not the real instance behind it). Consequently, at runtime, when the proxy delegates the call to a backing instance, all contextual proxies are null in there (simply put, not set).

@johnament @rmannibucau Addressing the issue requires a significant revamp of the CXF injection mechanism, it is turned out to be hard to solve even with `@AroundConstruct` or, previously, providing custom `@Context` injectors. The good news is that the field-based injection could be easily workarounded using setter-based injection. After conversations with @sberyozkin, we decided that encapsulating CXF injection implementation and than delegating the hard work to appropriate strategy (CDI, Spring, ...) would be better time investment than trying to patch the existing one. Since we have simple workaround, it sounds like an acceptable tradeoff (https://issues.apache.org/jira/browse/CXF-7571).

This PR fixes the patterns in `CdiClassUnwrapper`, adds tests for it and fixes the `FilterProviderInfo` resource / service class resolution (to match it to the `ProviderInfo`)