### PR TITLE
CXF-7758 MTOM + SchemaValidation results in empty input stream from d…

### DIFF
--- a/core/src/main/java/org/apache/cxf/helpers/ServiceUtils.java
+++ b/core/src/main/java/org/apache/cxf/helpers/ServiceUtils.java
@@ -108,30 +108,30 @@ public final class ServiceUtils {
 
     private static SchemaValidationType getSchemaValidationTypeFromModel(Message message) {
         Exchange exchange = message.getExchange();
+        SchemaValidationType validationType = null;
 
         if (exchange != null) {
+
             BindingOperationInfo boi = exchange.getBindingOperationInfo();
-            Endpoint endpoint = exchange.getEndpoint();
-
-            if (boi != null && endpoint != null) {
-                SchemaValidationType validationType = null;
+            if (boi != null) {
                 OperationInfo opInfo = boi.getOperationInfo();
-                EndpointInfo ep = endpoint.getEndpointInfo();
-
                 if (opInfo != null) {
                     validationType = getSchemaValidationTypeFromModel(opInfo);
+                }
+            }
 
-                    if (validationType == null && ep != null) {
+            if (validationType == null) {
+                Endpoint endpoint = exchange.getEndpoint();
+                if (endpoint != null) {
+                    EndpointInfo ep = endpoint.getEndpointInfo();
+                    if (ep != null) {
                         validationType = getSchemaValidationTypeFromModel(ep);
                     }
                 }
-
-                return validationType;
             }
         }
 
-        // else
-        return null;
+        return validationType;
     }
 
     private static SchemaValidationType getSchemaValidationTypeFromModel(

--- a/systests/jaxws/src/test/java/org/apache/cxf/systest/jaxws/attachment/AttachmentService.java
+++ b/systests/jaxws/src/test/java/org/apache/cxf/systest/jaxws/attachment/AttachmentService.java
@@ -1,0 +1,36 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.cxf.systest.jaxws.attachment;
+
+import javax.jws.WebMethod;
+import javax.jws.WebParam;
+import javax.jws.WebService;
+import javax.xml.bind.annotation.XmlElement;
+
+import org.apache.cxf.annotations.SchemaValidation;
+
+@WebService(name = "AttachmentService", targetNamespace = "http://org.apache.cxf/service/AttachmentService")
+@SchemaValidation(type = SchemaValidation.SchemaValidationType.IN)
+public interface AttachmentService {
+
+    @WebMethod
+    int test(@WebParam(name = "request") @XmlElement(required = true) Request request) throws Exception;
+
+}

--- a/systests/jaxws/src/test/java/org/apache/cxf/systest/jaxws/attachment/AttachmentServiceImpl.java
+++ b/systests/jaxws/src/test/java/org/apache/cxf/systest/jaxws/attachment/AttachmentServiceImpl.java
@@ -1,0 +1,45 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.cxf.systest.jaxws.attachment;
+
+import java.io.InputStream;
+
+import javax.activation.DataHandler;
+import javax.jws.WebMethod;
+import javax.jws.WebParam;
+import javax.jws.WebService;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.ws.soap.MTOM;
+
+import org.apache.cxf.annotations.SchemaValidation;
+import org.apache.cxf.helpers.IOUtils;
+
+@WebService(name = "AttachmentService", targetNamespace = "http://org.apache.cxf/service/AttachmentService")
+@SchemaValidation(type = SchemaValidation.SchemaValidationType.IN)
+@MTOM(enabled = true)
+public class AttachmentServiceImpl implements AttachmentService {
+
+    @WebMethod
+    public int test(@WebParam(name = "request") @XmlElement(required = true) Request request) throws Exception {
+        DataHandler dataHandler = request.getContent();
+        InputStream inputStream = dataHandler.getInputStream();
+        return IOUtils.readBytesFromStream(inputStream).length;
+    }
+}

--- a/systests/jaxws/src/test/java/org/apache/cxf/systest/jaxws/attachment/Request.java
+++ b/systests/jaxws/src/test/java/org/apache/cxf/systest/jaxws/attachment/Request.java
@@ -1,0 +1,45 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.cxf.systest.jaxws.attachment;
+
+import javax.activation.DataHandler;
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlType;
+
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "request", propOrder = {"content"})
+public class Request {
+
+    @XmlElement(name = "content", required = true)
+    private DataHandler content;
+
+    public Request() {
+    }
+
+    public DataHandler getContent() {
+        return content;
+    }
+
+    public void setContent(DataHandler content) {
+        this.content = content;
+    }
+}

--- a/systests/jaxws/src/test/java/org/apache/cxf/systest/jaxws/attachment/ValidationWithAttachmentTest.java
+++ b/systests/jaxws/src/test/java/org/apache/cxf/systest/jaxws/attachment/ValidationWithAttachmentTest.java
@@ -1,0 +1,83 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.cxf.systest.jaxws.attachment;
+
+import javax.activation.DataHandler;
+import javax.xml.ws.BindingProvider;
+import javax.xml.ws.soap.SOAPBinding;
+
+import org.apache.cxf.endpoint.Server;
+import org.apache.cxf.jaxws.JaxWsProxyFactoryBean;
+import org.apache.cxf.jaxws.JaxWsServerFactoryBean;
+import org.apache.cxf.testutil.common.TestUtil;
+
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class ValidationWithAttachmentTest {
+
+    static final String PORT = TestUtil.getNewPortNumber(ValidationWithAttachmentTest.class);
+    static final String ADDRESS = "http://localhost:" + PORT + "/" + ValidationWithAttachmentTest.class.getSimpleName();
+
+    static Server server;
+    static AttachmentService client;
+
+    @BeforeClass
+    public static void setUp() {
+        initServer();
+        initClient();
+    }
+
+    @AfterClass
+    public static void tearDown() {
+        server.stop();
+    }
+
+    @Test
+    public void test() throws Exception {
+        Request request = new Request();
+        request.setContent(new DataHandler("test", "text/plain"));
+
+        int bytes = client.test(request);
+        Assert.assertTrue("Attachment data were not received", bytes > 0);
+    }
+
+    private static void initServer() {
+        JaxWsServerFactoryBean factory = new JaxWsServerFactoryBean();
+        factory.setServiceClass(AttachmentServiceImpl.class);
+        factory.setAddress(ADDRESS);
+        factory.setServiceBean(new AttachmentServiceImpl());
+        server = factory.create();
+    }
+
+    private static void initClient() {
+        JaxWsProxyFactoryBean clientFactory = new JaxWsProxyFactoryBean();
+        clientFactory.setServiceClass(AttachmentService.class);
+        clientFactory.setAddress(ADDRESS);
+        client = (AttachmentService) clientFactory.create();
+
+        //enable MTOM in client
+        BindingProvider bp = (BindingProvider) client;
+        SOAPBinding binding = (SOAPBinding) bp.getBinding();
+        binding.setMTOMEnabled(true);
+    }
+}


### PR DESCRIPTION
…ata handler

https://issues.apache.org/jira/browse/CXF-7758
https://issues.jboss.org/browse/JBEAP-14830

This is to allow checking `endpoint.getEndpointInfo()` even when `exchange.getBindingOperationInfo()` is not yet set.

The `JAXBAttachmentSchemaValidationHack` is checking if the the validation is enabled in a phase before `exchange.getBindingOperationInfo()` is set. This leads to not correctly determining that validation is enabled and attachment datasources not being cached. Because the datasource is not cached, it returns the same InputStream to the validation unmarshaller and then to the application, resulting in the app not being able to read any data from the attachment DS.