### PR TITLE
[CXF-7832]WrappedMessageContext containsKey not consistent with get/put

### DIFF
--- a/rt/frontend/jaxws/src/main/java/org/apache/cxf/jaxws/context/WrappedMessageContext.java
+++ b/rt/frontend/jaxws/src/main/java/org/apache/cxf/jaxws/context/WrappedMessageContext.java
@@ -193,7 +193,8 @@ public class WrappedMessageContext implements MessageContext {
     }
 
     public final boolean containsKey(Object key) {
-        return message.containsKey(mapKey((String)key));
+        return message.containsKey(mapKey((String)key))
+            || get(key) != null;
     }
 
     public final boolean containsValue(Object value) {

--- a/rt/frontend/jaxws/src/test/java/org/apache/cxf/jaxws/context/WrappedMessageContextTest.java
+++ b/rt/frontend/jaxws/src/test/java/org/apache/cxf/jaxws/context/WrappedMessageContextTest.java
@@ -20,6 +20,7 @@
 package org.apache.cxf.jaxws.context;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -80,5 +81,19 @@ public class WrappedMessageContextTest extends Assert {
                 fail("unknown attachment");
             }
         }
+    }
+    
+    
+    @Test
+    public void testContainsKey() throws Exception {
+        WrappedMessageContext context =
+            new WrappedMessageContext(new HashMap<String, Object>(), null, Scope.APPLICATION);
+
+        Map<String, List<String>> headers = new HashMap<>();
+        context.put(MessageContext.HTTP_REQUEST_HEADERS, headers);
+
+        assertNotNull(context.get(MessageContext.HTTP_REQUEST_HEADERS));
+
+        assertTrue(context.containsKey(MessageContext.HTTP_REQUEST_HEADERS));
     }
 }


### PR DESCRIPTION
Upstream issue: https://issues.apache.org/jira/browse/CXF-7832
Upstream commit https://github.com/apache/cxf/commit/01ec97bfcfd6ba59687da128b31d3995194c3bfc

EAP 7.1.x jira: https://issues.jboss.org/browse/JBEAP-15389