### PR TITLE
CXF-7586: Remove @PersistenceContext

### DIFF
--- a/rt/rs/security/oauth-parent/oauth2/src/main/java/org/apache/cxf/rs/security/oauth2/grants/code/JPACMTCodeDataProvider.java
+++ b/rt/rs/security/oauth-parent/oauth2/src/main/java/org/apache/cxf/rs/security/oauth2/grants/code/JPACMTCodeDataProvider.java
@@ -24,19 +24,66 @@ import java.util.Map;
 import javax.persistence.EntityManager;
 import javax.persistence.EntityTransaction;
 import javax.persistence.LockModeType;
-import javax.persistence.PersistenceContext;
 
 import org.apache.cxf.rs.security.oauth2.common.ServerAccessToken;
 import org.apache.cxf.rs.security.oauth2.tokens.refresh.RefreshToken;
 
+/**
+ * Same as {@link JPACodeDataProvider} (stores Clients and tokens in a rdbms using
+ * JPA APIs).
+ *
+ * The transaction demarcation is handled by the container (be it Spring
+ * or Java EE).
+ *
+ * Sample usage with Spring XML:
+ <pre>
+ {@code
+     <bean id="oauthProvider" class="org.apache.cxf.rs.security.oauth2.grants.code.JPACMTCodeDataProvider"
+        init-method="init" destroy-method="close">
+
+         <property name="entityManager" ref="entityManager"/>
+         <!-- List of accepted scopes -->
+         <property name="supportedScopes" ref="supportedScopes"/>
+         <!-- List of required scopes -->
+         <!-- commented because bug in Resource Owner Flow
+         <property name="requiredScopes" ref="coreScopes"/>
+         -->
+         <!--
+         List of scopes that the consent/authorization form should make
+         selected by default. For example, asking a user to do an extra click
+         to approve an "oidc" scope is a redundant operation because this scope
+         is required anyway.
+         -->
+         <property name="defaultScopes" ref="coreScopes"/>
+         <property name="invisibleToClientScopes" ref="invisibleToClientScopes"/>
+     </bean>
+
+     <bean name="entityManager" class="org.springframework.orm.jpa.support.SharedEntityManagerBean">
+         <property name="entityManagerFactory" ref="entityManagerFactory"/>
+     </bean>
+     ...
+ }
+ </pre>
+
+ * You can also extend this class and inject your own entityManager:
+ {@code
+    public class MyJPACodeDataProvider extends JPACMTCodeDataProvider {
+
+        @PersistenceContext
+        @Override
+        public void setEntityManager(EntityManager entityManager) {
+            super.setEntityManager(entityManager);
+        }
+ }
+ }
+ */
 public class JPACMTCodeDataProvider extends JPACodeDataProvider {
 
     private static final int DEFAULT_PESSIMISTIC_LOCK_TIMEOUT = 10000;
-    
+
     private int pessimisticLockTimeout = DEFAULT_PESSIMISTIC_LOCK_TIMEOUT;
     private boolean useJpaLockForExistingRefreshToken = true;
-    
-    @PersistenceContext
+
     private EntityManager entityManager;
 
     /**
@@ -72,7 +119,7 @@ public class JPACMTCodeDataProvider extends JPACodeDataProvider {
     @Override
     protected void closeIfNeeded(EntityManager em) {
     }
-    
+
     @Override
     protected RefreshToken updateExistingRefreshToken(RefreshToken rt, ServerAccessToken at) {
         if (useJpaLockForExistingRefreshToken) {
@@ -82,7 +129,7 @@ public class JPACMTCodeDataProvider extends JPACodeDataProvider {
         }
         return super.updateExistingRefreshToken(rt, at);
     }
-    
+
     protected void lockRefreshTokenForUpdate(final RefreshToken refreshToken) {
         try {
             execute(new EntityManagerOperation<Void>() {
@@ -103,7 +150,7 @@ public class JPACMTCodeDataProvider extends JPACodeDataProvider {
             // entity is not managed yet. ignore
         }
     }
-    
+
     public void setPessimisticLockTimeout(int pessimisticLockTimeout) {
         this.pessimisticLockTimeout = pessimisticLockTimeout;
     }

--- a/rt/rs/security/oauth-parent/oauth2/src/test/resources/org/apache/cxf/rs/security/oauth2/grants/code/JPACMTCodeDataProvider.xml
+++ b/rt/rs/security/oauth-parent/oauth2/src/test/resources/org/apache/cxf/rs/security/oauth2/grants/code/JPACMTCodeDataProvider.xml
@@ -38,8 +38,8 @@ under the License.
     <bean id="oauthProvider"
           class="org.apache.cxf.rs.security.oauth2.grants.code.JPACMTCodeDataProvider"
           init-method="init" destroy-method="close">
+        <property name="entityManager" ref="entityManager"/>
     </bean>
-
 
     <bean id="transactionManager" class="org.springframework.orm.jpa.JpaTransactionManager">
         <property name="entityManagerFactory" ref="entityManagerFactory"/>
@@ -57,6 +57,10 @@ under the License.
             <tx:method name="*"/>
         </tx:attributes>
     </tx:advice>
+
+    <bean name="entityManager" class="org.springframework.orm.jpa.support.SharedEntityManagerBean">
+        <property name="entityManagerFactory" ref="entityManagerFactory"/>
+    </bean>
 
     <beans profile="hibernate">
         <bean id="entityManagerFactory"

--- a/rt/rs/security/sso/oidc/src/test/resources/org/apache/cxf/rs/security/oidc/idp/JPAOidcUserSubjectCMTTest.xml
+++ b/rt/rs/security/sso/oidc/src/test/resources/org/apache/cxf/rs/security/oidc/idp/JPAOidcUserSubjectCMTTest.xml
@@ -38,6 +38,7 @@ under the License.
     <bean id="oauthProvider"
           class="org.apache.cxf.rs.security.oauth2.grants.code.JPACMTCodeDataProvider"
           init-method="init" destroy-method="close">
+        <property name="entityManager" ref="entityManager"/>
     </bean>
 
 
@@ -58,6 +59,10 @@ under the License.
         </tx:attributes>
     </tx:advice>
 
+    <bean name="entityManager" class="org.springframework.orm.jpa.support.SharedEntityManagerBean">
+        <property name="entityManagerFactory" ref="entityManagerFactory"/>
+    </bean>
+    
     <beans profile="hibernate">
         <bean id="entityManagerFactory"
               class="org.springframework.orm.jpa.LocalContainerEntityManagerFactoryBean">


### PR DESCRIPTION
Remove PersistenceContext anotation
from JPACMTCodeDataProvider as it
impeds application startup on JBoss EAP 6.x
when the application declares multiple
persistence units in its persistence.xml.