### PR TITLE
[CXF-7639] Update dependency to servlet 4.0

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -63,7 +63,7 @@
         <cxf.osgi.javax.stream.version>[0.0,2)</cxf.osgi.javax.stream.version>
         <cxf.osgi.javax.activation.version>[0.0,2)</cxf.osgi.javax.activation.version>
         <cxf.osgi.javax.mail.version>[0.0,2)</cxf.osgi.javax.mail.version>
-        <cxf.osgi.javax.servlet.version>[0.0,4)</cxf.osgi.javax.servlet.version>
+        <cxf.osgi.javax.servlet.version>[0.0,4.1)</cxf.osgi.javax.servlet.version>
         <cxf.osgi.javax.xml.ws.version>[0.0,3)</cxf.osgi.javax.xml.ws.version>
         <!-- please maintain alphabetical order here -->
         <cxf.abdera.version>1.1.3</cxf.abdera.version>


### PR DESCRIPTION
Updating the Import-Package of javax.servlet.* packages to include 4.0.  This is a small change, but is used in several modules.  I'm mainly looking for an automated build to confirm that this change doesn't break anything, but review/suggestions welcome.  Thanks!