### PR TITLE
Revert "[CXF-7317] Non-URL encoded Content-Id href does not seem be serialized by CXF's AttachmentSerializer"

### DIFF
--- a/core/src/main/java/org/apache/cxf/attachment/AttachmentSerializer.java
+++ b/core/src/main/java/org/apache/cxf/attachment/AttachmentSerializer.java
@@ -24,6 +24,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.StringWriter;
 import java.io.Writer;
+import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.Iterator;
@@ -214,7 +215,7 @@ public class AttachmentSerializer {
         if (attachmentId != null) {
             attachmentId = checkAngleBrackets(attachmentId);
             writer.write("Content-ID: <");
-            writer.write(attachmentId);
+            writer.write(URLDecoder.decode(attachmentId, StandardCharsets.UTF_8.name()));
             writer.write(">\r\n");
         }
         // headers like Content-Disposition need to be serialized


### PR DESCRIPTION
Reverts apache/cxf#408

See https://www.rfc-editor.org/errata/rfc2392