### PR TITLE
[CXF-7726] allows targetSelector to be set in CircuitBreakerFailoverFeature

### DIFF
--- a/rt/features/clustering/src/main/java/org/apache/cxf/clustering/circuitbreaker/CircuitBreakerFailoverFeature.java
+++ b/rt/features/clustering/src/main/java/org/apache/cxf/clustering/circuitbreaker/CircuitBreakerFailoverFeature.java
@@ -60,6 +60,11 @@ public class CircuitBreakerFailoverFeature extends FailoverFeature {
         return this.targetSelector;
     }
 
+    @Override
+    public void setTargetSelector(FailoverTargetSelector targetSelector) {
+        this.targetSelector = targetSelector;
+    }
+
     public int getThreshold() {
         return threshold;
     }


### PR DESCRIPTION
Adds a setTargetSelector method to CircuitBreakerFailoverFeature