### PR TITLE
Consider the outermost proxy in X-Forwarded-Host

### DIFF
--- a/rt/transports/http/src/main/java/org/apache/cxf/transport/servlet/AbstractHTTPServlet.java
+++ b/rt/transports/http/src/main/java/org/apache/cxf/transport/servlet/AbstractHTTPServlet.java
@@ -484,10 +484,11 @@ public abstract class AbstractHTTPServlet extends HttpServlet implements Filter 
                 newRemoteAddr = (originalRemoteAddr.split(",")[0]).trim();
             }
             newRequestUri = calculateNewRequestUri(request, originalPrefix);
+            String outermostHost = (originalHost.split(",")[0]).trim();
             newRequestUrl = calculateNewRequestUrl(request, 
                                                    originalProto, 
                                                    originalPrefix,
-                                                   originalHost,
+                                                   outermostHost,
                                                    originalPort);
             newContextPath = calculateNewContextPath(request, originalPrefix);
             newServletPath = calculateNewServletPath(request, originalPrefix);


### PR DESCRIPTION
When behind more than one reverse proxy, each can add a new entry in X-Forwarded-Host, resulting in:
> X-Forwarded-Host: host1, host2

Consider the outermost proxy/host ('host1') like done for 'originalRemoteAddr'.