### PR TITLE
CXF-7867 - Allow the AbstractSpnegoAuthSupplier loginConfig to be used

### DIFF
--- a/rt/transports/http/src/main/java/org/apache/cxf/transport/http/auth/AbstractSpnegoAuthSupplier.java
+++ b/rt/transports/http/src/main/java/org/apache/cxf/transport/http/auth/AbstractSpnegoAuthSupplier.java
@@ -120,6 +120,10 @@ public abstract class AbstractSpnegoAuthSupplier {
                 lc.login();
                 subject = lc.getSubject();
             }
+        } else if (loginConfig != null) {
+            LoginContext lc = new LoginContext("", new Subject(), null, loginConfig);
+            lc.login();
+            subject = lc.getSubject();
         }
 
         GSSManager manager = GSSManager.getInstance();

--- a/rt/transports/http/src/main/java/org/apache/cxf/transport/http/auth/AbstractSpnegoAuthSupplier.java
+++ b/rt/transports/http/src/main/java/org/apache/cxf/transport/http/auth/AbstractSpnegoAuthSupplier.java
@@ -120,7 +120,7 @@ public abstract class AbstractSpnegoAuthSupplier {
                 lc.login();
                 subject = lc.getSubject();
             }
-        } else if (loginConfig != null) {
+        } else if (loginConfig != null && delegatedCred == null) {
             LoginContext lc = new LoginContext("", new Subject(), null, loginConfig);
             lc.login();
             subject = lc.getSubject();

--- a/rt/transports/http/src/main/java/org/apache/cxf/transport/http/auth/AbstractSpnegoAuthSupplier.java
+++ b/rt/transports/http/src/main/java/org/apache/cxf/transport/http/auth/AbstractSpnegoAuthSupplier.java
@@ -121,7 +121,7 @@ public abstract class AbstractSpnegoAuthSupplier {
                 subject = lc.getSubject();
             }
         } else if (loginConfig != null && delegatedCred == null) {
-            LoginContext lc = new LoginContext("", new Subject(), null, loginConfig);
+            LoginContext lc = new LoginContext("", null, null, loginConfig);
             lc.login();
             subject = lc.getSubject();
         }

--- a/services/sts/systests/advanced/src/test/java/org/apache/cxf/systest/sts/kerberos/KerberosDelegationTokenTest.java
+++ b/services/sts/systests/advanced/src/test/java/org/apache/cxf/systest/sts/kerberos/KerberosDelegationTokenTest.java
@@ -19,11 +19,8 @@
 package org.apache.cxf.systest.sts.kerberos;
 
 import java.net.URL;
-import java.util.HashMap;
 import java.util.Map;
 
-import javax.security.auth.login.AppConfigurationEntry;
-import javax.security.auth.login.Configuration;
 import javax.xml.namespace.QName;
 import javax.xml.ws.BindingProvider;
 import javax.xml.ws.Service;
@@ -132,48 +129,6 @@ public class KerberosDelegationTokenTest extends AbstractBusClientServerTestBase
         SpnegoAuthSupplier authSupplier = new SpnegoAuthSupplier();
         authSupplier.setServicePrincipalName("bob@service.ws.apache.org");
         authSupplier.setServiceNameType(GSSName.NT_HOSTBASED_SERVICE);
