### PR TITLE
CXF-7600: Add Automatic-Module-Name MANIFEST entry for Java 9 compatibility

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -31,6 +31,7 @@
         <relativePath>../parent/pom.xml</relativePath>
     </parent>
     <properties>
+        <cxf.module.name>org.apache.cxf.core</cxf.module.name>
         <cxf.bundle.activator>org.apache.cxf.bus.osgi.CXFActivator</cxf.bundle.activator>
         <cxf.osgi.export>
             !org.apache.cxf.internal,

--- a/distribution/javadoc/pom.xml
+++ b/distribution/javadoc/pom.xml
@@ -30,6 +30,9 @@
         <version>3.2.5-SNAPSHOT</version>
         <relativePath>../../parent</relativePath>
     </parent>
+    <properties>
+        <cxf.module.name>org.apache.cxf.javadoc</cxf.module.name>
+    </properties>
     <dependencies>
         <dependency>
             <groupId>org.apache.cxf</groupId>

--- a/distribution/manifest/pom.xml
+++ b/distribution/manifest/pom.xml
@@ -33,6 +33,7 @@
     <properties>
         <maven.test.skip>true</maven.test.skip>
         <cxf.version>${project.version}</cxf.version>
+        <cxf.module.name>org.apache.cxf.manifest</cxf.module.name>
     </properties>
     <dependencies>
         <dependency>

--- a/integration/cdi/pom.xml
+++ b/integration/cdi/pom.xml
@@ -32,6 +32,7 @@
     </parent>
     
     <properties>
+        <cxf.module.name>org.apache.cxf.cdi</cxf.module.name>
         <cxf.osgi.import>
             javax.servlet*;version="${cxf.osgi.javax.servlet.version}",
             javax.enterprise*;version="${cxf.cda.api.osgi.range}",

--- a/integration/jca/pom.xml
+++ b/integration/jca/pom.xml
@@ -30,6 +30,9 @@
         <version>3.2.5-SNAPSHOT</version>
         <relativePath>../../parent/pom.xml</relativePath>
     </parent>
+    <properties>
+        <cxf.module.name>org.apache.cxf.jca</cxf.module.name>
+    </properties>
     <dependencies>
         <dependency>
             <groupId>junit</groupId>

--- a/integration/spring-boot/autoconfigure/pom.xml
+++ b/integration/spring-boot/autoconfigure/pom.xml
@@ -30,6 +30,9 @@
         <version>3.2.5-SNAPSHOT</version>
         <relativePath>../../../parent/pom.xml</relativePath>
     </parent>
+    <properties>
+        <cxf.module.name>org.apache.cxf.spring.boot.autoconfigure</cxf.module.name>
+    </properties>
     <build>
         <plugins>
             <plugin>

--- a/integration/spring-boot/starter-jaxrs/pom.xml
+++ b/integration/spring-boot/starter-jaxrs/pom.xml
@@ -30,6 +30,9 @@
         <version>3.2.5-SNAPSHOT</version>
         <relativePath>../../../parent/pom.xml</relativePath>
     </parent>
+    <properties>
+        <cxf.module.name>org.apache.cxf.spring.boot.jaxrs</cxf.module.name>
+    </properties>
     <dependencies>
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/integration/spring-boot/starter-jaxws/pom.xml
+++ b/integration/spring-boot/starter-jaxws/pom.xml
@@ -30,6 +30,9 @@
         <version>3.2.5-SNAPSHOT</version>
         <relativePath>../../../parent/pom.xml</relativePath>
     </parent>
+    <properties>
+        <cxf.module.name>org.apache.cxf.spring.boot.jaxws</cxf.module.name>
+    </properties>
     <dependencies>
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/integration/tracing/tracing-brave/pom.xml
+++ b/integration/tracing/tracing-brave/pom.xml
@@ -32,6 +32,7 @@
     </parent>
     
     <properties>
+        <cxf.module.name>org.apache.cxf.tracing.brave</cxf.module.name>
         <cxf.osgi.export>
             org.apache.cxf.tracing,
             org.apache.cxf.tracing.brave,

--- a/integration/tracing/tracing-htrace/pom.xml
+++ b/integration/tracing/tracing-htrace/pom.xml
@@ -32,6 +32,7 @@
     </parent>
     
     <properties>
+        <cxf.module.name>org.apache.cxf.tracing.htrace</cxf.module.name>
         <cxf.osgi.export>
             org.apache.cxf.tracing
         </cxf.osgi.export>

--- a/integration/tracing/tracing-opentracing/pom.xml
+++ b/integration/tracing/tracing-opentracing/pom.xml
@@ -32,6 +32,7 @@
     </parent>
     
     <properties>
+        <cxf.module.name>org.apache.cxf.tracing.opentracing</cxf.module.name>
         <cxf.osgi.export>
             org.apache.cxf.tracing,
             org.apache.cxf.tracing.opentracing,

--- a/maven-plugins/codegen-plugin/pom.xml
+++ b/maven-plugins/codegen-plugin/pom.xml
@@ -29,6 +29,9 @@
         <artifactId>cxf-maven-plugins</artifactId>
         <version>3.2.5-SNAPSHOT</version>
     </parent>
+    <properties>
+        <cxf.module.name>org.apache.cxf.codegen.plugin</cxf.module.name>
+    </properties>
     <dependencies>
         <dependency>
             <groupId>junit</groupId>

--- a/maven-plugins/codegen-plugin/pom.xml
+++ b/maven-plugins/codegen-plugin/pom.xml
@@ -30,7 +30,7 @@
         <version>3.2.5-SNAPSHOT</version>
     </parent>
     <properties>
-        <cxf.module.name>org.apache.cxf.codegen.plugin</cxf.module.name>
+        <cxf.module.name>org.apache.cxf.plugin.codegen</cxf.module.name>
     </properties>
     <dependencies>
         <dependency>

--- a/maven-plugins/corba/pom.xml
+++ b/maven-plugins/corba/pom.xml
@@ -29,6 +29,9 @@
         <artifactId>cxf-maven-plugins</artifactId>
         <version>3.2.5-SNAPSHOT</version>
     </parent>
+    <properties>
+        <cxf.module.name>org.apache.cxf.corbatools.plugin</cxf.module.name>
+    </properties>
     <dependencies>
         <dependency>
             <groupId>junit</groupId>

--- a/maven-plugins/corba/pom.xml
+++ b/maven-plugins/corba/pom.xml
@@ -30,7 +30,7 @@
         <version>3.2.5-SNAPSHOT</version>
     </parent>
     <properties>
-        <cxf.module.name>org.apache.cxf.corbatools.plugin</cxf.module.name>
+        <cxf.module.name>org.apache.cxf.plugin.corbatools</cxf.module.name>
     </properties>
     <dependencies>
         <dependency>

--- a/maven-plugins/java2swagger-plugin/pom.xml
+++ b/maven-plugins/java2swagger-plugin/pom.xml
@@ -33,7 +33,7 @@
       <version>3.2.5-SNAPSHOT</version>
     </parent>
     <properties>
-        <cxf.module.name>org.apache.cxf.java2swagger.plugin</cxf.module.name>
+        <cxf.module.name>org.apache.cxf.plugin.java2swagger</cxf.module.name>
         <cxf.manifest.location />
     </properties>
 

--- a/maven-plugins/java2swagger-plugin/pom.xml
+++ b/maven-plugins/java2swagger-plugin/pom.xml
@@ -33,6 +33,7 @@
       <version>3.2.5-SNAPSHOT</version>
     </parent>
     <properties>
+        <cxf.module.name>org.apache.cxf.java2swagger.plugin</cxf.module.name>
         <cxf.manifest.location />
     </properties>
 

--- a/maven-plugins/java2wadl-plugin/pom.xml
+++ b/maven-plugins/java2wadl-plugin/pom.xml
@@ -34,7 +34,7 @@
       <version>3.2.5-SNAPSHOT</version>
     </parent>
     <properties>
-        <cxf.module.name>org.apache.cxf.java2wadl.plugin</cxf.module.name>
+        <cxf.module.name>org.apache.cxf.plugin.java2wadl</cxf.module.name>
         <cxf.manifest.location />
     </properties>
 

--- a/maven-plugins/java2wadl-plugin/pom.xml
+++ b/maven-plugins/java2wadl-plugin/pom.xml
@@ -34,6 +34,7 @@
       <version>3.2.5-SNAPSHOT</version>
     </parent>
     <properties>
+        <cxf.module.name>org.apache.cxf.java2wadl.plugin</cxf.module.name>
         <cxf.manifest.location />
     </properties>
 

--- a/maven-plugins/java2ws-plugin/pom.xml
+++ b/maven-plugins/java2ws-plugin/pom.xml
@@ -29,6 +29,9 @@
         <artifactId>cxf-maven-plugins</artifactId>
         <version>3.2.5-SNAPSHOT</version>
     </parent>
+    <properties>
+        <cxf.module.name>org.apache.cxf.java2ws.plugin</cxf.module.name>
+    </properties>
     <dependencies>
         <dependency>
             <groupId>junit</groupId>

--- a/maven-plugins/java2ws-plugin/pom.xml
+++ b/maven-plugins/java2ws-plugin/pom.xml
@@ -30,7 +30,7 @@
         <version>3.2.5-SNAPSHOT</version>
     </parent>
     <properties>
-        <cxf.module.name>org.apache.cxf.java2ws.plugin</cxf.module.name>
+        <cxf.module.name>org.apache.cxf.plugin.java2ws</cxf.module.name>
     </properties>
     <dependencies>
         <dependency>

--- a/maven-plugins/wadl2java-plugin/pom.xml
+++ b/maven-plugins/wadl2java-plugin/pom.xml
@@ -30,7 +30,7 @@
         <version>3.2.5-SNAPSHOT</version>
     </parent>
     <properties>
-        <cxf.module.name>org.apache.cxf.wadl2java.plugin</cxf.module.name>
+        <cxf.module.name>org.apache.cxf.plugin.wadl2java</cxf.module.name>
     </properties>
     <dependencies>
         <dependency>

--- a/maven-plugins/wadl2java-plugin/pom.xml
+++ b/maven-plugins/wadl2java-plugin/pom.xml
@@ -29,6 +29,9 @@
         <artifactId>cxf-maven-plugins</artifactId>
         <version>3.2.5-SNAPSHOT</version>
     </parent>
+    <properties>
+        <cxf.module.name>org.apache.cxf.wadl2java.plugin</cxf.module.name>
+    </properties>
     <dependencies>
         <dependency>
             <groupId>junit</groupId>

--- a/maven-plugins/wsdl-validator-plugin/pom.xml
+++ b/maven-plugins/wsdl-validator-plugin/pom.xml
@@ -30,7 +30,7 @@
         <version>3.2.5-SNAPSHOT</version>
     </parent>
     <properties>
-        <cxf.module.name>org.apache.cxf.wsdl.validator.plugin</cxf.module.name>
+        <cxf.module.name>org.apache.cxf.plugin.wsdl.validator</cxf.module.name>
     </properties>
     <dependencies>
         <dependency>

--- a/maven-plugins/wsdl-validator-plugin/pom.xml
+++ b/maven-plugins/wsdl-validator-plugin/pom.xml
@@ -29,6 +29,9 @@
         <artifactId>cxf-maven-plugins</artifactId>
         <version>3.2.5-SNAPSHOT</version>
     </parent>
+    <properties>
+        <cxf.module.name>org.apache.cxf.wsdl.validator.plugin</cxf.module.name>
+    </properties>
     <dependencies>
         <dependency>
             <groupId>junit</groupId>

--- a/osgi/bundle/compatible/pom.xml
+++ b/osgi/bundle/compatible/pom.xml
@@ -31,6 +31,7 @@
     </parent>
     <properties>
         <cxf.osgi.symbolic.name>${project.groupId}.bundle</cxf.osgi.symbolic.name>
+        <cxf.module.name>org.apache.cxf.bundle</cxf.module.name>
     </properties>
     <dependencies>
         <dependency>

--- a/osgi/karaf/commands/pom.xml
+++ b/osgi/karaf/commands/pom.xml
@@ -27,6 +27,9 @@
     <packaging>bundle</packaging>
     <name>Apache CXF Karaf Commands</name>
     <description>Apache CXF Karaf Commands</description>
+    <properties>
+        <cxf.module.name>org.apache.cxf.karaf.commands</cxf.module.name>
+    </properties>
     <dependencies>
         <!-- cxf -->
         <dependency>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -478,6 +478,7 @@
                                 <Implementation-Title>${project.name}</Implementation-Title>
                                 <Implementation-Vendor-Id>org.apache</Implementation-Vendor-Id>
                                 <Implementation-Vendor>The Apache Software Foundation</Implementation-Vendor>
+                                <Automatic-Module-Name>${cxf.module.name}</Automatic-Module-Name>
                             </manifestEntries>
                         </archive>
                     </configuration>
@@ -631,6 +632,7 @@
                             ${cxf.export.service}
                         </Export-Service>
                         <Bundle-Activator>${cxf.bundle.activator}</Bundle-Activator>
+                        <Automatic-Module-Name>${cxf.module.name}</Automatic-Module-Name>
                     </instructions>
                     <niceManifest>true</niceManifest>
                 </configuration>

--- a/rt/bindings/coloc/pom.xml
+++ b/rt/bindings/coloc/pom.xml
@@ -31,6 +31,7 @@
         <relativePath>../../../parent/pom.xml</relativePath>
     </parent>
     <properties>
