### PR TITLE
String.split via fastpath instead of precompiled Pattern

### DIFF
--- a/core/src/main/java/org/apache/cxf/common/util/ClasspathScanner.java
+++ b/core/src/main/java/org/apache/cxf/common/util/ClasspathScanner.java
@@ -175,7 +175,7 @@ public class ClasspathScanner {
     }
 
     public static Set<String> parsePackages(final String packagesAsCsv) {
-        final String[] values = StringUtils.split(packagesAsCsv, ",");
+        final String[] values = packagesAsCsv.split(",");
         final Set<String> basePackages = new HashSet<>(values.length);
         for (final String value : values) {
             final String trimmed = value.trim();

--- a/core/src/main/java/org/apache/cxf/common/util/StringUtils.java
+++ b/core/src/main/java/org/apache/cxf/common/util/StringUtils.java
@@ -26,22 +26,16 @@ import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Predicate;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Stream;
 
 public final class StringUtils {
-    public static final Map<String, Pattern> PATTERN_MAP = new HashMap<>();
-    static {
-        String[] patterns = {"/", " ", ":", ",", ";", "=", "\\.", "\\+"};
-        for (String p : patterns) {
-            PATTERN_MAP.put(p, Pattern.compile(p));
-        }
-    }
+    private static final Map<String, Pattern> PATTERN_MAP = new ConcurrentHashMap<>();
     private static final Predicate<String> NOT_EMPTY = (String s) -> !s.isEmpty();
 
     private StringUtils() {
@@ -51,13 +45,14 @@ public final class StringUtils {
     public static String[] split(String s, String regex) {
         return split(s, regex, 0);
     }
+    @Deprecated
     public static String[] split(String s, String regex, int limit) {
-        Pattern p = PATTERN_MAP.getOrDefault(regex, Pattern.compile(regex));
+        Pattern p = PATTERN_MAP.computeIfAbsent(regex, key -> Pattern.compile(key));
         return p.split(s, limit);
     }
-    
+    @Deprecated
     public static Stream<String> splitAsStream(String s, String regex) {
-        Pattern p = PATTERN_MAP.getOrDefault(regex, Pattern.compile(regex));
+        Pattern p = PATTERN_MAP.computeIfAbsent(regex, key -> Pattern.compile(key));
         return p.splitAsStream(s);
     }
 

--- a/core/src/main/java/org/apache/cxf/common/util/StringUtils.java
+++ b/core/src/main/java/org/apache/cxf/common/util/StringUtils.java
@@ -47,6 +47,7 @@ public final class StringUtils {
     private StringUtils() {
     }
 
+    /* String.split via fastpath preferred */
     public static String[] split(String s, String regex) {
         return split(s, regex, 0);
     }

--- a/core/src/main/java/org/apache/cxf/interceptor/security/SimpleAuthorizingInterceptor.java
+++ b/core/src/main/java/org/apache/cxf/interceptor/security/SimpleAuthorizingInterceptor.java
@@ -25,7 +25,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.apache.cxf.common.util.StringUtils;
 import org.apache.cxf.security.SecurityContext;
 
 
@@ -101,7 +100,7 @@ public class SimpleAuthorizingInterceptor extends AbstractAuthorizingInIntercept
     }
 
     public void setGlobalRoles(String roles) {
-        globalRoles = Arrays.asList(StringUtils.split(roles, " "));
+        globalRoles = Arrays.asList(roles.split(" "));
     }
 
     public void setCheckConfiguredRolesOnly(boolean checkConfiguredRolesOnly) {
@@ -111,7 +110,7 @@ public class SimpleAuthorizingInterceptor extends AbstractAuthorizingInIntercept
     private static Map<String, List<String>> parseRolesMap(Map<String, String> rolesMap) {
         Map<String, List<String>> map = new HashMap<>();
         for (Map.Entry<String, String> entry : rolesMap.entrySet()) {
-            map.put(entry.getKey(), Arrays.asList(StringUtils.split(entry.getValue(), " ")));
+            map.put(entry.getKey(), Arrays.asList(entry.getValue().split(" ")));
         }
         return map;
     }

--- a/rt/frontend/jaxrs/src/main/java/org/apache/cxf/jaxrs/blueprint/JAXRSServerFactoryBeanDefinitionParser.java
+++ b/rt/frontend/jaxrs/src/main/java/org/apache/cxf/jaxrs/blueprint/JAXRSServerFactoryBeanDefinitionParser.java
@@ -30,7 +30,6 @@ import org.apache.aries.blueprint.ParserContext;
 import org.apache.aries.blueprint.mutable.MutableBeanMetadata;
 import org.apache.aries.blueprint.mutable.MutableCollectionMetadata;
 import org.apache.aries.blueprint.mutable.MutablePassThroughMetadata;
-import org.apache.cxf.common.util.StringUtils;
 import org.apache.cxf.configuration.blueprint.SimpleBPBeanDefinitionParser;
 import org.apache.cxf.helpers.DOMUtils;
 import org.apache.cxf.jaxrs.JAXRSServerFactoryBean;
@@ -51,7 +50,7 @@ public class JAXRSServerFactoryBeanDefinitionParser extends SimpleBPBeanDefiniti
                                 Element e, String name,
                                 String val, ParserContext context) {
         if ("beanNames".equals(name)) {
-            String[] values = StringUtils.split(val, " ");
+            String[] values = val.split(" ");
             MutableCollectionMetadata tempFactories = context.createMetadata(MutableCollectionMetadata.class);
             for (String v : values) {
                 String theValue = v.trim();

--- a/rt/frontend/jaxrs/src/main/java/org/apache/cxf/jaxrs/impl/CacheControlHeaderProvider.java
+++ b/rt/frontend/jaxrs/src/main/java/org/apache/cxf/jaxrs/impl/CacheControlHeaderProvider.java
@@ -93,7 +93,7 @@ public class CacheControlHeaderProvider implements HeaderDelegate<CacheControl> 
                 noCache = true;
                 addFields(noCacheFields, token);
             } else {
-                String[] extPair = StringUtils.split(token, "=");
+                String[] extPair = token.split("=");
                 String value = extPair.length == 2 ? extPair[1] : "";
                 extensions.put(extPair[0], value);
             }
@@ -193,7 +193,7 @@ public class CacheControlHeaderProvider implements HeaderDelegate<CacheControl> 
             }
             f = f.length() == 2 ? "" : f.substring(1, f.length() - 1);
             if (f.length() > 0) {
-                String[] values = StringUtils.split(f, ",");
+                String[] values = f.split(",");
                 for (String v : values) {
                     fields.add(v.trim());
                 }

--- a/rt/frontend/jaxrs/src/main/java/org/apache/cxf/jaxrs/impl/CacheControlHeaderProvider.java
+++ b/rt/frontend/jaxrs/src/main/java/org/apache/cxf/jaxrs/impl/CacheControlHeaderProvider.java
@@ -30,7 +30,6 @@ import java.util.regex.Pattern;
 import javax.ws.rs.core.CacheControl;
 import javax.ws.rs.ext.RuntimeDelegate.HeaderDelegate;
 
-import org.apache.cxf.common.util.StringUtils;
 import org.apache.cxf.jaxrs.utils.ExceptionUtils;
 import org.apache.cxf.message.Message;
 import org.apache.cxf.phase.PhaseInterceptorChain;
@@ -131,7 +130,7 @@ public class CacheControlHeaderProvider implements HeaderDelegate<CacheControl> 
             return values.toArray(new String[0]);
         }
         String separator = getSeparator();
-        return StringUtils.split(c, separator);
+        return c.split(separator);
     }
 
     public String toString(CacheControl c) {

--- a/rt/frontend/jaxrs/src/main/java/org/apache/cxf/jaxrs/impl/CookieHeaderProvider.java
+++ b/rt/frontend/jaxrs/src/main/java/org/apache/cxf/jaxrs/impl/CookieHeaderProvider.java
@@ -21,8 +21,6 @@ package org.apache.cxf.jaxrs.impl;
 import javax.ws.rs.core.Cookie;
 import javax.ws.rs.ext.RuntimeDelegate.HeaderDelegate;
 
-import org.apache.cxf.common.util.StringUtils;
-
 public class CookieHeaderProvider implements HeaderDelegate<Cookie> {
 
     private static final String VERSION = "$Version";
@@ -42,7 +40,7 @@ public class CookieHeaderProvider implements HeaderDelegate<Cookie> {
         String domain = null;
 
         // ignore the fact the possible version may be seperated by ','
-        String[] tokens = StringUtils.split(c, ";");
+        String[] tokens = c.split(";");
         for (String token : tokens) {
             String theToken = token.trim();
             if (theToken.startsWith(VERSION)) {

--- a/rt/frontend/jaxrs/src/main/java/org/apache/cxf/jaxrs/impl/HttpHeadersImpl.java
+++ b/rt/frontend/jaxrs/src/main/java/org/apache/cxf/jaxrs/impl/HttpHeadersImpl.java
@@ -188,13 +188,13 @@ public class HttpHeadersImpl implements HttpHeaders {
         List<Locale> newLs = new ArrayList<>();
         Map<Locale, Float> prefs = new HashMap<>();
         for (String l : ls) {
-            String[] pair = StringUtils.split(l, ";");
+            String[] pair = l.split(";");
 
             Locale locale = HttpUtils.getLocale(pair[0].trim());
 
             newLs.add(locale);
             if (pair.length > 1) {
-                String[] pair2 = StringUtils.split(pair[1], "=");
+                String[] pair2 = pair[1].split("=");
                 if (pair2.length > 1) {
                     prefs.put(locale, JAXRSUtils.getMediaTypeQualityFactor(pair2[1].trim()));
                 } else {

--- a/rt/frontend/jaxrs/src/main/java/org/apache/cxf/jaxrs/impl/LinkBuilderImpl.java
+++ b/rt/frontend/jaxrs/src/main/java/org/apache/cxf/jaxrs/impl/LinkBuilderImpl.java
@@ -32,7 +32,6 @@ import javax.ws.rs.core.Link;
 import javax.ws.rs.core.Link.Builder;
 import javax.ws.rs.core.UriBuilder;
 
-import org.apache.cxf.common.util.StringUtils;
 import org.apache.cxf.jaxrs.utils.HttpUtils;
 
 public class LinkBuilderImpl implements Builder {
@@ -95,7 +94,7 @@ public class LinkBuilderImpl implements Builder {
             }
         }
 
-        String[] tokens = StringUtils.split(link, ";");
+        String[] tokens = link.split(";");
         for (String token : tokens) {
             String theToken = token.trim();
             if (!theToken.isEmpty()) {

--- a/rt/frontend/jaxrs/src/main/java/org/apache/cxf/jaxrs/impl/LinkHeaderProvider.java
+++ b/rt/frontend/jaxrs/src/main/java/org/apache/cxf/jaxrs/impl/LinkHeaderProvider.java
@@ -54,7 +54,7 @@ public class LinkHeaderProvider implements HeaderDelegate<Link> {
         builder.uri(value.substring(1, closeIndex).trim());
         if (closeIndex < value.length() - 1) {
 
-            String[] tokens = StringUtils.split(value.substring(closeIndex + 1), ";");
+            String[] tokens = value.substring(closeIndex + 1).split(";");
             for (String token : tokens) {
                 String theToken = token.trim();
                 if (theToken.isEmpty()) {
@@ -68,7 +68,7 @@ public class LinkHeaderProvider implements HeaderDelegate<Link> {
                     paramValue = i == theToken.length() - 1 ? "" : theToken.substring(i + 1).trim();
                 }
                 if (REL.equals(paramName)) {
-                    String[] rels = StringUtils.split(removeQuotesIfNeeded(paramValue), ",");
+                    String[] rels = removeQuotesIfNeeded(paramValue).split(",");
                     for (String rel : rels) {
                         builder.rel(rel.trim());
                     }

--- a/rt/frontend/jaxrs/src/main/java/org/apache/cxf/jaxrs/impl/NewCookieHeaderProvider.java
+++ b/rt/frontend/jaxrs/src/main/java/org/apache/cxf/jaxrs/impl/NewCookieHeaderProvider.java
@@ -25,7 +25,6 @@ import javax.ws.rs.core.Cookie;
 import javax.ws.rs.core.NewCookie;
 import javax.ws.rs.ext.RuntimeDelegate.HeaderDelegate;
 
-import org.apache.cxf.common.util.StringUtils;
 import org.apache.cxf.jaxrs.utils.HttpUtils;
 
 public class NewCookieHeaderProvider implements HeaderDelegate<NewCookie> {
@@ -62,7 +61,7 @@ public class NewCookieHeaderProvider implements HeaderDelegate<NewCookie> {
         boolean httpOnly = false;
         int version = Cookie.DEFAULT_VERSION;
 
-        String[] tokens = StringUtils.split(c, ";");
+        String[] tokens = c.split(";");
         for (String token : tokens) {
             String theToken = token.trim();
 

--- a/rt/frontend/jaxrs/src/main/java/org/apache/cxf/jaxrs/impl/RequestImpl.java
+++ b/rt/frontend/jaxrs/src/main/java/org/apache/cxf/jaxrs/impl/RequestImpl.java
@@ -166,9 +166,9 @@ public class RequestImpl implements Request {
             return Collections.emptyList();
         }
         List<String> list = new LinkedList<>();
-        String[] values = StringUtils.split(acceptEnc, ",");
+        String[] values = acceptEnc.split(",");
         for (String value : values) {
-            String[] pair = StringUtils.split(value.trim(), ";");
+            String[] pair = value.trim().split(";");
             // ignore encoding qualifiers if any for now
             list.add(pair[0]);
         }

--- a/rt/frontend/jaxrs/src/main/java/org/apache/cxf/jaxrs/impl/UriBuilderImpl.java
+++ b/rt/frontend/jaxrs/src/main/java/org/apache/cxf/jaxrs/impl/UriBuilderImpl.java
@@ -394,7 +394,7 @@ public class UriBuilderImpl extends UriBuilder implements Cloneable {
                 // contain template vars - technically this can be covered by checking where a given template
                 // var is coming from and act accordingly. Confusing nonetheless.
                 StringBuilder buf = new StringBuilder();
-                String[] values = StringUtils.split(theValue, "/");
+                String[] values = theValue.split("/");
                 for (int i = 0; i < values.length; i++) {
                     buf.append(HttpUtils.encodePartiallyEncoded(values[i], false));
                     if (i + 1 < values.length) {

--- a/rt/frontend/jaxrs/src/main/java/org/apache/cxf/jaxrs/security/JAASAuthenticationFilter.java
+++ b/rt/frontend/jaxrs/src/main/java/org/apache/cxf/jaxrs/security/JAASAuthenticationFilter.java
@@ -35,7 +35,6 @@ import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.ResponseBuilder;
 import javax.ws.rs.core.UriBuilder;
 
-import org.apache.cxf.common.util.StringUtils;
 import org.apache.cxf.interceptor.security.JAASLoginInterceptor;
 import org.apache.cxf.interceptor.security.NamePasswordCallbackHandler;
 import org.apache.cxf.jaxrs.impl.HttpHeadersImpl;
@@ -144,7 +143,7 @@ public class JAASAuthenticationFilter implements ContainerRequestFilter {
         List<String> authHeader = headers.getRequestHeader(HttpHeaders.AUTHORIZATION);
         if (authHeader != null && !authHeader.isEmpty()) {
             // should HttpHeadersImpl do it ?
-            String[] authValues = StringUtils.split(authHeader.get(0), " ");
+            String[] authValues = authHeader.get(0).split(" ");
             if (authValues.length > 0) {
                 sb.append(authValues[0]);
             }

--- a/rt/frontend/jaxrs/src/main/java/org/apache/cxf/jaxrs/security/KerberosAuthenticationFilter.java
+++ b/rt/frontend/jaxrs/src/main/java/org/apache/cxf/jaxrs/security/KerberosAuthenticationFilter.java
@@ -78,7 +78,7 @@ public class KerberosAuthenticationFilter implements ContainerRequestFilter {
             LOG.fine("No Authorization header is available");
             throw ExceptionUtils.toNotAuthorizedException(null, getFaultResponse());
         }
-        String[] authPair = StringUtils.split(authHeaders.get(0), " ");
+        String[] authPair = authHeaders.get(0).split(" ");
         if (authPair.length != 2 || !NEGOTIATE_SCHEME.equalsIgnoreCase(authPair[0])) {
             LOG.fine("Negotiate Authorization scheme is expected");
             throw ExceptionUtils.toNotAuthorizedException(null, getFaultResponse());

--- a/rt/frontend/jaxrs/src/main/java/org/apache/cxf/jaxrs/servlet/CXFNonSpringJaxrsServlet.java
+++ b/rt/frontend/jaxrs/src/main/java/org/apache/cxf/jaxrs/servlet/CXFNonSpringJaxrsServlet.java
@@ -205,7 +205,7 @@ public class CXFNonSpringJaxrsServlet extends CXFNonSpringServlet {
         List<String> list = new ArrayList<>();
         for (String loc : locations) {
             String theLoc = loc.trim();
-            if (theLoc.length() != 0) {
+            if (!theLoc.isEmpty()) {
                 list.add(theLoc);
             }
         }
@@ -229,12 +229,12 @@ public class CXFNonSpringJaxrsServlet extends CXFNonSpringServlet {
         if (value == null) {
             return;
         }
-        String[] values = StringUtils.split(value, splitChar);
+        String[] values = value.split(splitChar);
         List<Interceptor<? extends Message>> list = new ArrayList<>();
         for (String interceptorVal : values) {
             Map<String, List<String>> props = new HashMap<>();
             String theValue = getClassNameAndProperties(interceptorVal, props);
-            if (theValue.length() != 0) {
+            if (!theValue.isEmpty()) {
                 try {
                     Class<?> intClass = loadClass(theValue, "Interceptor");
                     Object object = intClass.newInstance();
@@ -267,7 +267,7 @@ public class CXFNonSpringJaxrsServlet extends CXFNonSpringServlet {
         }
         Map<String, List<String>> props = new HashMap<>();
         String theValue = getClassNameAndProperties(value, props);
-        if (theValue.length() != 0) {
+        if (!theValue.isEmpty()) {
             try {
                 Class<?> intClass = loadClass(theValue, "Invoker");
                 Object object = intClass.newInstance();
@@ -294,12 +294,12 @@ public class CXFNonSpringJaxrsServlet extends CXFNonSpringServlet {
             }
             throw new ServletException("At least one resource class should be specified");
         }
-        String[] classNames = StringUtils.split(serviceBeans, splitChar);
+        String[] classNames = serviceBeans.split(splitChar);
         Map<Class<?>, Map<String, List<String>>> map = new HashMap<>();
         for (String cName : classNames) {
             Map<String, List<String>> props = new HashMap<>();
             String theName = getClassNameAndProperties(cName, props);
-            if (theName.length() != 0) {
+            if (!theName.isEmpty()) {
                 Class<?> cls = loadClass(theName);
                 map.put(cls, props);
             }
@@ -317,12 +317,12 @@ public class CXFNonSpringJaxrsServlet extends CXFNonSpringServlet {
         if (featuresList == null) {
             return Collections.< Feature >emptyList();
         }
-        String[] classNames = StringUtils.split(featuresList, splitChar);
+        String[] classNames = featuresList.split(splitChar);
         List< Feature > features = new ArrayList<>();
         for (String cName : classNames) {
             Map<String, List<String>> props = new HashMap<>();
             String theName = getClassNameAndProperties(cName, props);
-            if (theName.length() != 0) {
+            if (!theName.isEmpty()) {
                 Class<?> cls = loadClass(theName);
                 if (Feature.class.isAssignableFrom(cls)) {
                     features.add((Feature)createSingletonInstance(cls, props, servletConfig));
@@ -337,12 +337,12 @@ public class CXFNonSpringJaxrsServlet extends CXFNonSpringServlet {
         if (providersList == null) {
             return Collections.emptyList();
         }
-        String[] classNames = StringUtils.split(providersList, splitChar);
+        String[] classNames = providersList.split(splitChar);
         List<Object> providers = new ArrayList<>();
         for (String cName : classNames) {
             Map<String, List<String>> props = new HashMap<>();
             String theName = getClassNameAndProperties(cName, props);
-            if (theName.length() != 0) {
+            if (!theName.isEmpty()) {
                 Class<?> cls = loadClass(theName);
                 providers.add(createSingletonInstance(cls, props, servletConfig));
             }
@@ -493,7 +493,7 @@ public class CXFNonSpringJaxrsServlet extends CXFNonSpringServlet {
 
         boolean ignoreApplicationPath = isIgnoreApplicationPath(servletConfig);
 
-        String[] classNames = StringUtils.split(applicationNames, getParameterSplitChar(servletConfig));
+        String[] classNames = applicationNames.split(getParameterSplitChar(servletConfig));
 
         if (classNames.length > 1 && ignoreApplicationPath) {
             throw new ServletException("\"" + IGNORE_APP_PATH_PARAM

--- a/rt/frontend/jaxrs/src/main/java/org/apache/cxf/jaxrs/servlet/CXFNonSpringJaxrsServlet.java
+++ b/rt/frontend/jaxrs/src/main/java/org/apache/cxf/jaxrs/servlet/CXFNonSpringJaxrsServlet.java
@@ -201,7 +201,7 @@ public class CXFNonSpringJaxrsServlet extends CXFNonSpringServlet {
         if (schemas == null) {
             return;
         }
-        String[] locations = StringUtils.split(schemas, " ");
+        String[] locations = schemas.split(" ");
         List<String> list = new ArrayList<>();
         for (String loc : locations) {
             String theLoc = loc.trim();
@@ -364,13 +364,13 @@ public class CXFNonSpringJaxrsServlet extends CXFNonSpringServlet {
         if (sequence != null) {
             sequence = sequence.trim();
             Map<String, List<String>> map = new HashMap<>();
-            String[] pairs = StringUtils.split(sequence, " ");
+            String[] pairs = sequence.split(" ");
             for (String pair : pairs) {
                 String thePair = pair.trim();
                 if (thePair.length() == 0) {
                     continue;
                 }
-                String[] values = StringUtils.split(thePair, "=");
+                String[] values = thePair.split("=");
                 String key;
                 String value;
                 if (values.length == 2) {

--- a/rt/frontend/jaxrs/src/main/java/org/apache/cxf/jaxrs/spring/JAXRSServerFactoryBeanDefinitionParser.java
+++ b/rt/frontend/jaxrs/src/main/java/org/apache/cxf/jaxrs/spring/JAXRSServerFactoryBeanDefinitionParser.java
@@ -68,7 +68,7 @@ public class JAXRSServerFactoryBeanDefinitionParser extends AbstractBeanDefiniti
     @Override
     protected void mapAttribute(BeanDefinitionBuilder bean, Element e, String name, String val) {
         if ("beanNames".equals(name)) {
-            String[] values = StringUtils.split(val, " ");
+            String[] values = val.split(" ");
             List<SpringResourceFactory> tempFactories = new ArrayList<>(values.length);
             for (String v : values) {
                 String theValue = v.trim();

--- a/rt/frontend/jaxrs/src/main/java/org/apache/cxf/jaxrs/utils/FormUtils.java
+++ b/rt/frontend/jaxrs/src/main/java/org/apache/cxf/jaxrs/utils/FormUtils.java
@@ -131,8 +131,8 @@ public final class FormUtils {
         if (StringUtils.isEmpty(postBody)) {
             return;
         }
-        List<String> parts = Arrays.asList(StringUtils.split(postBody, "&"));
-        checkNumberOfParts(m, parts.size());
+        String[] parts = postBody.split("&");
+        checkNumberOfParts(m, parts.length);
         for (String part : parts) {
             String[] keyValue = new String[2];
             int index = part.indexOf("=");

--- a/rt/frontend/jaxrs/src/main/java/org/apache/cxf/jaxrs/utils/InjectionUtils.java
+++ b/rt/frontend/jaxrs/src/main/java/org/apache/cxf/jaxrs/utils/InjectionUtils.java
@@ -989,7 +989,7 @@ public final class InjectionUtils {
         }
         List<String> newValues = new ArrayList<>();
         for (String v : values) {
-            String[] segments = StringUtils.split(v, "/");
+            String[] segments = v.split("/");
             for (String s : segments) {
                 if (s.length() != 0) {
                     newValues.add(s);

--- a/rt/frontend/jaxrs/src/main/java/org/apache/cxf/jaxrs/utils/JAXRSUtils.java
+++ b/rt/frontend/jaxrs/src/main/java/org/apache/cxf/jaxrs/utils/JAXRSUtils.java
@@ -181,7 +181,7 @@ public final class JAXRSUtils {
     public static List<PathSegment> getPathSegments(String thePath, boolean decode,
                                                     boolean ignoreLastSlash) {
         List<PathSegment> theList = 
-            StringUtils.splitAsStream(thePath, "/")
+            Arrays.asList(thePath.split("/")).stream()
             .filter(StringUtils.notEmpty())
             .map(p -> new PathSegmentImpl(p, decode))
             .collect(Collectors.toList());

--- a/rt/rs/description-openapi-v3/src/main/java/org/apache/cxf/jaxrs/openapi/OpenApiCustomizer.java
+++ b/rt/rs/description-openapi-v3/src/main/java/org/apache/cxf/jaxrs/openapi/OpenApiCustomizer.java
@@ -156,7 +156,7 @@ public class OpenApiCustomizer {
     protected String getNormalizedPath(String classResourcePath, String operationResourcePath) {
         StringBuilder normalizedPath = new StringBuilder();
 
-        String[] segments = StringUtils.split(classResourcePath + operationResourcePath, "/");
+        String[] segments = (classResourcePath + operationResourcePath).split("/");
         for (String segment : segments) {
             if (!StringUtils.isEmpty(segment)) {
                 normalizedPath.append("/").append(segment);

--- a/rt/rs/description-swagger/src/main/java/org/apache/cxf/jaxrs/swagger/Swagger2Customizer.java
+++ b/rt/rs/description-swagger/src/main/java/org/apache/cxf/jaxrs/swagger/Swagger2Customizer.java
@@ -154,7 +154,7 @@ public class Swagger2Customizer {
     protected String getNormalizedPath(String classResourcePath, String operationResourcePath) {
         StringBuilder normalizedPath = new StringBuilder();
 
-        String[] segments = StringUtils.split(classResourcePath + operationResourcePath, "/");
+        String[] segments = (classResourcePath + operationResourcePath).split("/");
         for (String segment : segments) {
             if (!StringUtils.isEmpty(segment)) {
                 normalizedPath.append("/").append(segment);

--- a/rt/rs/description-swagger/src/main/java/org/apache/cxf/jaxrs/swagger/Swagger2Feature.java
+++ b/rt/rs/description-swagger/src/main/java/org/apache/cxf/jaxrs/swagger/Swagger2Feature.java
@@ -45,7 +45,6 @@ import org.apache.cxf.annotations.Provider;
 import org.apache.cxf.annotations.Provider.Scope;
 import org.apache.cxf.annotations.Provider.Type;
 import org.apache.cxf.common.util.PropertyUtils;
-import org.apache.cxf.common.util.StringUtils;
 import org.apache.cxf.endpoint.Server;
 import org.apache.cxf.jaxrs.JAXRSServiceFactoryBean;
 import org.apache.cxf.jaxrs.ext.ContextProvider;
@@ -553,7 +552,7 @@ public class Swagger2Feature extends AbstractSwaggerFeature implements SwaggerUi
             rc.setScanAllResources(true);
             if (ignoreRoutesParam != null) {
                 Set<String> routes = new LinkedHashSet<>();
-                for (String route : StringUtils.split(ignoreRoutesParam, ",")) {
+                for (String route : ignoreRoutesParam.split(",")) {
                     routes.add(route.trim());
                 }
                 rc.setIgnoredRoutes(routes);

--- a/rt/rs/security/jose-parent/jose/src/main/java/org/apache/cxf/rs/security/jose/common/JoseUtils.java
+++ b/rt/rs/security/jose-parent/jose/src/main/java/org/apache/cxf/rs/security/jose/common/JoseUtils.java
@@ -32,7 +32,6 @@ import org.apache.cxf.Bus;
 import org.apache.cxf.common.classloader.ClassLoaderUtils;
 import org.apache.cxf.common.logging.LogUtils;
 import org.apache.cxf.common.util.PropertyUtils;
-import org.apache.cxf.common.util.StringUtils;
 import org.apache.cxf.jaxrs.json.basic.JsonMapObjectReaderWriter;
 import org.apache.cxf.message.Message;
 import org.apache.cxf.message.MessageUtils;
@@ -53,7 +52,7 @@ public final class JoseUtils {
         if (compactContent.startsWith("\"") && compactContent.endsWith("\"")) {
             compactContent = compactContent.substring(1, compactContent.length() - 1);
         }
-        return StringUtils.split(compactContent, "\\.");
+        return compactContent.split("\\.");
     }
     public static void setJoseContextProperty(JoseHeaders headers) {
         Message message = PhaseInterceptorChain.getCurrentMessage();

--- a/rt/rs/security/sso/oidc/src/main/java/org/apache/cxf/rs/security/oidc/rp/OidcClientCodeRequestFilter.java
+++ b/rt/rs/security/sso/oidc/src/main/java/org/apache/cxf/rs/security/oidc/rp/OidcClientCodeRequestFilter.java
@@ -27,7 +27,6 @@ import javax.ws.rs.core.SecurityContext;
 import javax.ws.rs.core.UriBuilder;
 import javax.ws.rs.core.UriInfo;
 
-import org.apache.cxf.common.util.StringUtils;
 import org.apache.cxf.jaxrs.json.basic.JsonMapObjectReaderWriter;
 import org.apache.cxf.jaxrs.utils.ExceptionUtils;
 import org.apache.cxf.rs.security.oauth2.client.ClientCodeRequestFilter;
@@ -60,7 +59,7 @@ public class OidcClientCodeRequestFilter extends ClientCodeRequestFilter {
     }
 
     public void setAuthenticationContextRef(String acr) {
-        this.authenticationContextRef = Arrays.asList(StringUtils.split(acr, " "));
+        this.authenticationContextRef = Arrays.asList(acr.split(" "));
     }
 
     @Override

--- a/rt/rs/security/xml/src/main/java/org/apache/cxf/rs/security/saml/SamlHeaderInHandler.java
+++ b/rt/rs/security/xml/src/main/java/org/apache/cxf/rs/security/saml/SamlHeaderInHandler.java
@@ -25,7 +25,6 @@ import javax.ws.rs.container.ContainerRequestContext;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.HttpHeaders;
 
-import org.apache.cxf.common.util.StringUtils;
 import org.apache.cxf.jaxrs.utils.JAXRSUtils;
 import org.apache.cxf.message.Message;
 
@@ -45,7 +44,7 @@ public class SamlHeaderInHandler extends AbstractSamlBase64InHandler {
             throwFault("Authorization header must be available and use SAML profile", null);
         }
 
-        String[] parts = StringUtils.split(values.get(0), " ");
+        String[] parts = values.get(0).split(" ");
         if (parts.length != 2) {
             throwFault("Authorization header is malformed", null);
         }

--- a/rt/transports/http/src/main/java/org/apache/cxf/transport/http/Cookies.java
+++ b/rt/transports/http/src/main/java/org/apache/cxf/transport/http/Cookies.java
@@ -22,7 +22,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
-import org.apache.cxf.common.util.StringUtils;
 import org.apache.cxf.message.Message;
 import org.apache.cxf.message.MessageUtils;
 
@@ -69,11 +68,11 @@ public class Cookies {
         }
 
         for (String header : headers) {
-            String[] cookies = StringUtils.split(header, ",");
+            String[] cookies = header.split(",");
             for (String cookie : cookies) {
-                String[] parts = StringUtils.split(cookie, ";");
+                String[] parts = cookie.split(";");
 
-                String[] kv = StringUtils.split(parts[0], "=", 2);
+                String[] kv = parts[0].split("=", 2);
                 if (kv.length != 2) {
                     continue;
                 }
@@ -82,7 +81,7 @@ public class Cookies {
                 Cookie newCookie = new Cookie(name, value);
 
                 for (int i = 1; i < parts.length; i++) {
-                    kv = StringUtils.split(parts[i], "=", 2);
+                    kv = parts[i].split("=", 2);
                     name = kv[0].trim();
                     value = (kv.length > 1) ? kv[1].trim() : null;
                     if (name.equalsIgnoreCase(Cookie.DISCARD_ATTRIBUTE)) {

--- a/rt/transports/http/src/main/java/org/apache/cxf/transport/servlet/AbstractHTTPServlet.java
+++ b/rt/transports/http/src/main/java/org/apache/cxf/transport/servlet/AbstractHTTPServlet.java
@@ -181,7 +181,7 @@ public abstract class AbstractHTTPServlet extends HttpServlet implements Filter 
     protected static List<Pattern> parseListSequence(String values) {
         if (values != null) {
             List<Pattern> list = new LinkedList<>();
-            String[] pathValues = StringUtils.split(values, " ");
+            String[] pathValues = values.split(" ");
             for (String value : pathValues) {
                 String theValue = value.trim();
                 if (theValue.length() > 0) {
@@ -197,13 +197,13 @@ public abstract class AbstractHTTPServlet extends HttpServlet implements Filter 
         if (sequence != null) {
             sequence = sequence.trim();
             Map<String, String> map = new HashMap<>();
-            String[] pairs = StringUtils.split(sequence, " ");
+            String[] pairs = sequence.split(" ");
             for (String pair : pairs) {
                 String thePair = pair.trim();
                 if (thePair.length() == 0) {
                     continue;
                 }
-                String[] value = StringUtils.split(thePair, "=");
+                String[] value = thePair.split("=");
                 if (value.length == 2) {
                     map.put(value[0].trim(), value[1].trim());
                 } else {

--- a/rt/transports/jms/src/main/java/org/apache/cxf/transport/jms/JMSMessageUtils.java
+++ b/rt/transports/jms/src/main/java/org/apache/cxf/transport/jms/JMSMessageUtils.java
@@ -40,7 +40,6 @@ import javax.jms.TextMessage;
 
 import org.apache.cxf.common.logging.LogUtils;
 import org.apache.cxf.common.util.PropertyUtils;
-import org.apache.cxf.common.util.StringUtils;
 import org.apache.cxf.helpers.CastUtils;
 import org.apache.cxf.helpers.HttpHeaderHelper;
 import org.apache.cxf.message.MessageImpl;
@@ -132,7 +131,7 @@ final class JMSMessageUtils {
         String contentType = ct.toLowerCase();
         String enc = null;
 
-        String[] tokens = StringUtils.split(contentType, ";");
+        String[] tokens = contentType.split(";");
         for (String token : tokens) {
             int index = token.indexOf("charset=");
             if (index >= 0) {

--- a/rt/transports/jms/src/main/java/org/apache/cxf/transport/jms/uri/JMSURIParser.java
+++ b/rt/transports/jms/src/main/java/org/apache/cxf/transport/jms/uri/JMSURIParser.java
@@ -27,7 +27,6 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import org.apache.cxf.common.logging.LogUtils;
-import org.apache.cxf.common.util.StringUtils;
 
 /**
  * Unfortunately soap/jms URIs are not recognized correctly in URI.
@@ -76,7 +75,7 @@ final class JMSURIParser {
     public Map<String, Object> parseQuery() {
         Map<String, Object> rc = new HashMap<>();
         if (query != null) {
-            String[] parameters = StringUtils.split(query, "&");
+            String[] parameters = query.split("&");
             for (String parameter : parameters) {
                 int p = parameter.indexOf("=");
                 if (p >= 0) {

--- a/rt/ws/security/src/main/java/org/apache/cxf/ws/security/wss4j/policyvalidators/AbstractBindingPolicyValidator.java
+++ b/rt/ws/security/src/main/java/org/apache/cxf/ws/security/wss4j/policyvalidators/AbstractBindingPolicyValidator.java
@@ -27,7 +27,6 @@ import javax.xml.namespace.QName;
 
 import org.w3c.dom.Element;
 
-import org.apache.cxf.common.util.StringUtils;
 import org.apache.cxf.helpers.CastUtils;
 import org.apache.cxf.message.Message;
 import org.apache.cxf.ws.policy.AssertionInfo;
@@ -119,7 +118,7 @@ public abstract class AbstractBindingPolicyValidator implements SecurityPolicyVa
                 for (WSDataRef dataRef : dataRefs) {
                     String xpath = dataRef.getXpath();
                     if (xpath != null) {
-                        String[] nodes = StringUtils.split(xpath, "/");
+                        String[] nodes = xpath.split("/");
                         // envelope/Body || envelope/Header/header || envelope/Header/wsse:Security/header
                         if (nodes.length < 3 || nodes.length > 5) {
                             return false;

--- a/rt/ws/security/src/main/java/org/apache/cxf/ws/security/wss4j/policyvalidators/LayoutPolicyValidator.java
+++ b/rt/ws/security/src/main/java/org/apache/cxf/ws/security/wss4j/policyvalidators/LayoutPolicyValidator.java
@@ -28,7 +28,6 @@ import javax.xml.namespace.QName;
 
 import org.w3c.dom.Element;
 
-import org.apache.cxf.common.util.StringUtils;
 import org.apache.cxf.helpers.CastUtils;
 import org.apache.cxf.ws.policy.AssertionInfo;
 import org.apache.cxf.ws.policy.AssertionInfoMap;
@@ -138,7 +137,7 @@ public class LayoutPolicyValidator extends AbstractSecurityPolicyValidator {
             for (WSDataRef r : sl) {
                 String xpath = r.getXpath();
                 if (xpath != null) {
-                    String[] nodes = StringUtils.split(xpath, "/");
+                    String[] nodes = xpath.split("/");
                     // envelope/Header/wsse:Security/header
                     if (nodes.length == 5) {
                         Element protectedElement = r.getProtectedElement();

--- a/services/ws-discovery/ws-discovery-api/src/main/java/org/apache/cxf/ws/discovery/internal/WSDiscoveryServiceImpl.java
+++ b/services/ws-discovery/ws-discovery-api/src/main/java/org/apache/cxf/ws/discovery/internal/WSDiscoveryServiceImpl.java
@@ -58,7 +58,6 @@ import org.apache.cxf.BusFactory;
 import org.apache.cxf.common.jaxb.JAXBContextCache;
 import org.apache.cxf.common.jaxb.JAXBUtils;
 import org.apache.cxf.common.logging.LogUtils;
-import org.apache.cxf.common.util.StringUtils;
 import org.apache.cxf.endpoint.Server;
 import org.apache.cxf.jaxws.EndpointImpl;
 import org.apache.cxf.jaxws.spi.ProviderImpl;
@@ -336,8 +335,8 @@ public class WSDiscoveryServiceImpl implements WSDiscoveryService {
     private boolean matchURIs(URI probe, URI target) {
         if (compare(target.getScheme(), probe.getScheme())
             && compare(target.getAuthority(), probe.getAuthority())) {
-            String[] ppath = StringUtils.split(probe.getPath(), "/");
-            String[] tpath = StringUtils.split(target.getPath(), "/");
+            String[] ppath = probe.getPath().split("/");
+            String[] tpath = target.getPath().split("/");
 
             if (ppath.length <= tpath.length) {
                 for (int i = 0; i < ppath.length; i++) {

--- a/tools/wadlto/jaxrs/src/main/java/org/apache/cxf/tools/wadlto/jaxrs/SourceGenerator.java
+++ b/tools/wadlto/jaxrs/src/main/java/org/apache/cxf/tools/wadlto/jaxrs/SourceGenerator.java
@@ -750,7 +750,7 @@ public class SourceGenerator {
                     String mediaType = requestRepWithElement.getAttribute("mediaType");
                     if (!StringUtils.isEmpty(mediaType)) {
                         String subType = MediaType.valueOf(mediaType).getSubtype();
-                        String[] parts = StringUtils.split(subType, "\\+");
+                        String[] parts = subType.split("\\+");
                         if (parts.length == 2) {
                             suffixName += StringUtils.capitalize(parts[1]);
                         } else {


### PR DESCRIPTION
https://stackoverflow.com/questions/29393086/pattern-split-slower-than-string-split

benchmark:

`
public class SplitTest {

    private static final int CNT = 131072;
    private static String[] STR = new String[CNT];
    private static final String SEPARATOR = " ";
    static {
        for (int i = 0; i < CNT; ++i) {
            STR[i] = i + SEPARATOR + i;
        }
    }

    @org.junit.Test
    public void stringSplit() {
        metrics("String.split", s -> s.split(SEPARATOR));
    }

    @org.junit.Test
    public void pattern() {
        metrics("Pattern", java.util.regex.Pattern.compile(SEPARATOR)::split);
    }

    private static void metrics(String label, Function<String, String[]> f) {
        Runtime.getRuntime().gc();
        long m = Runtime.getRuntime().freeMemory();
        long t = System.currentTimeMillis();
        for (int i = 0; i < CNT; ++i) {
            org.junit.Assert.assertSame(2, f.apply(STR[i]).length);
        }
        System.out.println(label + ": "
                + ((m - Runtime.getRuntime().freeMemory()) / 1000000) + " MB "
                + (System.currentTimeMillis() - t) + " ms");
    }

    public static void main(String[] args) {
        SplitTest splitTest = new SplitTest();
        for (int i = 0; i < 10; ++i) {
            splitTest.stringSplit();
            splitTest.pattern();
        }
    }
}
`

results using java version "1.8.0_192":
`
String.split: 33 MB 16 ms
Pattern: 57 MB 47 ms
`