### PR TITLE
[CXF-7676] Create a proxy OutputStream to create an EntityStream that…

### DIFF
--- a/rt/rs/client/src/main/java/org/apache/cxf/jaxrs/client/spec/ClientRequestFilterInterceptor.java
+++ b/rt/rs/client/src/main/java/org/apache/cxf/jaxrs/client/spec/ClientRequestFilterInterceptor.java
@@ -19,6 +19,7 @@
 package org.apache.cxf.jaxrs.client.spec;
 
 import java.io.IOException;
+import java.io.OutputStream;
 import java.util.List;
 import java.util.Map;
 
@@ -39,6 +40,7 @@ import org.apache.cxf.message.Message;
 import org.apache.cxf.message.MessageImpl;
 import org.apache.cxf.phase.Phase;
 import org.apache.cxf.transport.MessageObserver;
+import org.apache.cxf.transport.http.ProxyOutputStream;
 
 public class ClientRequestFilterInterceptor extends AbstractOutDatabindingInterceptor {
 
@@ -51,6 +53,12 @@ public class ClientRequestFilterInterceptor extends AbstractOutDatabindingInterc
         if (pf == null) {
             return;
         }
+
+        // create an empty proxy output stream that the filter can interact with
+        // and save a reference for later
+        ProxyOutputStream pos = new ProxyOutputStream();
+        outMessage.setContent(OutputStream.class, pos);
+        outMessage.setContent(ProxyOutputStream.class, pos);
 
         List<ProviderInfo<ClientRequestFilter>> filters = pf.getClientRequestFilters();
         if (!filters.isEmpty()) {

--- a/rt/transports/http/src/main/java/org/apache/cxf/transport/http/HTTPConduit.java
+++ b/rt/transports/http/src/main/java/org/apache/cxf/transport/http/HTTPConduit.java
@@ -562,11 +562,21 @@ public abstract class HTTPConduit
 
         setHeadersByAuthorizationPolicy(message, currentAddress.getURI());
         new Headers(message).setFromClientPolicy(getClient(message));
-        message.setContent(OutputStream.class,
-                           createOutputStream(message,
-                                              needToCacheRequest,
-                                              isChunking,
-                                              chunkThreshold));
+
+        // set the OutputStream on the ProxyOutputStream
+        ProxyOutputStream pos = message.getContent(ProxyOutputStream.class);
+        if (pos != null && message.getContent(OutputStream.class) != null) {
+            pos.setWrappedOutputStream(createOutputStream(message,
+                                                          needToCacheRequest,
+                                                          isChunking,
+                                                          chunkThreshold));
+        } else {
+            message.setContent(OutputStream.class,
+                               createOutputStream(message,
+                                                  needToCacheRequest,
+                                                  isChunking,
+                                                  chunkThreshold));
+        }
         // We are now "ready" to "send" the message.
     }
 

--- a/rt/transports/http/src/main/java/org/apache/cxf/transport/http/ProxyOutputStream.java
+++ b/rt/transports/http/src/main/java/org/apache/cxf/transport/http/ProxyOutputStream.java
@@ -1,0 +1,29 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.cxf.transport.http;
+
+import java.io.OutputStream;
+
+import org.apache.cxf.io.AbstractWrappedOutputStream;
+
+public class ProxyOutputStream extends AbstractWrappedOutputStream {
+    public void setWrappedOutputStream(OutputStream os) {
+        this.wrappedStream = os;
+    }
+}

--- a/systests/jaxrs/src/test/java/org/apache/cxf/systest/jaxrs/BookStore.java
+++ b/systests/jaxrs/src/test/java/org/apache/cxf/systest/jaxrs/BookStore.java
@@ -1668,6 +1668,14 @@ public class BookStore {
     public BookSubresource getBookFromSubresource() {
         return new BookSubresourceImpl();
     }
+    
+    @POST
+    @Path("/entityecho")
+    @Consumes("text/plain")
+    @Produces("text/plain")
+    public Response echoEntity(String entity) {
+        return Response.ok().entity(entity).build();
+    }
 
     public final String init() {
         books.clear();

--- a/systests/jaxrs/src/test/java/org/apache/cxf/systest/jaxrs/JAXRS20ClientServerBookTest.java
+++ b/systests/jaxrs/src/test/java/org/apache/cxf/systest/jaxrs/JAXRS20ClientServerBookTest.java
@@ -834,6 +834,27 @@ public class JAXRS20ClientServerBookTest extends AbstractBusClientServerTestBase
                     ExceptionUtils.getRootCause(e) instanceof UnknownHostException);
         }
     }
+    
+    @Test
+    public void testGetSetEntityStream() {
+        String address = "http://localhost:" + PORT + "/bookstore/entityecho";
+        String entity = "BOOKSTORE";
+
+        Client client = ClientBuilder.newClient();
+        client.register(new ClientRequestFilter() {
+            @Override
+            public void filter(ClientRequestContext context) throws IOException {
+                context.setEntityStream(new ReplacingOutputStream(
+                                 context.getEntityStream(), 'X', 'O'));
+            }
+        });
+
+        WebTarget target = client.target(address);
+
+        Response response = target.request().post(
+                Entity.entity(entity.replace('O', 'X'), "text/plain"));
+        assertEquals(entity, response.readEntity(String.class));
+    }
 
     private static class ReplaceBodyFilter implements ClientRequestFilter {
 

--- a/systests/jaxrs/src/test/java/org/apache/cxf/systest/jaxrs/ReplacingOutputStream.java
+++ b/systests/jaxrs/src/test/java/org/apache/cxf/systest/jaxrs/ReplacingOutputStream.java
@@ -1,0 +1,45 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.cxf.systest.jaxrs;
+
+import java.io.IOException;
+import java.io.OutputStream;
+
+import org.apache.cxf.io.AbstractWrappedOutputStream;
+
+public class ReplacingOutputStream extends AbstractWrappedOutputStream {
+
+    private char oldChar;
+    private char newChar;
+
+    public ReplacingOutputStream(OutputStream wrappedStream, char oldChar, char newChar) {
+        super(wrappedStream);
+        this.oldChar = oldChar;
+        this.newChar = newChar;
+    }
+
+    @Override
+    public void write(byte[] b) throws IOException {
+        replace(b);
+    }
+
+    private void replace(byte[] b) throws IOException {
+        this.wrappedStream.write(new String(b).replace(this.oldChar, this.newChar).getBytes());
+    }
+}


### PR DESCRIPTION
… a user's ClientRequestFilter can interact with and holds a reference that we can set our URLConnectionWrappedOutputStream to later.