### PR TITLE
Generate a help mojo for the cxf-codegen-plugin

### DIFF
--- a/maven-plugins/codegen-plugin/pom.xml
+++ b/maven-plugins/codegen-plugin/pom.xml
@@ -147,6 +147,12 @@
                             <goal>descriptor</goal>
                         </goals>
                     </execution>
+                    <execution>
+                        <id>generate-helpmojo</id>
+                        <goals>
+                            <goal>helpmojo</goal>
+                        </goals>
+                    </execution>
                 </executions>
             </plugin>
             <plugin>


### PR DESCRIPTION
Generate a help mojo for the cxf-codegen-plugin, so the user can get help regarding goals and parameters from the command line.

You can read more about how to use a help mojo here: https://maven.apache.org/plugin-tools/maven-plugin-plugin/help-mojo.html