+        <cxf.module.name>org.apache.cxf.binding.coloc</cxf.module.name>
         <cxf.osgi.import>
             org.springframework*;resolution:=optional;version="${cxf.osgi.spring.version}",
             org.apache.aries*;version="${cxf.aries.version.range}";resolution:=optional

--- a/rt/bindings/corba/pom.xml
+++ b/rt/bindings/corba/pom.xml
@@ -31,6 +31,7 @@
         <relativePath>../../../parent/pom.xml</relativePath>
     </parent>
     <properties>
+        <cxf.module.name>org.apache.cxf.binding.corba</cxf.module.name>
         <cxf.checkstyle.extension>-corba</cxf.checkstyle.extension>
         <cxf.osgi.import>
             org.objectweb.asm*;version="${cxf.osgi.asm.version}",

--- a/rt/bindings/soap/pom.xml
+++ b/rt/bindings/soap/pom.xml
@@ -31,6 +31,7 @@
         <relativePath>../../../parent/pom.xml</relativePath>
     </parent>
     <properties>
+        <cxf.module.name>org.apache.cxf.binding.soap</cxf.module.name>
         <cxf.osgi.import>
             org.apache.aries*;version="${cxf.aries.version.range}";resolution:=optional,
             org.springframework*;resolution:="optional";version="${cxf.osgi.spring.version}"

--- a/rt/bindings/xml/pom.xml
+++ b/rt/bindings/xml/pom.xml
@@ -30,6 +30,9 @@
         <version>3.2.5-SNAPSHOT</version>
         <relativePath>../../../parent/pom.xml</relativePath>
     </parent>
+    <properties>
+        <cxf.module.name>org.apache.cxf.binding.xml</cxf.module.name>
+    </properties>
     <dependencies>
         <dependency>
             <groupId>org.apache.cxf</groupId>

--- a/rt/databinding/aegis/pom.xml
+++ b/rt/databinding/aegis/pom.xml
@@ -32,6 +32,7 @@
     </parent>
     
     <properties>
+        <cxf.module.name>org.apache.cxf.databinding.aegis</cxf.module.name>
         <cxf.osgi.import>
             javax.xml.bind*;version="${cxf.osgi.javax.bind.version}",
             javax.activation;version="${cxf.osgi.javax.activation.version}",

--- a/rt/databinding/jaxb/pom.xml
+++ b/rt/databinding/jaxb/pom.xml
@@ -31,6 +31,7 @@
         <relativePath>../../../parent/pom.xml</relativePath>
     </parent>
     <properties>
+        <cxf.module.name>org.apache.cxf.databinding.jaxb</cxf.module.name>
         <cxf.osgi.import>
             javax.activation;version="${cxf.osgi.javax.activation.version}",
             javax.xml.bind*;version="${cxf.osgi.javax.bind.version}",

--- a/rt/features/clustering/pom.xml
+++ b/rt/features/clustering/pom.xml
@@ -31,6 +31,7 @@
         <relativePath>../../../parent/pom.xml</relativePath>
     </parent>
     <properties>
+        <cxf.module.name>org.apache.cxf.clustering</cxf.module.name>
         <cxf.bundle.activator>org.apache.cxf.clustering.blueprint.Activator</cxf.bundle.activator>
         <cxf.osgi.import>
             org.apache.aries*;version="${cxf.aries.version.range}";resolution:=optional,

--- a/rt/features/logging/pom.xml
+++ b/rt/features/logging/pom.xml
@@ -10,6 +10,7 @@
     <packaging>bundle</packaging>
     
     <properties>
+        <cxf.module.name>org.apache.cxf.logging</cxf.module.name>
         <cxf.bundle.activator>org.apache.cxf.ext.logging.osgi.Activator</cxf.bundle.activator>
     </properties>
 

--- a/rt/features/metrics/pom.xml
+++ b/rt/features/metrics/pom.xml
@@ -11,6 +11,10 @@
     <name>Apache CXF Metrics Feature</name>
     <description>Apache CXF Metrics Feature</description>
 
+    <properties>
+        <cxf.module.name>org.apache.cxf.metrics</cxf.module.name>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>org.apache.cxf</groupId>

--- a/rt/features/throttling/pom.xml
+++ b/rt/features/throttling/pom.xml
@@ -10,6 +10,10 @@
     <packaging>bundle</packaging>
     <name>Apache CXF Throttling Feature</name>
     <description>Apache CXF Throttling Feature</description>
+    
+    <properties>
+        <cxf.module.name>org.apache.cxf.throttling</cxf.module.name>
+    </properties>
 
     <dependencies>
         <dependency>
@@ -17,8 +21,6 @@
             <artifactId>cxf-core</artifactId>
             <version>${project.version}</version>
         </dependency>
-
-
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>

--- a/rt/frontend/jaxrs/pom.xml
+++ b/rt/frontend/jaxrs/pom.xml
@@ -31,6 +31,7 @@
         <relativePath>../../../parent/pom.xml</relativePath>
     </parent>
     <properties>
+        <cxf.module.name>org.apache.cxf.frontend.jaxrs</cxf.module.name>
         <cxf.osgi.import>
             javax.servlet*;version="${cxf.osgi.javax.servlet.version}",
             org.apache.aries*;version="${cxf.aries.version.range}";resolution:=optional,

--- a/rt/frontend/jaxws/pom.xml
+++ b/rt/frontend/jaxws/pom.xml
@@ -31,6 +31,7 @@
         <relativePath>../../../parent/pom.xml</relativePath>
     </parent>
     <properties>
+        <cxf.module.name>org.apache.cxf.frontend.jaxws</cxf.module.name>
         <cxf.osgi.import>
             javax.servlet*;version="${cxf.osgi.javax.servlet.version}",
             org.apache.aries*;version="${cxf.aries.version.range}";resolution:=optional,

--- a/rt/frontend/js/pom.xml
+++ b/rt/frontend/js/pom.xml
@@ -30,6 +30,9 @@
         <version>3.2.5-SNAPSHOT</version>
         <relativePath>../../../parent/pom.xml</relativePath>
     </parent>
+    <properties>
+        <cxf.module.name>org.apache.cxf.frontend.js</cxf.module.name>
+    </properties>
     <dependencies>
         <dependency>
             <groupId>rhino</groupId>

--- a/rt/frontend/simple/pom.xml
+++ b/rt/frontend/simple/pom.xml
@@ -31,6 +31,7 @@
         <relativePath>../../../parent/pom.xml</relativePath>
     </parent>
     <properties>
+        <cxf.module.name>org.apache.cxf.frontend.simple</cxf.module.name>
         <cxf.osgi.import>
             org.apache.aries*;version="${cxf.aries.version.range}";resolution:=optional,
             com.sun.tools*;resolution:=optional,

--- a/rt/javascript/javascript-rt/pom.xml
+++ b/rt/javascript/javascript-rt/pom.xml
@@ -29,6 +29,9 @@
         <artifactId>cxf-runtime-javascript</artifactId>
         <version>3.2.5-SNAPSHOT</version>
     </parent>
+    <properties>
+        <cxf.module.name>org.apache.cxf.js</cxf.module.name>
+    </properties>
     <dependencies>
         <dependency>
             <groupId>org.apache.cxf</groupId>

--- a/rt/javascript/javascript-tests/pom.xml
+++ b/rt/javascript/javascript-tests/pom.xml
@@ -29,6 +29,9 @@
         <artifactId>cxf-runtime-javascript</artifactId>
         <version>3.2.5-SNAPSHOT</version>
     </parent>
+    <properties>
+        <cxf.module.name>org.apache.cxf.js.tests</cxf.module.name>
+    </properties>
     <dependencies>
         <dependency>
             <groupId>org.apache.cxf</groupId>

--- a/rt/management/pom.xml
+++ b/rt/management/pom.xml
@@ -30,6 +30,9 @@
         <version>3.2.5-SNAPSHOT</version>
         <relativePath>../../parent/pom.xml</relativePath>
     </parent>
+    <properties>
+        <cxf.module.name>org.apache.cxf.management</cxf.module.name>
+    </properties>
     <dependencies>
         <dependency>
             <groupId>junit</groupId>

--- a/rt/rs/client/pom.xml
+++ b/rt/rs/client/pom.xml
@@ -31,6 +31,7 @@
         <relativePath>../../../parent/pom.xml</relativePath>
     </parent>
     <properties>
+        <cxf.module.name>org.apache.cxf.rs.client</cxf.module.name>
         <cxf.osgi.import>
             org.apache.aries*;version="${cxf.aries.version.range}";resolution:=optional,
             org.springframework*;resolution:="optional";version="${cxf.osgi.spring.version}"

--- a/rt/rs/description-openapi-v3/pom.xml
+++ b/rt/rs/description-openapi-v3/pom.xml
@@ -31,6 +31,7 @@
         <relativePath>../../../parent/pom.xml</relativePath>
     </parent>
     <properties>
+        <cxf.module.name>org.apache.cxf.rs.openapi.v3</cxf.module.name>
         <cxf.osgi.import>
             javax.servlet*;version="${cxf.osgi.javax.servlet.version}",
             javax.annotation;version="${cxf.osgi.javax.annotation.version}",

--- a/rt/rs/description-swagger-ui/pom.xml
+++ b/rt/rs/description-swagger-ui/pom.xml
@@ -30,6 +30,9 @@
         <version>3.2.5-SNAPSHOT</version>
         <relativePath>../../../parent/pom.xml</relativePath>
     </parent>
+    <properties>
+        <cxf.module.name>org.apache.cxf.rs.swagger.ui</cxf.module.name>
+    </properties>
     <dependencies>
         <dependency>
             <groupId>${cxf.servlet-api.group}</groupId>

--- a/rt/rs/description-swagger/pom.xml
+++ b/rt/rs/description-swagger/pom.xml
@@ -31,6 +31,7 @@
         <relativePath>../../../parent/pom.xml</relativePath>
     </parent>
     <properties>
+        <cxf.module.name>org.apache.cxf.rs.swagger</cxf.module.name>
         <cxf.osgi.import>
             javax.servlet*;version="${cxf.osgi.javax.servlet.version}",
             javax.annotation;version="${cxf.osgi.javax.annotation.version}",

--- a/rt/rs/description/pom.xml
+++ b/rt/rs/description/pom.xml
@@ -31,6 +31,7 @@
         <relativePath>../../../parent/pom.xml</relativePath>
     </parent>
     <properties>
+        <cxf.module.name>org.apache.cxf.rs.wadl</cxf.module.name>
         <cxf.osgi.import>
             javax.servlet*;version="${cxf.osgi.javax.servlet.version}",
         </cxf.osgi.import>

--- a/rt/rs/extensions/json-basic/pom.xml
+++ b/rt/rs/extensions/json-basic/pom.xml
@@ -30,6 +30,9 @@
         <version>3.2.5-SNAPSHOT</version>
         <relativePath>../../../../parent/pom.xml</relativePath>
     </parent>
+    <properties>
+        <cxf.module.name>org.apache.cxf.rs.json</cxf.module.name>
+    </properties>
     <dependencies>
         <dependency>
             <groupId>org.apache.cxf</groupId>

--- a/rt/rs/extensions/providers/pom.xml
+++ b/rt/rs/extensions/providers/pom.xml
@@ -31,6 +31,7 @@
         <relativePath>../../../../parent/pom.xml</relativePath>
     </parent>
     <properties>
+        <cxf.module.name>org.apache.cxf.rs.providers</cxf.module.name>
         <cxf.osgi.import>
             javax.servlet*;version="${cxf.osgi.javax.servlet.version}",
         </cxf.osgi.import>

--- a/rt/rs/extensions/reactivestreams/pom.xml
+++ b/rt/rs/extensions/reactivestreams/pom.xml
@@ -30,6 +30,9 @@
         <version>3.2.5-SNAPSHOT</version>
         <relativePath>../../../../parent/pom.xml</relativePath>
     </parent>
+    <properties>
+        <cxf.module.name>org.apache.cxf.rs.reactivestreams</cxf.module.name>
+    </properties>
     <dependencies>
         <dependency>
             <groupId>org.apache.cxf</groupId>

--- a/rt/rs/extensions/reactor/pom.xml
+++ b/rt/rs/extensions/reactor/pom.xml
@@ -30,6 +30,9 @@
         <version>3.2.5-SNAPSHOT</version>
         <relativePath>../../../../parent/pom.xml</relativePath>
     </parent>
+    <properties>
+        <cxf.module.name>org.apache.cxf.rs.reactor</cxf.module.name>
+    </properties>
     <dependencies>
         <dependency>
             <groupId>org.apache.cxf</groupId>

--- a/rt/rs/extensions/rx/pom.xml
+++ b/rt/rs/extensions/rx/pom.xml
@@ -30,6 +30,9 @@
         <version>3.2.5-SNAPSHOT</version>
         <relativePath>../../../../parent/pom.xml</relativePath>
     </parent>
+    <properties>
+        <cxf.module.name>org.apache.cxf.rs.rx</cxf.module.name>
+    </properties>
     <dependencies>
         <dependency>
             <groupId>org.apache.cxf</groupId>

--- a/rt/rs/extensions/rx2/pom.xml
+++ b/rt/rs/extensions/rx2/pom.xml
@@ -30,6 +30,9 @@
         <version>3.2.5-SNAPSHOT</version>
         <relativePath>../../../../parent/pom.xml</relativePath>
     </parent>
+    <properties>
+        <cxf.module.name>org.apache.cxf.rs.rx2</cxf.module.name>
+    </properties>
     <dependencies>
         <dependency>
             <groupId>org.apache.cxf</groupId>

