### PR TITLE
Config handling for MP rest client

### DIFF
--- a/rt/rs/microprofile-client/src/test/java/org/apache/cxf/microprofile/client/CxfTypeSafeClientBuilderTest.java
+++ b/rt/rs/microprofile-client/src/test/java/org/apache/cxf/microprofile/client/CxfTypeSafeClientBuilderTest.java
@@ -1,0 +1,94 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.cxf.microprofile.client;
+import java.net.URL;
+import javax.ws.rs.core.Response;
+import org.apache.cxf.microprofile.client.mock.HighPriorityClientReqFilter;
+import org.apache.cxf.microprofile.client.mock.HighPriorityMBW;
+import org.apache.cxf.microprofile.client.mock.LowPriorityClientReqFilter;
+import org.apache.cxf.microprofile.client.mock.MyClient;
+import org.eclipse.microprofile.rest.client.RestClientBuilder;
+
+import org.junit.Assert;
+import org.junit.Ignore;
+import org.junit.Test;
+
+public class CxfTypeSafeClientBuilderTest extends Assert {
+
+    @Test
+    public void testConfigMethods() {
+        RestClientBuilder builder = RestClientBuilder.newBuilder();
+
+        assertEquals("y", builder.property("x", "y").getConfiguration().getProperty("x"));
+
+        assertTrue(builder.register(HighPriorityMBW.class).getConfiguration().isRegistered(HighPriorityMBW.class));
+
+        HighPriorityMBW mbw = new HighPriorityMBW(1);
+        assertTrue(builder.register(mbw).getConfiguration().isRegistered(mbw));
+
+    }
+
+    @Ignore
+    @Test
+    public void testConfigPriorityOverrides() throws Exception {
+        RestClientBuilder builder = RestClientBuilder.newBuilder();
+        builder.register(HighPriorityClientReqFilter.class); // annotation priority of 10
+        builder.register(LowPriorityClientReqFilter.class, 5); // overriding priority to be 5 (preferred)
+        MyClient c = builder.baseUrl(new URL("http://localhost/null")).build(MyClient.class);
+        Response r = c.get();
+        assertEquals("low", r.readEntity(String.class));
+    }
+/** using for test coverage
+    @Override
+    public RestClientBuilder register(Class<?> componentClass, int priority) {
+      configImpl.register(componentClass, priority);
+      return this;
+    }
+
+    @Override
+    public RestClientBuilder register(Class<?> componentClass, Class<?>... contracts) {
+      configImpl.register(componentClass, contracts);
+      return this;
+    }
+
+    @Override
+    public RestClientBuilder register(Class<?> componentClass, Map<Class<?>, Integer> contracts) {
+      configImpl.register(componentClass, contracts);
+      return this;
+    }
+
+    @Override
+    public RestClientBuilder register(Object component, int priority) {
+      configImpl.register(component, priority);
+      return this;
+    }
+
+    @Override
+    public RestClientBuilder register(Object component, Class<?>... contracts) {
+      configImpl.register(component, contracts);
+      return this;
+    }
+
+    @Override
+    public RestClientBuilder register(Object component, Map<Class<?>, Integer> contracts) {
+      configImpl.register(component, contracts);
+      return this;
+    }
+**/
+}

--- a/rt/rs/microprofile-client/src/test/java/org/apache/cxf/microprofile/client/mock/HighPriorityClientReqFilter.java
+++ b/rt/rs/microprofile-client/src/test/java/org/apache/cxf/microprofile/client/mock/HighPriorityClientReqFilter.java
@@ -1,0 +1,36 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.cxf.microprofile.client.mock;
+
+import java.io.IOException;
+
+import javax.annotation.Priority;
+import javax.ws.rs.client.ClientRequestContext;
+import javax.ws.rs.client.ClientRequestFilter;
+import javax.ws.rs.core.Response;
+
+@Priority(10)
+public class HighPriorityClientReqFilter implements ClientRequestFilter {
+
+    @Override
+    public void filter(ClientRequestContext paramClientRequestContext) throws IOException {
+        paramClientRequestContext.abortWith(Response.ok("high").build());
+    }
+
+}

