### PR TITLE
[CXF-7704] False positive warning log

### DIFF
--- a/rt/ws/addr/src/main/java/org/apache/cxf/ws/addressing/policy/AddressingAssertionBuilder.java
+++ b/rt/ws/addr/src/main/java/org/apache/cxf/ws/addressing/policy/AddressingAssertionBuilder.java
@@ -85,7 +85,8 @@ public class AddressingAssertionBuilder implements AssertionBuilder<Element> {
                                                   policy);
                 }
             }.build(elem, factory);
-            if (!(nap instanceof PolicyContainingPrimitiveAssertion || nap instanceof PrimitiveAssertion)) {
+            if (!(nap instanceof PolicyContainingPrimitiveAssertion
+                    || nap instanceof org.apache.neethi.builders.PrimitiveAssertion)) {
                 // this happens when neethi fails to recognize the specified addressing policy element
                 LOG.warning("Unable to recognize the addressing policy");
             }


### PR DESCRIPTION
fix wrong log warning "Unable to recognize the addressing policy"