-        WebClient.getConfig(client).getHttpConduit().setAuthSupplier(authSupplier);
-
-        int resp = client.post(numToDouble, Integer.class);
-        org.junit.Assert.assertEquals(2 * numToDouble, resp);
-    }
-
-    @org.junit.Test
-    public void testKerberosTokenJAXRSCustomLogin() throws Exception {
-
-        final String configLocation = "org/apache/cxf/systest/sts/kerberos/cxf-intermediary-jaxrs-client.xml";
-        final String address = "https://localhost:" + INTERMEDIARY_PORT + "/doubleit/services/doubleit-rs";
-        final int numToDouble = 35;
-
-        WebClient client = WebClient.create(address, configLocation);
-        client.type("text/plain").accept("text/plain");
-
-        Map<String, Object> requestContext = WebClient.getConfig(client).getRequestContext();
-        requestContext.put("auth.spnego.useKerberosOid", "true");
-        requestContext.put("auth.spnego.requireCredDelegation", "true");
-
-        SpnegoAuthSupplier authSupplier = new SpnegoAuthSupplier();
-        authSupplier.setServicePrincipalName("bob@service.ws.apache.org");
-        authSupplier.setServiceNameType(GSSName.NT_HOSTBASED_SERVICE);
-        Map<String, String> loginConfig = new HashMap<>();
-
-        loginConfig.put("useKeyTab", "true");
-        loginConfig.put("storeKey", "true");
-        loginConfig.put("refreshKrb5Config", "true");
-        loginConfig.put("keyTab", "/some/fake/keytab.keytab");
-        loginConfig.put("principal", "someuser@service.ws.apache.org");
-        loginConfig.put("useTicketCache", "true");
-        loginConfig.put("debug", String.valueOf(true));
-
-        authSupplier.setLoginConfig(new Configuration() {
-            @Override
-            public AppConfigurationEntry[] getAppConfigurationEntry(String name) {
-                return new AppConfigurationEntry[] {
-                  new AppConfigurationEntry("com.sun.security.auth.module.Krb5LoginModule",
-                    AppConfigurationEntry.LoginModuleControlFlag.REQUIRED,
-                    loginConfig)};
-            }
-        });
         WebClient.getConfig(client).getHttpConduit().setAuthSupplier(authSupplier);
 
         int resp = client.post(numToDouble, Integer.class);

--- a/services/sts/systests/advanced/src/test/java/org/apache/cxf/systest/sts/kerberos/KerberosDelegationTokenTest.java
+++ b/services/sts/systests/advanced/src/test/java/org/apache/cxf/systest/sts/kerberos/KerberosDelegationTokenTest.java
@@ -19,8 +19,11 @@
 package org.apache.cxf.systest.sts.kerberos;
 
 import java.net.URL;
+import java.util.HashMap;
 import java.util.Map;
 
+import javax.security.auth.login.AppConfigurationEntry;
+import javax.security.auth.login.Configuration;
 import javax.xml.namespace.QName;
 import javax.xml.ws.BindingProvider;
 import javax.xml.ws.Service;
@@ -129,6 +132,48 @@ public class KerberosDelegationTokenTest extends AbstractBusClientServerTestBase
         SpnegoAuthSupplier authSupplier = new SpnegoAuthSupplier();
         authSupplier.setServicePrincipalName("bob@service.ws.apache.org");
         authSupplier.setServiceNameType(GSSName.NT_HOSTBASED_SERVICE);
+        WebClient.getConfig(client).getHttpConduit().setAuthSupplier(authSupplier);
+
+        int resp = client.post(numToDouble, Integer.class);
+        org.junit.Assert.assertEquals(2 * numToDouble, resp);
+    }
+
+    @org.junit.Test
+    public void testKerberosTokenJAXRSCustomLogin() throws Exception {
+
+        final String configLocation = "org/apache/cxf/systest/sts/kerberos/cxf-intermediary-jaxrs-client.xml";
+        final String address = "https://localhost:" + INTERMEDIARY_PORT + "/doubleit/services/doubleit-rs";
+        final int numToDouble = 35;
+
+        WebClient client = WebClient.create(address, configLocation);
+        client.type("text/plain").accept("text/plain");
+
+        Map<String, Object> requestContext = WebClient.getConfig(client).getRequestContext();
+        requestContext.put("auth.spnego.useKerberosOid", "true");
+        requestContext.put("auth.spnego.requireCredDelegation", "true");
+
+        SpnegoAuthSupplier authSupplier = new SpnegoAuthSupplier();
+        authSupplier.setServicePrincipalName("bob@service.ws.apache.org");
+        authSupplier.setServiceNameType(GSSName.NT_HOSTBASED_SERVICE);
+        Map<String, String> loginConfig = new HashMap<>();
+
+        loginConfig.put("useKeyTab", "true");
+        loginConfig.put("storeKey", "true");
+        loginConfig.put("refreshKrb5Config", "true");
+        loginConfig.put("keyTab", "/some/fake/keytab.keytab");
+        loginConfig.put("principal", "someuser@service.ws.apache.org");
+        loginConfig.put("useTicketCache", "true");
+        loginConfig.put("debug", String.valueOf(true));
+
+        authSupplier.setLoginConfig(new Configuration() {
+            @Override
+            public AppConfigurationEntry[] getAppConfigurationEntry(String name) {
+                return new AppConfigurationEntry[] {
+                  new AppConfigurationEntry("com.sun.security.auth.module.Krb5LoginModule",
+                    AppConfigurationEntry.LoginModuleControlFlag.REQUIRED,
+                    loginConfig)};
+            }
+        });
         WebClient.getConfig(client).getHttpConduit().setAuthSupplier(authSupplier);
 
         int resp = client.post(numToDouble, Integer.class);

--- a/systests/kerberos/pom.xml
+++ b/systests/kerberos/pom.xml
@@ -222,6 +222,12 @@
             <version>${cxf.kerby.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>${cxf.mockito.version}</version>
+            <scope>test</scope>
+        </dependency>
 
     </dependencies>
     <profiles>

--- a/systests/kerberos/src/test/java/org/apache/cxf/systest/kerberos/wssec/spnego/SpnegoAuthSupplierTest.java
+++ b/systests/kerberos/src/test/java/org/apache/cxf/systest/kerberos/wssec/spnego/SpnegoAuthSupplierTest.java
@@ -1,0 +1,43 @@
+package org.apache.cxf.systest.kerberos.wssec.spnego;
+
+import org.apache.cxf.configuration.security.AuthorizationPolicy;
+import org.apache.cxf.message.Message;
+import org.apache.cxf.transport.http.auth.SpnegoAuthSupplier;
+import org.mockito.Mockito;
+
+import javax.security.auth.login.AppConfigurationEntry;
+import javax.security.auth.login.Configuration;
+import java.net.URI;
+import java.util.HashMap;
+import java.util.Map;
+
+public class SpnegoAuthSupplierTest {
+    @org.junit.Test
+    public void testSpnegoOverSymmetric() throws Exception {
+      SpnegoAuthSupplier spnegoAuthSupplier = new SpnegoAuthSupplier();
+
+      Map<String, String> loginConfig = new HashMap<>();
+      loginConfig.put("useKeyTab", "false");
+      loginConfig.put("storeKey", "true");
+      loginConfig.put("refreshKrb5Config", "true");
+      loginConfig.put("principal", "myuser@my.domain.com");
+      loginConfig.put("useTicketCache", "true");
+      loginConfig.put("debug", String.valueOf(true));
+
+      spnegoAuthSupplier.setLoginConfig(new Configuration() {
+        @Override
+        public AppConfigurationEntry[] getAppConfigurationEntry(String name) {
+          return new AppConfigurationEntry[] {
+            new AppConfigurationEntry("com.sun.security.auth.module.Krb5LoginModule",
+              AppConfigurationEntry.LoginModuleControlFlag.REQUIRED,
+              loginConfig)};
+        }
+      });
+
+      URI uri = new URI("http://some-test-domain-doesnt-exist.com/");
+
+      AuthorizationPolicy authorizationPolicy = Mockito.mock(AuthorizationPolicy.class);
+      Message message = Mockito.mock(Message.class);
+      spnegoAuthSupplier.getAuthorization(authorizationPolicy, uri, message, "ignored anyway");
+    }
+}


### PR DESCRIPTION
See https://issues.apache.org/jira/browse/CXF-7867 

Currently if you set a Spnego auth supplier then set its `LoginConfig` with: `org.apache.cxf.transport.http.auth.AbstractSpnegoAuthSupplier#setLoginConfig`

It will not use it.

This makes it so you are forced to use the JVM-wide login configuration... unless I don't understand something.

Might be good to add something that can use this optional parameter when sent.