--- a/rt/rs/extensions/search/pom.xml
+++ b/rt/rs/extensions/search/pom.xml
@@ -33,6 +33,7 @@
     <properties>
         <hibernate.em.version>4.1.0.Final</hibernate.em.version>
         <hsqldb.version>1.8.0.10</hsqldb.version>
+        <cxf.module.name>org.apache.cxf.rs.search</cxf.module.name>
     </properties>
     <dependencies>
         <dependency>

--- a/rt/rs/http-sci/pom.xml
+++ b/rt/rs/http-sci/pom.xml
@@ -31,6 +31,7 @@
         <relativePath>../../../parent/pom.xml</relativePath>
     </parent>
     <properties>
+        <cxf.module.name>org.apache.cxf.rs.sci</cxf.module.name>
         <cxf.osgi.import>
             javax.servlet*;version="${cxf.osgi.javax.servlet.version}",
         </cxf.osgi.import>

--- a/rt/rs/microprofile-client/pom.xml
+++ b/rt/rs/microprofile-client/pom.xml
@@ -31,6 +31,7 @@
         <relativePath>../../../parent/pom.xml</relativePath>
     </parent>
     <properties>
+        <cxf.module.name>org.apache.cxf.rs.client.mp</cxf.module.name>
         <cxf.osgi.import>
             org.apache.aries*;version="${cxf.aries.version.range}";resolution:=optional,
             org.springframework*;resolution:="optional";version="${cxf.osgi.spring.version}",

--- a/rt/rs/security/cors/pom.xml
+++ b/rt/rs/security/cors/pom.xml
@@ -30,6 +30,9 @@
         <version>3.2.5-SNAPSHOT</version>
         <relativePath>../../../../parent/pom.xml</relativePath>
     </parent>
+    <properties>
+        <cxf.module.name>org.apache.cxf.rs.security.cors</cxf.module.name>
+    </properties>
     <dependencies>
         <dependency>
             <groupId>junit</groupId>

--- a/rt/rs/security/jcs-parent/jcs/pom.xml
+++ b/rt/rs/security/jcs-parent/jcs/pom.xml
@@ -30,6 +30,9 @@
         <version>3.2.1-SNAPSHOT</version>
         <relativePath>../../../../../parent/pom.xml</relativePath>
     </parent>
+    <properties>
+        <cxf.module.name>org.apache.cxf.rs.security.jcs</cxf.module.name>
+    </properties>
     <dependencies>
         <dependency>
             <groupId>org.apache.cxf</groupId>

--- a/rt/rs/security/jose-parent/jose-jaxrs/pom.xml
+++ b/rt/rs/security/jose-parent/jose-jaxrs/pom.xml
@@ -30,6 +30,9 @@
         <version>3.2.5-SNAPSHOT</version>
         <relativePath>../../../../../parent/pom.xml</relativePath>
     </parent>
+    <properties>
+        <cxf.module.name>org.apache.cxf.rs.security.jose.jaxrs</cxf.module.name>
+    </properties>
     <dependencies>
         <dependency>
             <groupId>org.apache.cxf</groupId>

--- a/rt/rs/security/jose-parent/jose/pom.xml
+++ b/rt/rs/security/jose-parent/jose/pom.xml
@@ -30,6 +30,9 @@
         <version>3.2.5-SNAPSHOT</version>
         <relativePath>../../../../../parent/pom.xml</relativePath>
     </parent>
+    <properties>
+        <cxf.module.name>org.apache.cxf.rs.security.jose</cxf.module.name>
+    </properties>
     <dependencies>
         <dependency>
             <groupId>org.apache.cxf</groupId>

--- a/rt/rs/security/oauth-parent/oauth/pom.xml
+++ b/rt/rs/security/oauth-parent/oauth/pom.xml
@@ -31,6 +31,7 @@
         <relativePath>../pom.xml</relativePath>
     </parent>
     <properties>
+        <cxf.module.name>org.apache.cxf.rs.security.oauth</cxf.module.name>
         <cxf.osgi.import>
             javax.servlet*;version="${cxf.osgi.javax.servlet.version}",
         </cxf.osgi.import>

--- a/rt/rs/security/oauth-parent/oauth2-saml/pom.xml
+++ b/rt/rs/security/oauth-parent/oauth2-saml/pom.xml
@@ -31,6 +31,7 @@
         <relativePath>../pom.xml</relativePath>
     </parent>
     <properties>
+        <cxf.module.name>org.apache.cxf.rs.security.oauth2.saml</cxf.module.name>
         <cxf.osgi.import>
             org.opensaml*;version="${cxf.opensaml.osgi.version.range}",
         </cxf.osgi.import>

--- a/rt/rs/security/oauth-parent/oauth2/pom.xml
+++ b/rt/rs/security/oauth-parent/oauth2/pom.xml
@@ -31,6 +31,7 @@
     <relativePath>../pom.xml</relativePath>
   </parent>
   <properties>
+    <cxf.module.name>org.apache.cxf.rs.security.oauth2</cxf.module.name>
     <cxf.osgi.import>
       net.sf.ehcache*;resolution:=optional;version="[2.5, 3.0.0)",
       javax.servlet*;version="${cxf.osgi.javax.servlet.version}"

--- a/rt/rs/security/sso/oidc/pom.xml
+++ b/rt/rs/security/sso/oidc/pom.xml
@@ -34,6 +34,7 @@
     <hibernate.em.version>4.1.0.Final</hibernate.em.version>
     <hsqldb.version>1.8.0.10</hsqldb.version>
     <compilerArguments>-Aopenjpa.source=7 -Aopenjpa.metamodel=true</compilerArguments>
+    <cxf.module.name>org.apache.cxf.rs.security.sso.oidc</cxf.module.name>
   </properties>
   <dependencies>
     <dependency>

--- a/rt/rs/security/sso/saml/pom.xml
+++ b/rt/rs/security/sso/saml/pom.xml
@@ -31,6 +31,7 @@
         <relativePath>../../../../../parent/pom.xml</relativePath>
     </parent>
     <properties>
+        <cxf.module.name>org.apache.cxf.rs.security.sso.saml</cxf.module.name>
         <cxf.osgi.import>
             javax.servlet*;version="${cxf.osgi.javax.servlet.version}",
             net.sf.ehcache*;resolution:=optional;version="[2.5, 3.0.0)",

--- a/rt/rs/security/xml/pom.xml
+++ b/rt/rs/security/xml/pom.xml
@@ -31,6 +31,7 @@
         <relativePath>../../../../parent/pom.xml</relativePath>
     </parent>
     <properties>
+        <cxf.module.name>org.apache.cxf.rs.security.xml</cxf.module.name>
         <cxf.osgi.import>
             org.opensaml*;version="${cxf.opensaml.osgi.version.range}",
         </cxf.osgi.import>

--- a/rt/rs/sse/pom.xml
+++ b/rt/rs/sse/pom.xml
@@ -31,6 +31,7 @@
         <relativePath>../../../parent/pom.xml</relativePath>
     </parent>
     <properties>
+        <cxf.module.name>org.apache.cxf.rs.sse</cxf.module.name>
         <cxf.osgi.import>
             javax.servlet*;version="${cxf.osgi.javax.servlet.version}",
         </cxf.osgi.import>

--- a/rt/security-saml/pom.xml
+++ b/rt/security-saml/pom.xml
@@ -31,6 +31,7 @@
         <relativePath>../../parent/pom.xml</relativePath>
     </parent>
     <properties>
+        <cxf.module.name>org.apache.cxf.security.saml</cxf.module.name>
         <cxf.osgi.import>
             org.opensaml*;version="${cxf.opensaml.osgi.version.range}",
         </cxf.osgi.import>

--- a/rt/security/pom.xml
+++ b/rt/security/pom.xml
@@ -30,6 +30,9 @@
         <version>3.2.5-SNAPSHOT</version>
         <relativePath>../../parent/pom.xml</relativePath>
     </parent>
+    <properties>
+        <cxf.module.name>org.apache.cxf.security</cxf.module.name>
+    </properties>
     <dependencies>
         <dependency>
             <groupId>org.apache.cxf</groupId>

--- a/rt/transports/http-hc/pom.xml
+++ b/rt/transports/http-hc/pom.xml
@@ -31,6 +31,7 @@
         <relativePath>../../../parent/pom.xml</relativePath>
     </parent>
     <properties>
+        <cxf.module.name>org.apache.cxf.transport.http.hc</cxf.module.name>
         <cxf.bundle.activator>org.apache.cxf.transport.http.asyncclient.Activator</cxf.bundle.activator>
         <cxf.osgi.import>
             javax.annotation;version="${cxf.osgi.javax.annotation.version}",

--- a/rt/transports/http-jetty/pom.xml
+++ b/rt/transports/http-jetty/pom.xml
@@ -31,6 +31,7 @@
         <relativePath>../../../parent/pom.xml</relativePath>
     </parent>
     <properties>
+        <cxf.module.name>org.apache.cxf.transport.http.jetty</cxf.module.name>
         <cxf.bundle.activator>org.apache.cxf.transport.http_jetty.osgi.HTTPJettyTransportActivator</cxf.bundle.activator>
         <cxf.osgi.import>
             javax.servlet*;version="${cxf.osgi.javax.servlet.version}",

--- a/rt/transports/http-netty/netty-client/pom.xml
+++ b/rt/transports/http-netty/netty-client/pom.xml
@@ -31,6 +31,7 @@
         <relativePath>../../../../parent/pom.xml</relativePath>
     </parent>
     <properties>
+        <cxf.module.name>org.apache.cxf.transport.http.netty.client</cxf.module.name>
         <cxf.osgi.import>
             javax.servlet*;version="[2,4)",
             io.netty.*;version="${cxf.netty.version.range}",

--- a/rt/transports/http-netty/netty-server/pom.xml
+++ b/rt/transports/http-netty/netty-server/pom.xml
@@ -31,6 +31,7 @@
         <relativePath>../../../../parent/pom.xml</relativePath>
     </parent>
     <properties>
+        <cxf.module.name>org.apache.cxf.transport.http.netty.server</cxf.module.name>
         <cxf.bundle.activator>org.apache.cxf.transport.http.netty.server.blueprint.Activator</cxf.bundle.activator>
         <cxf.osgi.import>
             javax.servlet*;version="[2,4)",

--- a/rt/transports/http-undertow/pom.xml
+++ b/rt/transports/http-undertow/pom.xml
@@ -31,6 +31,7 @@
         <relativePath>../../../parent/pom.xml</relativePath>
     </parent>
     <properties>
+        <cxf.module.name>org.apache.cxf.transport.http.undertow</cxf.module.name>
         <cxf.bundle.activator>org.apache.cxf.transport.http_undertow.osgi.HTTPUndertowTransportActivator</cxf.bundle.activator>
         <cxf.osgi.import>
             javax.servlet*;version="${cxf.osgi.javax.servlet.version}",

--- a/rt/transports/http/pom.xml
+++ b/rt/transports/http/pom.xml
@@ -31,6 +31,7 @@
         <relativePath>../../../parent/pom.xml</relativePath>
     </parent>
     <properties>
+        <cxf.module.name>org.apache.cxf.transport.http</cxf.module.name>
         <cxf.bundle.activator>org.apache.cxf.transport.http.osgi.HTTPTransportActivator</cxf.bundle.activator>
         <cxf.osgi.import>
             javax.net,

--- a/rt/transports/jms/pom.xml
+++ b/rt/transports/jms/pom.xml
@@ -25,6 +25,7 @@
     <properties>
         <cxf.spi-dir>spi-2.1</cxf.spi-dir>
         <cxf.osgi.import>javax.jms;version="[1.1,3)"</cxf.osgi.import>
+        <cxf.module.name>org.apache.cxf.transport.jms</cxf.module.name>
     </properties>
     <dependencies>
         <dependency>

--- a/rt/transports/local/pom.xml
+++ b/rt/transports/local/pom.xml
@@ -30,6 +30,9 @@
         <version>3.2.5-SNAPSHOT</version>
         <relativePath>../../../parent/pom.xml</relativePath>
     </parent>
+    <properties>
+        <cxf.module.name>org.apache.cxf.transport.local</cxf.module.name>
+    </properties>
     <dependencies>
         <dependency>
             <groupId>junit</groupId>

--- a/rt/transports/udp/pom.xml
+++ b/rt/transports/udp/pom.xml
@@ -30,6 +30,9 @@
         <version>3.2.5-SNAPSHOT</version>
         <relativePath>../../../parent/pom.xml</relativePath>
     </parent>
+    <properties>
+        <cxf.module.name>org.apache.cxf.transport.udp</cxf.module.name>
+    </properties>
     <dependencies>
         <dependency>
             <groupId>junit</groupId>

--- a/rt/transports/websocket/pom.xml
+++ b/rt/transports/websocket/pom.xml
@@ -36,6 +36,7 @@
                     org.eclipse.jetty.websocket;version="${cxf.jetty.osgi.version}";resolution:=optional,
         
 -->
+        <cxf.module.name>org.apache.cxf.transport.websocket</cxf.module.name>
         <cxf.osgi.import>
             javax.servlet*;version="${cxf.osgi.javax.servlet.version}",
             org.eclipse.jetty*;version="${cxf.jetty.osgi.version}";resolution:=optional,

--- a/rt/ws/addr/pom.xml
+++ b/rt/ws/addr/pom.xml
@@ -31,6 +31,7 @@
         <relativePath>../../../parent/pom.xml</relativePath>
     </parent>
     <properties>
