### PR TITLE
Fix newRemoteAddr is never assigned

### DIFF
--- a/rt/transports/http/src/main/java/org/apache/cxf/transport/servlet/AbstractHTTPServlet.java
+++ b/rt/transports/http/src/main/java/org/apache/cxf/transport/servlet/AbstractHTTPServlet.java
@@ -480,7 +480,7 @@ public abstract class AbstractHTTPServlet extends HttpServlet implements Filter 
                                            String originalPort) {
             super(request);
             this.newProtocol = originalProto;
-            if (newRemoteAddr != null) {
+            if (originalRemoteAddr != null) {
                 newRemoteAddr = (originalRemoteAddr.split(",")[0]).trim();
             }
             newRequestUri = calculateNewRequestUri(request, originalPrefix);


### PR DESCRIPTION
* Using the wrong variable for not null validation before HttpServletRequestXForwardedFilter.newRemoteAddr assignment.

That way, the header **_X-Forwarded-For_**, passed from AbstractHTTPServlet.checkXForwardedHeaders() was never considered.