### PR TITLE
CXF-7878: ClientPolicyCalculator ignores ConnectionRequestTimeout property

### DIFF
--- a/rt/transports/http/src/main/java/org/apache/cxf/transport/http/policy/impl/ClientPolicyCalculator.java
+++ b/rt/transports/http/src/main/java/org/apache/cxf/transport/http/policy/impl/ClientPolicyCalculator.java
@@ -67,6 +67,7 @@ public class ClientPolicyCalculator implements PolicyCalculator<HTTPClientPolicy
                   && (p1.isSetProxyServerPort() ? p1.getProxyServerPort() == p2.getProxyServerPort() : !p2
                       .isSetProxyServerPort())
                   && p1.getProxyServerType().value().equals(p2.getProxyServerType().value())
+                  && (p1.getConnectionRequestTimeout() == p2.getConnectionRequestTimeout())
                   && (p1.getReceiveTimeout() == p2.getReceiveTimeout())
                   && StringUtils.equals(p1.getReferer(), p2.getReferer());
 
@@ -140,6 +141,11 @@ public class ClientPolicyCalculator implements PolicyCalculator<HTTPClientPolicy
             p.setConnectionTimeout(p1.getConnectionTimeout());
         } else if (p2.isSetConnectionTimeout()) {
             p.setConnectionTimeout(p2.getConnectionTimeout());
+        }
+        if (p1.isSetConnectionRequestTimeout()) {
+            p.setConnectionRequestTimeout(p1.getConnectionRequestTimeout());
+        } else if (p2.isSetConnectionRequestTimeout()) {
+            p.setConnectionRequestTimeout(p2.getConnectionRequestTimeout());
         }
         if (p1.isSetReceiveTimeout()) {
             p.setReceiveTimeout(p1.getReceiveTimeout());

--- a/rt/transports/http/src/test/java/org/apache/cxf/transport/http/policy/ClientPolicyCalculatorTest.java
+++ b/rt/transports/http/src/test/java/org/apache/cxf/transport/http/policy/ClientPolicyCalculatorTest.java
@@ -18,6 +18,8 @@
  */
 package org.apache.cxf.transport.http.policy;
 
+import java.util.concurrent.ThreadLocalRandom;
+
 import org.apache.cxf.transport.http.policy.impl.ClientPolicyCalculator;
 import org.apache.cxf.transports.http.configuration.HTTPClientPolicy;
 
@@ -46,6 +48,7 @@ public class ClientPolicyCalculatorTest extends Assert {
 
     @Test
     public void testIntersectClientPolicies() {
+        ThreadLocalRandom random = ThreadLocalRandom.current();
         ClientPolicyCalculator calc = new ClientPolicyCalculator();
         HTTPClientPolicy p1 = new HTTPClientPolicy();
         HTTPClientPolicy p2 = new HTTPClientPolicy();
@@ -55,9 +58,22 @@ public class ClientPolicyCalculatorTest extends Assert {
         p = calc.intersect(p1, p2);
         assertEquals("browser", p.getBrowserType());
         p1.setBrowserType(null);
-        p1.setConnectionTimeout(10000L);
+
+        long connectionRequestTimeout = random.nextLong(0, 10000);
+        p1.setConnectionRequestTimeout(connectionRequestTimeout);
         p = calc.intersect(p1, p2);
-        assertEquals(10000L, p.getConnectionTimeout());
+        assertEquals(connectionRequestTimeout, p.getConnectionRequestTimeout());
+
+        long receiveTimeout = random.nextLong(0, 10000);
+        p1.setReceiveTimeout(receiveTimeout);
+        p = calc.intersect(p1, p2);
+        assertEquals(receiveTimeout, p.getReceiveTimeout());
+
+        long connectionTimeout = random.nextLong(0, 10000);
+        p1.setConnectionTimeout(connectionTimeout);
+        p = calc.intersect(p1, p2);
+        assertEquals(connectionTimeout, p.getConnectionTimeout());
+
         p1.setAllowChunking(false);
         p2.setAllowChunking(false);
         p = calc.intersect(p1, p2);


### PR DESCRIPTION
https://issues.apache.org/jira/browse/CXF-7878

Timeout values set to random numbers in the test to avoid accidentally setting them to the same value as a default and not noticing.