### PR TITLE
CXF-7708: fix groovy verification for jdk9 and jdk10

### DIFF
--- a/maven-plugins/codegen-plugin/pom.xml
+++ b/maven-plugins/codegen-plugin/pom.xml
@@ -190,12 +190,17 @@
                             </pomIncludes>
                             <settingsFile>src/it/settings.xml</settingsFile>
                             <cloneProjectsTo>${project.build.directory}/it</cloneProjectsTo>
-                            <!-- CXF-7708 temporarily disabled as it fails with JDK 9
                             <postBuildHookScript>verify</postBuildHookScript>
-                            -->
                         </configuration>
                     </execution>
                 </executions>
+                <dependencies>
+                   <dependency>
+                       <groupId>javax.xml.bind</groupId>
+                       <artifactId>jaxb-api</artifactId>
+                       <version>${cxf.jaxb.version}</version>
+                    </dependency>
+                </dependencies>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
Fixed and tested on JDK 8,9 and 10. @deki please review.