### PR TITLE
CXF-7734 Fix media type for the root page

### DIFF
--- a/rt/rs/description-swagger/src/main/java/org/apache/cxf/jaxrs/swagger/Swagger2Feature.java
+++ b/rt/rs/description-swagger/src/main/java/org/apache/cxf/jaxrs/swagger/Swagger2Feature.java
@@ -620,6 +620,7 @@ public class Swagger2Feature extends AbstractSwaggerFeature {
             
             try {
                 URL resourceURL = locator.locate(resourcePath);
+                resourcePath = resourceURL.getPath();
                 
                 String mediaType = null;
                 int ind = resourcePath.lastIndexOf('.');


### PR DESCRIPTION
After migration from 3.1.14 to 3.1.15, It is impossible to see **api-docs** page according to example in
[Swagger2Feature - Automatic UI Activation](http://cxf.apache.org/docs/swaggerfeature-swagger2feature.html#SwaggerFeature/Swagger2Feature-AutomaticUIActivation)

This fix allows to restore this functionality.