### PR TITLE
[CXF-7625] Handle schemeSpecificPart that looks like host:port

### DIFF
--- a/rt/frontend/jaxrs/src/main/java/org/apache/cxf/jaxrs/impl/UriBuilderImpl.java
+++ b/rt/frontend/jaxrs/src/main/java/org/apache/cxf/jaxrs/impl/UriBuilderImpl.java
@@ -639,6 +639,10 @@ public class UriBuilderImpl extends UriBuilder implements Cloneable {
         } else {
             schemeSpecificPart = uri.getSchemeSpecificPart();
         }
+        if (scheme != null && host == null && (query == null || query.isEmpty()) && userInfo == null 
+            && uri.getSchemeSpecificPart() != null) {
+            schemeSpecificPart = uri.getSchemeSpecificPart();
+        }
         String theFragment = uri.getFragment();
         if (theFragment != null) {
             fragment = theFragment;

--- a/rt/frontend/jaxrs/src/test/java/org/apache/cxf/jaxrs/impl/UriBuilderImplTest.java
+++ b/rt/frontend/jaxrs/src/test/java/org/apache/cxf/jaxrs/impl/UriBuilderImplTest.java
@@ -1606,6 +1606,37 @@ public class UriBuilderImplTest extends Assert {
         assertEquals(uri.toString(), "/sub");
     }
 
+    @Test
+    public void testURItoStringMatchesOriginalURI() {
+        String[] uriStrings = new String[]{"mailto:bob@apache.org",
+                                           "news:comp.lang.java",
+                                           "urn:isbn:096139210x",
+                                           "docs/guide/collections/designfaq.html#28",
+                                           "../../../demo/jfc/SwingSet2/src/SwingSet2.java",
+                                           "file:///~/calendar",
+                                           "bob@somehost.com",
+                                           "http://localhost/somePath",
+                                           "http://localhost:1234/someOtherPath",
+                                           "http://127.0.0.1",
+                                           "http://127.0.0.1/",
+                                           "http://127.0.0.1/index.html",
+                                           "myscheme://a.host:7575/",
+                                           "myscheme://not.really.a.host:fakePort/"
+        };
+        for (String uriString :uriStrings) {
+            URI uri = UriBuilder.fromUri(uriString).build();
+            assertEquals(uriString, uri.toString());
+        }
+    }
+
+    @Test
+    public void testURIWithNonIntegerPort() {
+        String url = "myscheme://not.really.a.host:port/";
+        UriBuilder builder = UriBuilder.fromUri(url);
+        URI uri = builder.build();
+        assertEquals(url, uri.toString());
+    }
+
     @Path(value = "/TestPath")
     public static class TestPath {
 


### PR DESCRIPTION
The JAX-RS 2.1 TCK checks that a URI that has a non-integer port - i.e.
a scheme specific part that looks like host:port. They expect that the
string returned from UriBuilder.fromUri(uri).build().toString() should
include the scheme and the scheme-specific part, but CXF currently drops
the scheme-specific part.  This change helps to ensure that we preserve
it, and adds a test similar to the TCK.