+        <cxf.module.name>org.apache.cxf.ws.addr</cxf.module.name>
         <cxf.bundle.activator>org.apache.cxf.ws.addressing.blueprint.Activator</cxf.bundle.activator>
         <cxf.osgi.import>
             org.springframework*;resolution:="optional";version="${cxf.osgi.spring.version}",

--- a/rt/ws/eventing/pom.xml
+++ b/rt/ws/eventing/pom.xml
@@ -12,6 +12,9 @@
         <version>3.2.5-SNAPSHOT</version>
         <relativePath>../../../parent/pom.xml</relativePath>
     </parent>
+    <properties>
+        <cxf.module.name>org.apache.cxf.ws.eventing</cxf.module.name>
+    </properties>
     <dependencies>
         <dependency>
             <groupId>org.apache.cxf</groupId>

--- a/rt/ws/mex/pom.xml
+++ b/rt/ws/mex/pom.xml
@@ -30,6 +30,9 @@
         <version>3.2.5-SNAPSHOT</version>
         <relativePath>../../../parent/pom.xml</relativePath>
     </parent>
+    <properties>
+        <cxf.module.name>org.apache.cxf.ws.mex</cxf.module.name>
+    </properties>
     <dependencies>
         <dependency>
             <groupId>org.apache.cxf</groupId>

--- a/rt/ws/policy/pom.xml
+++ b/rt/ws/policy/pom.xml
@@ -31,6 +31,7 @@
         <relativePath>../../../parent/pom.xml</relativePath>
     </parent>
     <properties>
+        <cxf.module.name>org.apache.cxf.ws.policy</cxf.module.name>
         <cxf.bundle.activator>org.apache.cxf.ws.policy.blueprint.Activator</cxf.bundle.activator>
         <cxf.osgi.import>
             org.springframework*;resolution:="optional";version="${cxf.osgi.spring.version}",

--- a/rt/ws/rm/pom.xml
+++ b/rt/ws/rm/pom.xml
@@ -31,6 +31,7 @@
         <relativePath>../../../parent/pom.xml</relativePath>
     </parent>
     <properties>
+        <cxf.module.name>org.apache.cxf.ws.rm</cxf.module.name>
         <cxf.bundle.activator>org.apache.cxf.ws.rm.blueprint.Activator</cxf.bundle.activator>
         <cxf.osgi.import>
             org.apache.aries*;version="${cxf.aries.version.range}";resolution:=optional,

--- a/rt/ws/security/pom.xml
+++ b/rt/ws/security/pom.xml
@@ -31,6 +31,7 @@
         <relativePath>../../../parent/pom.xml</relativePath>
     </parent>
     <properties>
+        <cxf.module.name>org.apache.cxf.ws.security</cxf.module.name>
         <cxf.osgi.import>
             net.sf.ehcache*;resolution:=optional;version="[2.5, 3.0.0)",
             org.opensaml*;version="${cxf.opensaml.osgi.version.range}",

--- a/rt/ws/transfer/pom.xml
+++ b/rt/ws/transfer/pom.xml
@@ -15,6 +15,7 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <cxf.module.name>org.apache.cxf.ws.transfer</cxf.module.name>
   </properties>
 
   <dependencies>

--- a/rt/wsdl/pom.xml
+++ b/rt/wsdl/pom.xml
@@ -30,6 +30,9 @@
         <version>3.2.5-SNAPSHOT</version>
         <relativePath>../../parent/pom.xml</relativePath>
     </parent>
+    <properties>
+        <cxf.module.name>org.apache.cxf.wsdl</cxf.module.name>
+    </properties>
     <dependencies>
         <dependency>
             <groupId>org.apache.cxf</groupId>

--- a/services/sts/sts-core/pom.xml
+++ b/services/sts/sts-core/pom.xml
@@ -30,6 +30,9 @@
         <version>3.2.5-SNAPSHOT</version>
         <relativePath>../../../parent/pom.xml</relativePath>
     </parent>
+    <properties>
+        <cxf.module.name>org.apache.cxf.sts.core</cxf.module.name>
+    </properties>
     <dependencies>
         <dependency>
             <groupId>org.apache.cxf</groupId>

--- a/services/sts/systests/advanced/pom.xml
+++ b/services/sts/systests/advanced/pom.xml
@@ -30,6 +30,11 @@
         <version>3.2.5-SNAPSHOT</version>
         <relativePath>../../../../parent/pom.xml</relativePath>
     </parent>
+    
+    <properties>
+        <cxf.module.name>org.apache.cxf.systests.sts.advanced</cxf.module.name>
+    </properties>
+    
     <dependencies>
         <dependency>
             <groupId>junit</groupId>

--- a/services/sts/systests/basic/pom.xml
+++ b/services/sts/systests/basic/pom.xml
@@ -30,6 +30,11 @@
         <version>3.2.5-SNAPSHOT</version>
         <relativePath>../../../../parent/pom.xml</relativePath>
     </parent>
+    
+    <properties>
+        <cxf.module.name>org.apache.cxf.systests.sts.basic</cxf.module.name>
+    </properties>
+    
     <dependencies>
         <dependency>
             <groupId>junit</groupId>

--- a/services/sts/systests/sts-itests/pom.xml
+++ b/services/sts/systests/sts-itests/pom.xml
@@ -29,6 +29,11 @@
         <version>3.2.5-SNAPSHOT</version>
         <relativePath>../../../../parent/pom.xml</relativePath>
     </parent>
+    
+    <properties>
+        <cxf.module.name>org.apache.cxf.systests.sts.integration</cxf.module.name>
+    </properties>
+    
     <dependencies>
         <dependency>
             <groupId>org.osgi</groupId>

--- a/services/sts/systests/sts-osgi/pom.xml
+++ b/services/sts/systests/sts-osgi/pom.xml
@@ -30,6 +30,11 @@
         <version>3.2.5-SNAPSHOT</version>
         <relativePath>../../../../parent/pom.xml</relativePath>
     </parent>
+    
+    <properties>
+        <cxf.module.name>org.apache.cxf.systests.sts.osgi</cxf.module.name>
+    </properties>
+    
     <dependencies>
         <dependency>
             <groupId>org.apache.cxf.services.sts</groupId>

--- a/services/ws-discovery/ws-discovery-api/pom.xml
+++ b/services/ws-discovery/ws-discovery-api/pom.xml
@@ -32,6 +32,7 @@
         <relativePath>../../../parent/pom.xml</relativePath>
     </parent>
     <properties>
+        <cxf.module.name>org.apache.cxf.ws.discovery</cxf.module.name>
         <cxf.osgi.export>
             =org.apache.cxf.ws.discovery.internal,
             org.apache.cxf.ws.discovery.*,

--- a/services/ws-discovery/ws-discovery-service/pom.xml
+++ b/services/ws-discovery/ws-discovery-service/pom.xml
@@ -32,6 +32,7 @@
         <relativePath>../../../parent/pom.xml</relativePath>
     </parent>
     <properties>
+        <cxf.module.name>org.apache.cxf.ws.discovery.service</cxf.module.name>
         <cxf.osgi.import>org.apache.cxf.ws.discovery.listeners</cxf.osgi.import>
     </properties>
     <dependencies>

--- a/services/wsn/wsn-api/pom.xml
+++ b/services/wsn/wsn-api/pom.xml
@@ -31,6 +31,9 @@
         <version>3.2.5-SNAPSHOT</version>
         <relativePath>../../../parent/pom.xml</relativePath>
     </parent>
+    <properties>
+        <cxf.module.name>org.apache.cxf.wsn</cxf.module.name>
+    </properties>
     <dependencies>
         <dependency>
             <groupId>org.apache.cxf</groupId>

--- a/services/wsn/wsn-core/pom.xml
+++ b/services/wsn/wsn-core/pom.xml
@@ -32,6 +32,7 @@
         <relativePath>../../../parent/pom.xml</relativePath>
     </parent>
     <properties>
+        <cxf.module.name>org.apache.cxf.wsn.core</cxf.module.name>
         <cxf.server.launcher.vmargs />
         <cxf.surefire.enable.assertions>false</cxf.surefire.enable.assertions>
     </properties>

--- a/services/wsn/wsn-osgi/pom.xml
+++ b/services/wsn/wsn-osgi/pom.xml
@@ -31,6 +31,9 @@
         <version>3.2.5-SNAPSHOT</version>
         <relativePath>../../../parent/pom.xml</relativePath>
     </parent>
+    <properties>
+        <cxf.module.name>org.apache.cxf.wsn.osgi</cxf.module.name>
+    </properties>
     <dependencies>
         <dependency>
             <groupId>org.apache.cxf.services.wsn</groupId>

--- a/services/xkms/xkms-client/pom.xml
+++ b/services/xkms/xkms-client/pom.xml
@@ -30,6 +30,9 @@
         <version>3.2.5-SNAPSHOT</version>
         <relativePath>../../../parent/pom.xml</relativePath>
     </parent>
+    <properties>
+        <cxf.module.name>org.apache.cxf.xkms.client</cxf.module.name>
+    </properties>
     <build>
         <testSourceDirectory>${basedir}/src/test/java</testSourceDirectory>
         <testResources>

--- a/services/xkms/xkms-common/pom.xml
+++ b/services/xkms/xkms-common/pom.xml
@@ -30,6 +30,9 @@
         <version>3.2.5-SNAPSHOT</version>
         <relativePath>../../../parent/pom.xml</relativePath>
     </parent>
+    <properties>
+        <cxf.module.name>org.apache.cxf.xkms.common</cxf.module.name>
+    </properties>
     <dependencies>
         <dependency>
             <groupId>org.apache.cxf</groupId>

--- a/services/xkms/xkms-features/pom.xml
+++ b/services/xkms/xkms-features/pom.xml
@@ -30,6 +30,9 @@
         <version>3.2.5-SNAPSHOT</version>
         <relativePath>../../../parent/pom.xml</relativePath>
     </parent>
+    <properties>
+        <cxf.module.name>org.apache.cxf.xkms.features</cxf.module.name>
+    </properties>
     <build>
         <resources>
             <resource>

--- a/services/xkms/xkms-itests/pom.xml
+++ b/services/xkms/xkms-itests/pom.xml
@@ -29,12 +29,14 @@
         <version>3.2.5-SNAPSHOT</version>
         <relativePath>../../../parent/pom.xml</relativePath>
     </parent>
+    <properties>
+        <cxf.module.name>org.apache.cxf.xkms.itests</cxf.module.name>
+    </properties>
     <dependencies>
         <dependency>
             <groupId>org.osgi</groupId>
             <artifactId>org.osgi.core</artifactId>
         </dependency>
-    
         <dependency>
             <groupId>org.apache.cxf.services.xkms</groupId>
             <artifactId>cxf-services-xkms-common</artifactId>

--- a/services/xkms/xkms-osgi/pom.xml
+++ b/services/xkms/xkms-osgi/pom.xml
@@ -30,6 +30,9 @@
         <version>3.2.5-SNAPSHOT</version>
         <relativePath>../../../parent/pom.xml</relativePath>
     </parent>
+    <properties>
+        <cxf.module.name>org.apache.cxf.xkms.osgi</cxf.module.name>
+    </properties>
     <dependencies>
         <dependency>
             <groupId>org.apache.cxf.services.xkms</groupId>

--- a/services/xkms/xkms-service/pom.xml
+++ b/services/xkms/xkms-service/pom.xml
@@ -30,6 +30,9 @@
         <version>3.2.5-SNAPSHOT</version>
         <relativePath>../../../parent/pom.xml</relativePath>
     </parent>
+    <properties>
+        <cxf.module.name>org.apache.cxf.xkms.service</cxf.module.name>
+    </properties>
     <dependencies>
         <dependency>
             <groupId>org.apache.cxf.services.xkms</groupId>

--- a/services/xkms/xkms-x509-handlers/pom.xml
+++ b/services/xkms/xkms-x509-handlers/pom.xml
@@ -30,6 +30,9 @@
         <version>3.2.5-SNAPSHOT</version>
         <relativePath>../../../parent/pom.xml</relativePath>
     </parent>
+    <properties>
+        <cxf.module.name>org.apache.cxf.xkms.x509.handlers</cxf.module.name>
+    </properties>
     <dependencies>
         <dependency>
             <groupId>org.apache.cxf</groupId>

--- a/services/xkms/xkms-x509-repo-ldap/pom.xml
+++ b/services/xkms/xkms-x509-repo-ldap/pom.xml
@@ -12,6 +12,10 @@
     <name>Apache CXF XKMS LDAP repository</name>
     <url>http://cxf.apache.org</url>
     
+    <properties>
+        <cxf.module.name>org.apache.cxf.xkms.x509.ldap</cxf.module.name>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>org.apache.cxf.services.xkms</groupId>

--- a/systests/cdi/base/pom.xml
+++ b/systests/cdi/base/pom.xml
@@ -28,6 +28,11 @@
 
     <artifactId>cxf-systests-cdi-base</artifactId>
     <name>Apache CXF CDI Integration System Tests - Base</name>
+    
+    <properties>
+        <cxf.module.name>org.apache.cxf.systests.cdi.base</cxf.module.name>
+    </properties>
+    
     <dependencies>
         <dependency>
             <groupId>org.eclipse.jetty</groupId>

--- a/systests/cdi/cdi-owb/cdi-multiple-apps-owb/pom.xml
+++ b/systests/cdi/cdi-owb/cdi-multiple-apps-owb/pom.xml
@@ -29,4 +29,8 @@
     <name>Apache CXF CDI Integration System Tests - OWB with multiple apps</name>
     <description>Apache CXF CDI Integration System Tests - OpenWebBeans with multiple apps</description>
     <url>http://cxf.apache.org</url>
