### PR TITLE
CXF-7746 Swagger2Feature - SwaggerUiResolver & JBoss 7.0 EAP

### DIFF
--- a/rt/rs/description-swagger-ui/src/main/java/org/apache/cxf/jaxrs/swagger/SwaggerUiResolver.java
+++ b/rt/rs/description-swagger-ui/src/main/java/org/apache/cxf/jaxrs/swagger/SwaggerUiResolver.java
@@ -58,19 +58,15 @@ public class SwaggerUiResolver {
 
     protected static String checkUiRoot(String urlStr, String swaggerUiVersion) {
         int swaggerUiIndex = urlStr.lastIndexOf("/swagger-ui-");
-        if (swaggerUiIndex != -1) {
-            boolean urlEndsWithJarSep = urlStr.endsWith(".jar!/");
-            if (urlEndsWithJarSep || urlStr.endsWith(".jar")) {
-                int offset = urlEndsWithJarSep ? 6 : 4;
-                String version = urlStr.substring(swaggerUiIndex + 12, urlStr.length() - offset);
-                if (swaggerUiVersion != null && !swaggerUiVersion.equals(version)) {
-                    return null;
-                }
-                if (!urlEndsWithJarSep) {
-                    urlStr = "jar:" + urlStr + "!/";
-                }
-                return urlStr + UI_RESOURCES_ROOT_START + version + "/";
+        if (swaggerUiIndex != -1 && urlStr.matches("^.*\\.jar!?/?$")) {
+            String version = urlStr.substring(swaggerUiIndex + 12, urlStr.lastIndexOf(".jar"));
+            if (swaggerUiVersion != null && !swaggerUiVersion.equals(version)) {
+                return null;
             }
+            if (!urlStr.endsWith("/")) {
+                urlStr = "jar:" + urlStr + "!/";
+            }
+            return urlStr + UI_RESOURCES_ROOT_START + version + "/";
         }
         return null;
     }


### PR DESCRIPTION
Add support for JBoss 7.0 EAP class loader which is returning an url ending with ".jar/" instead of the expected ".jar" or ".jar!/"