### PR TITLE
Ensure JAXB and javax.activation are not required for JAX-RS

### DIFF
--- a/core/src/main/java/org/apache/cxf/service/model/EndpointInfo.java
+++ b/core/src/main/java/org/apache/cxf/service/model/EndpointInfo.java
@@ -21,6 +21,7 @@ package org.apache.cxf.service.model;
 
 import javax.xml.namespace.QName;
 
+import org.apache.cxf.ws.addressing.AttributedURIType;
 import org.apache.cxf.ws.addressing.EndpointReferenceType;
 import org.apache.cxf.ws.addressing.EndpointReferenceUtils;
 
@@ -94,7 +95,12 @@ public class EndpointInfo extends AbstractDescriptionElement implements NamedIte
 
     public void setAddress(String addr) {
         if (null == address) {
-            address = EndpointReferenceUtils.getEndpointReference(addr);
+            // address = EndpointReferenceUtils.getEndpointReference(addr); loads jaxb and we want to avoid it
+            final EndpointReferenceType reference = new EndpointReferenceType();
+            final AttributedURIType a = new AttributedURIType();
+            a.setValue("/");
+            reference.setAddress(a);
+            address = reference;
         } else {
             EndpointReferenceUtils.setAddress(address, addr);
         }

--- a/core/src/main/java/org/apache/cxf/service/model/EndpointInfo.java
+++ b/core/src/main/java/org/apache/cxf/service/model/EndpointInfo.java
@@ -23,7 +23,6 @@ import javax.xml.namespace.QName;
 
 import org.apache.cxf.ws.addressing.AttributedURIType;
 import org.apache.cxf.ws.addressing.EndpointReferenceType;
-import org.apache.cxf.ws.addressing.EndpointReferenceUtils;
 
 /**
  * The EndpointInfo contains the information for a web service 'port' inside of a service.

--- a/core/src/main/java/org/apache/cxf/service/model/EndpointInfo.java
+++ b/core/src/main/java/org/apache/cxf/service/model/EndpointInfo.java
@@ -98,11 +98,14 @@ public class EndpointInfo extends AbstractDescriptionElement implements NamedIte
             // address = EndpointReferenceUtils.getEndpointReference(addr); loads jaxb and we want to avoid it
             final EndpointReferenceType reference = new EndpointReferenceType();
             final AttributedURIType a = new AttributedURIType();
-            a.setValue("/");
+            a.setValue(addr);
             reference.setAddress(a);
             address = reference;
         } else {
-            EndpointReferenceUtils.setAddress(address, addr);
+            final AttributedURIType a = new AttributedURIType();
+            a.setValue(addr);
+            address.setAddress(a);
+            // EndpointReferenceUtils.setAddress(address, addr);
         }
     }
 

--- a/core/src/main/java/org/apache/cxf/transport/AbstractDestination.java
+++ b/core/src/main/java/org/apache/cxf/transport/AbstractDestination.java
@@ -25,6 +25,7 @@ import java.util.logging.Logger;
 import org.apache.cxf.Bus;
 import org.apache.cxf.message.Message;
 import org.apache.cxf.service.model.EndpointInfo;
+import org.apache.cxf.ws.addressing.AttributedURIType;
 import org.apache.cxf.ws.addressing.EndpointReferenceType;
 import org.apache.cxf.ws.addressing.EndpointReferenceUtils;
 
@@ -95,7 +96,7 @@ public abstract class AbstractDestination
     protected abstract class AbstractBackChannelConduit extends AbstractConduit {
 
         public AbstractBackChannelConduit() {
-            super(EndpointReferenceUtils.getAnonymousEndpointReference());
+            super(getAnonymousEndpointReference());
         }
 
         /**
@@ -110,6 +111,15 @@ public abstract class AbstractDestination
         protected Logger getLogger() {
             return AbstractDestination.this.getLogger();
         }
+    }
+
+    // EndpointReferenceUtils#getAnonymousEndpointReference would load jaxb, avoid it
+    private static EndpointReferenceType getAnonymousEndpointReference() {
+        final EndpointReferenceType reference = new EndpointReferenceType();
+        final AttributedURIType a = new AttributedURIType();
+        a.setValue(EndpointReferenceUtils.ANONYMOUS_ADDRESS);
+        reference.setAddress(a);
+        return reference;
     }
 
     /**

--- a/core/src/main/java/org/apache/cxf/ws/addressing/ContextJAXBUtils.java
+++ b/core/src/main/java/org/apache/cxf/ws/addressing/ContextJAXBUtils.java
@@ -1,0 +1,77 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.cxf.ws.addressing;
+
+
+import java.util.HashSet;
+import java.util.Set;
+
+import javax.xml.bind.JAXBContext;
+import javax.xml.bind.JAXBException;
+
+import org.apache.cxf.common.jaxb.JAXBContextCache;
+import org.apache.cxf.common.jaxb.JAXBContextCache.CachedContextAndSchemas;
+
+/**
+ * Holder for utility methods relating to contexts, allows to lazily load JAXB compared to ContextUtils.
+ */
+public final class ContextJAXBUtils {
+    private static JAXBContext jaxbContext;
+    private static Set<Class<?>> jaxbContextClasses;
+
+   /**
+    * Prevents instantiation.
+    */
+    private ContextJAXBUtils() {
+    }
+
+    /**
+     * Retrieve a JAXBContext for marshalling and unmarshalling JAXB generated
+     * types.
+     *
+     * @return a JAXBContext
+     */
+    public static JAXBContext getJAXBContext() throws JAXBException {
+        synchronized (ContextJAXBUtils.class) {
+            if (jaxbContext == null || jaxbContextClasses == null) {
+                Set<Class<?>> tmp = new HashSet<>();
+                JAXBContextCache.addPackage(tmp, ContextUtils.WSA_OBJECT_FACTORY.getClass().getPackage().getName(),
+                            ContextUtils.WSA_OBJECT_FACTORY.getClass().getClassLoader());
+                JAXBContextCache.scanPackages(tmp);
+                CachedContextAndSchemas ccs
+                    = JAXBContextCache.getCachedContextAndSchemas(tmp, null, null, null, false);
+                jaxbContextClasses = ccs.getClasses();
+                jaxbContext = ccs.getContext();
+            }
+        }
+        return jaxbContext;
+    }
+
+    /**
+     * Set the encapsulated JAXBContext (used by unit tests).
+     *
+     * @param ctx JAXBContext
+     */
+    public static void setJAXBContext(JAXBContext ctx) {
+        synchronized (ContextJAXBUtils.class) {
+            jaxbContext = ctx;
+            jaxbContextClasses = new HashSet<>();
+        }
+    }
+}

--- a/core/src/main/java/org/apache/cxf/ws/addressing/ContextUtils.java
+++ b/core/src/main/java/org/apache/cxf/ws/addressing/ContextUtils.java
@@ -22,18 +22,11 @@ package org.apache.cxf.ws.addressing;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.HashSet;
-import java.util.Set;
 import java.util.UUID;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import javax.xml.bind.JAXBContext;
-import javax.xml.bind.JAXBException;
-
 import org.apache.cxf.Bus;
-import org.apache.cxf.common.jaxb.JAXBContextCache;
-import org.apache.cxf.common.jaxb.JAXBContextCache.CachedContextAndSchemas;
 import org.apache.cxf.common.logging.LogUtils;
 import org.apache.cxf.common.util.StringUtils;
 import org.apache.cxf.endpoint.Endpoint;
@@ -59,8 +52,7 @@ public final class ContextUtils {
     public static final ObjectFactory WSA_OBJECT_FACTORY = new ObjectFactory();
     public static final String ACTION = ContextUtils.class.getName() + ".ACTION";
 
-    private static final EndpointReferenceType NONE_ENDPOINT_REFERENCE =
-        EndpointReferenceUtils.getEndpointReference(Names.WSA_NONE_ADDRESS);
+    private static final EndpointReferenceType NONE_ENDPOINT_REFERENCE = new EndpointReferenceType();
 
     private static final Logger LOG = LogUtils.getL7dLogger(ContextUtils.class);
 
@@ -68,9 +60,6 @@ public final class ContextUtils {
      * Used to fabricate a Uniform Resource Name from a UUID string
      */
     private static final String URN_UUID = "urn:uuid:";
-
-    private static JAXBContext jaxbContext;
-    private static Set<Class<?>> jaxbContextClasses;
 
     /**
      * Used by MAPAggregator to cache bad MAP fault name
@@ -89,6 +78,11 @@ public final class ContextUtils {
      */
     private static final String PARTIAL_RESPONSE_SENT_PROPERTY =
         "org.apache.cxf.ws.addressing.partial.response.sent";
+
+    static {
+        NONE_ENDPOINT_REFERENCE.setAddress(new AttributedURIType());
+        NONE_ENDPOINT_REFERENCE.getAddress().setValue(Names.WSA_NONE_ADDRESS);
+    }
 
    /**
     * Prevents instantiation.
@@ -514,41 +508,6 @@ public final class ContextUtils {
         Boolean ret = (Boolean)message.get(Message.ASYNC_POST_RESPONSE_DISPATCH);
         return ret != null && ret.booleanValue();
     }
-
-    /**
-     * Retrieve a JAXBContext for marshalling and unmarshalling JAXB generated
-     * types.
-     *
-     * @return a JAXBContext
-     */
-    public static JAXBContext getJAXBContext() throws JAXBException {
-        synchronized (ContextUtils.class) {
-            if (jaxbContext == null || jaxbContextClasses == null) {
-                Set<Class<?>> tmp = new HashSet<>();
-                JAXBContextCache.addPackage(tmp, WSA_OBJECT_FACTORY.getClass().getPackage().getName(),
-                                            WSA_OBJECT_FACTORY.getClass().getClassLoader());
-                JAXBContextCache.scanPackages(tmp);
-                CachedContextAndSchemas ccs
-                    = JAXBContextCache.getCachedContextAndSchemas(tmp, null, null, null, false);
-                jaxbContextClasses = ccs.getClasses();
-                jaxbContext = ccs.getContext();
-            }
-        }
-        return jaxbContext;
-    }
-
-    /**
-     * Set the encapsulated JAXBContext (used by unit tests).
-     *
-     * @param ctx JAXBContext
-     */
-    public static void setJAXBContext(JAXBContext ctx) throws JAXBException {
-        synchronized (ContextUtils.class) {
-            jaxbContext = ctx;
-            jaxbContextClasses = new HashSet<>();
-        }
-    }
-
 
     /**
      * @return a generated UUID

--- a/core/src/main/java/org/apache/cxf/ws/addressing/EndpointReferenceUtils.java
+++ b/core/src/main/java/org/apache/cxf/ws/addressing/EndpointReferenceUtils.java
@@ -752,7 +752,7 @@ public final class EndpointReferenceUtils {
      * @return EndpointReferenceType - the endpoint reference
      */
     public static EndpointReferenceType getAnonymousEndpointReference() {
-        EndpointReferenceType reference = new EndpointReferenceType();
+        final EndpointReferenceType reference = new EndpointReferenceType();
         setAddress(reference, ANONYMOUS_ADDRESS);
         return reference;
     }

--- a/core/src/main/java/org/apache/cxf/ws/addressing/VersionTransformer.java
+++ b/core/src/main/java/org/apache/cxf/ws/addressing/VersionTransformer.java
@@ -482,7 +482,7 @@ public class VersionTransformer {
     public static JAXBContext getExposedJAXBContext(String exposedURI) throws JAXBException {
 
         return NATIVE_VERSION.equals(exposedURI)
-            ? ContextUtils.getJAXBContext() : Names200408.WSA_NAMESPACE_NAME.equals(exposedURI) ? Names200408
+            ? ContextJAXBUtils.getJAXBContext() : Names200408.WSA_NAMESPACE_NAME.equals(exposedURI) ? Names200408
                 .getJAXBContext() : Names200403.WSA_NAMESPACE_NAME.equals(exposedURI) ? Names200403
                 .getJAXBContext() : null;
     }

--- a/rt/frontend/jaxrs/src/main/java/org/apache/cxf/jaxrs/provider/AbstractJAXBProvider.java
+++ b/rt/frontend/jaxrs/src/main/java/org/apache/cxf/jaxrs/provider/AbstractJAXBProvider.java
@@ -192,10 +192,10 @@ public abstract class AbstractJAXBProvider<T> extends AbstractConfigurableProvid
             if (cris != null) {
                 allTypes = new HashSet<>(ResourceUtils.getAllRequestResponseTypes(cris, true)
                     .getAllTypes().keySet());
-                context = ResourceUtils.createJaxbContext(allTypes, extraClass, cProperties);
+                context = org.apache.cxf.jaxrs.utils.JAXBUtils.createJaxbContext(allTypes, extraClass, cProperties);
             } else if (extraClass != null) {
                 allTypes = new HashSet<>(Arrays.asList(extraClass));
-                context = ResourceUtils.createJaxbContext(allTypes, null, cProperties);
+                context = org.apache.cxf.jaxrs.utils.JAXBUtils.createJaxbContext(allTypes, null, cProperties);
             }
 
             if (context != null) {

--- a/rt/frontend/jaxrs/src/main/java/org/apache/cxf/jaxrs/utils/AnnotationUtils.java
+++ b/rt/frontend/jaxrs/src/main/java/org/apache/cxf/jaxrs/utils/AnnotationUtils.java
@@ -20,6 +20,7 @@
 package org.apache.cxf.jaxrs.utils;
 
 import java.lang.annotation.Annotation;
+import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.Collections;
 import java.util.HashSet;
@@ -27,7 +28,6 @@ import java.util.LinkedHashSet;
 import java.util.Set;
 import java.util.logging.Logger;
 
-import javax.annotation.Priority;
 import javax.ws.rs.BeanParam;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.CookieParam;
@@ -48,6 +48,10 @@ import org.apache.cxf.common.logging.LogUtils;
 
 public final class AnnotationUtils {
     private static final Logger LOG = LogUtils.getL7dLogger(AnnotationUtils.class);
+    private static final Class<? extends Annotation> PRIORITY_API =
+            (Class<? extends Annotation>) loadClassOrNull("javax.annotation.Priority");
+    private static final Method PRIORITY_VALUE = getMethodOrNull(PRIORITY_API, "value");
+
     private static final Set<Class<?>> PARAM_ANNOTATION_CLASSES;
     private static final Set<Class<?>> METHOD_ANNOTATION_CLASSES;
     static {
@@ -59,6 +63,25 @@ public final class AnnotationUtils {
 
     }
 
+    private static Method getMethodOrNull(final Class<?> type, final String name) {
+        if (type == null) {
+            return null;
+        }
+        try {
+            return type.getMethod(name);
+        } catch (final NoSuchMethodException e) {
+            return null;
+        }
+    }
+
+    private static Class<?> loadClassOrNull(final String name) {
+        try {
+            return org.apache.cxf.common.classloader.ClassLoaderUtils.loadClass(
+                    name, AnnotationUtils.class);
+        } catch (final ClassNotFoundException e) {
+            return null;
+        }
+    }
 
     private static Set<Class<?>> initParamAnnotationClasses() {
         Set<Class<?>> classes = new HashSet<>();
@@ -82,8 +105,12 @@ public final class AnnotationUtils {
     }
 
     public static int getBindingPriority(Class<?> providerCls) {
-        Priority b = getClassAnnotation(providerCls, Priority.class);
-        return b == null ? Priorities.USER : b.value();
+        Annotation b = getClassAnnotation(providerCls, PRIORITY_API);
+        try {
+            return b == null ? Priorities.USER : Integer.class.cast(PRIORITY_VALUE.invoke(b));
+        } catch (final IllegalAccessException | InvocationTargetException e) {
+            return Priorities.USER;
+        }
     }
     public static Set<String> getNameBindings(Annotation[] targetAnns) {
         if (targetAnns.length == 0) {

--- a/rt/frontend/jaxrs/src/main/java/org/apache/cxf/jaxrs/utils/AnnotationUtils.java
+++ b/rt/frontend/jaxrs/src/main/java/org/apache/cxf/jaxrs/utils/AnnotationUtils.java
@@ -105,6 +105,9 @@ public final class AnnotationUtils {
     }
 
     public static int getBindingPriority(Class<?> providerCls) {
+        if (PRIORITY_API == null) {
+            return Priorities.USER;
+        }
         Annotation b = getClassAnnotation(providerCls, PRIORITY_API);
         try {
             return b == null ? Priorities.USER : Integer.class.cast(PRIORITY_VALUE.invoke(b));

--- a/rt/frontend/jaxrs/src/main/java/org/apache/cxf/jaxrs/utils/JAXBUtils.java
+++ b/rt/frontend/jaxrs/src/main/java/org/apache/cxf/jaxrs/utils/JAXBUtils.java
@@ -22,9 +22,13 @@ import java.io.Closeable;
 import java.io.IOException;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
+import java.util.Map;
+import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import javax.xml.bind.JAXBContext;
+import javax.xml.bind.JAXBException;
 import javax.xml.bind.Unmarshaller;
 import javax.xml.bind.annotation.adapters.XmlAdapter;
 import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
@@ -37,6 +41,24 @@ public final class JAXBUtils {
     private JAXBUtils() {
 
     }
+
+    public static JAXBContext createJaxbContext(Set<Class<?>> classes, Class<?>[] extraClass,
+                                                Map<String, Object> contextProperties) {
+        if (classes == null || classes.isEmpty()) {
+            return null;
+        }
+        org.apache.cxf.common.jaxb.JAXBUtils.scanPackages(classes, extraClass, null);
+
+        JAXBContext ctx;
+        try {
+            ctx = JAXBContext.newInstance(classes.toArray(new Class[0]), contextProperties);
+            return ctx;
+        } catch (JAXBException ex) {
+            LOG.log(Level.SEVERE, "No JAXB context can be created", ex);
+        }
+        return null;
+    }
+
     public static void closeUnmarshaller(Unmarshaller u) {
         if (u instanceof Closeable) {
             //need to do this to clear the ThreadLocal cache

--- a/rt/rs/description/src/main/java/org/apache/cxf/jaxrs/model/wadl/WadlGenerator.java
+++ b/rt/rs/description/src/main/java/org/apache/cxf/jaxrs/model/wadl/WadlGenerator.java
@@ -327,7 +327,8 @@ public class WadlGenerator implements ContainerRequestFilter {
 
         JAXBContext jaxbContext = null;
         if (useJaxbContextForQnames && !allTypes.isEmpty()) {
-            jaxbContext = ResourceUtils.createJaxbContext(new HashSet<>(allTypes), null, jaxbContextProperties);
+            jaxbContext = org.apache.cxf.jaxrs.utils.JAXBUtils
+                    .createJaxbContext(new HashSet<>(allTypes), null, jaxbContextProperties);
             if (jaxbContext == null) {
                 LOG.warning("JAXB Context is null: possibly due to one of input classes being not accepted");
             }

--- a/rt/ws/addr/src/test/java/org/apache/cxf/ws/addressing/soap/MAPCodecTest.java
+++ b/rt/ws/addr/src/test/java/org/apache/cxf/ws/addressing/soap/MAPCodecTest.java
@@ -43,6 +43,7 @@ import org.apache.cxf.message.Message;
 import org.apache.cxf.message.MessageImpl;
 import org.apache.cxf.ws.addressing.AddressingProperties;
 import org.apache.cxf.ws.addressing.AttributedURIType;
+import org.apache.cxf.ws.addressing.ContextJAXBUtils;
 import org.apache.cxf.ws.addressing.ContextUtils;
 import org.apache.cxf.ws.addressing.EndpointReferenceType;
 import org.apache.cxf.ws.addressing.EndpointReferenceUtils;
@@ -91,7 +92,7 @@ public class MAPCodecTest extends Assert {
         expectedNamespaceURI = null;
         mimeHeaders = null;
         correlatedExchange = null;
-        ContextUtils.setJAXBContext(null);
+        ContextJAXBUtils.setJAXBContext(null);
         nonReplyRelationship = null;
     }
 
@@ -310,7 +311,7 @@ public class MAPCodecTest extends Assert {
         });
         List<Header> headers = message.getHeaders();
         JAXBContext jaxbContext = control.createMock(JAXBContext.class);
-        ContextUtils.setJAXBContext(jaxbContext);
+        ContextJAXBUtils.setJAXBContext(jaxbContext);
         Names200408.setJAXBContext(jaxbContext);
         Names200403.setJAXBContext(jaxbContext);
         if (outbound) {
@@ -345,7 +346,7 @@ public class MAPCodecTest extends Assert {
     private void setUpDecode(SoapMessage message, List<Header> headers, AddressingProperties maps,
                              String mapProperty, boolean requestor) throws Exception {
         Unmarshaller unmarshaller = control.createMock(Unmarshaller.class);
-        ContextUtils.getJAXBContext().createUnmarshaller();
+        ContextJAXBUtils.getJAXBContext().createUnmarshaller();
         EasyMock.expectLastCall().andReturn(unmarshaller);
         String uri = maps.getNamespaceURI();
         boolean exposedAsNative = Names.WSA_NAMESPACE_NAME.equals(uri);


### PR DESCRIPTION
Goal is to ensure default java11 experience is still good when not needing JAXB/activation (which is pretty much often these days with JAX-RS)