+    
+    <properties>
+        <cxf.module.name>org.apache.cxf.systests.cdi.owb.multiapp</cxf.module.name>
+    </properties>
 </project>

--- a/systests/cdi/cdi-owb/cdi-no-apps-owb/pom.xml
+++ b/systests/cdi/cdi-owb/cdi-no-apps-owb/pom.xml
@@ -30,4 +30,8 @@
     <name>Apache CXF CDI Integration System Tests - OWB with no apps</name>
     <description>Apache CXF CDI Integration System Tests - OpenWebBeans with no apps</description>
     <url>http://cxf.apache.org</url>
+    
+    <properties>
+        <cxf.module.name>org.apache.cxf.systests.cdi.owb.noapp</cxf.module.name>
+    </properties>
 </project>

--- a/systests/cdi/cdi-owb/cdi-producers-owb/pom.xml
+++ b/systests/cdi/cdi-owb/cdi-producers-owb/pom.xml
@@ -31,6 +31,10 @@
     <description>Apache CXF CDI Integration System Tests - OpenWebBeans with producers</description>
     <url>http://cxf.apache.org</url>
     
+    <properties>
+        <cxf.module.name>org.apache.cxf.systests.cdi.owb.producers</cxf.module.name>
+    </properties>
+    
     <dependencies>
         <dependency>
              <groupId>org.apache.cxf</groupId>

--- a/systests/cdi/cdi-weld/cdi-multiple-apps-weld/pom.xml
+++ b/systests/cdi/cdi-weld/cdi-multiple-apps-weld/pom.xml
@@ -29,4 +29,9 @@
     <name>Apache CXF CDI Integration System Tests - Weld with multiple apps</name>
     <description>Apache CXF CDI Integration System Tests - Weld with multiple apps</description>
     <url>http://cxf.apache.org</url>
+    
+    <properties>
+        <cxf.module.name>org.apache.cxf.systests.cdi.weld.multiapp</cxf.module.name>
+    </properties>
+    
 </project>

--- a/systests/cdi/cdi-weld/cdi-no-apps-weld/pom.xml
+++ b/systests/cdi/cdi-weld/cdi-no-apps-weld/pom.xml
@@ -30,4 +30,9 @@
     <name>Apache CXF CDI Integration System Tests - Weld with no apps</name>
     <description>Apache CXF CDI Integration System Tests - Weld with no apps</description>
     <url>http://cxf.apache.org</url>
+    
+    <properties>
+        <cxf.module.name>org.apache.cxf.systests.cdi.weld.noapp</cxf.module.name>
+    </properties>
+    
 </project>

--- a/systests/cdi/cdi-weld/cdi-producers-weld/pom.xml
+++ b/systests/cdi/cdi-weld/cdi-producers-weld/pom.xml
@@ -31,6 +31,10 @@
     <description>Apache CXF CDI Integration System Tests - Weld with producers</description>
     <url>http://cxf.apache.org</url>
     
+    <properties>
+        <cxf.module.name>org.apache.cxf.systests.cdi.weld.producers</cxf.module.name>
+    </properties>
+    
     <dependencies>
         <dependency>
              <groupId>org.apache.cxf</groupId>

--- a/systests/cdi/pom.xml
+++ b/systests/cdi/pom.xml
@@ -142,18 +142,27 @@
         </dependencies>
     </dependencyManagement>
     <build>
-        <plugins>
-            <plugin>
-                <artifactId>maven-jar-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>attach-sources</id>
-                        <goals>
-                            <goal>test-jar</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-        </plugins>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <artifactId>maven-jar-plugin</artifactId>
+                    <executions>
+                        <execution>
+                            <id>attach-sources</id>
+                            <goals>
+                                <goal>test-jar</goal>
+                            </goals>
+                            <configuration>
+                                <archive>
+                                    <manifestEntries>
+                                        <Automatic-Module-Name>${cxf.module.name}.tests</Automatic-Module-Name>
+                                    </manifestEntries>
+                                </archive>
+                            </configuration>
+                        </execution>
+                    </executions>
+                </plugin>
+            </plugins>
+        </pluginManagement>
     </build>
 </project>

--- a/systests/container-integration/grizzly/pom.xml
+++ b/systests/container-integration/grizzly/pom.xml
@@ -28,6 +28,11 @@
     <artifactId>cxf-systests-ci-grizzly</artifactId>
     <name>Apache CXF Container Integration Test Grizzly</name>
     <description>Apache CXF Container Integration Test Grizzly</description>
+    
+    <properties>
+        <cxf.module.name>org.apache.cxf.systests.ci.grizzly</cxf.module.name>
+    </properties>
+
     <repositories>
         <repository>
             <id>maven2-repository.dev.java.net</id>

--- a/systests/container-integration/webapp/pom.xml
+++ b/systests/container-integration/webapp/pom.xml
@@ -29,6 +29,11 @@
     <name>Apache CXF Container Integration Test Webapp</name>
     <description>Apache CXF Container Integration Test Webapp</description>
     <packaging>war</packaging>
+    
+    <properties>
+        <cxf.module.name>org.apache.cxf.systests.ci.webapp</cxf.module.name>
+    </properties>
+    
     <dependencies>
         <dependency>
             <groupId>org.apache.cxf</groupId>

--- a/systests/databinding/pom.xml
+++ b/systests/databinding/pom.xml
@@ -33,6 +33,7 @@
     <properties>
         <hello.world.binding.file>hello_world.xml</hello.world.binding.file>
         <doc.lit.bare.binding.file>doc_lit_bare.xml</doc.lit.bare.binding.file>
+        <cxf.module.name>org.apache.cxf.systests.databinding</cxf.module.name>
     </properties>
     <build>
         <plugins>
@@ -44,6 +45,13 @@
                         <goals>
                             <goal>test-jar</goal>
                         </goals>
+                        <configuration>
+                            <archive>
+                                <manifestEntries>
+                                    <Automatic-Module-Name>${cxf.module.name}.tests</Automatic-Module-Name>
+                                </manifestEntries>
+                            </archive>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>

--- a/systests/jaxrs/pom.xml
+++ b/systests/jaxrs/pom.xml
@@ -33,6 +33,7 @@
     <properties>
         <cxf.el.api.version>3.0-b02</cxf.el.api.version>
         <cxf.glassfish.el.version>3.0-b01</cxf.glassfish.el.version>
+        <cxf.module.name>org.apache.cxf.systests.jaxrs</cxf.module.name>
     </properties>
     <dependencies>
         <dependency>
@@ -556,6 +557,13 @@
                         <goals>
                             <goal>test-jar</goal>
                         </goals>
+                        <configuration>
+                            <archive>
+                                <manifestEntries>
+                                    <Automatic-Module-Name>${cxf.module.name}.tests</Automatic-Module-Name>
+                                </manifestEntries>
+                            </archive>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>

--- a/systests/jaxws/pom.xml
+++ b/systests/jaxws/pom.xml
@@ -30,6 +30,11 @@
     <name>Apache CXF JAX-WS System Tests</name>
     <description>Apache CXF JAX-WS System Tests</description>
     <url>http://cxf.apache.org</url>
+    
+    <properties>
+        <cxf.module.name>org.apache.cxf.systests.jaxws</cxf.module.name>
+    </properties>
+    
     <build>
         <plugins>
             <plugin>
@@ -68,6 +73,13 @@
                         <goals>
                             <goal>test-jar</goal>
                         </goals>
+                        <configuration>
+                            <archive>
+                                <manifestEntries>
+                                    <Automatic-Module-Name>${cxf.module.name}.tests</Automatic-Module-Name>
+                                </manifestEntries>
+                            </archive>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>

--- a/systests/kerberos/pom.xml
+++ b/systests/kerberos/pom.xml
@@ -30,6 +30,11 @@
     <name>Apache CXF Kerberos Integration System Tests</name>
     <description>Apache CXF Kerberos Integration System Tests</description>
     <url>http://cxf.apache.org</url>
+    
+    <properties>
+        <cxf.module.name>org.apache.cxf.systests.kerberos</cxf.module.name>
+    </properties>
+    
     <build>
         <testSourceDirectory>${basedir}/src/test/java</testSourceDirectory>
         <testResources>
@@ -81,6 +86,13 @@
                         <goals>
                             <goal>test-jar</goal>
                         </goals>
+                        <configuration>
+                            <archive>
+                                <manifestEntries>
+                                    <Automatic-Module-Name>${cxf.module.name}.tests</Automatic-Module-Name>
+                                </manifestEntries>
+                            </archive>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>

--- a/systests/ldap/pom.xml
+++ b/systests/ldap/pom.xml
@@ -30,6 +30,11 @@
     <name>Apache CXF LDAP Integration System Tests</name>
     <description>Apache CXF LDAP Integration System Tests</description>
     <url>http://cxf.apache.org</url>
+    
+    <properties>
+        <cxf.module.name>org.apache.cxf.systests.ldap</cxf.module.name>
+    </properties>
+    
     <build>
         <testSourceDirectory>${basedir}/src/test/java</testSourceDirectory>
         <testResources>
@@ -55,6 +60,13 @@
                         <goals>
                             <goal>test-jar</goal>
                         </goals>
+                        <configuration>
+                            <archive>
+                                <manifestEntries>
+                                    <Automatic-Module-Name>${cxf.module.name}.tests</Automatic-Module-Name>
+                                </manifestEntries>
+                            </archive>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>

--- a/systests/microprofile/client/weld/pom.xml
+++ b/systests/microprofile/client/weld/pom.xml
@@ -25,10 +25,15 @@
         <version>3.2.5-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
+    
     <modelVersion>4.0.0</modelVersion>
-
     <artifactId>cxf-systests-microprofile-weld</artifactId>
     <name>Apache CXF System Tests - MicroProfile Rest Client TCK on Weld</name>
+    
+    <properties>
+        <cxf.module.name>org.apache.cxf.systests.microprofile.weld</cxf.module.name>
+    </properties>
+    
     <dependencies>
         <dependency>
             <groupId>org.jboss.arquillian.testng</groupId>

--- a/systests/rs-http-sci/pom.xml
+++ b/systests/rs-http-sci/pom.xml
@@ -32,6 +32,7 @@
     <url>http://cxf.apache.org</url>
     <properties>
         <cxf.jetty.version>${cxf.jetty9.version}</cxf.jetty.version>
+        <cxf.module.name>org.apache.cxf.systests.rs.sci</cxf.module.name>
     </properties>
     <dependencies>
         <dependency>
@@ -135,6 +136,13 @@
                         <goals>
                             <goal>test-jar</goal>
                         </goals>
+                        <configuration>
+                            <archive>
+                                <manifestEntries>
+                                    <Automatic-Module-Name>${cxf.module.name}.tests</Automatic-Module-Name>
+                                </manifestEntries>
+                            </archive>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>

--- a/systests/rs-security/pom.xml
+++ b/systests/rs-security/pom.xml
@@ -32,6 +32,7 @@
     <url>http://cxf.apache.org</url>
     <properties>
         <oauth.version>20100527</oauth.version>
+        <cxf.module.name>org.apache.cxf.systests.security</cxf.module.name>
     </properties>
     <dependencies>
         <dependency>
@@ -206,6 +207,13 @@
                         <goals>
                             <goal>test-jar</goal>
                         </goals>
+                        <configuration>
+                            <archive>
+                                <manifestEntries>
+                                    <Automatic-Module-Name>${cxf.module.name}.tests</Automatic-Module-Name>
+                                </manifestEntries>
+                            </archive>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>

--- a/systests/rs-sse/pom.xml
+++ b/systests/rs-sse/pom.xml
@@ -94,19 +94,28 @@
     </dependencies>
     
     <build>
-        <plugins>
-            <plugin>
-                <artifactId>maven-jar-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>attach-sources</id>
-                        <goals>
-                            <goal>test-jar</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-        </plugins>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <artifactId>maven-jar-plugin</artifactId>
+                    <executions>
+                        <execution>
+                            <id>attach-sources</id>
+                            <goals>
+                                <goal>test-jar</goal>
+                            </goals>
+                            <configuration>
+                                <archive>
+                                    <manifestEntries>
+                                        <Automatic-Module-Name>${cxf.module.name}.tests</Automatic-Module-Name>
+                                    </manifestEntries>
+                                </archive>
+                            </configuration>
+                        </execution>
+                    </executions>
+                </plugin>
+            </plugins>
+        </pluginManagement>
     </build>
     <profiles>
         <profile>

--- a/systests/rs-sse/rs-sse-base/pom.xml
+++ b/systests/rs-sse/rs-sse-base/pom.xml
@@ -30,6 +30,10 @@
     <description>Apache CXF SSE Integration System base classes</description>
     <url>http://cxf.apache.org</url>
 
+    <properties>
+        <cxf.module.name>org.apache.cxf.systests.rs.sse.base</cxf.module.name>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>junit</groupId>

--- a/systests/rs-sse/rs-sse-jetty/pom.xml
+++ b/systests/rs-sse/rs-sse-jetty/pom.xml
@@ -31,6 +31,7 @@
     <url>http://cxf.apache.org</url>
     <properties>
         <cxf.jetty.version>${cxf.jetty9.version}</cxf.jetty.version>
+        <cxf.module.name>org.apache.cxf.systests.rs.sse.jetty</cxf.module.name>
     </properties>
     <dependencies>
         <dependency>

--- a/systests/rs-sse/rs-sse-tomcat/pom.xml
+++ b/systests/rs-sse/rs-sse-tomcat/pom.xml
@@ -31,6 +31,7 @@
     <url>http://cxf.apache.org</url>
     <properties>
         <cxf.tomcat.version>8.0.32</cxf.tomcat.version>
