### PR TITLE
[CXF-7317] Non-URL encoded Content-Id href does not seem be serialized by CXF's AttachmentSerializer

### DIFF
--- a/core/src/main/java/org/apache/cxf/attachment/AttachmentSerializer.java
+++ b/core/src/main/java/org/apache/cxf/attachment/AttachmentSerializer.java
@@ -24,7 +24,6 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.StringWriter;
 import java.io.Writer;
-import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.Iterator;
@@ -215,7 +214,7 @@ public class AttachmentSerializer {
         if (attachmentId != null) {
             attachmentId = checkAngleBrackets(attachmentId);
             writer.write("Content-ID: <");
-            writer.write(URLDecoder.decode(attachmentId, StandardCharsets.UTF_8.name()));
+            writer.write(attachmentId);
             writer.write(">\r\n");
         }
         // headers like Content-Disposition need to be serialized


### PR DESCRIPTION
JIRA: https://issues.apache.org/jira/browse/CXF-7317
downstream: https://issues.jboss.org/browse/JBWS-4064

According to https://tools.ietf.org/html/rfc2392, Content-ID header shouldn't be decoded

> For example, "cid:foo4%25foo1@bar.net" corresponds to Content-ID: \<foo4%25foo1@bar.net\>

See comments in JBWS-4064 for more info