### PR TITLE
Handle ResponseExceptionMappers

### DIFF
--- a/rt/rs/microprofile-client/src/main/java/org/apache/cxf/microprofile/client/MicroProfileClientProviderFactory.java
+++ b/rt/rs/microprofile-client/src/main/java/org/apache/cxf/microprofile/client/MicroProfileClientProviderFactory.java
@@ -21,8 +21,8 @@ package org.apache.cxf.microprofile.client;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
-import java.util.LinkedList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import javax.ws.rs.core.Configuration;
 
@@ -91,18 +91,14 @@ public final class MicroProfileClientProviderFactory extends ProviderFactory {
 
     public List<ResponseExceptionMapper<?>> createResponseExceptionMapper(Message m, Class<?> paramType) {
 
-        List<ResponseExceptionMapper<?>> candidates = new LinkedList<>();
-
-        for (ProviderInfo<ResponseExceptionMapper<?>> em : responseExceptionMappers) {
-            if (handleMapper(em, paramType, m, ResponseExceptionMapper.class, true)) {
-                candidates.add(em.getProvider());
-            }
-        }
-        if (candidates.size() == 0) {
+        if (responseExceptionMappers.isEmpty()) {
             return Collections.emptyList();
         }
-        candidates.sort(new ResponseExceptionMapperComparator());
-        return Collections.unmodifiableList(candidates);
+        return Collections.unmodifiableList(responseExceptionMappers
+                                            .stream()
+                                            .map(ProviderInfo::getProvider)
+                                            .sorted(new ResponseExceptionMapperComparator())
+                                            .collect(Collectors.toList()));
     }
 
     @Override

--- a/rt/rs/microprofile-client/src/test/java/org/apache/cxf/microprofile/client/CxfTypeSafeClientBuilderTest.java
+++ b/rt/rs/microprofile-client/src/test/java/org/apache/cxf/microprofile/client/CxfTypeSafeClientBuilderTest.java
@@ -117,8 +117,7 @@ public class CxfTypeSafeClientBuilderTest extends Assert {
             .build(ExceptionMappingClient.class);
 
         Response r = client.getEntity();
-        System.out.println(r.getStatus());
-        fail("Did not throw expected mapped exception: NoSuchEntityException");
+        fail(r, "Did not throw expected mapped exception: NoSuchEntityException");
     }
     
     @Test(expected = WebApplicationException.class)
@@ -129,7 +128,11 @@ public class CxfTypeSafeClientBuilderTest extends Assert {
             .build(ExceptionMappingClient.class);
 
         Response r = client.getEntity();
+        fail(r, "Did not throw expected mapped exception: WebApplicationException");
+    }
+    
+    private void fail(Response r, String failureMessage) {
         System.out.println(r.getStatus());
-        fail("Did not throw expected mapped exception: WebApplicationException");
+        fail(failureMessage);
     }
 }

--- a/rt/rs/microprofile-client/src/test/java/org/apache/cxf/microprofile/client/CxfTypeSafeClientBuilderTest.java
+++ b/rt/rs/microprofile-client/src/test/java/org/apache/cxf/microprofile/client/CxfTypeSafeClientBuilderTest.java
@@ -21,12 +21,17 @@ package org.apache.cxf.microprofile.client;
 import java.net.URL;
 
 import javax.ws.rs.core.Response;
+import javax.ws.rs.WebApplicationException;
 
 import org.apache.cxf.microprofile.client.mock.EchoClientReqFilter;
+import org.apache.cxf.microprofile.client.mock.ExceptionMappingClient;
 import org.apache.cxf.microprofile.client.mock.HighPriorityClientReqFilter;
 import org.apache.cxf.microprofile.client.mock.HighPriorityMBW;
 import org.apache.cxf.microprofile.client.mock.LowPriorityClientReqFilter;
 import org.apache.cxf.microprofile.client.mock.MyClient;
+import org.apache.cxf.microprofile.client.mock.NoSuchEntityException;
+import org.apache.cxf.microprofile.client.mock.NotFoundClientReqFilter;
+import org.apache.cxf.microprofile.client.mock.NotFoundExceptionMapper;
 import org.eclipse.microprofile.rest.client.RestClientBuilder;
 import org.eclipse.microprofile.rest.client.tck.interfaces.InterfaceWithoutProvidersDefined;
 import org.eclipse.microprofile.rest.client.tck.providers.TestClientRequestFilter;
@@ -103,41 +108,28 @@ public class CxfTypeSafeClientBuilderTest extends Assert {
         //assertEquals(TestWriterInterceptor.getAndResetValue(), 1);
     }
 
-/** using for test coverage
-    @Override
-    public RestClientBuilder register(Class<?> componentClass, int priority) {
-      configImpl.register(componentClass, priority);
-      return this;
-    }
+    @Test(expected = NoSuchEntityException.class)
+    public void testResponseExceptionMapper() throws Exception {
+        ExceptionMappingClient client = new CxfTypeSafeClientBuilder()
+            .register(NotFoundExceptionMapper.class)
+            .register(NotFoundClientReqFilter.class)
+            .baseUrl(new URL("http://localhost/null"))
+            .build(ExceptionMappingClient.class);
 
-    @Override
-    public RestClientBuilder register(Class<?> componentClass, Class<?>... contracts) {
-      configImpl.register(componentClass, contracts);
-      return this;
+        Response r = client.getEntity();
+        System.out.println(r.getStatus());
+        fail("Did not throw expected mapped exception: NoSuchEntityException");
     }
+    
+    @Test(expected = WebApplicationException.class)
+    public void testDefaultResponseExceptionMapper() throws Exception {
+        ExceptionMappingClient client = new CxfTypeSafeClientBuilder()
+            .register(NotFoundClientReqFilter.class)
+            .baseUrl(new URL("http://localhost/null"))
+            .build(ExceptionMappingClient.class);
 
-    @Override
-    public RestClientBuilder register(Class<?> componentClass, Map<Class<?>, Integer> contracts) {
-      configImpl.register(componentClass, contracts);
-      return this;
+        Response r = client.getEntity();
+        System.out.println(r.getStatus());
+        fail("Did not throw expected mapped exception: WebApplicationException");
     }
-
-    @Override
-    public RestClientBuilder register(Object component, int priority) {
-      configImpl.register(component, priority);
-      return this;
-    }
-
-    @Override
-    public RestClientBuilder register(Object component, Class<?>... contracts) {
-      configImpl.register(component, contracts);
-      return this;
-    }
-
-    @Override
-    public RestClientBuilder register(Object component, Map<Class<?>, Integer> contracts) {
-      configImpl.register(component, contracts);
-      return this;
-    }
-**/
 }

