### PR TITLE
UI not resolved correctly if version not specificed

### DIFF
--- a/rt/rs/description-swagger-ui/src/main/java/org/apache/cxf/jaxrs/swagger/OsgiSwaggerUiResolver.java
+++ b/rt/rs/description-swagger-ui/src/main/java/org/apache/cxf/jaxrs/swagger/OsgiSwaggerUiResolver.java
@@ -81,7 +81,7 @@ public class OsgiSwaggerUiResolver extends SwaggerUiResolver {
 
     private String getSwaggerUiRoot(Bundle b, String swaggerUiVersion) {
         if (swaggerUiVersion == null) { 
-            swaggerUiVersion = "";
+            swaggerUiVersion = b.getVersion().toString();
         }
         URL entry = b.getEntry(SwaggerUiResolver.UI_RESOURCES_ROOT_START + swaggerUiVersion);
         if (entry != null) {


### PR DESCRIPTION
When findSwaggerUiRootInternal(null, null) is called, the root is returned without the version number which is needed to locate the index.html and other resources within the bundle.
/META-INF/resources/webjars/swagger-ui//index.html
instead of 
/META-INF/resources/webjars/swagger-ui/3.17.6/index.html