### PR TITLE
NPE when annotations bundle found but not active

### DIFF
--- a/rt/rs/description-swagger-ui/src/main/java/org/apache/cxf/jaxrs/swagger/OsgiSwaggerUiResolver.java
+++ b/rt/rs/description-swagger-ui/src/main/java/org/apache/cxf/jaxrs/swagger/OsgiSwaggerUiResolver.java
@@ -48,8 +48,8 @@ public class OsgiSwaggerUiResolver extends SwaggerUiResolver {
                 return null;
             }
             if (bundle.getState() != Bundle.ACTIVE) {
-				bundle.start();
-			}
+                bundle.start();
+            }
             String[] locations = swaggerUiMavenGroupAndArtifact == null ? DEFAULT_LOCATIONS
                 : new String[]{"mvn:" + swaggerUiMavenGroupAndArtifact + "/",
                                "wrap:mvn:" + swaggerUiMavenGroupAndArtifact + "/"};

--- a/rt/rs/description-swagger-ui/src/main/java/org/apache/cxf/jaxrs/swagger/OsgiSwaggerUiResolver.java
+++ b/rt/rs/description-swagger-ui/src/main/java/org/apache/cxf/jaxrs/swagger/OsgiSwaggerUiResolver.java
@@ -47,6 +47,9 @@ public class OsgiSwaggerUiResolver extends SwaggerUiResolver {
             if (bundle == null) {
                 return null;
             }
+            if (bundle.getState() != Bundle.ACTIVE) {
+				bundle.start();
+			}
             String[] locations = swaggerUiMavenGroupAndArtifact == null ? DEFAULT_LOCATIONS
                 : new String[]{"mvn:" + swaggerUiMavenGroupAndArtifact + "/",
                                "wrap:mvn:" + swaggerUiMavenGroupAndArtifact + "/"};


### PR DESCRIPTION
bundle.getBundleContext() will give an NPE (in Equinox) if the bundle can be found but is not active.
Would also be good to at least log the exception in debug mode to point to a possible problem.