### PR TITLE
CXF-7604 Refine error message during error handling

### DIFF
--- a/core/src/main/java/org/apache/cxf/interceptor/AbstractFaultChainInitiatorObserver.java
+++ b/core/src/main/java/org/apache/cxf/interceptor/AbstractFaultChainInitiatorObserver.java
@@ -111,10 +111,10 @@ public abstract class AbstractFaultChainInitiatorObserver implements MessageObse
             try {
                 chain.doIntercept(faultMessage);
             } catch (RuntimeException exc) {
-                LOG.log(Level.SEVERE, "Error occurred during error handling, give up!", exc);
+                LOG.log(Level.SEVERE, "ERROR_DURING_ERROR_PROCESSING", exc);
                 throw exc;
             } catch (Exception exc) {
-                LOG.log(Level.SEVERE, "Error occurred during error handling, give up!", exc);
+                LOG.log(Level.SEVERE, "ERROR_DURING_ERROR_PROCESSING", exc);
                 throw new RuntimeException(exc);
             }
         } finally {

--- a/core/src/main/java/org/apache/cxf/interceptor/Messages.properties
+++ b/core/src/main/java/org/apache/cxf/interceptor/Messages.properties
@@ -42,4 +42,5 @@ EXCEPTION_WHILE_WRITING_FAULT = Exception occurred while writing fault.
 EXCEPTION_WHILE_CREATING_EXCEPTION = Exception occurred while creating exception: {0}
 UNEXPECTED_WRAPPER_ELEMENT = Unexpected wrapper element {0} found.   Expected {1}.
 UNEXPECTED_ELEMENT = Unexpected element {0} found.   Expected {1}.
+ERROR_DURING_ERROR_PROCESSING=An unexpected error occurred during error handling. No further error processing will occur.
  


### PR DESCRIPTION
Use Messages.properties and change message to better indicate that an
error occurred during error handling, preventing further action.