### PR TITLE
CXF-7695 wsdl2java client jar generation fails if jaxws binding is used

### DIFF
--- a/tools/wsdlto/frontend/jaxws/src/main/java/org/apache/cxf/tools/wsdlto/frontend/jaxws/customization/JAXWSBindingSerializer.java
+++ b/tools/wsdlto/frontend/jaxws/src/main/java/org/apache/cxf/tools/wsdlto/frontend/jaxws/customization/JAXWSBindingSerializer.java
@@ -1,0 +1,44 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.cxf.tools.wsdlto.frontend.jaxws.customization;
+
+import java.io.*;
+
+import javax.wsdl.Definition;
+import javax.wsdl.WSDLException;
+import javax.wsdl.extensions.ExtensibilityElement;
+import javax.wsdl.extensions.ExtensionRegistry;
+import javax.wsdl.extensions.ExtensionSerializer;
+import javax.xml.namespace.QName;
+
+public class JAXWSBindingSerializer implements ExtensionSerializer, Serializable {
+    public static final long serialVersionUID = 1;
+
+    public void marshall(@SuppressWarnings("rawtypes") Class parentType,
+                         QName elementType,
+                         ExtensibilityElement extension,
+                         PrintWriter pw,
+                         Definition def,
+                         ExtensionRegistry extReg)
+        throws WSDLException {
+        // This class is needed to generate the WSDL file included in the client jar. 
+        // It simply ignores the JAXWS Binding when generating the WSDL file. 
+    }
+}

--- a/tools/wsdlto/frontend/jaxws/src/main/java/org/apache/cxf/tools/wsdlto/frontend/jaxws/wsdl11/JAXWSDefinitionBuilder.java
+++ b/tools/wsdlto/frontend/jaxws/src/main/java/org/apache/cxf/tools/wsdlto/frontend/jaxws/wsdl11/JAXWSDefinitionBuilder.java
@@ -55,6 +55,7 @@ import org.apache.cxf.tools.wsdlto.core.WSDLDefinitionBuilder;
 import org.apache.cxf.tools.wsdlto.frontend.jaxws.customization.CustomizationParser;
 import org.apache.cxf.tools.wsdlto.frontend.jaxws.customization.JAXWSBinding;
 import org.apache.cxf.tools.wsdlto.frontend.jaxws.customization.JAXWSBindingDeserializer;
+import org.apache.cxf.tools.wsdlto.frontend.jaxws.customization.JAXWSBindingSerializer;
 import org.apache.cxf.wsdl.WSDLManager;
 
 public class JAXWSDefinitionBuilder extends AbstractWSDLBuilder {
@@ -99,6 +100,7 @@ public class JAXWSDefinitionBuilder extends AbstractWSDLBuilder {
     }
 
     private void registerJAXWSBinding(ExtensionRegistry registry, Class<?> clz) {
+        registry.registerSerializer(clz, ToolConstants.JAXWS_BINDINGS, new JAXWSBindingSerializer());
         registry.registerDeserializer(clz, ToolConstants.JAXWS_BINDINGS, new JAXWSBindingDeserializer());
         registry.mapExtensionTypes(clz, ToolConstants.JAXWS_BINDINGS, JAXWSBinding.class);
     }


### PR DESCRIPTION
Revert some changes from commit bcb6385a095dcaaf8390ecfc33e9e22b9149daad that causes problem when generating ws client jar with jaxws bindings