### PR TITLE
[CXF-7023] Add oneSessionPerConnection property to JMS transport

### DIFF
--- a/rt/transports/jms/src/main/java/org/apache/cxf/transport/jms/JMSConfigFactory.java
+++ b/rt/transports/jms/src/main/java/org/apache/cxf/transport/jms/JMSConfigFactory.java
@@ -86,6 +86,8 @@ public final class JMSConfigFactory {
         jmsConfig.setUserName(endpoint.getUsername());
         jmsConfig.setPassword(endpoint.getPassword());
         jmsConfig.setConcurrentConsumers(endpoint.getConcurrentConsumers());
+        jmsConfig.setOneSessionPerConnection(endpoint.isOneSessionPerConnection());
+        jmsConfig.setMessageSelector(endpoint.getMessageSelector());
 
         TransactionManager tm = getTransactionManager(bus, endpoint);
         jmsConfig.setTransactionManager(tm);

--- a/rt/transports/jms/src/main/java/org/apache/cxf/transport/jms/JMSConfiguration.java
+++ b/rt/transports/jms/src/main/java/org/apache/cxf/transport/jms/JMSConfiguration.java
@@ -91,6 +91,7 @@ public class JMSConfiguration {
     private boolean useConduitIdSelector = true;
     private String conduitSelectorPrefix;
     private boolean jmsProviderTibcoEms;
+    private boolean oneSessionPerConnection;
 
     private TransactionManager transactionManager;
 
@@ -430,6 +431,14 @@ public class JMSConfiguration {
      */
     public void setJmsProviderTibcoEms(boolean jmsProviderTibcoEms) {
         this.jmsProviderTibcoEms = jmsProviderTibcoEms;
+    }
+
+    public boolean isOneSessionPerConnection() {
+        return oneSessionPerConnection;
+    }
+
+    public void setOneSessionPerConnection(boolean oneSessionPerConnection) {
+        this.oneSessionPerConnection = oneSessionPerConnection;
     }
 
     public static Destination resolveOrCreateDestination(final Session session,

--- a/rt/transports/jms/src/main/java/org/apache/cxf/transport/jms/uri/JMSEndpoint.java
+++ b/rt/transports/jms/src/main/java/org/apache/cxf/transport/jms/uri/JMSEndpoint.java
@@ -88,6 +88,7 @@ public class JMSEndpoint {
     private int concurrentConsumers = 1;
     private String messageSelector;
     private int retryInterval = 5000;
+    private boolean oneSessionPerConnection;
 
     /**
      * @param uri
@@ -499,4 +500,16 @@ public class JMSEndpoint {
         this.retryInterval = Integer.valueOf(retryInterval);
     }
     
+    public boolean isOneSessionPerConnection() {
+        return oneSessionPerConnection;
+    }
+    
+    public void setOneSessionPerConnection(String oneSessionPerConnection) {
+        this.oneSessionPerConnection = Boolean.valueOf(oneSessionPerConnection);
+    }
+    
+    public void setOneSessionPerConnection(boolean oneSessionPerConnection) {
+        this.oneSessionPerConnection = oneSessionPerConnection;
+    }
+
 }

--- a/rt/transports/jms/src/main/java/org/apache/cxf/transport/jms/util/PollingMessageListenerContainer.java
+++ b/rt/transports/jms/src/main/java/org/apache/cxf/transport/jms/util/PollingMessageListenerContainer.java
@@ -34,10 +34,22 @@ import javax.transaction.Status;
 import javax.transaction.Transaction;
 
 import org.apache.cxf.common.logging.LogUtils;
+import org.apache.cxf.transport.jms.JMSConfiguration;
+import org.apache.cxf.transport.jms.JMSFactory;
 
 public class PollingMessageListenerContainer extends AbstractMessageListenerContainer {
     private static final Logger LOG = LogUtils.getL7dLogger(PollingMessageListenerContainer.class);
     private ExceptionListener exceptionListener;
+
+    private JMSConfiguration jmsConfig;
+    private boolean reply;
+
+    public PollingMessageListenerContainer(JMSConfiguration jmsConfig, boolean isReply,
+                                           MessageListener listenerHandler) {
+        this.jmsConfig = jmsConfig;
+        this.reply = isReply;
+        this.listenerHandler = listenerHandler;
+    }
 
     public PollingMessageListenerContainer(Connection connection, Destination destination,
                                            MessageListener listenerHandler, ExceptionListener exceptionListener) {
@@ -55,9 +67,16 @@ public class PollingMessageListenerContainer extends AbstractMessageListenerCont
             while (running) {
                 try (ResourceCloser closer = new ResourceCloser()) {
                     closer.register(createInitialContext());
-                    // Create session early to optimize performance                // In
+                    Connection connection;
+                    if (jmsConfig != null && jmsConfig.isOneSessionPerConnection()) {
+                        connection = closer.register(createConnection());
+                    } else {
+                        connection = PollingMessageListenerContainer.this.connection;
+                    }
+                    // Create session early to optimize performance
                     session = closer.register(connection.createSession(transacted, acknowledgeMode));
-                    MessageConsumer consumer = closer.register(createConsumer(session));
+                    MessageConsumer consumer = closer.register(createConsumer(connection, session));
+
                     while (running) {
                         Message message = consumer.receive(1000);
                         try {
@@ -108,12 +127,20 @@ public class PollingMessageListenerContainer extends AbstractMessageListenerCont
                         throw new IllegalStateException("External transactions are not supported in XAPoller");
                     }
                     transactionManager.begin();
+
+                    Connection connection;
+                    if (getConnection() == null) {
+                        connection = closer.register(createConnection());
+                    } else {
+                        connection = getConnection();
+                    }
+
                     /*
                      * Create session inside transaction to give it the
                      * chance to enlist itself as a resource
                      */
                     Session session = closer.register(connection.createSession(transacted, acknowledgeMode));
-                    MessageConsumer consumer = closer.register(createConsumer(session));
+                    MessageConsumer consumer = closer.register(createConsumer(connection, session));
                     Message message = consumer.receive(1000);
                     try {
                         if (message != null) {
@@ -122,7 +149,7 @@ public class PollingMessageListenerContainer extends AbstractMessageListenerCont
                         transactionManager.commit();
                     } catch (Throwable e) {
                         LOG.log(Level.WARNING, "Exception while processing jms message in cxf. Rolling back", e);
-                        safeRollBack(session);
+                        safeRollBack();
                     }
                 } catch (Throwable e) {
                     handleException(e);
@@ -131,7 +158,7 @@ public class PollingMessageListenerContainer extends AbstractMessageListenerCont
 
         }
 
-        protected void safeRollBack(Session session) {
+        private void safeRollBack() {
             try {
                 transactionManager.rollback();
             } catch (Throwable e) {
@@ -141,7 +168,31 @@ public class PollingMessageListenerContainer extends AbstractMessageListenerCont
 
     }
 
+    private MessageConsumer createConsumer(final Connection connection, final Session session)
+            throws JMSException {
+        final MessageConsumer consumer;
+        
+        if (jmsConfig != null && jmsConfig.isOneSessionPerConnection()) {
+            Destination destination;
+            if (!isReply()) {
+                destination = jmsConfig.getTargetDestination(session);
+            } else {
+                destination = jmsConfig.getReplyDestination(session);
+            }
+            consumer = createConsumer(destination, session);
+            connection.start();
+        } else {
+            consumer = createConsumer(session);
+        }
+        
+        return consumer;
+    }
+
     private MessageConsumer createConsumer(Session session) throws JMSException {
+        return createConsumer(this.destination, session);
+    }
+
+    private MessageConsumer createConsumer(Destination destination, Session session) throws JMSException {
         if (durableSubscriptionName != null && destination instanceof Topic) {
             return session.createDurableSubscriber((Topic)destination, durableSubscriptionName,
                                                    messageSelector, pubSubNoLocal);
@@ -159,6 +210,19 @@ public class PollingMessageListenerContainer extends AbstractMessageListenerCont
             wrapped.addSuppressed(e);
         }
         this.exceptionListener.onException(wrapped);
+    }
+
+    private boolean isReply() {
+        return reply;
+    }
+
+    private Connection createConnection() {
+        try {
+            return JMSFactory.createConnection(jmsConfig);
+        } catch (JMSException e) {
+            handleException(e);
+            throw JMSUtil.convertJmsException(e);
+        }
     }
 
     @Override

--- a/systests/transport-jms/src/test/java/org/apache/cxf/jms/testsuite/testcases/SoapJmsSpecTest.java
+++ b/systests/transport-jms/src/test/java/org/apache/cxf/jms/testsuite/testcases/SoapJmsSpecTest.java
@@ -106,7 +106,7 @@ public class SoapJmsSpecTest extends AbstractVmJMSTest {
         JMSMessageHeadersType responseHeader = (JMSMessageHeadersType)responseContext
             .get(JMSConstants.JMS_CLIENT_RESPONSE_HEADERS);
         Assert.assertEquals("1.0", responseHeader.getSOAPJMSBindingVersion());
-        Assert.assertEquals(null, responseHeader.getSOAPJMSSOAPAction());
+        Assert.assertEquals("\"test\"", responseHeader.getSOAPJMSSOAPAction());
         Assert.assertEquals(DeliveryMode.PERSISTENT, responseHeader.getJMSDeliveryMode());
         Assert.assertEquals(7, responseHeader.getJMSPriority());
     }


### PR DESCRIPTION
This is an updated and slightly modified version of pull request #166 which aims to fix [CXF-7023](https://issues.apache.org/jira/browse/CXF-7023).

It introduces a new `oneSessionPerConnection` JMS property which prevents the reuse of JMS connections for multiple sessions. This is required with IBM WebSphere MQ which only allows one session per connection.