### PR TITLE
CXF-8065 Stop using static factories in StaxUtils

### DIFF
--- a/core/src/main/java/org/apache/cxf/helpers/DOMUtils.java
+++ b/core/src/main/java/org/apache/cxf/helpers/DOMUtils.java
@@ -149,7 +149,7 @@ public final class DOMUtils {
         return f.newDocumentBuilder();
     }
 
-    private static ClassLoader getContextClassLoader() {
+    public static ClassLoader getContextClassLoader() {
         final SecurityManager sm = System.getSecurityManager();
         if (sm != null) {
             return AccessController.doPrivileged(new PrivilegedAction<ClassLoader>() {
@@ -161,7 +161,7 @@ public final class DOMUtils {
         return Thread.currentThread().getContextClassLoader();
     }
 
-    private static ClassLoader getClassLoader(final Class<?> clazz) {
+    public static ClassLoader getClassLoader(final Class<?> clazz) {
         final SecurityManager sm = System.getSecurityManager();
         if (sm != null) {
             return AccessController.doPrivileged(new PrivilegedAction<ClassLoader>() {


### PR DESCRIPTION
This is a PR to stop using static XMLInputFactory/XMLOutputFactory instances in StaxUtils and to instead rely on the parser pool, which is keyed off the ClassLoader.