### PR TITLE
CXF-7842: ContainerRequestFilter.getHeaders() Does Not Honor Header Split Setting

### DIFF
--- a/rt/frontend/jaxrs/src/main/java/org/apache/cxf/jaxrs/impl/ContainerRequestContextImpl.java
+++ b/rt/frontend/jaxrs/src/main/java/org/apache/cxf/jaxrs/impl/ContainerRequestContextImpl.java
@@ -86,8 +86,7 @@ public class ContainerRequestContextImpl extends AbstractRequestContextImpl
     }
 
     public MultivaluedMap<String, String> getHeaders() {
-        h = null;
-        return HttpUtils.getModifiableStringHeaders(m);
+        return h.getRequestHeaders();
     }
 
 

--- a/rt/frontend/jaxrs/src/test/java/org/apache/cxf/jaxrs/impl/ContainerRequestContextImplTest.java
+++ b/rt/frontend/jaxrs/src/test/java/org/apache/cxf/jaxrs/impl/ContainerRequestContextImplTest.java
@@ -1,0 +1,49 @@
+package org.apache.cxf.jaxrs.impl;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import javax.ws.rs.core.MultivaluedMap;
+
+import org.apache.cxf.message.ExchangeImpl;
+import org.apache.cxf.message.Message;
+import org.apache.cxf.message.MessageImpl;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class ContainerRequestContextImplTest {
+
+    @Test
+    public void shouldSplitHeadersWhenPropertySet() {
+        Message m = new MessageImpl();
+        m.setExchange(new ExchangeImpl());
+        Map<String, List<String>> headers = new HashMap<>();
+        headers.put("foo", new ArrayList<>(Collections.singletonList("bar,baz")));
+        m.put(Message.PROTOCOL_HEADERS, headers);
+        m.put("org.apache.cxf.http.header.split", true);
+
+        final ContainerRequestContextImpl context = new ContainerRequestContextImpl(m, false, false);
+        final MultivaluedMap<String, String> actual = context.getHeaders();
+        assertEquals(1, actual.size());
+        assertEquals(Arrays.asList("bar", "baz"), actual.get("foo"));
+    }
+
+    @Test
+    public void shouldConcatenateHeadersByDefault() {
+        Message m = new MessageImpl();
+        m.setExchange(new ExchangeImpl());
+        Map<String, List<String>> headers = new HashMap<>();
+        headers.put("foo", new ArrayList<>(Collections.singletonList("bar,baz")));
+        m.put(Message.PROTOCOL_HEADERS, headers);
+
+        final ContainerRequestContextImpl context = new ContainerRequestContextImpl(m, false, false);
+        final MultivaluedMap<String, String> actual = context.getHeaders();
+        assertEquals(1, actual.size());
+        assertEquals(Collections.singletonList("bar,baz"), actual.get("foo"));
+    }
+}


### PR DESCRIPTION
There was a very strange line in the ContainerRequestContextImpl which nulled out the HttpHeaders that were already there as a field.  So, a simple solution was to not null it out and return what HttpHeaders was returning, since it already does the right thing.  Let me know if this will work.  All tests in the frontend-jaxrs module passed for me.  My Jenkins is still running the full build, but I thought I'd get this in front of you guys to let me know if I'm on the right track.  Thanks.