--- a/rt/rs/microprofile-client/src/test/java/org/apache/cxf/microprofile/client/mock/ExceptionMappingClient.java
+++ b/rt/rs/microprofile-client/src/test/java/org/apache/cxf/microprofile/client/mock/ExceptionMappingClient.java
@@ -1,0 +1,31 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.cxf.microprofile.client.mock;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.core.Response;
+
+public interface ExceptionMappingClient {
+
+    @GET
+    @Path("/wontBeFound")
+    Response getEntity() throws NoSuchEntityException;
+}

--- a/rt/rs/microprofile-client/src/test/java/org/apache/cxf/microprofile/client/mock/NoSuchEntityException.java
+++ b/rt/rs/microprofile-client/src/test/java/org/apache/cxf/microprofile/client/mock/NoSuchEntityException.java
@@ -1,0 +1,46 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.cxf.microprofile.client.mock;
+
+@SuppressWarnings("serial")
+public class NoSuchEntityException extends Exception {
+
+    public NoSuchEntityException() {
+        super();
+    }
+
+    public NoSuchEntityException(String message) {
+        super(message);
+
+    }
+
+    public NoSuchEntityException(Throwable cause) {
+        super(cause);
+    }
+
+    public NoSuchEntityException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public NoSuchEntityException(String message, Throwable cause, boolean enableSuppression,
+                                 boolean writableStackTrace) {
+        super(message, cause, enableSuppression, writableStackTrace);
+    }
+}

--- a/rt/rs/microprofile-client/src/test/java/org/apache/cxf/microprofile/client/mock/NotFoundClientReqFilter.java
+++ b/rt/rs/microprofile-client/src/test/java/org/apache/cxf/microprofile/client/mock/NotFoundClientReqFilter.java
@@ -1,0 +1,36 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.cxf.microprofile.client.mock;
+
+import java.io.IOException;
+
+import javax.annotation.Priority;
+import javax.ws.rs.client.ClientRequestContext;
+import javax.ws.rs.client.ClientRequestFilter;
+import javax.ws.rs.core.Response;
+
+@Priority(Integer.MAX_VALUE)
+public class NotFoundClientReqFilter implements ClientRequestFilter {
+
+    @Override
+    public void filter(ClientRequestContext crc) throws IOException {
+        crc.abortWith(Response.status(404).entity(crc.getEntity()).build());
+    }
+
+}

--- a/rt/rs/microprofile-client/src/test/java/org/apache/cxf/microprofile/client/mock/NotFoundExceptionMapper.java
+++ b/rt/rs/microprofile-client/src/test/java/org/apache/cxf/microprofile/client/mock/NotFoundExceptionMapper.java
@@ -1,0 +1,38 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.cxf.microprofile.client.mock;
+
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.core.Response;
+
+import org.eclipse.microprofile.rest.client.ext.ResponseExceptionMapper;
+
+public class NotFoundExceptionMapper implements ResponseExceptionMapper<NoSuchEntityException> {
+
+    @Override
+    public boolean handles(int status, MultivaluedMap<String, Object> headers) {
+        return status == 404;
+    }
+
+    @Override
+    public NoSuchEntityException toThrowable(Response response) {
+        return new NoSuchEntityException();
+    }
+}


### PR DESCRIPTION
We should not need to call handleMapper for the ResponseExceptionMappers
 - they already require the parameterized type to be a subclass of 
Throwable. And the handleMapper method checks whether the Throwable
class can be assigned to the type in the user's REM - which it never
will be (unless they define ResponseExceptionMapper<Throwable>).

This also adds unit tests ensuring that the REM is executed.

@johnament - can you review this to make sure I'm on the right track?