### PR TITLE
[CXF-7630] Do not preset namebindings when installing through a Feature

### DIFF
--- a/rt/frontend/jaxrs/src/main/java/org/apache/cxf/jaxrs/model/FilterProviderInfo.java
+++ b/rt/frontend/jaxrs/src/main/java/org/apache/cxf/jaxrs/model/FilterProviderInfo.java
@@ -49,7 +49,7 @@ public class FilterProviderInfo<T> extends ProviderInfo<T> {
                               boolean dynamic,
                               Map<Class<?>, Integer> supportedContracts) {
         super(resourceClass, serviceClass, provider, bus, true);
-        this.nameBinding = Collections.singleton(nameBinding);
+        this.nameBinding = nameBinding == null ? null : Collections.singleton(nameBinding);
         this.supportedContracts = supportedContracts;
         this.dynamic = dynamic;
     }

--- a/rt/frontend/jaxrs/src/main/java/org/apache/cxf/jaxrs/provider/ServerProviderFactory.java
+++ b/rt/frontend/jaxrs/src/main/java/org/apache/cxf/jaxrs/provider/ServerProviderFactory.java
@@ -219,6 +219,8 @@ public final class ServerProviderFactory extends ProviderFactory {
                                                                         providerCls,
                                                                         featureProvider,
                                                                         getBus(),
+                                                                        null,
+                                                                        false,
                                                                         contracts));
                     } else {
                         allProviders.add(featureProvider);

--- a/systests/jaxrs/src/test/java/org/apache/cxf/systest/jaxrs/BookServer20.java
+++ b/systests/jaxrs/src/test/java/org/apache/cxf/systest/jaxrs/BookServer20.java
@@ -90,7 +90,11 @@ public class BookServer20 extends AbstractBusTestServerBase {
         providers.add(new PreMatchContainerRequestFilter2());
         providers.add(new PreMatchContainerRequestFilter());
         providers.add(new PostMatchContainerResponseFilter());
-        providers.add(new PostMatchContainerResponseFilter3());
+        providers.add((Feature) context -> {
+            context.register(new PostMatchContainerResponseFilter3());
+
+            return true;
+        });
         providers.add(new PostMatchContainerResponseFilter2());
         providers.add(new CustomReaderBoundInterceptor());
         providers.add(new CustomReaderInterceptor());


### PR DESCRIPTION
This makes `@NameBinding` work also when installing filters using a `Feature`