### PR TITLE
CXF-7864: Fix issue if lifetime only specify expired without created

### DIFF
--- a/services/sts/sts-core/src/main/java/org/apache/cxf/sts/token/provider/DefaultConditionsProvider.java
+++ b/services/sts/sts-core/src/main/java/org/apache/cxf/sts/token/provider/DefaultConditionsProvider.java
@@ -78,6 +78,7 @@ public class DefaultConditionsProvider implements ConditionsProvider {
      * doesn't specify a lifetime element
      * @return the lifetime in seconds
      */
+    @Override
     public long getLifetime() {
         return lifetime;
     }
@@ -134,25 +135,17 @@ public class DefaultConditionsProvider implements ConditionsProvider {
     /**
      * Get a ConditionsBean object.
      */
+    @Override
     public ConditionsBean getConditions(TokenProviderParameters providerParameters) {
         ConditionsBean conditions = new ConditionsBean();
 
         Lifetime tokenLifetime = providerParameters.getTokenRequirements().getLifetime();
         if (lifetime > 0) {
-            if (acceptClientLifetime && tokenLifetime != null
-                && tokenLifetime.getCreated() != null && tokenLifetime.getExpires() != null) {
-                Instant creationTime = null;
-                Instant expirationTime = null;
-                try {
-                    creationTime = ZonedDateTime.parse(tokenLifetime.getCreated()).toInstant();
-                    expirationTime = ZonedDateTime.parse(tokenLifetime.getExpires()).toInstant();
-                } catch (DateTimeParseException ex) {
-                    LOG.fine("Error in parsing Timestamp Created or Expiration Strings");
-                    throw new STSException(
-                        "Error in parsing Timestamp Created or Expiration Strings",
-                        STSException.INVALID_TIME
-                    );
-                }
+            if (acceptClientLifetime && tokenLifetime != null &&
+                    (tokenLifetime.getCreated() != null || tokenLifetime.getExpires() != null)) {
+                Instant creationTime = parsedInstantOrDefault(tokenLifetime.getCreated(), Instant.now());
+                Instant expirationTime = parsedInstantOrDefault(tokenLifetime.getExpires(),
+                        creationTime.plusSeconds(lifetime));
 
                 // Check to see if the created time is in the future
                 Instant validCreation = Instant.now();
@@ -196,6 +189,21 @@ public class DefaultConditionsProvider implements ConditionsProvider {
         }
 
         return conditions;
+    }
+
+    private Instant parsedInstantOrDefault(String dateTime, Instant defaultInstant) {
+        if (dateTime == null || dateTime.isEmpty()) {
+            return defaultInstant;
+        }
+        try {
+            return ZonedDateTime.parse(dateTime).toInstant();
+        } catch (DateTimeParseException ex) {
+            LOG.fine("Error in parsing Timestamp Created or Expiration Strings");
+            throw new STSException(
+                "Error in parsing Timestamp Created or Expiration Strings",
+                STSException.INVALID_TIME
+            );
+        }
     }
 
     /**

--- a/services/sts/sts-core/src/main/java/org/apache/cxf/sts/token/provider/DefaultConditionsProvider.java
+++ b/services/sts/sts-core/src/main/java/org/apache/cxf/sts/token/provider/DefaultConditionsProvider.java
@@ -141,8 +141,8 @@ public class DefaultConditionsProvider implements ConditionsProvider {
 
         Lifetime tokenLifetime = providerParameters.getTokenRequirements().getLifetime();
         if (lifetime > 0) {
-            if (acceptClientLifetime && tokenLifetime != null &&
-                    (tokenLifetime.getCreated() != null || tokenLifetime.getExpires() != null)) {
+            if (acceptClientLifetime && tokenLifetime != null
+                    && (tokenLifetime.getCreated() != null || tokenLifetime.getExpires() != null)) {
                 Instant creationTime = parsedInstantOrDefault(tokenLifetime.getCreated(), Instant.now());
                 Instant expirationTime = parsedInstantOrDefault(tokenLifetime.getExpires(),
                         creationTime.plusSeconds(lifetime));

--- a/services/sts/sts-core/src/test/java/org/apache/cxf/sts/token/provider/SAMLProviderLifetimeTest.java
+++ b/services/sts/sts-core/src/test/java/org/apache/cxf/sts/token/provider/SAMLProviderLifetimeTest.java
@@ -23,6 +23,8 @@ import java.time.Instant;
 import java.time.ZoneOffset;
 import java.util.Properties;
 
+import org.w3c.dom.Element;
+
 import org.apache.cxf.jaxws.context.WrappedMessageContext;
 import org.apache.cxf.message.MessageImpl;
 import org.apache.cxf.sts.STSConstants;
@@ -40,7 +42,7 @@ import org.apache.wss4j.common.ext.WSSecurityException;
 import org.apache.wss4j.common.principal.CustomTokenPrincipal;
 import org.apache.wss4j.common.util.DOM2Writer;
 import org.apache.wss4j.common.util.DateUtil;
-import org.w3c.dom.Element;
+
 
 
 /**

--- a/services/sts/sts-core/src/test/java/org/apache/cxf/sts/token/provider/SAMLProviderLifetimeTest.java
+++ b/services/sts/sts-core/src/test/java/org/apache/cxf/sts/token/provider/SAMLProviderLifetimeTest.java
@@ -23,8 +23,6 @@ import java.time.Instant;
 import java.time.ZoneOffset;
 import java.util.Properties;
 
-import org.w3c.dom.Element;
-
 import org.apache.cxf.jaxws.context.WrappedMessageContext;
 import org.apache.cxf.message.MessageImpl;
 import org.apache.cxf.sts.STSConstants;
@@ -42,6 +40,7 @@ import org.apache.wss4j.common.ext.WSSecurityException;
 import org.apache.wss4j.common.principal.CustomTokenPrincipal;
 import org.apache.wss4j.common.util.DOM2Writer;
 import org.apache.wss4j.common.util.DateUtil;
+import org.w3c.dom.Element;
 
 
 /**
@@ -84,6 +83,40 @@ public class SAMLProviderLifetimeTest extends org.junit.Assert {
         Element token = (Element)providerResponse.getToken();
         String tokenString = DOM2Writer.nodeToString(token);
         assertTrue(tokenString.contains(providerResponse.getTokenId()));
+    }
+
+    /**
+     *
+     * As specified in ws-trust
+     * "If this attribute isn't specified, then the current time is used as an initial period."
+     * if creation time is not specified, we use current time instead.
+     *
+     */
+    @org.junit.Test
+    public void saml2LifetimeWithoutCreated() throws WSSecurityException {
+        int requestedLifetime = 60;
+        SAMLTokenProvider samlTokenProvider = new SAMLTokenProvider();
+        DefaultConditionsProvider conditionsProvider = new DefaultConditionsProvider();
+        conditionsProvider.setAcceptClientLifetime(true);
+        samlTokenProvider.setConditionsProvider(conditionsProvider);
+
+        TokenProviderParameters providerParameters =
+            createProviderParameters(
+                WSS4JConstants.WSS_SAML2_TOKEN_TYPE, STSConstants.BEARER_KEY_KEYTYPE
+            );
+
+        // Set expected lifetime to 1 minute
+        Lifetime lifetime = new Lifetime();
+        Instant expirationTime = Instant.now().plusSeconds(requestedLifetime);
+
+        lifetime.setExpires(expirationTime.atZone(ZoneOffset.UTC).format(DateUtil.getDateTimeFormatter(true)));
+        providerParameters.getTokenRequirements().setLifetime(lifetime);
+
+        assertTrue(samlTokenProvider.canHandleToken(WSS4JConstants.WSS_SAML2_TOKEN_TYPE));
+        TokenProviderResponse providerResponse = samlTokenProvider.createToken(providerParameters);
+        assertTrue(providerResponse != null);
+        assertTrue(providerResponse.getToken() != null && providerResponse.getTokenId() != null);
+        assertEquals(providerResponse.getExpires(), expirationTime);
     }
 
 
@@ -223,14 +256,14 @@ public class SAMLProviderLifetimeTest extends org.junit.Assert {
         Lifetime lifetime = new Lifetime();
         lifetime.setCreated(creationTime.atZone(ZoneOffset.UTC).format(DateUtil.getDateTimeFormatter(true)));
         lifetime.setExpires(expirationTime.atZone(ZoneOffset.UTC).format(DateUtil.getDateTimeFormatter(true)));
-        
+
         providerParameters.getTokenRequirements().setLifetime(lifetime);
 
         assertTrue(samlTokenProvider.canHandleToken(WSS4JConstants.WSS_SAML2_TOKEN_TYPE));
         TokenProviderResponse providerResponse = samlTokenProvider.createToken(providerParameters);
         assertTrue(providerResponse != null);
         assertTrue(providerResponse.getToken() != null && providerResponse.getTokenId() != null);
-        
+
         long duration = Duration.between(providerResponse.getCreated(), providerResponse.getExpires()).getSeconds();
         assertEquals(maxLifetime, duration);
         Element token = (Element)providerResponse.getToken();
@@ -264,14 +297,14 @@ public class SAMLProviderLifetimeTest extends org.junit.Assert {
         Lifetime lifetime = new Lifetime();
         lifetime.setCreated(creationTime.atZone(ZoneOffset.UTC).format(DateUtil.getDateTimeFormatter(true)));
         lifetime.setExpires(expirationTime.atZone(ZoneOffset.UTC).format(DateUtil.getDateTimeFormatter(true)));
-        
+
         providerParameters.getTokenRequirements().setLifetime(lifetime);
 
         assertTrue(samlTokenProvider.canHandleToken(WSS4JConstants.WSS_SAML2_TOKEN_TYPE));
         TokenProviderResponse providerResponse = samlTokenProvider.createToken(providerParameters);
         assertTrue(providerResponse != null);
         assertTrue(providerResponse.getToken() != null && providerResponse.getTokenId() != null);
-        
+
         long duration = Duration.between(providerResponse.getCreated(), providerResponse.getExpires()).getSeconds();
         assertEquals(50, duration);
         Element token = (Element)providerResponse.getToken();
@@ -304,7 +337,7 @@ public class SAMLProviderLifetimeTest extends org.junit.Assert {
         Lifetime lifetime = new Lifetime();
         lifetime.setCreated(creationTime.atZone(ZoneOffset.UTC).format(DateUtil.getDateTimeFormatter(true)));
         lifetime.setExpires(expirationTime.atZone(ZoneOffset.UTC).format(DateUtil.getDateTimeFormatter(true)));
-        
+
         providerParameters.getTokenRequirements().setLifetime(lifetime);
 
         assertTrue(samlTokenProvider.canHandleToken(WSS4JConstants.WSS_SAML2_TOKEN_TYPE));
@@ -336,6 +369,7 @@ public class SAMLProviderLifetimeTest extends org.junit.Assert {
         SAMLTokenProvider samlTokenProvider = new SAMLTokenProvider();
         DefaultConditionsProvider conditionsProvider = new DefaultConditionsProvider();
         conditionsProvider.setAcceptClientLifetime(true);
+        conditionsProvider.setFutureTimeToLive(180L);
         samlTokenProvider.setConditionsProvider(conditionsProvider);
 
         TokenProviderParameters providerParameters =
@@ -348,7 +382,7 @@ public class SAMLProviderLifetimeTest extends org.junit.Assert {
 
         Lifetime lifetime = new Lifetime();
         lifetime.setCreated(creationTime.atZone(ZoneOffset.UTC).format(DateUtil.getDateTimeFormatter(true)));
-        
+
         providerParameters.getTokenRequirements().setLifetime(lifetime);
 
         assertTrue(samlTokenProvider.canHandleToken(WSS4JConstants.WSS_SAML2_TOKEN_TYPE));
@@ -356,7 +390,7 @@ public class SAMLProviderLifetimeTest extends org.junit.Assert {
         TokenProviderResponse providerResponse = samlTokenProvider.createToken(providerParameters);
         assertTrue(providerResponse != null);
         assertTrue(providerResponse.getToken() != null && providerResponse.getTokenId() != null);
-        
+
         long duration = Duration.between(providerResponse.getCreated(), providerResponse.getExpires()).getSeconds();
         assertEquals(conditionsProvider.getLifetime(), duration);
         Element token = (Element)providerResponse.getToken();


### PR DESCRIPTION
WS-trust define that a `/wst:RequestSecurityToken/wst:Lifetime` can be specified with only having `wsu:Expires`. In that case the creationTime shall be set to the current time. CXF simply ignore the lifetime if either expires or created is not present.

I have fixed the behavior and provide a unit test for it. I have to also modify test `testSaml2NoExpires` because it fails after my changes, because the creationTime was too fare in the future. The "old" implementation just ignore the creationTime, which was wrong.

If my change is acceptable, could you please also merge the fix to 3.2-branch. Thank you.