### PR TITLE
JAX-RS 2.1 TCK issues

### DIFF
--- a/rt/rs/client/src/main/java/org/apache/cxf/jaxrs/client/AbstractClient.java
+++ b/rt/rs/client/src/main/java/org/apache/cxf/jaxrs/client/AbstractClient.java
@@ -352,6 +352,10 @@ public abstract class AbstractClient implements Client {
         closed = null;
     }
 
+    public void removeAllHeaders() {
+        state.getRequestHeaders().clear();
+    }
+
     private void possiblyAddHeader(String name, String value) {
         if (!isDuplicate(name, value)) {
             state.getRequestHeaders().add(name, value);

--- a/rt/rs/client/src/main/java/org/apache/cxf/jaxrs/client/spec/ClientRequestFilterInterceptor.java
+++ b/rt/rs/client/src/main/java/org/apache/cxf/jaxrs/client/spec/ClientRequestFilterInterceptor.java
@@ -20,16 +20,19 @@ package org.apache.cxf.jaxrs.client.spec;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Map;
 
 import javax.ws.rs.ProcessingException;
 import javax.ws.rs.client.ClientRequestContext;
 import javax.ws.rs.client.ClientRequestFilter;
 import javax.ws.rs.core.Response;
 
+import org.apache.cxf.helpers.CastUtils;
 import org.apache.cxf.interceptor.AbstractOutDatabindingInterceptor;
 import org.apache.cxf.interceptor.Fault;
 import org.apache.cxf.jaxrs.client.ClientProviderFactory;
 import org.apache.cxf.jaxrs.model.ProviderInfo;
+import org.apache.cxf.jaxrs.utils.HttpUtils;
 import org.apache.cxf.jaxrs.utils.InjectionUtils;
 import org.apache.cxf.message.Exchange;
 import org.apache.cxf.message.Message;
@@ -58,6 +61,11 @@ public class ClientRequestFilterInterceptor extends AbstractOutDatabindingInterc
                 InjectionUtils.injectContexts(filter.getProvider(), filter, outMessage);
                 try {
                     filter.getProvider().filter(context);
+
+                    @SuppressWarnings("unchecked")
+                    Map<String, List<Object>> headers = CastUtils.cast((Map<String, List<Object>>) 
+                                                                       outMessage.get(Message.PROTOCOL_HEADERS));
+                    HttpUtils.convertHeaderValuesToString(headers, false);
 
                     Response response = outMessage.getExchange().get(Response.class);
                     if (response != null) {

--- a/rt/rs/client/src/main/java/org/apache/cxf/jaxrs/client/spec/InvocationBuilderImpl.java
+++ b/rt/rs/client/src/main/java/org/apache/cxf/jaxrs/client/spec/InvocationBuilderImpl.java
@@ -253,10 +253,13 @@ public class InvocationBuilderImpl implements Invocation.Builder {
 
     @Override
     public Builder headers(MultivaluedMap<String, Object> headers) {
-        RuntimeDelegate rd = HttpUtils.getOtherRuntimeDelegate();
-        for (Map.Entry<String, List<Object>> entry : headers.entrySet()) {
-            for (Object value : entry.getValue()) {
-                doSetHeader(rd, entry.getKey(), value);
+        webClient.removeAllHeaders();
+        if (headers != null) {
+            RuntimeDelegate rd = HttpUtils.getOtherRuntimeDelegate();
+            for (Map.Entry<String, List<Object>> entry : headers.entrySet()) {
+                for (Object value : entry.getValue()) {
+                    doSetHeader(rd, entry.getKey(), value);
+                }
             }
         }
         return this;

--- a/rt/rs/client/src/test/java/org/apache/cxf/jaxrs/client/spec/ClientRequestFilterTest.java
+++ b/rt/rs/client/src/test/java/org/apache/cxf/jaxrs/client/spec/ClientRequestFilterTest.java
@@ -1,0 +1,80 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.cxf.jaxrs.client.spec;
+
+import java.io.IOException;
+
+import javax.annotation.Priority;
+import javax.ws.rs.client.ClientBuilder;
+import javax.ws.rs.client.ClientRequestContext;
+import javax.ws.rs.client.ClientRequestFilter;
+import javax.ws.rs.core.Response;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class ClientRequestFilterTest extends Assert {
+
+    public static class NonStringObject {
+        private String theString;
+
+        NonStringObject(String s) {
+            theString = s;
+        }
+
+        @Override
+        public String toString() {
+            return "hello " + theString;
+        }
+    }
+
+    @Priority(1)
+    public static class AddNonStringHeaderFilter implements ClientRequestFilter {
+
+        /** {@inheritDoc}*/
+        @Override
+        public void filter(ClientRequestContext context) throws IOException {
+            context.getHeaders().add("MyHeader", new NonStringObject("rabbit"));
+        }
+    }
+
+    @Priority(2)
+    public static class TestHeaderFilter implements ClientRequestFilter {
+
+        /** {@inheritDoc}*/
+        @Override
+        public void filter(ClientRequestContext context) throws IOException {
+            Object o = context.getHeaders().getFirst("MyHeader");
+            Response r = (o instanceof String) ? Response.ok(o).build() : Response.serverError().build();
+            context.abortWith(r);
+        }
+    }
+
+    @Test
+    public void testHeaderObjectInFilterIsConvertedToString() {
+        Response response = ClientBuilder.newClient()
+                                         .register(AddNonStringHeaderFilter.class)
+                                         .register(TestHeaderFilter.class)
+                                         .target("http://localhost:8080/notReally")
+                                         .request()
+                                         .get();
+        assertEquals(200, response.getStatus());
+        assertEquals("hello rabbit", response.readEntity(String.class));
+    }
+}

--- a/rt/rs/client/src/test/java/org/apache/cxf/jaxrs/client/spec/InvocationBuilderImplTest.java
+++ b/rt/rs/client/src/test/java/org/apache/cxf/jaxrs/client/spec/InvocationBuilderImplTest.java
@@ -1,0 +1,74 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.cxf.jaxrs.client.spec;
+
+import java.io.IOException;
+
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.ClientBuilder;
+import javax.ws.rs.client.ClientRequestContext;
+import javax.ws.rs.client.ClientRequestFilter;
+import javax.ws.rs.client.Invocation.Builder;
+import javax.ws.rs.core.MultivaluedHashMap;
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.core.Response;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class InvocationBuilderImplTest extends Assert {
+
+    public static class TestFilter implements ClientRequestFilter {
+
+        /** {@inheritDoc}*/
+        @Override
+        public void filter(ClientRequestContext context) throws IOException {
+            MultivaluedMap<String, Object> headers = context.getHeaders();
+            StringBuilder entity = new StringBuilder();
+            for (String key : headers.keySet()) {
+                entity.append(key).append("=").append(headers.getFirst(key)).append(";");
+            }
+            context.abortWith(Response.ok(entity.toString()).build());
+        }
+        
+    }
+
+    @Test
+    public void testHeadersMethod() {
+        // the javadoc for the Invocation.Builder.headers(MultivaluedMap) method says that
+        // invoking this method should remove all previously existing headers
+        Client client = ClientBuilder.newClient().register(TestFilter.class);
+        Builder builder = client.target("http://localhost:8080/notReal").request();
+        builder.header("Header1", "a");
+        builder.header("UnexpectedHeader", "should be removed");
+        MultivaluedMap<String, Object> map = new MultivaluedHashMap<>();
+        map.putSingle("Header1", "b");
+        builder.headers(map);
+
+        Response response = builder.get();
+        String sentHeaders = response.readEntity(String.class);
+        assertTrue(sentHeaders.contains("Header1=b"));
+        assertFalse(sentHeaders.contains("UnexpectedHeader"));
+        
+        // null headers map should clear all headers
+        builder.headers(null);
+        response = builder.get();
+        assertEquals("", response.readEntity(String.class));
+    }
+}

--- a/rt/rs/sse/src/main/java/org/apache/cxf/jaxrs/sse/client/SseEventSourceImpl.java
+++ b/rt/rs/sse/src/main/java/org/apache/cxf/jaxrs/sse/client/SseEventSourceImpl.java
@@ -29,12 +29,11 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 import java.util.logging.Logger;
 
+import javax.ws.rs.client.Invocation;
 import javax.ws.rs.client.WebTarget;
 import javax.ws.rs.core.Configuration;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.MultivaluedHashMap;
-import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.sse.InboundSseEvent;
 import javax.ws.rs.sse.SseEventSource;
@@ -184,16 +183,12 @@ public class SseEventSourceImpl implements SseEventSource {
         Response response = null;
         
         try {
-            final MultivaluedMap<String, Object> headers = new MultivaluedHashMap<>();
+            Invocation.Builder builder = target.request(MediaType.SERVER_SENT_EVENTS);
             if (lastEventId != null) {
-                headers.putSingle(HttpHeaders.LAST_EVENT_ID_HEADER, lastEventId);
+                builder.header(HttpHeaders.LAST_EVENT_ID_HEADER, lastEventId);
             }
-            
-            response = target
-                .request(MediaType.SERVER_SENT_EVENTS)
-                .headers(headers)
-                .get();
-            
+            response = builder.get();
+
             // A client can be told to stop reconnecting using the HTTP 204 No Content 
             // response code. In this case, we should give up.
             if (response.getStatus() == 204) {

--- a/rt/rs/sse/src/test/java/org/apache/cxf/jaxrs/sse/client/SseEventSourceImplTest.java
+++ b/rt/rs/sse/src/test/java/org/apache/cxf/jaxrs/sse/client/SseEventSourceImplTest.java
@@ -35,7 +35,6 @@ import java.util.concurrent.TimeUnit;
 import javax.ws.rs.client.Invocation;
 import javax.ws.rs.core.Configuration;
 import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.sse.InboundSseEvent;
 import javax.ws.rs.sse.SseEventSource;
@@ -132,13 +131,12 @@ public class SseEventSourceImplTest extends Assert {
     @Mock
     private Response response;
 
-    @SuppressWarnings("unchecked")
     @Before
     public void setUp() {
         when(target.getConfiguration()).thenReturn(configuration);
         when(target.getWebClient()).thenReturn(client);
         when(target.request(MediaType.SERVER_SENT_EVENTS)).thenReturn(builder);
-        when(builder.headers(any(MultivaluedMap.class))).thenReturn(builder);
+        when(builder.header(any(String.class), any(Object.class))).thenReturn(builder);
         when(builder.get()).thenReturn(response);
         when(client.getConfiguration()).thenReturn(clientConfiguration);
         when(clientConfiguration.getEndpoint()).thenReturn(endpoint);

--- a/rt/transports/http/src/main/java/org/apache/cxf/transport/http/Headers.java
+++ b/rt/transports/http/src/main/java/org/apache/cxf/transport/http/Headers.java
@@ -43,7 +43,6 @@ import javax.servlet.http.HttpServletResponse;
 
 import org.apache.cxf.common.logging.LogUtils;
 import org.apache.cxf.common.util.PropertyUtils;
-import org.apache.cxf.common.util.StringUtils;
 import org.apache.cxf.helpers.CastUtils;
 import org.apache.cxf.helpers.HttpHeaderHelper;
 import org.apache.cxf.message.Message;
@@ -587,13 +586,6 @@ public class Headers {
     }
 
     public static String toHttpLanguage(Locale locale) {
-        StringBuilder sb = new StringBuilder();
-        sb.append(locale.getLanguage());
-        String country = locale.getCountry();
-        if (!StringUtils.isEmpty(country)) {
-            // Locale.toString() will add "_" instead, '-' is typically expected
-            sb.append('-').append(country);
-        }
-        return sb.toString();
+        return locale.toString().replace('_', '-');
     }
 }

--- a/rt/transports/http/src/main/java/org/apache/cxf/transport/http/Headers.java
+++ b/rt/transports/http/src/main/java/org/apache/cxf/transport/http/Headers.java
@@ -43,6 +43,7 @@ import javax.servlet.http.HttpServletResponse;
 
 import org.apache.cxf.common.logging.LogUtils;
 import org.apache.cxf.common.util.PropertyUtils;
+import org.apache.cxf.common.util.StringUtils;
 import org.apache.cxf.helpers.CastUtils;
 import org.apache.cxf.helpers.HttpHeaderHelper;
 import org.apache.cxf.message.Message;
@@ -588,9 +589,10 @@ public class Headers {
     public static String toHttpLanguage(Locale locale) {
         StringBuilder sb = new StringBuilder();
         sb.append(locale.getLanguage());
-        if (locale.getCountry() != null) {
+        String country = locale.getCountry();
+        if (!StringUtils.isEmpty(country)) {
             // Locale.toString() will add "_" instead, '-' is typically expected
-            sb.append('-').append(locale.getCountry());
+            sb.append('-').append(country);
         }
         return sb.toString();
     }

--- a/rt/transports/http/src/test/java/org/apache/cxf/transport/http/HeadersTest.java
+++ b/rt/transports/http/src/test/java/org/apache/cxf/transport/http/HeadersTest.java
@@ -22,6 +22,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.logging.Handler;
 import java.util.logging.Level;
@@ -206,5 +207,20 @@ public class HeadersTest extends Assert {
                      headers.determineContentType());
 
         control.verify();
+    }
+    
+    @Test
+    public void httpLanguage() {
+        Locale locale = new Locale("en", "US");
+        assertEquals("en-US", Headers.toHttpLanguage(locale));
+
+        locale = new Locale("de");
+        assertEquals("de", Headers.toHttpLanguage(locale));
+
+        locale = new Locale("aa", "ZZ");
+        assertEquals("aa-ZZ", Headers.toHttpLanguage(locale));
+
+        locale = new Locale("es", "");
+        assertEquals("es", Headers.toHttpLanguage(locale));
     }
 }


### PR DESCRIPTION
In testing the JAX-RS 2.1 TCK, we've found a few issues:
1) The `Headers.toHttpLanguage(...)` method will return things like "en-" in some cases - I believe this is because there is an empty (but non-null) country passed in as part of the Locale.  This seems like an error condition to me, but it seems to be tested by the TCK, so the fix is pretty simple - just checking whether the country is non-empty rather than just non-null.
2) The javadoc for `Invocation.Builder.headers(...)` method says that when called, all pre-existing headers must be removed.  Currently, we're just adding the new headers, but not removing the old ones.  

I provided test cases for these conditions, but I won't have confirmation that these fixes actually pass the TCK until tomorrow, but I wanted to get the PR out now to ensure that the fixes get into the 3.2.2 release.  If the fixes are unsuccessful, I'll abort this PR and try again after 3.2.2 is released.  If they are successful (and assuming no glaring issues uncovered during review), then I'll plan to merge ASAP.

Thanks, Andy