### PR TITLE
[CXF-7830] Support for running java2ws-plugin using JDK9+ on Windows.

### DIFF
--- a/core/src/main/java/org/apache/cxf/helpers/JavaUtils.java
+++ b/core/src/main/java/org/apache/cxf/helpers/JavaUtils.java
@@ -46,6 +46,7 @@ public final class JavaUtils {
         "void", "volatile", "while"
     ));
 
+    private static boolean isJava11Compatible;
     private static boolean isJava9Compatible;
     private static boolean isJava8Before161;
 
@@ -66,6 +67,7 @@ public final class JavaUtils {
         }
 
         setJava9Compatible(Integer.valueOf(version) >= 9);
+        setJava11Compatible(Integer.valueOf(version) >= 11);
     }
 
     private JavaUtils() {
@@ -91,9 +93,17 @@ public final class JavaUtils {
     public static boolean isJava9Compatible() {
         return isJava9Compatible;
     }
+    
+    public static boolean isJava11Compatible() {
+        return isJava11Compatible;
+    }
 
     private static void setJava9Compatible(boolean java9Compatible) {
         JavaUtils.isJava9Compatible = java9Compatible;
+    }
+    
+    private static void setJava11Compatible(boolean java11Compatible) {
+        JavaUtils.isJava11Compatible = java11Compatible;
     }
 
     public static boolean isJava8Before161() {


### PR DESCRIPTION
### Problem description
When using the `cxf-java2ws-plugin` from a Maven project using JDK 9+ (10 and 11 release candidate) on Windows 10, it fails to run because the generated command line is too long.

As an example, in one project I'm working on, the generated classpath was more than 75000 characters long – Yes, it is a big project. It works on JDK 8.

`[ERROR] Failed to execute goal org.apache.cxf:cxf-java2ws-plugin:3.2.6:java2ws (EXECUTIONNAME) on project PROJECTNAME: Error while executing process.: Cannot run program "cmd.exe" (in directory "C:\opt\dev\..._PROJECTNAME_\target"): CreateProcess error=206, The filename or extension is too long -> [Help 1]`

The current code base (3.3.0-SNAPSHOT) does not work at all with JDK 10 or 11.

The problem is that the classpath is part of the command line and on Windows it seems to be limited to around 8000 characters.

### This commit includes:

Fix for "CreateProcess error=206, The filename or extension is too long":
 - Added parameter `classpathAsEnvVar`, which is `false` by default,
   unless plugin is running in a Windows OS using JDK 9+, in which
   case it is activated automatically. This parameter controls if
   the CLASSPATH is applied via environment variable or as an
   argument to the command line that executes the java2ws tool.

Cleaning up the JDK9+ JVM arguments code:
 - Single block for JDK 9, 10, 11 and up.
 - For JDK 11 and up the java.xml.ws module is skipped since
   it was moved out of the JDK.

More verbose error reporting:
 - If command fails to execute, the reported message
   includes information about the command line, and
   the CLASSPATH environment variable if defined.

Other fixes:
 - Fixed NPE when classifier is undefined.