+        <cxf.module.name>org.apache.cxf.systests.rs.sse.tomcat</cxf.module.name>
     </properties>
     <dependencies>
         <dependency>

--- a/systests/rs-sse/rs-sse-undertow/pom.xml
+++ b/systests/rs-sse/rs-sse-undertow/pom.xml
@@ -29,6 +29,11 @@
     <name>Apache CXF SSE Integration System Tests for Undertow</name>
     <description>Apache CXF SSE Integration System Tests Undertow</description>
     <url>http://cxf.apache.org</url>
+    
+    <properties>
+        <cxf.module.name>org.apache.cxf.systests.rs.sse.undertow</cxf.module.name>
+    </properties>
+    
     <dependencies>
         <dependency>
             <groupId>io.undertow</groupId>

--- a/systests/tracing/pom.xml
+++ b/systests/tracing/pom.xml
@@ -30,6 +30,11 @@
     <name>Apache CXF Distributed Tracing Integration System Tests</name>
     <description>Apache CXF Distributed Tracing Integration System Tests</description>
     <url>http://cxf.apache.org</url>
+    
+    <properties>
+        <cxf.module.name>org.apache.cxf.systests.tracing</cxf.module.name>
+    </properties>
+    
     <dependencies>
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
@@ -157,6 +162,13 @@
                         <goals>
                             <goal>test-jar</goal>
                         </goals>
+                        <configuration>
+                            <archive>
+                                <manifestEntries>
+                                    <Automatic-Module-Name>${cxf.module.name}.tests</Automatic-Module-Name>
+                                </manifestEntries>
+                            </archive>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>

--- a/systests/transport-jms/pom.xml
+++ b/systests/transport-jms/pom.xml
@@ -30,6 +30,11 @@
     <name>Apache CXF Transport System Tests JMS</name>
     <description>Apache CXF Transport System Tests JMS</description>
     <url>http://cxf.apache.org</url>
+    
+    <properties>
+        <cxf.module.name>org.apache.cxf.systests.transport.jms</cxf.module.name>
+    </properties>
+    
     <build>
         <plugins>
             <plugin>
@@ -59,6 +64,13 @@
                         <goals>
                             <goal>test-jar</goal>
                         </goals>
+                        <configuration>
+                            <archive>
+                                <manifestEntries>
+                                    <Automatic-Module-Name>${cxf.module.name}.tests</Automatic-Module-Name>
+                                </manifestEntries>
+                            </archive>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>

--- a/systests/transport-undertow/pom.xml
+++ b/systests/transport-undertow/pom.xml
@@ -30,6 +30,11 @@
     <name>Apache CXF Undertow Transport System Tests</name>
     <description>Apache CXF Undertow Transport System Tests</description>
     <url>http://cxf.apache.org</url>
+    
+    <properties>
+        <cxf.module.name>org.apache.cxf.systests.transport.undertow</cxf.module.name>
+    </properties>
+    
     <build>
         <testSourceDirectory>${basedir}/src/test/java</testSourceDirectory>
         <testResources>
@@ -74,6 +79,13 @@
                         <goals>
                             <goal>test-jar</goal>
                         </goals>
+                        <configuration>
+                            <archive>
+                                <manifestEntries>
+                                    <Automatic-Module-Name>${cxf.module.name}.tests</Automatic-Module-Name>
+                                </manifestEntries>
+                            </archive>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>

--- a/systests/transports-ssl3/pom.xml
+++ b/systests/transports-ssl3/pom.xml
@@ -30,6 +30,11 @@
     <name>Apache CXF Transport SSL3 System Tests</name>
     <description>Apache CXF Transport SSL3 System Tests</description>
     <url>http://cxf.apache.org</url>
+    
+    <properties>
+        <cxf.module.name>org.apache.cxf.systests.transport.ssl3</cxf.module.name>
+    </properties>
+
     <build>
         <testSourceDirectory>${basedir}/src/test/java</testSourceDirectory>
         <testResources>
@@ -55,6 +60,13 @@
                         <goals>
                             <goal>test-jar</goal>
                         </goals>
+                        <configuration>
+                            <archive>
+                                <manifestEntries>
+                                    <Automatic-Module-Name>${cxf.module.name}.tests</Automatic-Module-Name>
+                                </manifestEntries>
+                            </archive>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>

--- a/systests/transports/pom.xml
+++ b/systests/transports/pom.xml
@@ -32,6 +32,7 @@
     <url>http://cxf.apache.org</url>
     <properties>
         <cxf.surefire.fork.vmargs>-Djdk.http.auth.tunneling.disabledSchemes=""</cxf.surefire.fork.vmargs>
+        <cxf.module.name>org.apache.cxf.systests.transport</cxf.module.name>
     </properties>
     <build>
         <testSourceDirectory>${basedir}/src/test/java</testSourceDirectory>
@@ -77,6 +78,13 @@
                         <goals>
                             <goal>test-jar</goal>
                         </goals>
+                        <configuration>
+                            <archive>
+                                <manifestEntries>
+                                    <Automatic-Module-Name>${cxf.module.name}.tests</Automatic-Module-Name>
+                                </manifestEntries>
+                            </archive>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>

--- a/systests/uncategorized/pom.xml
+++ b/systests/uncategorized/pom.xml
@@ -30,6 +30,11 @@
     <name>Apache CXF Uncategorized System Tests</name>
     <description>Apache CXF Uncategorized System Tests</description>
     <url>http://cxf.apache.org</url>
+    
+    <properties>
+        <cxf.module.name>org.apache.cxf.systests.uncategorized</cxf.module.name>
+    </properties>
+    
     <build>
         <plugins>
             <plugin>
@@ -115,6 +120,13 @@
                         <goals>
                             <goal>test-jar</goal>
                         </goals>
+                        <configuration>
+                            <archive>
+                                <manifestEntries>
+                                    <Automatic-Module-Name>${cxf.module.name}.tests</Automatic-Module-Name>
+                                </manifestEntries>
+                            </archive>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>

--- a/systests/ws-rm/pom.xml
+++ b/systests/ws-rm/pom.xml
@@ -30,6 +30,11 @@
     <name>Apache CXF WS-RM Specifications System Tests</name>
     <description>Apache CXF WS-RM Specifications System Tests</description>
     <url>http://cxf.apache.org</url>
+    
+    <properties>
+        <cxf.module.name>org.apache.cxf.systests.ws.rm</cxf.module.name>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>org.apache.cxf</groupId>

--- a/systests/ws-security-examples/pom.xml
+++ b/systests/ws-security-examples/pom.xml
@@ -30,6 +30,11 @@
     <name>Apache CXF WS-Security Interop System Tests</name>
     <description>Apache CXF WS-Security Interop System Tests</description>
     <url>http://cxf.apache.org</url>
+    
+    <properties>
+        <cxf.module.name>org.apache.cxf.systests.ws.security.examples</cxf.module.name>
+    </properties>
+    
     <build>
         <testSourceDirectory>${basedir}/src/test/java</testSourceDirectory>
         <testResources>
@@ -77,6 +82,13 @@
                         <goals>
                             <goal>test-jar</goal>
                         </goals>
+                        <configuration>
+                            <archive>
+                                <manifestEntries>
+                                    <Automatic-Module-Name>${cxf.module.name}.tests</Automatic-Module-Name>
+                                </manifestEntries>
+                            </archive>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>

--- a/systests/ws-security/pom.xml
+++ b/systests/ws-security/pom.xml
@@ -30,6 +30,9 @@
     <name>Apache CXF WS-Security System Tests</name>
     <description>Apache CXF WS-Security System Tests</description>
     <url>http://cxf.apache.org</url>
+    <properties>
+        <cxf.module.name>org.apache.cxf.systests.ws.security</cxf.module.name>
+    </properties>
     <build>
         <testSourceDirectory>${basedir}/src/test/java</testSourceDirectory>
         <testResources>
@@ -100,6 +103,13 @@
                         <goals>
                             <goal>test-jar</goal>
                         </goals>
+                        <configuration>
+                            <archive>
+                                <manifestEntries>
+                                    <Automatic-Module-Name>${cxf.module.name}.tests</Automatic-Module-Name>
+                                </manifestEntries>
+                            </archive>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>

--- a/systests/ws-specs/pom.xml
+++ b/systests/ws-specs/pom.xml
@@ -30,6 +30,11 @@
     <name>Apache CXF WS-* Specifications System Tests</name>
     <description>Apache CXF WS-* Specifications System Tests</description>
     <url>http://cxf.apache.org</url>
+    
+    <properties>
+        <cxf.module.name>org.apache.cxf.systests.ws.specs</cxf.module.name>
+    </properties>
+    
     <build>
         <plugins>
             <plugin>
@@ -69,6 +74,13 @@
                         <goals>
                             <goal>test-jar</goal>
                         </goals>
+                        <configuration>
+                            <archive>
+                                <manifestEntries>
+                                    <Automatic-Module-Name>${cxf.module.name}.tests</Automatic-Module-Name>
+                                </manifestEntries>
+                            </archive>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>

--- a/systests/ws-transfer/pom.xml
+++ b/systests/ws-transfer/pom.xml
@@ -32,6 +32,10 @@
         <relativePath>../../parent/pom.xml</relativePath>
     </parent>
     
+    <properties>
+        <cxf.module.name>org.apache.cxf.systests.ws.transfer</cxf.module.name>
+    </properties>
+    
     <dependencies>
         <dependency>
           <groupId>junit</groupId>

--- a/systests/wsdl_maven/codegen/pom.xml
+++ b/systests/wsdl_maven/codegen/pom.xml
@@ -29,6 +29,11 @@
         <version>3.2.5-SNAPSHOT</version>
         <relativePath>../../../parent/pom.xml</relativePath>
     </parent>
+    
+    <properties>
+        <cxf.module.name>org.apache.cxf.systests.plugin.codegen</cxf.module.name>
+    </properties>
+    
     <build>
         <plugins>
             <plugin>

--- a/systests/wsdl_maven/java2ws/pom.xml
+++ b/systests/wsdl_maven/java2ws/pom.xml
@@ -29,6 +29,11 @@
         <version>3.2.5-SNAPSHOT</version>
         <relativePath>../../../parent/pom.xml</relativePath>
     </parent>
+    
+    <properties>
+        <cxf.module.name>org.apache.cxf.systests.plugin.java2ws</cxf.module.name>
+    </properties>
+    
     <build>
         <plugins>
             <plugin>

--- a/testutils/pom.xml
+++ b/testutils/pom.xml
@@ -30,6 +30,9 @@
         <version>3.2.5-SNAPSHOT</version>
         <relativePath>../parent/pom.xml</relativePath>
     </parent>
+    <properties>
+        <cxf.module.name>org.apache.cxf.testutils</cxf.module.name>
+    </properties>
     <dependencies>
         <dependency>
             <groupId>junit</groupId>

