### PR TITLE
CXF-7643 ensure CDI extension defaults are CDI compliant

### DIFF
--- a/integration/cdi/src/main/java/org/apache/cxf/cdi/ContextProducerBean.java
+++ b/integration/cdi/src/main/java/org/apache/cxf/cdi/ContextProducerBean.java
@@ -34,16 +34,19 @@ import org.apache.cxf.phase.PhaseInterceptorChain;
 
 public class ContextProducerBean extends AbstractCXFBean<Object> implements PassivationCapable {
     private final Type type;
+    private final Set<Annotation> qualifiers;
 
-    ContextProducerBean(Type type) {
+    ContextProducerBean(Type type, boolean defaultQualifier) {
         this.type = type;
+        this.qualifiers = new HashSet<>(defaultQualifier ? 2 : 1);
+        this.qualifiers.add(ContextResolved.LITERAL);
+        if (defaultQualifier) {
+            this.qualifiers.add(DEFAULT);
+        }
     }
 
     @Override
     public Set<Annotation> getQualifiers() {
-        Set<Annotation> qualifiers = new HashSet<>(2);
-        qualifiers.add(ContextResolved.LITERAL);
-        qualifiers.add(DEFAULT);
         return qualifiers;
     }
 

--- a/systests/cdi/base/src/main/java/org/apache/cxf/systests/cdi/base/AbstractCdiSingleAppTest.java
+++ b/systests/cdi/base/src/main/java/org/apache/cxf/systests/cdi/base/AbstractCdiSingleAppTest.java
@@ -36,6 +36,35 @@ import org.junit.Test;
 
 public abstract class AbstractCdiSingleAppTest extends AbstractBusClientServerTestBase {
     @Test
+    public void testAvailableInjections() {
+        assertEquals("configuration=Configuration/"
+            + "contextResolver=ContextResolver/"
+            + "cxfApplication=Application/"
+            + "cxfConfiguration=Configuration/"
+            + "cxfContextResolver=ContextResolver/"
+            + "cxfHttpHeaders=HttpHeaders/"
+            + "cxfHttpServletRequest=HttpServletRequest/"
+            + "cxfProviders=Providers/"
+            + "cxfRequest=Request/"
+            + "cxfResourceContext=ResourceContext/"
+            + "cxfResourceInfo=ResourceInfo/"
+            + "cxfSecurityContext=SecurityContext/"
+            + "cxfServletContext=ServletContext/"
+            + "cxfUriInfo=UriInfo/"
+            + "cxfhttpServletResponse=HttpServletRequest/"
+            + "httpHeaders=HttpHeaders/"
+            + "httpServletRequest=HttpServletRequest/"
+            + "httpServletResponse=HttpServletResponse/"
+            + "providers=Providers/request=Request/"
+            + "resourceContext=ResourceContext/"
+            + "resourceInfo=ResourceInfo/"
+            + "securityContext=SecurityContext/"
+            + "servletContext=ServletContext/"
+            + "uriInfo=UriInfo",
+            createWebClient(getBasePath() + "/injections", MediaType.TEXT_PLAIN).get(String.class).trim());
+    }
+
+    @Test
     public void testInjectedVersionIsProperlyReturned() {
         Response r = createWebClient(getBasePath() + "/version", MediaType.TEXT_PLAIN).get();
         String pathInfo = r.getHeaderString(Message.PATH_INFO);

--- a/systests/cdi/base/src/main/java/org/apache/cxf/systests/cdi/base/BookStore.java
+++ b/systests/cdi/base/src/main/java/org/apache/cxf/systests/cdi/base/BookStore.java
@@ -39,15 +39,24 @@ public class BookStore {
     private BookStoreService service;
     private BookStoreVersion bookStoreVersion;
     private UriInfo uriInfo;
+    private Injections injections;
 
     public BookStore() {
     }
 
     @Inject
-    public BookStore(BookStoreService service, BookStoreVersion bookStoreVersion, UriInfo uriInfo) {
+    public BookStore(BookStoreService service, BookStoreVersion bookStoreVersion, UriInfo uriInfo,
+                     Injections injections) {
         this.service = service;
         this.bookStoreVersion = bookStoreVersion;
         this.uriInfo = uriInfo;
+        this.injections = injections;
+    }
+
+    @GET
+    @Path("injections")
+    public String injections() {
+        return injections.state();
     }
 
     @Path("/version")

--- a/systests/cdi/base/src/main/java/org/apache/cxf/systests/cdi/base/Injections.java
+++ b/systests/cdi/base/src/main/java/org/apache/cxf/systests/cdi/base/Injections.java
@@ -1,0 +1,154 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.cxf.systests.cdi.base;
+
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+import javax.servlet.ServletContext;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.ws.rs.container.ResourceContext;
+import javax.ws.rs.container.ResourceInfo;
+import javax.ws.rs.core.Application;
+import javax.ws.rs.core.Configuration;
+import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.Request;
+import javax.ws.rs.core.SecurityContext;
+import javax.ws.rs.core.UriInfo;
+import javax.ws.rs.ext.ContextResolver;
+import javax.ws.rs.ext.Providers;
+
+import org.apache.cxf.cdi.ContextResolved;
+
+@ApplicationScoped
+public class Injections {
+    /* this one is not supposed to work in the systests
+    @Inject
+    private Application application;
+    */
+
+    @Inject
+    @ContextResolved
+    private Application cxfApplication; //NOPMD
+
+    @Inject
+    private UriInfo uriInfo; //NOPMD
+
+    @Inject
+    @ContextResolved
+    private UriInfo cxfUriInfo; //NOPMD
+
+    @Inject
+    private HttpHeaders httpHeaders; //NOPMD
+
+    @Inject
+    @ContextResolved
+    private HttpHeaders cxfHttpHeaders; //NOPMD
+
+    @Inject
+    private Request request; //NOPMD
+
+    @Inject
+    @ContextResolved
+    private Request cxfRequest; //NOPMD
+
+    @Inject
+    private SecurityContext securityContext; //NOPMD
+
+    @Inject
+    @ContextResolved
+    private SecurityContext cxfSecurityContext; //NOPMD
+
+    @Inject
+    private Providers providers; //NOPMD
+
+    @Inject
+    @ContextResolved
+    private Providers cxfProviders; //NOPMD
+
+    @Inject
+    private ContextResolver contextResolver; //NOPMD
+
+    @Inject
+    @ContextResolved
+    private ContextResolver cxfContextResolver; //NOPMD
+
+    @Inject
+    private HttpServletRequest httpServletRequest; //NOPMD
+
+    @Inject
+    @ContextResolved
+    private HttpServletRequest cxfHttpServletRequest; //NOPMD
+
+    @Inject
+    private HttpServletResponse httpServletResponse; //NOPMD
+
+    @Inject
+    @ContextResolved
+    private HttpServletRequest cxfhttpServletResponse; //NOPMD
+
+    @Inject
+    private ServletContext servletContext; //NOPMD
+
+    @Inject
+    @ContextResolved
+    private ServletContext cxfServletContext; //NOPMD
+
+    @Inject
+    private ResourceContext resourceContext; //NOPMD
+
+    @Inject
+    @ContextResolved
+    private ResourceContext cxfResourceContext; //NOPMD
+
+    @Inject
+    private ResourceInfo resourceInfo; //NOPMD
+
+    @Inject
+    @ContextResolved
+    private ResourceInfo cxfResourceInfo; //NOPMD
+
+    @Inject
+    private Configuration configuration; //NOPMD
+
+    @Inject
+    @ContextResolved
+    private Configuration cxfConfiguration; //NOPMD
+
+    public String state() {
+        return Stream.of(Injections.class.getDeclaredFields())
+                .filter(f -> f.isAnnotationPresent(Inject.class))
+                .map(f -> {
+                    if (!f.isAccessible()) {
+                        f.setAccessible(true);
+                    }
+                    try {
+                        // the standard name otherwise not portable
+                        return f.get(Injections.this) != null ? f.getName() + "=" + f.getType().getSimpleName() : "";
+                    } catch (final IllegalAccessException e) {
+                        return "";
+                    }
+                })
+                .sorted() // be deterministic in the test, java reflection is no more since java7
+                .collect(Collectors.joining("/"));
+    }
+}


### PR DESCRIPTION
This PR tries to make defaults of the CDI extension better, here are the changes:

1. if it detects OWB-web or weld-web it deactivate default context beans for HttpServletRequest and ServletContext
2. it observes beans to detect the types conflicting with "auto" context beans
3. it fires the extension and exposes the list of exclusion to let integration layers configure it properly if 1/2 defaults are not enough 
4. when it adds context beans it removes @Default from the ones which are found with 1/2/3 - but it keeps it with the cxf specific qualifier if needed (best practise being to use this classifier for internal/extensions needs)

