### PR TITLE
[CXF-7670] create a single ClassResourceInfo per class + annotated method

### DIFF
--- a/core/src/main/java/org/apache/cxf/helpers/DOMUtils.java
+++ b/core/src/main/java/org/apache/cxf/helpers/DOMUtils.java
@@ -99,6 +99,7 @@ public final class DOMUtils {
             DocumentBuilderFactory f = DocumentBuilderFactory.newInstance();
             f.setNamespaceAware(true);
             f.setFeature(javax.xml.XMLConstants.FEATURE_SECURE_PROCESSING, true);
+            f.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
             return f.newDocumentBuilder();
         }
         DocumentBuilder factory = DOCUMENT_BUILDERS.get(loader);
@@ -106,6 +107,7 @@ public final class DOMUtils {
             DocumentBuilderFactory f2 = DocumentBuilderFactory.newInstance();
             f2.setNamespaceAware(true);
             f2.setFeature(javax.xml.XMLConstants.FEATURE_SECURE_PROCESSING, true);
+            f2.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
             factory = f2.newDocumentBuilder();
             DOCUMENT_BUILDERS.put(loader, factory);
         }

--- a/rt/databinding/aegis/src/main/java/org/apache/cxf/aegis/type/XMLTypeCreator.java
+++ b/rt/databinding/aegis/src/main/java/org/apache/cxf/aegis/type/XMLTypeCreator.java
@@ -115,6 +115,11 @@ public class XMLTypeCreator extends AbstractTypeCreator {
     static {
         AEGIS_DOCUMENT_BUILDER_FACTORY = DocumentBuilderFactory.newInstance();
         AEGIS_DOCUMENT_BUILDER_FACTORY.setNamespaceAware(true);
+        try {
+            AEGIS_DOCUMENT_BUILDER_FACTORY.setFeature(javax.xml.XMLConstants.FEATURE_SECURE_PROCESSING, true);
+        } catch (javax.xml.parsers.ParserConfigurationException ex) {
+            // ignore
+        }
 
         String path = "/META-INF/cxf/aegis.xsd";
         InputStream is = XMLTypeCreator.class.getResourceAsStream(path);

--- a/rt/frontend/jaxrs/src/main/java/org/apache/cxf/jaxrs/utils/ResourceUtils.java
+++ b/rt/frontend/jaxrs/src/main/java/org/apache/cxf/jaxrs/utils/ResourceUtils.java
@@ -311,44 +311,54 @@ public final class ResourceUtils {
         MethodDispatcher md = new MethodDispatcher();
         Class<?> serviceClass = cri.getServiceClass();
 
+        final Set<Method> annotatedMethods = new HashSet<>();
+
         for (Method m : serviceClass.getMethods()) {
 
             Method annotatedMethod = AnnotationUtils.getAnnotatedMethod(serviceClass, m);
 
-            String httpMethod = AnnotationUtils.getHttpMethodValue(annotatedMethod);
-            Path path = AnnotationUtils.getMethodAnnotation(annotatedMethod, Path.class);
-
-            if (httpMethod != null || path != null) {
-                if (!checkAsyncResponse(annotatedMethod)) {
-                    continue;
-                }
-
-                md.bind(createOperationInfo(m, annotatedMethod, cri, path, httpMethod), m);
-                if (httpMethod == null) {
-                    // subresource locator
-                    Class<?> subClass = m.getReturnType();
-                    if (subClass == Class.class) {
-                        subClass = InjectionUtils.getActualType(m.getGenericReturnType());
-                    }
-                    if (enableStatic) {
-                        ClassResourceInfo subCri = cri.findResource(subClass, subClass);
-                        if (subCri == null) {
-                            ClassResourceInfo ancestor = getAncestorWithSameServiceClass(cri, subClass);
-                            subCri = ancestor != null ? ancestor
-                                     : createClassResourceInfo(subClass, subClass, cri, false, enableStatic,
-                                                               cri.getBus());
-                        }
-
-                        if (subCri != null) {
-                            cri.addSubClassResourceInfo(subCri);
-                        }
-                    }
-                }
-            } else {
-                reportInvalidResourceMethod(m, NOT_RESOURCE_METHOD_MESSAGE_ID, Level.FINE);
+            if (!annotatedMethods.contains(annotatedMethod)) {
+                evaluateResourceMethod(cri, enableStatic, md, m, annotatedMethod);
+                annotatedMethods.add(annotatedMethod);
             }
+
         }
         cri.setMethodDispatcher(md);
+    }
+
+    private static void evaluateResourceMethod(ClassResourceInfo cri, boolean enableStatic, MethodDispatcher md, Method m, Method annotatedMethod) {
+        String httpMethod = AnnotationUtils.getHttpMethodValue(annotatedMethod);
+        Path path = AnnotationUtils.getMethodAnnotation(annotatedMethod, Path.class);
+
+        if (httpMethod != null || path != null) {
+            if (!checkAsyncResponse(annotatedMethod)) {
+                return;
+            }
+
+            md.bind(createOperationInfo(m, annotatedMethod, cri, path, httpMethod), m);
+            if (httpMethod == null) {
+                // subresource locator
+                Class<?> subClass = m.getReturnType();
+                if (subClass == Class.class) {
+                    subClass = InjectionUtils.getActualType(m.getGenericReturnType());
+                }
+                if (enableStatic) {
+                    ClassResourceInfo subCri = cri.findResource(subClass, subClass);
+                    if (subCri == null) {
+                        ClassResourceInfo ancestor = getAncestorWithSameServiceClass(cri, subClass);
+                        subCri = ancestor != null ? ancestor
+                                : createClassResourceInfo(subClass, subClass, cri, false, enableStatic,
+                                cri.getBus());
+                    }
+
+                    if (subCri != null) {
+                        cri.addSubClassResourceInfo(subCri);
+                    }
+                }
+            }
+        } else {
+            reportInvalidResourceMethod(m, NOT_RESOURCE_METHOD_MESSAGE_ID, Level.FINE);
+        }
     }
 
     private static void reportInvalidResourceMethod(Method m, String messageId, Level logLevel) {

--- a/rt/frontend/jaxrs/src/main/java/org/apache/cxf/jaxrs/utils/ResourceUtils.java
+++ b/rt/frontend/jaxrs/src/main/java/org/apache/cxf/jaxrs/utils/ResourceUtils.java
@@ -326,7 +326,8 @@ public final class ResourceUtils {
         cri.setMethodDispatcher(md);
     }
 
-    private static void evaluateResourceMethod(ClassResourceInfo cri, boolean enableStatic, MethodDispatcher md, Method m, Method annotatedMethod) {
+    private static void evaluateResourceMethod(ClassResourceInfo cri, boolean enableStatic, MethodDispatcher md,
+                                               Method m, Method annotatedMethod) {
         String httpMethod = AnnotationUtils.getHttpMethodValue(annotatedMethod);
         Path path = AnnotationUtils.getMethodAnnotation(annotatedMethod, Path.class);
 

--- a/rt/transports/http-hc/src/main/java/org/apache/cxf/transport/http/asyncclient/AsyncHTTPConduit.java
+++ b/rt/transports/http-hc/src/main/java/org/apache/cxf/transport/http/asyncclient/AsyncHTTPConduit.java
@@ -224,7 +224,7 @@ public class AsyncHTTPConduit extends URLConnectionHTTPConduit {
         Proxy p = proxyFactory.createProxy(csPolicy, uri);
         if (p != null && p.type() != Proxy.Type.DIRECT) {
             InetSocketAddress isa = (InetSocketAddress)p.address();
-            HttpHost proxy = new HttpHost(isa.getHostName(), isa.getPort());
+            HttpHost proxy = new HttpHost(isa.getHostString(), isa.getPort());
             b.setProxy(proxy);
         }
         e.setConfig(b.build());


### PR DESCRIPTION
In each resource class, an annotated method should be registered only once.