### PR TITLE
HttpHeaderHelper: String.replace instead of Pattern.matcher().replaceAll

### DIFF
--- a/core/src/main/java/org/apache/cxf/helpers/HttpHeaderHelper.java
+++ b/core/src/main/java/org/apache/cxf/helpers/HttpHeaderHelper.java
@@ -21,12 +21,12 @@ package org.apache.cxf.helpers;
 
 import java.nio.charset.Charset;
 import java.nio.charset.IllegalCharsetNameException;
+import java.nio.charset.StandardCharsets;
 import java.nio.charset.UnsupportedCharsetException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.regex.Pattern;
 
 public final class HttpHeaderHelper {
     public static final String ACCEPT_ENCODING = "Accept-Encoding";
@@ -41,11 +41,10 @@ public final class HttpHeaderHelper {
     public static final String CONNECTION = "Connection";
     public static final String CLOSE = "close";
     public static final String AUTHORIZATION = "Authorization";
-    private static final String ISO88591 = Charset.forName("ISO-8859-1").name();
+    static final String ISO88591 = StandardCharsets.ISO_8859_1.name();
 
     private static Map<String, String> internalHeaders = new HashMap<>();
     private static ConcurrentHashMap<String, String> encodings = new ConcurrentHashMap<>();
-    private static Pattern charsetPattern = Pattern.compile("\"|'");
 
     static {
         internalHeaders.put("Accept-Encoding", "accept-encoding");
@@ -112,8 +111,8 @@ public final class HttpHeaderHelper {
         }
         // Charsets can be quoted. But it's quite certain that they can't have escaped quoted or
         // anything like that.
-        enc = charsetPattern.matcher(enc).replaceAll("").trim();
-        if ("".equals(enc)) {
+        enc = enc.replace('"', ' ').replace('\'', ' ').trim();
+        if (enc.isEmpty()) {
             return deflt;
         }
         String newenc = encodings.get(enc);

--- a/core/src/test/java/org/apache/cxf/common/util/Base64UtilityTest.java
+++ b/core/src/test/java/org/apache/cxf/common/util/Base64UtilityTest.java
@@ -30,17 +30,6 @@ import org.junit.Test;
 
 public class Base64UtilityTest extends Assert {
 
-    public Base64UtilityTest() {
-        super();
-    }
-
-    void assertEquals(byte[] b1, byte[] b2) {
-        assertEquals(b1.length, b2.length);
-        for (int x = 0; x < b1.length; x++) {
-            assertEquals(b1[x], b2[x]);
-        }
-    }
-
     @Test
     public void testEncodeMultipleChunks() throws Exception {
         final String text = "The true sign of intelligence is not knowledge but imagination.";
@@ -83,7 +72,7 @@ public class Base64UtilityTest extends Assert {
         encodedChars = Base64Utility.encodeChunk(bytes, 0, bytes.length);
         assertNotNull(encodedChars);
         byte[] bytesDecoded = Base64Utility.decodeChunk(encodedChars, 0, encodedChars.length);
-        assertEquals(bytes, bytesDecoded);
+        assertArrayEquals(bytes, bytesDecoded);
 
         //require padding
         bytes = new byte[99];
@@ -93,7 +82,7 @@ public class Base64UtilityTest extends Assert {
         encodedChars = Base64Utility.encodeChunk(bytes, 0, bytes.length);
         assertNotNull(encodedChars);
         bytesDecoded = Base64Utility.decodeChunk(encodedChars, 0, encodedChars.length);
-        assertEquals(bytes, bytesDecoded);
+        assertArrayEquals(bytes, bytesDecoded);
 
         //require padding
         bytes = new byte[98];
@@ -103,7 +92,7 @@ public class Base64UtilityTest extends Assert {
         encodedChars = Base64Utility.encodeChunk(bytes, 0, bytes.length);
         assertNotNull(encodedChars);
         bytesDecoded = Base64Utility.decodeChunk(encodedChars, 0, encodedChars.length);
-        assertEquals(bytes, bytesDecoded);
+        assertArrayEquals(bytes, bytesDecoded);
 
         //require padding
         bytes = new byte[97];
@@ -113,7 +102,7 @@ public class Base64UtilityTest extends Assert {
         encodedChars = Base64Utility.encodeChunk(bytes, 0, bytes.length);
         assertNotNull(encodedChars);
         bytesDecoded = Base64Utility.decodeChunk(encodedChars, 0, encodedChars.length);
-        assertEquals(bytes, bytesDecoded);
+        assertArrayEquals(bytes, bytesDecoded);
 
 
         bytesDecoded = Base64Utility.decodeChunk(new char[3], 0, 3);
@@ -129,15 +118,10 @@ public class Base64UtilityTest extends Assert {
         assertEquals(in, encoded);
     }
 
-    @Test
+    @Test(expected = Base64Exception.class)
     public void testDecodeInvalidString() throws Exception {
-        try {
-            String in = "QWxhZGRpbjpcGVuIHNlc2FtZQ==";
-            Base64Utility.decode(in);
-            fail("This test should be fail");
-        } catch (Base64Exception e) {
-            //nothing to do
-        }
+        String in = "QWxhZGRpbjpcGVuIHNlc2FtZQ==";
+        Base64Utility.decode(in);
     }
 
     @Test
@@ -154,7 +138,7 @@ public class Base64UtilityTest extends Assert {
                              0,
                              encodedString.length(),
                              bout2);
-        assertEquals(bytes, bout2.toByteArray());
+        assertArrayEquals(bytes, bout2.toByteArray());
 
 
         String in = "QWxhZGRpbjpvcGVuIHNlc2FtZQ==";

--- a/core/src/test/java/org/apache/cxf/helpers/HttpHeaderHelperTest.java
+++ b/core/src/test/java/org/apache/cxf/helpers/HttpHeaderHelperTest.java
@@ -19,11 +19,12 @@
 
 package org.apache.cxf.helpers;
 
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 
 /**
  *
@@ -32,25 +33,50 @@ public class HttpHeaderHelperTest {
 
     @Test
     public void testMapCharset() {
-        String cs = HttpHeaderHelper.mapCharset("utf-8");
-        assertEquals(Charset.forName("utf-8").name(), cs);
+        final String charset = StandardCharsets.UTF_8.name();
+
+        String cs = HttpHeaderHelper.mapCharset(charset);
+        assertEquals(charset, cs);
+
+        cs = HttpHeaderHelper.mapCharset("\"" + charset + "\"");
+        assertEquals(charset, cs);
+
+        cs = HttpHeaderHelper.mapCharset("'" + charset + "'");
+        assertEquals(charset, cs);
+
         cs = HttpHeaderHelper.mapCharset(null);
-        assertEquals("ISO-8859-1", cs);
-        cs = HttpHeaderHelper.mapCharset("\"utf-8\"");
-        assertEquals(Charset.forName("utf-8").name(), cs);
-        cs = HttpHeaderHelper.mapCharset("'utf-8'");
-        assertEquals(Charset.forName("utf-8").name(), cs);
+        assertEquals(HttpHeaderHelper.ISO88591, cs);
+
+        cs = HttpHeaderHelper.mapCharset("''");
+        assertEquals(HttpHeaderHelper.ISO88591, cs);
+
+        cs = HttpHeaderHelper.mapCharset("wrong-charset-name");
+        assertNull(cs);
     }
 
     @Test
     public void testEmptyCharset() {
         String cs = HttpHeaderHelper.mapCharset(HttpHeaderHelper.findCharset("foo/bar; charset="));
-        assertEquals("ISO-8859-1", cs);
+        assertEquals(HttpHeaderHelper.ISO88591, cs);
     }
+
     @Test
     public void testEmptyCharset2() {
         String cs = HttpHeaderHelper.mapCharset(HttpHeaderHelper.findCharset("foo/bar; charset=;"));
-        assertEquals("ISO-8859-1", cs);
+        assertEquals(HttpHeaderHelper.ISO88591, cs);
+    }
+
+    @Test
+    public void testNoCharset() {
+        String cs = HttpHeaderHelper.mapCharset(HttpHeaderHelper.findCharset("foo/bar"));
+        assertEquals(HttpHeaderHelper.ISO88591, cs);
+    }
+
+    @Test
+    public void testFindCharset() {
+        final String charset = StandardCharsets.UTF_8.name();
+        String cs = HttpHeaderHelper.findCharset("foo/bar; charset=" + charset);
+        assertEquals(charset, cs);
     }
 
 }

--- a/rt/transports/jms/src/main/java/org/apache/cxf/transport/jms/JMSMessageUtils.java
+++ b/rt/transports/jms/src/main/java/org/apache/cxf/transport/jms/JMSMessageUtils.java
@@ -128,18 +128,7 @@ final class JMSMessageUtils {
 
 
     static String getEncoding(String ct) throws UnsupportedEncodingException {
-        String contentType = ct.toLowerCase();
-        String enc = null;
-
-        String[] tokens = contentType.split(";");
-        for (String token : tokens) {
-            int index = token.indexOf("charset=");
-            if (index >= 0) {
-                enc = token.substring(index + 8);
-                break;
-            }
-        }
-
+        String enc = HttpHeaderHelper.findCharset(ct);
         String normalizedEncoding = HttpHeaderHelper.mapCharset(enc, StandardCharsets.UTF_8.name());
         if (normalizedEncoding == null) {
             String m = new org.apache.cxf.common.i18n.Message("INVALID_ENCODING_MSG", LOG, new Object[] {

--- a/rt/transports/jms/src/test/java/org/apache/cxf/transport/jms/JMSMessageUtilTest.java
+++ b/rt/transports/jms/src/test/java/org/apache/cxf/transport/jms/JMSMessageUtilTest.java
@@ -19,7 +19,6 @@
 
 package org.apache.cxf.transport.jms;
 
-import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.nio.charset.StandardCharsets;
 
@@ -29,18 +28,17 @@ import org.junit.Test;
 public class JMSMessageUtilTest extends Assert {
 
     @Test
-    public void testGetEncoding() throws IOException {
-        assertEquals("Get the wrong encoding", JMSMessageUtils.getEncoding("text/xml; charset=utf-8"),
-                     StandardCharsets.UTF_8.name());
-        assertEquals("Get the wrong encoding", JMSMessageUtils.getEncoding("text/xml"),
-                     StandardCharsets.UTF_8.name());
-        assertEquals("Get the wrong encoding", JMSMessageUtils.getEncoding("text/xml; charset=GBK"), "GBK");
+    public void testGetEncoding() throws Exception {
+        assertEquals("Get the wrong encoding", StandardCharsets.UTF_8.name(),
+                JMSMessageUtils.getEncoding("text/xml; charset=utf-8"));
+        assertEquals("Get the wrong encoding", StandardCharsets.UTF_8.name(),
+                JMSMessageUtils.getEncoding("text/xml"));
+        assertEquals("Get the wrong encoding", "GBK", JMSMessageUtils.getEncoding("text/xml; charset=GBK"));
         try {
             JMSMessageUtils.getEncoding("text/xml; charset=asci");
             fail("Expect the exception here");
-        } catch (Exception ex) {
-            assertTrue("we should get the UnsupportedEncodingException here",
-                       ex instanceof UnsupportedEncodingException);
+        } catch (UnsupportedEncodingException ex) {
+            // we should get the UnsupportedEncodingException here
         }
     }
 


### PR DESCRIPTION
benchmark [1] results:
- old: 40 MB 47 ms
- new: 9 MB 0 ms
1.
```
public class HttpHeaderHelperMapCharsetTest {
    private static final int CNT = 131072;
    static final String charset = java.nio.charset.StandardCharsets.UTF_8.name();
    private static final String[] STR = new String[CNT];
    static {
        for (int i = 0; i < CNT; ++i) {
            if (i % 3 == 0) {
                STR[i] = "\"" + charset + "\"";
            } else if (i % 3 == 1) {
                STR[i] = "'" + charset + "'";
            } else {
                STR[i] = charset;
            }
        }
    }

    @org.junit.Test
    public void mapCharset() {
        metrics("HttpHeaderHelper::mapCharset", HttpHeaderHelper::mapCharset);
    }

    @org.junit.Test
    public void mapCharset2() {
        metrics("HttpHeaderHelper::mapCharset2", HttpHeaderHelper::mapCharset2);
    }

    private static void metrics(String label, java.util.function.Function<String, String> f) {
        Runtime.getRuntime().gc();
        long m = Runtime.getRuntime().freeMemory();
        long t = System.currentTimeMillis();
        for (int i = 0; i < CNT; ++i) {
            org.junit.Assert.assertEquals(charset, f.apply(STR[i]));
        }
        System.out.println(label + ": " + ((m - Runtime.getRuntime().freeMemory()) / (1024 * 1024)) + " MB "
                + (System.currentTimeMillis() - t) + " ms");
    }

    public static void main(String[] args) {
        final HttpHeaderHelperMapCharsetTest splitTest = new HttpHeaderHelperMapCharsetTest();
        for (int i = 0; i < 10; ++i) {
            System.out.println("Round #" + i);
            splitTest.mapCharset();
            splitTest.mapCharset2();
        }
    }

}
```