### PR TITLE
[CXF-7638] Only register provider if it implements specified contracts

### DIFF
--- a/integration/cdi/src/main/java/org/apache/cxf/cdi/CdiServerConfigurableFactory.java
+++ b/integration/cdi/src/main/java/org/apache/cxf/cdi/CdiServerConfigurableFactory.java
@@ -83,7 +83,7 @@ public class CdiServerConfigurableFactory implements ServerConfigurableFactory {
         private final Instantiator instantiator;
         
         CdiServerFeatureContextConfigurable(FeatureContext mc, BeanManager beanManager) {
-            super(mc, RuntimeType.SERVER, SERVER_FILTER_INTERCEPTOR_CLASSES);
+            super(mc, RuntimeType.SERVER);
             this.instantiator = new CdiInstantiator(beanManager);
         }
         

--- a/rt/frontend/jaxrs/src/main/java/org/apache/cxf/jaxrs/impl/ConfigurationImpl.java
+++ b/rt/frontend/jaxrs/src/main/java/org/apache/cxf/jaxrs/impl/ConfigurationImpl.java
@@ -74,7 +74,8 @@ public class ConfigurationImpl implements Configuration {
         if (contracts != null) {
             providers.put(o, contracts);
         } else {
-            register(o, AnnotationUtils.getBindingPriority(o.getClass()), ConfigurableImpl.getImplementedContracts(o));
+            register(o, AnnotationUtils.getBindingPriority(o.getClass()), 
+                        ConfigurableImpl.getImplementedContracts(o, new Class<?>[]{}));
         }
     }
 

--- a/rt/frontend/jaxrs/src/main/java/org/apache/cxf/jaxrs/impl/ConfigurationImpl.java
+++ b/rt/frontend/jaxrs/src/main/java/org/apache/cxf/jaxrs/impl/ConfigurationImpl.java
@@ -132,13 +132,15 @@ public class ConfigurationImpl implements Configuration {
 
     @Override
     public boolean isEnabled(Feature f) {
-        return features.containsKey(f);
+        return features.containsKey(f) && features.get(f);
     }
 
     @Override
     public boolean isEnabled(Class<? extends Feature> f) {
-        for (Feature feature : features.keySet()) {
-            if (feature.getClass().isAssignableFrom(f)) {
+        for (Entry<Feature, Boolean> entry : features.entrySet()) {
+            Feature feature = entry.getKey();
+            Boolean enabled = entry.getValue();
+            if (f.isAssignableFrom(feature.getClass()) && enabled.booleanValue()) {
                 return true;
             }
         }

--- a/rt/frontend/jaxrs/src/main/java/org/apache/cxf/jaxrs/provider/ServerConfigurableFactory.java
+++ b/rt/frontend/jaxrs/src/main/java/org/apache/cxf/jaxrs/provider/ServerConfigurableFactory.java
@@ -19,12 +19,8 @@
 
 package org.apache.cxf.jaxrs.provider;
 
-import javax.ws.rs.container.ContainerRequestFilter;
-import javax.ws.rs.container.ContainerResponseFilter;
 import javax.ws.rs.core.Configurable;
 import javax.ws.rs.core.FeatureContext;
-import javax.ws.rs.ext.ReaderInterceptor;
-import javax.ws.rs.ext.WriterInterceptor;
 
 /**
  * Manages the creation of server-side {@code Configurable<FeatureContext>} depending on 
@@ -34,12 +30,6 @@ import javax.ws.rs.ext.WriterInterceptor;
  * notice, please be aware of that. 
  */
 public interface ServerConfigurableFactory {
-    Class<?>[] SERVER_FILTER_INTERCEPTOR_CLASSES = new Class<?>[] {
-        ContainerRequestFilter.class,
-        ContainerResponseFilter.class,
-        ReaderInterceptor.class,
-        WriterInterceptor.class 
-    };
-    
+
     Configurable<FeatureContext> create(FeatureContext context);
 }

--- a/rt/frontend/jaxrs/src/main/java/org/apache/cxf/jaxrs/provider/ServerProviderFactory.java
+++ b/rt/frontend/jaxrs/src/main/java/org/apache/cxf/jaxrs/provider/ServerProviderFactory.java
@@ -453,7 +453,7 @@ public final class ServerProviderFactory extends ProviderFactory {
 
     private static class ServerFeatureContextConfigurable extends ConfigurableImpl<FeatureContext> {
         protected ServerFeatureContextConfigurable(FeatureContext mc) {
-            super(mc, RuntimeType.SERVER, ServerConfigurableFactory.SERVER_FILTER_INTERCEPTOR_CLASSES);
+            super(mc, RuntimeType.SERVER);
         }
     }
 

--- a/rt/rs/client/src/main/java/org/apache/cxf/jaxrs/client/spec/ClientConfigurableImpl.java
+++ b/rt/rs/client/src/main/java/org/apache/cxf/jaxrs/client/spec/ClientConfigurableImpl.java
@@ -20,22 +20,13 @@
 package org.apache.cxf.jaxrs.client.spec;
 
 import javax.ws.rs.RuntimeType;
-import javax.ws.rs.client.ClientRequestFilter;
-import javax.ws.rs.client.ClientResponseFilter;
 import javax.ws.rs.core.Configurable;
 import javax.ws.rs.core.Configuration;
-import javax.ws.rs.ext.ReaderInterceptor;
-import javax.ws.rs.ext.WriterInterceptor;
 
 import org.apache.cxf.jaxrs.impl.ConfigurableImpl;
 import org.apache.cxf.jaxrs.impl.ConfigurationImpl;
 
 public class ClientConfigurableImpl<C extends Configurable<C>> extends ConfigurableImpl<C> {
-    private static final Class<?>[] CLIENT_FILTER_INTERCEPTOR_CLASSES =
-        new Class<?>[] {ClientRequestFilter.class,
-                        ClientResponseFilter.class,
-                        ReaderInterceptor.class,
-                        WriterInterceptor.class};
 
 
     public ClientConfigurableImpl(C configurable) {
@@ -44,8 +35,7 @@ public class ClientConfigurableImpl<C extends Configurable<C>> extends Configura
 
     public ClientConfigurableImpl(C configurable, Configuration config) {
         super(configurable,
-              CLIENT_FILTER_INTERCEPTOR_CLASSES,
               config == null ? new ConfigurationImpl(RuntimeType.CLIENT)
-                  : new ConfigurationImpl(config, CLIENT_FILTER_INTERCEPTOR_CLASSES));
+                  : new ConfigurationImpl(config));
     }
 }

--- a/rt/rs/client/src/test/java/org/apache/cxf/jaxrs/client/spec/ClientImplTest.java
+++ b/rt/rs/client/src/test/java/org/apache/cxf/jaxrs/client/spec/ClientImplTest.java
@@ -164,7 +164,7 @@ public class ClientImplTest extends Assert {
         ClientBuilder.newClient().register(MyInterceptor.class, (Class<?>[]) null);
 
         for (String message : handler.messages) {
-            if (message.startsWith("WARN") && message.contains("Null or empty contracts")) {
+            if (message.startsWith("WARN") && message.contains("Null, empty or invalid contracts specified")) {
                 return; // success
             }
         }
@@ -181,7 +181,7 @@ public class ClientImplTest extends Assert {
         ClientBuilder.newClient().register(new MyInterceptor(), (Class<?>[]) null);
 
         for (String message : handler.messages) {
-            if (message.startsWith("WARN") && message.contains("Null or empty contracts")) {
+            if (message.startsWith("WARN") && message.contains("Null, empty or invalid contracts specified")) {
                 return; // success
             }
         }

--- a/rt/rs/microprofile-client/src/main/java/org/apache/cxf/microprofile/client/MicroProfileClientConfigurableImpl.java
+++ b/rt/rs/microprofile-client/src/main/java/org/apache/cxf/microprofile/client/MicroProfileClientConfigurableImpl.java
@@ -46,9 +46,8 @@ public class MicroProfileClientConfigurableImpl<C extends Configurable<C>>
     }
 
     public MicroProfileClientConfigurableImpl(C configurable, Configuration config) {
-        super(configurable,
-                CONTRACTS, config == null ? new ConfigurationImpl(RuntimeType.CLIENT)
-                        : new ConfigurationImpl(config, CONTRACTS));
+        super(configurable, config == null ? new ConfigurationImpl(RuntimeType.CLIENT)
+                        : new ConfigurationImpl(config));
     }
 
     boolean isDefaultExceptionMapperDisabled() {


### PR DESCRIPTION
Per JAX-RS javadoc, all registered components must implement the
contracts specified in the passed in array of Classes or the map of 
contracts to priorities.  CXF should also log a warning when an invalid
contract is passed in to alert the user that the call to register has
been ignored.

Since ServerProviderFactory and CdiServerConfigurableFactory also used
this same registration mechanism (passing in server side filters/
interceptors, these parts also needed changes.

Looking for a review because I'm not 100% certain what the supportedContracts flow was really doing or if there are any negative effects from removing it.