### PR TITLE
[CXF-7572] default port in OAuth discovery doc

### DIFF
--- a/rt/rs/security/oauth-parent/oauth2/src/main/java/org/apache/cxf/rs/security/oauth2/services/AuthorizationMetadataService.java
+++ b/rt/rs/security/oauth-parent/oauth2/src/main/java/org/apache/cxf/rs/security/oauth2/services/AuthorizationMetadataService.java
@@ -206,9 +206,8 @@ public class AuthorizationMetadataService {
         if ((uri.getPort() == 80 && "http".equals(uri.getScheme()))
                 || (uri.getPort() == 443 && "https".equals(uri.getScheme()))) {
             try {
-                URI newURI = new URI(uri.getScheme(), uri.getUserInfo(), uri.getHost(), -1,
+                return new URI(uri.getScheme(), uri.getUserInfo(), uri.getHost(), -1,
                         uri.getPath(), uri.getQuery(), uri.getFragment());
-                return newURI;
             } catch (URISyntaxException e) {
                 throw new IllegalArgumentException("Invalid URI " + uri + " : " + e.toString(), e);
             }


### PR DESCRIPTION
Default port should be removed from
issuer and endpoints in discovery
documents.

aka
"issuer":"https://authorization-server:443"
should be
"issuer":"https://authorization-server"