--- a/testutils/pom.xml
+++ b/testutils/pom.xml
@@ -305,12 +305,24 @@
                             <includes>
                                 <include>**/*.*</include>
                             </includes>
+                            <archive>
+                                <manifestEntries>
+                                    <Automatic-Module-Name>${cxf.module.name}.key</Automatic-Module-Name>
+                                </manifestEntries>
+                            </archive>
                         </configuration>
                     </execution>
                     <execution>
                         <goals>
                             <goal>test-jar</goal>
                         </goals>
+                        <configuration>
+                            <archive>
+                                <manifestEntries>
+                                    <Automatic-Module-Name>${cxf.module.name}.tests</Automatic-Module-Name>
+                                </manifestEntries>
+                            </archive>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>

--- a/tools/common/pom.xml
+++ b/tools/common/pom.xml
@@ -30,6 +30,9 @@
         <version>3.2.5-SNAPSHOT</version>
         <relativePath>../../parent/pom.xml</relativePath>
     </parent>
+    <properties>
+        <cxf.module.name>org.apache.cxf.tools.common</cxf.module.name>
+    </properties>
     <dependencies>
         <dependency>
             <groupId>junit</groupId>

--- a/tools/corba/pom.xml
+++ b/tools/corba/pom.xml
@@ -30,6 +30,9 @@
         <version>3.2.5-SNAPSHOT</version>
         <relativePath>../../parent/pom.xml</relativePath>
     </parent>
+    <properties>
+        <cxf.module.name>org.apache.cxf.tools.corba</cxf.module.name>
+    </properties>
     <dependencies>
         <dependency>
             <groupId>junit</groupId>

--- a/tools/javato/ws/pom.xml
+++ b/tools/javato/ws/pom.xml
@@ -30,6 +30,9 @@
         <version>3.2.5-SNAPSHOT</version>
         <relativePath>../../../parent/pom.xml</relativePath>
     </parent>
+    <properties>
+        <cxf.module.name>org.apache.cxf.tools.java2ws</cxf.module.name>
+    </properties>
     <dependencies>
         <dependency>
             <groupId>org.apache.cxf</groupId>

--- a/tools/validator/pom.xml
+++ b/tools/validator/pom.xml
@@ -31,6 +31,7 @@
         <relativePath>../../parent/pom.xml</relativePath>
     </parent>
     <properties>
+        <cxf.module.name>org.apache.cxf.tools.validator</cxf.module.name>
         <cxf.osgi.export>
             =org.apache.cxf.tools.validator.internal,
             org.apache.cxf.tools.validator.*,

--- a/tools/wadlto/jaxrs/pom.xml
+++ b/tools/wadlto/jaxrs/pom.xml
@@ -30,6 +30,9 @@
         <version>3.2.5-SNAPSHOT</version>
         <relativePath>../../../parent/pom.xml</relativePath>
     </parent>
+    <properties>
+        <cxf.module.name>org.apache.cxf.tools.wadl</cxf.module.name>
+    </properties>
     <dependencies>
         <dependency>
             <groupId>junit</groupId>

--- a/tools/wsdlto/core/pom.xml
+++ b/tools/wsdlto/core/pom.xml
@@ -30,6 +30,9 @@
         <version>3.2.5-SNAPSHOT</version>
         <relativePath>../../../parent/pom.xml</relativePath>
     </parent>
+    <properties>
+        <cxf.module.name>org.apache.cxf.tools.wsdl.core</cxf.module.name>
+    </properties>
     <dependencies>
         <dependency>
             <groupId>org.apache.cxf</groupId>

--- a/tools/wsdlto/databinding/jaxb/pom.xml
+++ b/tools/wsdlto/databinding/jaxb/pom.xml
@@ -30,6 +30,9 @@
         <version>3.2.5-SNAPSHOT</version>
         <relativePath>../../../../parent/pom.xml</relativePath>
     </parent>
+    <properties>
+        <cxf.module.name>org.apache.cxf.tools.wsdl.jaxb</cxf.module.name>
+    </properties>
     <dependencies>
         <dependency>
             <groupId>com.sun.xml.bind</groupId>

--- a/tools/wsdlto/frontend/javascript/pom.xml
+++ b/tools/wsdlto/frontend/javascript/pom.xml
@@ -30,6 +30,9 @@
         <version>3.2.5-SNAPSHOT</version>
         <relativePath>../../../../parent/pom.xml</relativePath>
     </parent>
+    <properties>
+        <cxf.module.name>org.apache.cxf.tools.wsdl.js</cxf.module.name>
+    </properties>
     <dependencies>
         <dependency>
             <groupId>junit</groupId>

--- a/tools/wsdlto/frontend/jaxws/pom.xml
+++ b/tools/wsdlto/frontend/jaxws/pom.xml
@@ -30,6 +30,9 @@
         <version>3.2.5-SNAPSHOT</version>
         <relativePath>../../../../parent/pom.xml</relativePath>
     </parent>
+    <properties>
+        <cxf.module.name>org.apache.cxf.tools.wsdl.jaxws</cxf.module.name>
+    </properties>
     <dependencies>
         <dependency>
             <groupId>junit</groupId>

--- a/tools/wsdlto/misc/pom.xml
+++ b/tools/wsdlto/misc/pom.xml
@@ -30,6 +30,9 @@
         <version>3.2.5-SNAPSHOT</version>
         <relativePath>../../../parent/pom.xml</relativePath>
     </parent>
+    <properties>
+        <cxf.module.name>org.apache.cxf.tools.misc</cxf.module.name>
+    </properties>
     <dependencies>
         <dependency>
             <groupId>junit</groupId>

--- a/tools/wsdlto/test/pom.xml
+++ b/tools/wsdlto/test/pom.xml
@@ -30,6 +30,9 @@
         <version>3.2.5-SNAPSHOT</version>
         <relativePath>../../../parent/pom.xml</relativePath>
     </parent>
+    <properties>
+        <cxf.module.name>org.apache.cxf.tools.wsdl.test</cxf.module.name>
+    </properties>
     <dependencies>
         <dependency>
             <groupId>org.apache.cxf</groupId>


### PR DESCRIPTION
This PR (work in progress) adds `Automatic-Module-Name` to all CXF modules in order to provide the consistent way to deal with CXF in the modern modular (JPMS-based) Java applications. The list of modules is included below:

| Module       | Automatic-Module-Name  |
| ------------- |----------------------------|
|cxf-manifest.jar| org.apache.cxf.manifest|
|cxf-bundle-compatible-3.2.5-SNAPSHOT.jar| org.apache.cxf.bundle|
|cxf-codegen-plugin-3.2.5-SNAPSHOT.jar| org.apache.cxf.plugin.codegen|
|cxf-corbatools-maven-plugin-3.2.5-SNAPSHOT.jar| org.apache.cxf.plugin.corbatools|
|cxf-core-3.2.5-SNAPSHOT.jar| org.apache.cxf.core|
|cxf-distribution-javadoc-3.2.5-SNAPSHOT.jar| org.apache.cxf.javadoc|
|cxf-integration-cdi-3.2.5-SNAPSHOT.jar| org.apache.cxf.cdi|
|cxf-integration-jca-3.2.5-SNAPSHOT.jar| org.apache.cxf.jca|
|cxf-integration-tracing-brave-3.2.5-SNAPSHOT.jar| org.apache.cxf.tracing.brave|
|cxf-integration-tracing-htrace-3.2.5-SNAPSHOT.jar| org.apache.cxf.tracing.htrace|
|cxf-integration-tracing-opentracing-3.2.5-SNAPSHOT.jar| org.apache.cxf.tracing.opentracing|
|cxf-java2swagger-plugin-3.2.5-SNAPSHOT.jar| org.apache.cxf.plugin.java2swagger|
|cxf-java2wadl-plugin-3.2.5-SNAPSHOT.jar| org.apache.cxf.plugin.java2wadl|
|cxf-java2ws-plugin-3.2.5-SNAPSHOT.jar| org.apache.cxf.plugin.java2ws|
|cxf-karaf-commands-3.2.5-SNAPSHOT.jar| org.apache.cxf.karaf.commands|
|cxf-rt-bindings-coloc-3.2.5-SNAPSHOT.jar| org.apache.cxf.binding.coloc|
|cxf-rt-bindings-corba-3.2.5-SNAPSHOT.jar| org.apache.cxf.binding.corba|
|cxf-rt-bindings-soap-3.2.5-SNAPSHOT.jar| org.apache.cxf.binding.soap|
|cxf-rt-bindings-xml-3.2.5-SNAPSHOT.jar| org.apache.cxf.binding.xml|
|cxf-rt-databinding-aegis-3.2.5-SNAPSHOT.jar| org.apache.cxf.databinding.aegis|
|cxf-rt-databinding-jaxb-3.2.5-SNAPSHOT.jar| org.apache.cxf.databinding.jaxb|
|cxf-rt-features-clustering-3.2.5-SNAPSHOT.jar| org.apache.cxf.clustering|
|cxf-rt-features-logging-3.2.5-SNAPSHOT.jar| org.apache.cxf.logging|
|cxf-rt-features-metrics-3.2.5-SNAPSHOT.jar| org.apache.cxf.metrics|
|cxf-rt-features-throttling-3.2.5-SNAPSHOT.jar| org.apache.cxf.throttling|
|cxf-rt-frontend-jaxrs-3.2.5-SNAPSHOT.jar| org.apache.cxf.frontend.jaxrs|
|cxf-rt-frontend-jaxws-3.2.5-SNAPSHOT.jar| org.apache.cxf.frontend.jaxws|
|cxf-rt-frontend-js-3.2.5-SNAPSHOT.jar| org.apache.cxf.frontend.js|
|cxf-rt-frontend-simple-3.2.5-SNAPSHOT.jar| org.apache.cxf.frontend.simple|
|cxf-rt-javascript-3.2.5-SNAPSHOT.jar| org.apache.cxf.js|
|cxf-rt-javascript-tests-3.2.5-SNAPSHOT.jar| org.apache.cxf.js.tests|
|cxf-rt-management-3.2.5-SNAPSHOT.jar| org.apache.cxf.management|
|cxf-rt-rs-client-3.2.5-SNAPSHOT.jar| org.apache.cxf.rs.client|
|cxf-rt-rs-extension-providers-3.2.5-SNAPSHOT.jar| org.apache.cxf.rs.provider|
|cxf-rt-rs-extension-reactivestreams-3.2.5-SNAPSHOT.jar| org.apache.cxf.rs.reactivestreams|
|cxf-rt-rs-extension-reactor-3.2.5-SNAPSHOT.jar| org.apache.cxf.rs.reactor|
|cxf-rt-rs-extension-rx2-3.2.5-SNAPSHOT.jar| org.apache.cxf.rs.rx2|
|cxf-rt-rs-extension-rx-3.2.5-SNAPSHOT.jar| org.apache.cxf.rs.rx|
|cxf-rt-rs-extension-search-3.2.5-SNAPSHOT.jar| org.apache.cxf.rs.search|
|cxf-rt-rs-http-sci-3.2.5-SNAPSHOT.jar| org.apache.cxf.rs.sci|
|cxf-rt-rs-json-basic-3.2.5-SNAPSHOT.jar| org.apache.cxf.rs.json|
|cxf-rt-rs-mp-client-3.2.5-SNAPSHOT.jar| org.apache.cxf.rs.client.mp|
|cxf-rt-rs-security-cors-3.2.5-SNAPSHOT.jar| org.apache.cxf.rs.security.cors|
|cxf-rt-rs-security-jose-3.2.5-SNAPSHOT.jar| org.apache.cxf.rs.security.jose|
|cxf-rt-rs-security-jose-jaxrs-3.2.5-SNAPSHOT.jar| org.apache.cxf.rs.security.jose.jaxrs|
|cxf-rt-rs-security-oauth2-3.2.5-SNAPSHOT.jar| org.apache.cxf.rs.security.oauth2|
|cxf-rt-rs-security-oauth2-saml-3.2.5-SNAPSHOT.jar| org.apache.cxf.rs.security.oauth2.saml|
|cxf-rt-rs-security-oauth-3.2.5-SNAPSHOT.jar| org.apache.cxf.rs.security.oauth|
|cxf-rt-rs-security-sso-oidc-3.2.5-SNAPSHOT.jar| org.apache.cxf.rs.security.sso.oidc|
|cxf-rt-rs-security-sso-saml-3.2.5-SNAPSHOT.jar| org.apache.cxf.rs.security.sso.saml|
|cxf-rt-rs-security-xml-3.2.5-SNAPSHOT.jar| org.apache.cxf.rs.security.xml|
|cxf-rt-rs-service-description-3.2.5-SNAPSHOT.jar| org.apache.cxf.rs.wadl|
|cxf-rt-rs-service-description-openapi-v3-3.2.5-SNAPSHOT.jar| org.apache.cxf.rs.openapi.v3|
|cxf-rt-rs-service-description-swagger-3.2.5-SNAPSHOT.jar| org.apache.cxf.rs.swagger|
|cxf-rt-rs-service-description-swagger-ui-3.2.5-SNAPSHOT.jar| org.apache.cxf.rs.swagger.ui|
|cxf-rt-rs-sse-3.2.5-SNAPSHOT.jar| org.apache.cxf.rs.sse|
|cxf-rt-security-3.2.5-SNAPSHOT.jar| org.apache.cxf.security|
|cxf-rt-security-saml-3.2.5-SNAPSHOT.jar| org.apache.cxf.security.saml|
|cxf-rt-transports-http-3.2.5-SNAPSHOT.jar| org.apache.cxf.transport.http|
|cxf-rt-transports-http-hc-3.2.5-SNAPSHOT.jar| org.apache.cxf.transport.http.hc|
|cxf-rt-transports-http-jetty-3.2.5-SNAPSHOT.jar| org.apache.cxf.transport.http.jetty|
|cxf-rt-transports-http-netty-client-3.2.5-SNAPSHOT.jar| org.apache.cxf.transport.http.netty.client|
|cxf-rt-transports-http-netty-server-3.2.5-SNAPSHOT.jar| org.apache.cxf.transport.http.netty.server|
|cxf-rt-transports-http-undertow-3.2.5-SNAPSHOT.jar| org.apache.cxf.transport.http.undertow|
|cxf-rt-transports-jms-3.2.5-SNAPSHOT.jar| org.apache.cxf.transport.jms|
|cxf-rt-transports-local-3.2.5-SNAPSHOT.jar| org.apache.cxf.transport.local|
|cxf-rt-transports-udp-3.2.5-SNAPSHOT.jar| org.apache.cxf.transport.udp|
|cxf-rt-transports-websocket-3.2.5-SNAPSHOT.jar| org.apache.cxf.transport.websocket|
|cxf-rt-ws-addr-3.2.5-SNAPSHOT.jar| org.apache.cxf.ws.addr|
|cxf-rt-wsdl-3.2.5-SNAPSHOT.jar| org.apache.cxf.wsdl|
|cxf-rt-ws-eventing-3.2.5-SNAPSHOT.jar| org.apache.cxf.ws.eventing|
|cxf-rt-ws-mex-3.2.5-SNAPSHOT.jar| org.apache.cxf.ws.mex|
|cxf-rt-ws-policy-3.2.5-SNAPSHOT.jar| org.apache.cxf.ws.policy|
|cxf-rt-ws-rm-3.2.5-SNAPSHOT.jar| org.apache.cxf.ws.rm|
|cxf-rt-ws-security-3.2.5-SNAPSHOT.jar| org.apache.cxf.ws.security|
|cxf-rt-ws-transfer-3.2.5-SNAPSHOT.jar| org.apache.cxf.ws.transfer|
|cxf-services-sts-core-3.2.5-SNAPSHOT.jar| org.apache.cxf.sts.core|
|cxf-services-ws-discovery-api-3.2.5-SNAPSHOT.jar| org.apache.cxf.ws.discovery|
|cxf-services-ws-discovery-service-3.2.5-SNAPSHOT.jar| org.apache.cxf.ws.discovery.service|
|cxf-services-wsn-api-3.2.5-SNAPSHOT.jar| org.apache.cxf.wsn|
|cxf-services-wsn-core-3.2.5-SNAPSHOT.jar| org.apache.cxf.wsn.core|
|cxf-services-wsn-osgi-3.2.5-SNAPSHOT.jar| org.apache.cxf.wsn.osgi|
|cxf-services-xkms-client-3.2.5-SNAPSHOT.jar| org.apache.cxf.xkms.client|
|cxf-services-xkms-common-3.2.5-SNAPSHOT.jar| org.apache.cxf.xkms.common|
|cxf-services-xkms-itests-3.2.5-SNAPSHOT.jar| org.apache.cxf.xkms.itests|
|cxf-services-xkms-osgi-3.2.5-SNAPSHOT.jar| org.apache.cxf.xkms.osgi|
|cxf-services-xkms-service-3.2.5-SNAPSHOT.jar| org.apache.cxf.xkms.service|
|cxf-services-xkms-x509-handlers-3.2.5-SNAPSHOT.jar| org.apache.cxf.xkms.x509.handlers|
|cxf-services-xkms-x509-repo-ldap-3.2.5-SNAPSHOT.jar| org.apache.cxf.xkms.x509.ldap|
|cxf-spring-boot-autoconfigure-3.2.5-SNAPSHOT.jar| org.apache.cxf.spring.boot.autoconfigure|
|cxf-spring-boot-starter-jaxrs-3.2.5-SNAPSHOT.jar| org.apache.cxf.spring.boot.jaxrs|
|cxf-spring-boot-starter-jaxws-3.2.5-SNAPSHOT.jar| org.apache.cxf.spring.boot.jaxws|
|cxf-testutils-3.2.5-SNAPSHOT.jar| org.apache.cxf.testutils|
|cxf-testutils-3.2.5-SNAPSHOT-keys.jar| org.apache.cxf.testutils.keys|
|cxf-testutils-3.2.5-SNAPSHOT-tests.jar| org.apache.cxf.testutils.tests|
|cxf-tools-common-3.2.5-SNAPSHOT.jar| org.apache.cxf.tools.common|
|cxf-tools-corba-3.2.5-SNAPSHOT.jar| org.apache.cxf.tools.corba|
|cxf-tools-java2ws-3.2.5-SNAPSHOT.jar| org.apache.cxf.tools.java2ws|
|cxf-tools-misctools-3.2.5-SNAPSHOT.jar| org.apache.cxf.tools.misc|
|cxf-tools-validator-3.2.5-SNAPSHOT.jar| org.apache.cxf.tools.validator|
|cxf-tools-wadlto-jaxrs-3.2.5-SNAPSHOT.jar| org.apache.cxf.tools.wadl|
|cxf-tools-wsdlto-core-3.2.5-SNAPSHOT.jar| org.apache.cxf.tools.wsdl.core|
|cxf-tools-wsdlto-databinding-jaxb-3.2.5-SNAPSHOT.jar| org.apache.cxf.tools.wsdl.jaxb|
|cxf-tools-wsdlto-frontend-javascript-3.2.5-SNAPSHOT.jar| org.apache.cxf.tools.wsdl.js|
|cxf-tools-wsdlto-frontend-jaxws-3.2.5-SNAPSHOT.jar| org.apache.cxf.tools.wsdl.jaxws|
|cxf-tools-wsdlto-test-3.2.5-SNAPSHOT.jar| org.apache.cxf.tools.wsdl.test|
|cxf-wadl2java-plugin-3.2.5-SNAPSHOT.jar| org.apache.cxf.plugin.wadl2java|
|cxf-wsdl-validator-plugin-3.2.5-SNAPSHOT.jar| org.apache.cxf.plugin.wsdl.validator|

Since we publish test artifacts as well, they have been enriched with `Automactic-Module-Name` entry as well (otherwise `Maven Archiver Plugin` included an empty one):

| Test Module       | Automatic-Module-Name  |
| ------------- |----------------------------|
|cxf-services-sts-systests-advanced-3.2.5-SNAPSHOT.jar| org.apache.cxf.systests.sts.advanced|
|cxf-services-sts-systests-basic-3.2.5-SNAPSHOT.jar| org.apache.cxf.systests.sts.basic|
|cxf-services-sts-systests-itests-3.2.5-SNAPSHOT.jar| org.apache.cxf.systests.sts.integration|
|cxf-services-sts-systests-osgi-3.2.5-SNAPSHOT.jar| org.apache.cxf.systests.sts.osgi|
|cxf-systests-cdi-base-3.2.5-SNAPSHOT.jar| org.apache.cxf.systests.cdi.base|
|cxf-systests-cdi-base-3.2.5-SNAPSHOT-tests.jar| org.apache.cxf.systests.cdi.base.tests|
|cxf-systests-cdi-owb-multiple-apps-3.2.5-SNAPSHOT.jar| org.apache.cxf.systests.cdi.owb.multiapp|
|cxf-systests-cdi-owb-multiple-apps-3.2.5-SNAPSHOT-tests.jar| org.apache.cxf.systests.cdi.owb.multiapp.tests|
|cxf-systests-cdi-owb-no-apps-3.2.5-SNAPSHOT.jar| org.apache.cxf.systests.cdi.owb.noapp|
|cxf-systests-cdi-owb-no-apps-3.2.5-SNAPSHOT-tests.jar| org.apache.cxf.systests.cdi.owb.noapp.tests|
|cxf-systests-cdi-owb-producers-3.2.5-SNAPSHOT.jar| org.apache.cxf.systests.cdi.owb.producers|
|cxf-systests-cdi-owb-producers-3.2.5-SNAPSHOT-tests.jar| org.apache.cxf.systests.cdi.owb.producers.tests|
|cxf-systests-cdi-weld-multiple-apps-3.2.5-SNAPSHOT.jar| org.apache.cxf.systests.cdi.weld.multiapp|
|cxf-systests-cdi-weld-multiple-apps-3.2.5-SNAPSHOT-tests.jar| org.apache.cxf.systests.cdi.weld.multiapp.tests|
|cxf-systests-cdi-weld-no-apps-3.2.5-SNAPSHOT.jar| org.apache.cxf.systests.cdi.weld.noapp|
|cxf-systests-cdi-weld-no-apps-3.2.5-SNAPSHOT-tests.jar| org.apache.cxf.systests.cdi.weld.noapp.tests|
|cxf-systests-cdi-weld-producers-3.2.5-SNAPSHOT.jar| org.apache.cxf.systests.cdi.weld.producers|
|cxf-systests-cdi-weld-producers-3.2.5-SNAPSHOT-tests.jar| org.apache.cxf.systests.cdi.weld.producers.tests|
|cxf-systests-ci-grizzly-3.2.5-SNAPSHOT.jar| org.apache.cxf.systests.ci.grizzly|
|cxf-systests-codegen-3.2.5-SNAPSHOT.jar| org.apache.cxf.systests.plugin.codegen|
|cxf-systests-databinding-3.2.5-SNAPSHOT.jar| org.apache.cxf.systests.databinding|
|cxf-systests-databinding-3.2.5-SNAPSHOT-tests.jar| org.apache.cxf.systests.databinding.tests|
|cxf-systests-http-sci-3.2.5-SNAPSHOT.jar| org.apache.cxf.systests.rs.sci|
|cxf-systests-java2ws-3.2.5-SNAPSHOT.jar| org.apache.cxf.systests.plugin.java2ws|
|cxf-systests-http-sci-3.2.5-SNAPSHOT-tests.jar| org.apache.cxf.systests.rs.sci.tests|
|cxf-systests-jaxrs-3.2.5-SNAPSHOT.jar| org.apache.cxf.systests.jaxrs|
|cxf-systests-jaxrs-3.2.5-SNAPSHOT-tests.jar| org.apache.cxf.systests.jaxrs.tests|
|cxf-systests-jaxws-3.2.5-SNAPSHOT.jar| org.apache.cxf.systests.jaxws|
|cxf-systests-jaxws-3.2.5-SNAPSHOT-tests.jar| org.apache.cxf.systests.jaxws.tests|
|cxf-systests-kerberos-3.2.5-SNAPSHOT.jar| org.apache.cxf.systests.kerberos|
|cxf-systests-kerberos-3.2.5-SNAPSHOT-tests.jar| org.apache.cxf.systests.kerberos.tests|
|cxf-systests-ldap-3.2.5-SNAPSHOT.jar| org.apache.cxf.systests.ldap|
|cxf-systests-ldap-3.2.5-SNAPSHOT-tests.jar| org.apache.cxf.systests.ldap.tests|
|cxf-systests-microprofile-weld-3.2.5-SNAPSHOT.jar| org.apache.cxf.systests.microprofile.weld|
|cxf-systests-rs-security-3.2.5-SNAPSHOT.jar| org.apache.cxf.systests.security|
|cxf-systests-rs-security-3.2.5-SNAPSHOT-tests.jar| org.apache.cxf.systests.security.tests|
|cxf-systests-rs-sse-base-3.2.5-SNAPSHOT.jar| org.apache.cxf.systests.rs.sse.base|
|cxf-systests-rs-sse-base-3.2.5-SNAPSHOT-tests.jar| org.apache.cxf.systests.rs.sse.base.tests|
|cxf-systests-rs-sse-jetty-3.2.5-SNAPSHOT.jar| org.apache.cxf.systests.rs.sse.jetty|
|cxf-systests-rs-sse-jetty-3.2.5-SNAPSHOT-tests.jar| org.apache.cxf.systests.rs.sse.jetty.tests|
|cxf-systests-rs-sse-tomcat-3.2.5-SNAPSHOT.jar| org.apache.cxf.systests.rs.sse.tomcat|
|cxf-systests-rs-sse-tomcat-3.2.5-SNAPSHOT-tests.jar| org.apache.cxf.systests.rs.sse.tomcat.tests|
|cxf-systests-rs-sse-undertow-3.2.5-SNAPSHOT.jar| org.apache.cxf.systests.rs.sse.undertow|
|cxf-systests-rs-sse-undertow-3.2.5-SNAPSHOT-tests.jar| org.apache.cxf.systests.rs.sse.undertow.tests|
|cxf-systests-tracing-3.2.5-SNAPSHOT.jar| org.apache.cxf.systests.tracing|
|cxf-systests-tracing-3.2.5-SNAPSHOT-tests.jar| org.apache.cxf.systests.tracing.tests|
|cxf-systests-transport-jms-3.2.5-SNAPSHOT.jar| org.apache.cxf.systests.transport.jms|
|cxf-systests-transport-jms-3.2.5-SNAPSHOT-tests.jar| org.apache.cxf.systests.transport.jms.tests|
|cxf-systests-transports-3.2.5-SNAPSHOT.jar| org.apache.cxf.systests.transport|
|cxf-systests-transports-3.2.5-SNAPSHOT-tests.jar| org.apache.cxf.systests.transport.tests|
|cxf-systests-transports-ssl3-3.2.5-SNAPSHOT.jar| org.apache.cxf.systests.transport.ssl3|
|cxf-systests-transports-ssl3-3.2.5-SNAPSHOT-tests.jar| org.apache.cxf.systests.transport.ssl3.tests|
|cxf-systests-transport-undertow-3.2.5-SNAPSHOT.jar| org.apache.cxf.systests.transport.undertow|
|cxf-systests-transport-undertow-3.2.5-SNAPSHOT-tests.jar| org.apache.cxf.systests.transport.undertow.tests|
|cxf-systests-uncategorized-3.2.5-SNAPSHOT.jar| org.apache.cxf.systests.uncategorized|
|cxf-systests-uncategorized-3.2.5-SNAPSHOT-tests.jar| org.apache.cxf.systests.uncategorized.tests|
|cxf-systests-ws-rm-3.2.5-SNAPSHOT.jar| org.apache.cxf.systests.ws.rm|
|cxf-systests-ws-security-3.2.5-SNAPSHOT.jar| org.apache.cxf.systests.ws.security|
|cxf-systests-ws-security-3.2.5-SNAPSHOT-tests.jar| org.apache.cxf.systests.ws.security.tests|
|cxf-systests-ws-security-examples-3.2.5-SNAPSHOT.jar| org.apache.cxf.systests.ws.security.examples|
|cxf-systests-ws-security-examples-3.2.5-SNAPSHOT-tests.jar| org.apache.cxf.systests.ws.security.examples.tests|
|cxf-systests-ws-specs-3.2.5-SNAPSHOT.jar| org.apache.cxf.systests.ws.specs|
|cxf-systests-ws-specs-3.2.5-SNAPSHOT-tests.jar| org.apache.cxf.systests.ws.specs.tests|
|cxf-systests-ws-transfer-3.2.5-SNAPSHOT.jar| org.apache.cxf.systests.ws.transfer|


The naming scheme has been adopted following the Stephen Colebourne  recommendations (http://blog.joda.org/2017/04/java-se-9-jpms-module-naming.html) and based on package name.

The typical example which illustrates the usage of selected CXF modules from the modular Java application (in this case, the one which leverages SSE capabilities) looks like that:

```
module com.example.sse {
    exports com.example.sse;
    
    requires org.apache.cxf.frontend.jaxrs;
    requires org.apache.cxf.transport.http;
    requires org.apache.cxf.rs.sse;
    requires com.fasterxml.jackson.jaxrs.json;
    requires com.fasterxml.jackson.annotation;
    requires io.reactivex.rxjava2;
    
    requires transitive java.ws.rs;
    requires transitive org.reactivestreams;
    
    requires javax.servlet.api;
    requires jetty.server;
    requires jetty.servlet;
    requires jetty.util;
    
    requires java.xml.bind;
}
```