### PR TITLE
CXF-7659: Improve SSE automatic configuration. 

### DIFF
--- a/core/src/main/java/org/apache/cxf/bus/managers/DestinationFactoryManagerImpl.java
+++ b/core/src/main/java/org/apache/cxf/bus/managers/DestinationFactoryManagerImpl.java
@@ -135,7 +135,7 @@ public final class DestinationFactoryManagerImpl implements DestinationFactoryMa
     }
     
     @Override
-    public Set<String> getRegisterDestinationFactoryNames() {
+    public Set<String> getRegisteredDestinationFactoryNames() {
         return destinationFactories == null ? Collections.emptySet() 
                 : Collections.unmodifiableSet(destinationFactories.keySet());
     }

--- a/core/src/main/java/org/apache/cxf/bus/managers/DestinationFactoryManagerImpl.java
+++ b/core/src/main/java/org/apache/cxf/bus/managers/DestinationFactoryManagerImpl.java
@@ -19,6 +19,7 @@
 
 package org.apache.cxf.bus.managers;
 
+import java.util.Collections;
 import java.util.Map;
 import java.util.Properties;
 import java.util.ResourceBundle;
@@ -108,6 +109,7 @@ public final class DestinationFactoryManagerImpl implements DestinationFactoryMa
      *
      * @param namespace the namespace.
      */
+    @Override
     public DestinationFactory getDestinationFactory(String namespace) throws BusException {
         DestinationFactory factory = destinationFactories.get(namespace);
         if (factory == null && !failed.contains(namespace)) {
@@ -124,11 +126,17 @@ public final class DestinationFactoryManagerImpl implements DestinationFactoryMa
         return factory;
     }
 
+    @Override
     public DestinationFactory getDestinationFactoryForUri(String uri) {
         return new TransportFinder<DestinationFactory>(bus,
                 destinationFactories,
                 loaded,
                 DestinationFactory.class).findTransportForURI(uri);
     }
-
+    
+    @Override
+    public Set<String> getRegisterDestinationFactoryNames() {
+        return destinationFactories == null ? Collections.emptySet() 
+                : Collections.unmodifiableSet(destinationFactories.keySet());
+    }
 }

--- a/core/src/main/java/org/apache/cxf/transport/AbstractTransportFactory.java
+++ b/core/src/main/java/org/apache/cxf/transport/AbstractTransportFactory.java
@@ -26,6 +26,8 @@ import java.util.Set;
  * Helper methods for {@link DestinationFactory}s and {@link ConduitInitiator}s.
  */
 public abstract class AbstractTransportFactory {
+    public static final String PREFERRED_TRANSPORT_ID = "org.apache.cxf.preferred.transport.id";
+    
     private List<String> transportIds;
 
     public AbstractTransportFactory() {

--- a/core/src/main/java/org/apache/cxf/transport/DestinationFactoryManager.java
+++ b/core/src/main/java/org/apache/cxf/transport/DestinationFactoryManager.java
@@ -49,7 +49,7 @@ public interface DestinationFactoryManager {
      * Returns all registered (as of the moment of the call) destination factories.
      * @return all registered (as of the moment of the call) destination factories.
      */
-    Set<String> getRegisterDestinationFactoryNames();
+    Set<String> getRegisteredDestinationFactoryNames();
 
     /**
      * Returns the <code>DestinationFactory</code> registered with the specified name,

--- a/core/src/main/java/org/apache/cxf/transport/DestinationFactoryManager.java
+++ b/core/src/main/java/org/apache/cxf/transport/DestinationFactoryManager.java
@@ -19,6 +19,8 @@
 
 package org.apache.cxf.transport;
 
+import java.util.Set;
+
 import org.apache.cxf.BusException;
 
 /**
@@ -42,6 +44,12 @@ public interface DestinationFactoryManager {
      * <code>DestinationFactory</code>.
      */
     void deregisterDestinationFactory(String name);
+    
+    /**
+     * Returns all registered (as of the moment of the call) destination factories.
+     * @return all registered (as of the moment of the call) destination factories.
+     */
+    Set<String> getRegisterDestinationFactoryNames();
 
     /**
      * Returns the <code>DestinationFactory</code> registered with the specified name,
@@ -53,5 +61,13 @@ public interface DestinationFactoryManager {
      */
     DestinationFactory getDestinationFactory(String name) throws BusException;
 
+    /**
+     * Returns the <code>DestinationFactory</code> registered with the specified URI,
+     * loading the appropriate plugin if necessary.
+     *
+     * @param uri the uri to look up <code>DestinationFactory</code>
+     * @return the registered <code>DestinationFactory</code>
+     * @throws BusException
+     */
     DestinationFactory getDestinationFactoryForUri(String uri);
 }

--- a/rt/rs/sse/src/main/java/org/apache/cxf/jaxrs/sse/ext/SseTransportCustomizationExtension.java
+++ b/rt/rs/sse/src/main/java/org/apache/cxf/jaxrs/sse/ext/SseTransportCustomizationExtension.java
@@ -18,10 +18,12 @@
  */
 package org.apache.cxf.jaxrs.sse.ext;
 
+import org.apache.cxf.Bus;
 import org.apache.cxf.jaxrs.JAXRSServerFactoryBean;
 import org.apache.cxf.jaxrs.ext.JAXRSServerFactoryCustomizationExtension;
 import org.apache.cxf.jaxrs.sse.SseContextProvider;
 import org.apache.cxf.jaxrs.sse.atmosphere.SseAtmosphereEventSinkContextProvider;
+import org.apache.cxf.transport.AbstractTransportFactory;
 import org.apache.cxf.transport.sse.SseHttpTransportFactory;
 
 public class SseTransportCustomizationExtension implements JAXRSServerFactoryCustomizationExtension {
@@ -30,5 +32,10 @@ public class SseTransportCustomizationExtension implements JAXRSServerFactoryCus
         bean.setTransportId(SseHttpTransportFactory.TRANSPORT_ID);
         bean.setProvider(new SseContextProvider());
         bean.setProvider(new SseAtmosphereEventSinkContextProvider());
+        
+        final Bus bus = bean.getBus();
+        if (bus != null) {
+            bus.setProperty(AbstractTransportFactory.PREFERRED_TRANSPORT_ID, SseHttpTransportFactory.TRANSPORT_ID);
+        }
     }
 }

--- a/rt/transports/http/src/main/java/org/apache/cxf/transport/servlet/CXFNonSpringServlet.java
+++ b/rt/transports/http/src/main/java/org/apache/cxf/transport/servlet/CXFNonSpringServlet.java
@@ -21,6 +21,7 @@ package org.apache.cxf.transport.servlet;
 import java.io.IOException;
 import java.lang.reflect.Method;
 import java.util.Collection;
+import java.util.Set;
 
 import javax.servlet.FilterChain;
 import javax.servlet.ServletConfig;
@@ -41,6 +42,7 @@ import org.apache.cxf.common.classloader.ClassLoaderUtils.ClassLoaderHolder;
 import org.apache.cxf.common.util.StringUtils;
 import org.apache.cxf.helpers.CastUtils;
 import org.apache.cxf.resource.ResourceManager;
+import org.apache.cxf.transport.AbstractTransportFactory;
 import org.apache.cxf.transport.DestinationFactory;
 import org.apache.cxf.transport.DestinationFactoryManager;
 import org.apache.cxf.transport.http.AbstractHTTPDestination;
@@ -53,7 +55,7 @@ public class CXFNonSpringServlet extends AbstractHTTPServlet {
 
     private static final long serialVersionUID = -2437897227486327166L;
     private static final String IGNORE_SERVLET_CONTEXT_RESOLVER = "ignore.servlet.context.resolver";
-
+    private static final String DEFAULT_TRANSPORT_ID = "http://cxf.apache.org/transports/http/configuration";
     protected Bus bus;
     private DestinationRegistry destinationRegistry;
     private boolean globalRegistry;
@@ -116,9 +118,31 @@ public class CXFNonSpringServlet extends AbstractHTTPServlet {
     protected DestinationRegistry getDestinationRegistryFromBusOrDefault(final String transportId) {
         DestinationFactoryManager dfm = bus.getExtension(DestinationFactoryManager.class);
         try {
-            DestinationFactory df = StringUtils.isEmpty(transportId)
-                ? dfm.getDestinationFactory("http://cxf.apache.org/transports/http/configuration")
-                    : dfm.getDestinationFactory(transportId);
+            String peferredTransportId = transportId;
+            
+            // Check if the preferred transport is set on a bus level (f.e., from any
+            // extension or customization).
+            if (StringUtils.isEmpty(peferredTransportId) && getBus() != null) {
+                peferredTransportId = (String)getBus().getProperty(AbstractTransportFactory.PREFERRED_TRANSPORT_ID);
+            }
+            
+            if (StringUtils.isEmpty(peferredTransportId)) {
+                final Set<String> candidates = dfm.getRegisterDestinationFactoryNames();
+                
+                // If the default transport is present, fall back to it and don't even 
+                // consider other candidates
+                if (!candidates.contains(DEFAULT_TRANSPORT_ID)) {
+                    peferredTransportId = candidates
+                        .stream()
+                        .filter(name -> name.endsWith("/configuration"))
+                        .findAny()
+                        .orElse(DEFAULT_TRANSPORT_ID);
+                }
+            }
+            
+            DestinationFactory df = StringUtils.isEmpty(peferredTransportId)
+                ? dfm.getDestinationFactory(DEFAULT_TRANSPORT_ID)
+                    : dfm.getDestinationFactory(peferredTransportId);
             if (df instanceof HTTPTransportFactory) {
                 HTTPTransportFactory transportFactory = (HTTPTransportFactory)df;
                 return transportFactory.getRegistry();

--- a/rt/transports/http/src/main/java/org/apache/cxf/transport/servlet/CXFNonSpringServlet.java
+++ b/rt/transports/http/src/main/java/org/apache/cxf/transport/servlet/CXFNonSpringServlet.java
@@ -56,6 +56,7 @@ public class CXFNonSpringServlet extends AbstractHTTPServlet {
     private static final long serialVersionUID = -2437897227486327166L;
     private static final String IGNORE_SERVLET_CONTEXT_RESOLVER = "ignore.servlet.context.resolver";
     private static final String DEFAULT_TRANSPORT_ID = "http://cxf.apache.org/transports/http/configuration";
+    
     protected Bus bus;
     private DestinationRegistry destinationRegistry;
     private boolean globalRegistry;
@@ -127,7 +128,7 @@ public class CXFNonSpringServlet extends AbstractHTTPServlet {
             }
             
             if (StringUtils.isEmpty(peferredTransportId)) {
-                final Set<String> candidates = dfm.getRegisterDestinationFactoryNames();
+                final Set<String> candidates = dfm.getRegisteredDestinationFactoryNames();
                 
                 // If the default transport is present, fall back to it and don't even 
                 // consider other candidates


### PR DESCRIPTION
Enhanced the default transport selection mechanism to consult bus property and already registered destination factories. It gives customization extensions (like SSE for example) to hint about preferred transport to use in case none of them is specified explicitly. 