--- a/rt/rs/microprofile-client/src/test/java/org/apache/cxf/microprofile/client/mock/HighPriorityMBW.java
+++ b/rt/rs/microprofile-client/src/test/java/org/apache/cxf/microprofile/client/mock/HighPriorityMBW.java
@@ -1,0 +1,69 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.cxf.microprofile.client.mock;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+
+import javax.annotation.Priority;
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.ext.MessageBodyWriter;
+
+@Priority(10)
+public class HighPriorityMBW implements MessageBodyWriter<MyObject> {
+
+    private final int id;
+
+    public HighPriorityMBW() {
+        this(0);
+    }
+
+    public HighPriorityMBW(int id) {
+        this.id = id;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        return o instanceof HighPriorityMBW && ((HighPriorityMBW)o).id == this.id;
+    }
+
+    @Override
+    public int hashCode() {
+        return id;
+    }
+
+    @Override
+    public boolean isWriteable(Class<?> type, Type genericType,
+                               Annotation[] annotations, MediaType mediaType) {
+        return true;
+    }
+
+    @Override
+    public void writeTo(MyObject t, Class<?> type, Type genericType,
+                        Annotation[] annotations, MediaType mediaType,
+                        MultivaluedMap<String, Object> httpHeaders,
+                        OutputStream entityStream) throws IOException,
+                                                          WebApplicationException {
+        entityStream.write(t.toString().getBytes());
+    }
+}

--- a/rt/rs/microprofile-client/src/test/java/org/apache/cxf/microprofile/client/mock/LowPriorityClientReqFilter.java
+++ b/rt/rs/microprofile-client/src/test/java/org/apache/cxf/microprofile/client/mock/LowPriorityClientReqFilter.java
@@ -1,0 +1,36 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.cxf.microprofile.client.mock;
+
+import java.io.IOException;
+
+import javax.annotation.Priority;
+import javax.ws.rs.client.ClientRequestContext;
+import javax.ws.rs.client.ClientRequestFilter;
+import javax.ws.rs.core.Response;
+
+@Priority(6000)
+public class LowPriorityClientReqFilter implements ClientRequestFilter {
+
+    @Override
+    public void filter(ClientRequestContext paramClientRequestContext) throws IOException {
+        paramClientRequestContext.abortWith(Response.ok("low").build());
+    }
+
+}

--- a/rt/rs/microprofile-client/src/test/java/org/apache/cxf/microprofile/client/mock/MyClient.java
+++ b/rt/rs/microprofile-client/src/test/java/org/apache/cxf/microprofile/client/mock/MyClient.java
@@ -1,0 +1,29 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.cxf.microprofile.client.mock;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.core.Response;
+
+@Path("/")
+public interface MyClient {
+    @GET
+    Response get();
+}

--- a/rt/rs/microprofile-client/src/test/java/org/apache/cxf/microprofile/client/mock/MyObject.java
+++ b/rt/rs/microprofile-client/src/test/java/org/apache/cxf/microprofile/client/mock/MyObject.java
@@ -1,0 +1,34 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.cxf.microprofile.client.mock;
+
+public class MyObject {
+    private String name;
+    private int id;
+
+    public MyObject(String name, int id) {
+        this.name = name;
+        this.id = id;
+    }
+
+    @Override
+    public String toString() {
+        return "name=\"" + name + "\" : id=" + id;
+    }
+}


### PR DESCRIPTION
@johnament Can you take a look at these changes?

This should help us handle the `Configurable` methods.  Notice that the overrides of the priority do not currently work (note the test that has the `@Ignore` annotation).  I ran a similar test using the JAX-RS client and that worked, so I'm probably just missing something simple...  if you see it, please let me know.  Thanks!