### PR TITLE
[CXF-7926] Initial MP Rest Client 1.2 impl - part 2

### DIFF
--- a/rt/rs/microprofile-client/pom.xml
+++ b/rt/rs/microprofile-client/pom.xml
@@ -42,7 +42,7 @@
             org.apache.aries.blueprint.NamespaceHandler;osgi.service.blueprint.namespace="http://cxf.apache.org/blueprint/jaxrs-client"
         </cxf.export.service>
         <cxf.bundle.activator>org.apache.cxf.jaxrs.client.blueprint.Activator</cxf.bundle.activator>
-        <mp.rest.client.version>1.2-m2</mp.rest.client.version>
+        <mp.rest.client.version>1.2-RC1</mp.rest.client.version>
     </properties>
     <dependencies>
         <dependency>

--- a/rt/rs/microprofile-client/src/main/java/org/apache/cxf/microprofile/client/CxfTypeSafeClientBuilder.java
+++ b/rt/rs/microprofile-client/src/main/java/org/apache/cxf/microprofile/client/CxfTypeSafeClientBuilder.java
@@ -29,16 +29,12 @@ import java.util.ServiceLoader;
 import java.util.WeakHashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
 import javax.ws.rs.core.Configurable;
 import javax.ws.rs.core.Configuration;
 
-import org.apache.cxf.common.logging.LogUtils;
-import org.apache.cxf.microprofile.client.config.ConfigFacade;
 import org.eclipse.microprofile.rest.client.RestClientBuilder;
 import org.eclipse.microprofile.rest.client.annotation.RegisterProvider;
 import org.eclipse.microprofile.rest.client.spi.RestClientListener;
@@ -47,9 +43,6 @@ import static org.apache.cxf.jaxrs.client.ClientProperties.HTTP_CONNECTION_TIMEO
 import static org.apache.cxf.jaxrs.client.ClientProperties.HTTP_RECEIVE_TIMEOUT_PROP;
 
 public class CxfTypeSafeClientBuilder implements RestClientBuilder, Configurable<RestClientBuilder> {
-    private static final Logger LOG = LogUtils.getL7dLogger(CxfTypeSafeClientBuilder.class);
-    private static final String REST_CONN_TIMEOUT_FORMAT = "%s/mp-rest/connectTimeout";
-    private static final String REST_READ_TIMEOUT_FORMAT = "%s/mp-rest/readTimeout";
     private static final Map<ClassLoader, Collection<RestClientListener>> REST_CLIENT_LISTENERS = 
         new WeakHashMap<>();
 
@@ -135,24 +128,6 @@ public class CxfTypeSafeClientBuilder implements RestClientBuilder, Configurable
                 }
             }
         }
-
-        final String interfaceName = aClass.getName();
-
-        ConfigFacade.getOptionalLong(String.format(REST_CONN_TIMEOUT_FORMAT, interfaceName)).ifPresent(
-            timeoutValue -> {
-                connectTimeout(timeoutValue, TimeUnit.MILLISECONDS);
-                if (LOG.isLoggable(Level.FINEST)) {
-                    LOG.finest("readTimeout set by MP Config: " + timeoutValue);
-                }
-            });
-
-        ConfigFacade.getOptionalLong(String.format(REST_READ_TIMEOUT_FORMAT, interfaceName)).ifPresent(
-            timeoutValue -> {
-                readTimeout(timeoutValue, TimeUnit.MILLISECONDS);
-                if (LOG.isLoggable(Level.FINEST)) {
-                    LOG.finest("readTimeout set by MP Config: " + timeoutValue);
-                }
-            });
 
         listeners().forEach(l -> l.onNewClient(aClass, this));
 

--- a/rt/rs/microprofile-client/src/main/java/org/apache/cxf/microprofile/client/Messages.properties
+++ b/rt/rs/microprofile-client/src/main/java/org/apache/cxf/microprofile/client/Messages.properties
@@ -30,3 +30,10 @@ ASYNC_INTERCEPTOR_EXCEPTION_APPLY_CONTEXT=The AsyncInvocationInterceptor, {0} ha
 ASYNC_INTERCEPTOR_EXCEPTION_REMOVE_CONTEXT=The AsyncInvocationInterceptor, {0} has thrown an exception during the invocation of the removeContext method.
 
 INVALID_TIMEOUT_PROPERTY=The timeout property, {0} is specified as {1}, and is invalid. It must be a non-negative integer.
+
+CLIENT_HEADER_NO_NAME=A @ClientHeaderParam annotation specified in the {0} interface is invalid because it has a null or empty name.
+CLIENT_HEADER_NO_VALUE=A @ClientHeaderParam annotation specified in the {0} interface is invalid because it does not define a valid value attribute.
+CLIENT_HEADER_INVALID_COMPUTE_METHOD=A @ClientHeaderParam annotation specified in the {0} interface is invalid because it's value attribute specifies a method, {1}, that does not exist, is not accessible, or contains an incorrect signature. The signature must return a String or String[] and must contain either no arguments or contain exactly one String argument.
+CLIENT_HEADER_MULTI_METHOD=A @ClientHeaderParam annotation specified in the {0} interface is invalid because it's value attribute specifies multiple values and at least one of those values is a compute method. If the value attribute specifies a compute method, that must be the only value.
+CLIENT_HEADER_COMPUTE_CLASS_NOT_FOUND=A @ClientHeaderParam annotation specified in the {0} interface is invalid because it specifies a compute method on a class that cannot be found.
+CLIENT_HEADER_MULTIPLE_SAME_HEADER_NAMES=A @ClientHeaderParam annotation specified in the {0} interface is invalid because it specifies a header name that is already specified on the same target. A header name may only be specified in one @ClientHeaderParam per target.

--- a/rt/rs/microprofile-client/src/main/java/org/apache/cxf/microprofile/client/MicroProfileClientFactoryBean.java
+++ b/rt/rs/microprofile-client/src/main/java/org/apache/cxf/microprofile/client/MicroProfileClientFactoryBean.java
@@ -115,10 +115,10 @@ public class MicroProfileClientFactoryBean extends JAXRSClientFactoryBean {
     private Set<Object> processProviders() {
         Set<Object> providers = new LinkedHashSet<>();
         for (Object provider : configuration.getInstances()) {
-            Class<?> providerCls = ClassHelper.getRealClass(bus, provider);
+            Class<?> providerCls = ClassHelper.getRealClass(getBus(), provider);
             if (provider instanceof ClientRequestFilter || provider instanceof ClientResponseFilter) {
                 FilterProviderInfo<Object> filter = new FilterProviderInfo<>(providerCls, providerCls,
-                        provider, bus, configuration.getContracts(providerCls));
+                        provider, getBus(), configuration.getContracts(providerCls));
                 providers.add(filter);
             } else {
                 providers.add(provider);

--- a/rt/rs/microprofile-client/src/test/java/org/apache/cxf/microprofile/client/ClientHeadersTest.java
+++ b/rt/rs/microprofile-client/src/test/java/org/apache/cxf/microprofile/client/ClientHeadersTest.java
@@ -1,0 +1,92 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.cxf.microprofile.client;
+
+import java.net.URI;
+
+import org.apache.cxf.microprofile.client.mock.HeaderCaptureClientRequestFilter;
+import org.apache.cxf.microprofile.client.mock.HeadersFactoryClient;
+import org.apache.cxf.microprofile.client.mock.HeadersOnInterfaceClient;
+import org.apache.cxf.microprofile.client.mock.HeadersOnMethodClient;
+import org.apache.cxf.microprofile.client.mock.MyClientHeadersFactory;
+import org.eclipse.microprofile.rest.client.RestClientBuilder;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.apache.cxf.microprofile.client.mock.HeaderCaptureClientRequestFilter.getOutboundHeaders;
+import static org.apache.cxf.microprofile.client.mock.MyClientHeadersFactory.getInitialHeaders;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+public class ClientHeadersTest {
+
+    @Before
+    public void clearHeaders() {
+        HeaderCaptureClientRequestFilter.setOutboundHeaders(null);
+        MyClientHeadersFactory.setInitialHeaders(null);
+    }
+
+    @Test
+    public void testClientHeaderParamsOnInterface() {
+        HeadersOnInterfaceClient client = RestClientBuilder.newBuilder()
+                                                           .baseUri(URI.create("http://localhost/notUsed"))
+                                                           .register(HeaderCaptureClientRequestFilter.class)
+                                                           .build(HeadersOnInterfaceClient.class);
+        assertEquals("SUCCESS", client.put("ignored"));
+        assertNotNull(getOutboundHeaders());
+        assertEquals("value1", getOutboundHeaders().getFirst("IntfHeader1"));
+        assertEquals("value2,value3", getOutboundHeaders().getFirst("IntfHeader2"));
+        assertEquals("HeadersOnInterfaceClientValueForIntfHeader3", getOutboundHeaders().getFirst("IntfHeader3"));
+        assertEquals("valueForIntfHeader4", getOutboundHeaders().getFirst("IntfHeader4"));
+    }
+
+    @Test
+    public void testClientHeaderParamsOnMethod() {
+        HeadersOnMethodClient client = RestClientBuilder.newBuilder()
+                                                        .baseUri(URI.create("http://localhost/notUsed"))
+                                                        .register(HeaderCaptureClientRequestFilter.class)
+                                                        .build(HeadersOnMethodClient.class);
+        assertEquals("SUCCESS", client.delete("ignored"));
+        assertNotNull(getOutboundHeaders());
+        assertEquals("valueA", getOutboundHeaders().getFirst("MethodHeader1"));
+        assertEquals("valueB,valueC", getOutboundHeaders().getFirst("MethodHeader2"));
+        assertEquals("HeadersOnMethodClientValueForMethodHeader3", getOutboundHeaders().getFirst("MethodHeader3"));
+        assertEquals("valueForMethodHeader4", getOutboundHeaders().getFirst("MethodHeader4"));
+    }
+
+    @Test
+    public void testClientHeadersFactory() {
+        HeadersFactoryClient client = RestClientBuilder.newBuilder()
+                                                       .baseUri(URI.create("http://localhost/notUsed"))
+                                                       .register(HeaderCaptureClientRequestFilter.class)
+                                                       .build(HeadersFactoryClient.class);
+        assertEquals("SUCCESS", client.get("headerParamValue1"));
+        assertNotNull(getInitialHeaders());
+        assertEquals("headerParamValue1", getInitialHeaders().getFirst("HeaderParam1"));
+        assertEquals("abc", getInitialHeaders().getFirst("IntfHeader1"));
+        assertEquals("def", getInitialHeaders().getFirst("MethodHeader1"));
+
+        assertNotNull(getOutboundHeaders());
+        assertEquals("1eulaVmaraPredaeh", getOutboundHeaders().getFirst("HeaderParam1"));
+        assertEquals("cba", getOutboundHeaders().getFirst("IntfHeader1"));
+        assertEquals("fed", getOutboundHeaders().getFirst("MethodHeader1"));
+        
+    }
+}

--- a/rt/rs/microprofile-client/src/test/java/org/apache/cxf/microprofile/client/ValidatorTest.java
+++ b/rt/rs/microprofile-client/src/test/java/org/apache/cxf/microprofile/client/ValidatorTest.java
@@ -27,10 +27,12 @@ import javax.ws.rs.POST;
 import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
+import javax.ws.rs.client.ClientRequestContext;
 import javax.ws.rs.core.Response;
 
 import org.eclipse.microprofile.rest.client.RestClientBuilder;
 import org.eclipse.microprofile.rest.client.RestClientDefinitionException;
+import org.eclipse.microprofile.rest.client.annotation.ClientHeaderParam;
 
 import org.junit.Test;
 
@@ -94,6 +96,62 @@ public class ValidatorTest {
         Response get(@PathParam("any") String any);
     }
 
+    public interface ClientHeaderParamNoName {
+        @ClientHeaderParam(name = "", value = "something")
+        @GET
+        Response get();
+    }
+
+    public interface ClientHeaderParamNoComputeMethod {
+        @ClientHeaderParam(name = "SomeHeader", value = "{missingComputeMethod}")
+        @GET
+        Response get();
+    }
+
+    public interface ClientHeaderParamNonDefaultComputeMethod {
+        @ClientHeaderParam(name = "SomeHeader", value = "{nonDefaultComputeMethod}")
+        @GET
+        Response get();
+
+        String nonDefaultComputeMethod();
+    }
+
+    public interface ClientHeaderParamComputeMethodDoesNotExist {
+        @ClientHeaderParam(name = "SomeHeader", value = "{nonExistentComputeMethod}")
+        @GET
+        Response get();
+    }
+
+    public interface ClientHeaderParamInaccessibleComputeMethod {
+        @ClientHeaderParam(name = "SomeHeader", 
+            value = "{org.apache.cxf.microprofile.client.mock.HeaderGenerator.generateHeaderPrivate}")
+        @GET
+        Response get();
+    }
+
+    public interface ClientHeaderParamNoValidComputeMethodSignatures {
+        @ClientHeaderParam(name = "SomeHeader", value = "{computeMethod}")
+        @GET
+        Response get();
+
+        default String computeMethod(String x, String y) {
+            return "must only contain one String argument";
+        }
+        default String computeMethod(ClientRequestContext x, ClientRequestContext y) {
+            return "must only contain one ClientRequestContext argument";
+        }
+        default Integer computeMethod() {
+            return 5; // must return a String
+        }
+        default void computeMethod(String headerName) { } // must return a String
+        default String computeMethod(java.util.Date date) {
+            return "unexpected argument";
+        }
+        default String computeMethod(String headerName, ClientRequestContext context, int extra) {
+            return "too many arguments";
+        }
+    }
+
     private static RestClientBuilder newBuilder() {
         RestClientBuilder builder = RestClientBuilder.newBuilder();
         try {
@@ -130,6 +188,38 @@ public class ValidatorTest {
     @Test
     public void testMissingTemplate() {
         test(ExtraParamTemplate.class, "extra path segments", "ExtraParamTemplate");
+    }
+
+    @Test
+    public void testClientHeaderParamNoName() {
+        test(ClientHeaderParamNoName.class, ClientHeaderParamNoName.class.getName(), "null or empty name");
+    }
+
+    @Test
+    public void testClientHeaderParamNoComputeMethod() {
+        test(ClientHeaderParamNoComputeMethod.class, ClientHeaderParamNoComputeMethod.class.getName(), 
+             "value attribute specifies a method", "that does not exist");
+    }
+
+    @Test
+    public void testClientHeaderParamNonDefaultComputeMethod() {
+        test(ClientHeaderParamNonDefaultComputeMethod.class,
+             ClientHeaderParamNonDefaultComputeMethod.class.getName(),
+             " is not accessible");
+    }
+
+    @Test
+    public void testClientHeaderParamComputeMethodDoesNotExist() {
+        test(ClientHeaderParamNonDefaultComputeMethod.class,
+             ClientHeaderParamNonDefaultComputeMethod.class.getName(),
+             " does not exist");
+    }
+
+    @Test
+    public void testClientHeaderParamNoValidComputeMethodSignatures() {
+        test(ClientHeaderParamNoValidComputeMethodSignatures.class,
+             ClientHeaderParamNoValidComputeMethodSignatures.class.getName(),
+             " contains an incorrect signature");
     }
 
     private void test(Class<?> clientInterface, String...expectedMessageTexts) {

--- a/rt/rs/microprofile-client/src/test/java/org/apache/cxf/microprofile/client/mock/HeaderCaptureClientRequestFilter.java
+++ b/rt/rs/microprofile-client/src/test/java/org/apache/cxf/microprofile/client/mock/HeaderCaptureClientRequestFilter.java
@@ -1,0 +1,46 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.cxf.microprofile.client.mock;
+
+import java.io.IOException;
+
+import javax.ws.rs.client.ClientRequestContext;
+import javax.ws.rs.client.ClientRequestFilter;
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.core.Response;
+
+public class HeaderCaptureClientRequestFilter implements ClientRequestFilter {
+
+    private static MultivaluedMap<String, String> outboundHeaders;
+
+    public static MultivaluedMap<String, String> getOutboundHeaders() {
+        return outboundHeaders;
+    }
+
+    public static void setOutboundHeaders(MultivaluedMap<String, String> newHeaders) {
+        outboundHeaders = newHeaders;
+    }
+
+    @Override
+    public void filter(ClientRequestContext ctx) throws IOException {
+        setOutboundHeaders(ctx.getStringHeaders());
+        ctx.abortWith(Response.ok("SUCCESS").build());
+    }
+
+}

--- a/rt/rs/microprofile-client/src/test/java/org/apache/cxf/microprofile/client/mock/HeaderGenerator.java
+++ b/rt/rs/microprofile-client/src/test/java/org/apache/cxf/microprofile/client/mock/HeaderGenerator.java
@@ -1,0 +1,33 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.cxf.microprofile.client.mock;
+
+public final class HeaderGenerator {
+
+    private HeaderGenerator() {
+    }
+
+    public static String generateHeader(String headerName) {
+        return generateHeaderPrivate(headerName);
+    }
+
+    private static String generateHeaderPrivate(String headerName) {
+        return "valueFor" + headerName;
+    }
+}

--- a/rt/rs/microprofile-client/src/test/java/org/apache/cxf/microprofile/client/mock/HeadersFactoryClient.java
+++ b/rt/rs/microprofile-client/src/test/java/org/apache/cxf/microprofile/client/mock/HeadersFactoryClient.java
@@ -1,0 +1,40 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.cxf.microprofile.client.mock;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.HeaderParam;
+import javax.ws.rs.Path;
+
+import org.eclipse.microprofile.rest.client.annotation.ClientHeaderParam;
+import org.eclipse.microprofile.rest.client.annotation.RegisterClientHeaders;
+
+@RegisterClientHeaders(MyClientHeadersFactory.class)
+@ClientHeaderParam(name = "IntfHeader1", value = "abc")
+public interface HeadersFactoryClient {
+
+    default String computeHeader(String headerName) {
+        return "HeadersOnMethodClientValueFor" + headerName;
+    }
+
+    @ClientHeaderParam(name = "MethodHeader1", value = "def")
+    @GET
+    @Path("/")
+    String get(@HeaderParam("HeaderParam1") String someValue);
+}

--- a/rt/rs/microprofile-client/src/test/java/org/apache/cxf/microprofile/client/mock/HeadersOnInterfaceClient.java
+++ b/rt/rs/microprofile-client/src/test/java/org/apache/cxf/microprofile/client/mock/HeadersOnInterfaceClient.java
@@ -1,0 +1,40 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.cxf.microprofile.client.mock;
+
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+
+import org.eclipse.microprofile.rest.client.annotation.ClientHeaderParam;
+
+@ClientHeaderParam(name = "IntfHeader1", value = "value1")
+@ClientHeaderParam(name = "IntfHeader2", value = {"value2", "value3"})
+@ClientHeaderParam(name = "IntfHeader3", value = "{computeHeader}")
+@ClientHeaderParam(name = "IntfHeader4",
+    value = "{org.apache.cxf.microprofile.client.mock.HeaderGenerator.generateHeader}")
+public interface HeadersOnInterfaceClient {
+
+    default String computeHeader(String headerName) {
+        return "HeadersOnInterfaceClientValueFor" + headerName;
+    }
+
+    @PUT
+    @Path("/")
+    String put(String someValue);
+}

--- a/rt/rs/microprofile-client/src/test/java/org/apache/cxf/microprofile/client/mock/HeadersOnMethodClient.java
+++ b/rt/rs/microprofile-client/src/test/java/org/apache/cxf/microprofile/client/mock/HeadersOnMethodClient.java
@@ -1,0 +1,41 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.cxf.microprofile.client.mock;
+
+import javax.ws.rs.DELETE;
+import javax.ws.rs.Path;
+
+import org.eclipse.microprofile.rest.client.annotation.ClientHeaderParam;
+
+
+public interface HeadersOnMethodClient {
+
+    default String computeHeader(String headerName) {
+        return "HeadersOnMethodClientValueFor" + headerName;
+    }
+
+    @ClientHeaderParam(name = "MethodHeader1", value = "valueA")
+    @ClientHeaderParam(name = "MethodHeader2", value = {"valueB", "valueC"})
+    @ClientHeaderParam(name = "MethodHeader3", value = "{computeHeader}")
+    @ClientHeaderParam(name = "MethodHeader4",
+        value = "{org.apache.cxf.microprofile.client.mock.HeaderGenerator.generateHeader}")
+    @DELETE
+    @Path("/")
+    String delete(String someValue);
+}

--- a/rt/rs/microprofile-client/src/test/java/org/apache/cxf/microprofile/client/mock/MyClientHeadersFactory.java
+++ b/rt/rs/microprofile-client/src/test/java/org/apache/cxf/microprofile/client/mock/MyClientHeadersFactory.java
@@ -1,0 +1,61 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.cxf.microprofile.client.mock;
+
+import javax.ws.rs.core.MultivaluedHashMap;
+import javax.ws.rs.core.MultivaluedMap;
+
+import org.eclipse.microprofile.rest.client.ext.ClientHeadersFactory;
+
+public class MyClientHeadersFactory implements ClientHeadersFactory {
+
+    private static MultivaluedMap<String, String> initialHeaders;
+
+    public static MultivaluedMap<String, String> getInitialHeaders() {
+        return initialHeaders;
+    }
+
+    public static void setInitialHeaders(MultivaluedMap<String, String> newHeaders) {
+        initialHeaders = newHeaders;
+    }
+
+    private static String reverse(String s) {
+        StringBuilder sb = new StringBuilder();
+        char[] ch = s.toCharArray();
+        //CHECKSTYLE:OFF
+        for (int i = ch.length-1; i >= 0; i--) {
+            sb.append(ch[i]);
+        }
+        //CHECKSTYLE:ON
+        return sb.toString();
+    }
+
+    @Override
+    public MultivaluedMap<String, String> update(MultivaluedMap<String, String> incomingHeaders,
+                                                 MultivaluedMap<String, String> clientOutgoingHeaders) {
+
+        initialHeaders = new MultivaluedHashMap<>();
+        initialHeaders.putAll(clientOutgoingHeaders);
+        MultivaluedMap<String, String> updatedMap = new MultivaluedHashMap<>();
+        clientOutgoingHeaders.forEach((k, v) -> {
+            updatedMap.putSingle(k, reverse(v.get(0))); });
+        return updatedMap;
+    }
+}

--- a/systests/microprofile/client/async/pom.xml
+++ b/systests/microprofile/client/async/pom.xml
@@ -26,14 +26,14 @@
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.apache.cxf.systests</groupId>
-    <artifactId>cxf-microprofile-async</artifactId>
+    <artifactId>cxf-systests-microprofile-async</artifactId>
     <name>Apache CXF MicroProfile Async Sys Tests</name>
     <description>Apache CXF System Tests - MicroProfile Rest Client Async Tests</description>
     <url>http://cxf.apache.org</url>
     <properties>
         <cxf.module.name>org.apache.cxf.systests.microprofile.async</cxf.module.name>
         <cxf.geronimo.config.version>1.0</cxf.geronimo.config.version>
-        <cxf.microprofile.rest.client.version>1.2-m2</cxf.microprofile.rest.client.version>
+        <cxf.microprofile.rest.client.version>1.2-RC1</cxf.microprofile.rest.client.version>
         <cxf.wiremock.params>--port=8765</cxf.wiremock.params>
         <cxf.weld.se.version>2.4.5.Final</cxf.weld.se.version>
         <cxf.arquillian.weld.container.version>2.0.0.Final</cxf.arquillian.weld.container.version>

--- a/systests/microprofile/client/jaxrs/pom.xml
+++ b/systests/microprofile/client/jaxrs/pom.xml
@@ -1,0 +1,190 @@
+<?xml version="1.0"?>
+<!--
+  ~  Licensed to the Apache Software Foundation (ASF) under one
+  ~  or more contributor license agreements.  See the NOTICE file
+  ~  distributed with this work for additional information
+  ~  regarding copyright ownership.  The ASF licenses this file
+  ~  to you under the Apache License, Version 2.0 (the
+  ~  "License"); you may not use this file except in compliance
+  ~  with the License.  You may obtain a copy of the License at
+  ~
+  ~  http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~  Unless required by applicable law or agreed to in writing,
+  ~  software distributed under the License is distributed on an
+  ~  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~  KIND, either express or implied.  See the License for the
+  ~  specific language governing permissions and limitations
+  ~  under the License.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <parent>
+        <artifactId>cxf-microprofile-tck</artifactId>
+        <groupId>org.apache.cxf.systests</groupId>
+        <version>3.3.0-SNAPSHOT</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>org.apache.cxf.systests</groupId>
+    <artifactId>cxf-systests-microprofile-jaxrs</artifactId>
+    <name>Apache CXF MicroProfile JAX-RS integration Sys Tests</name>
+    <description>Apache CXF System Tests - verifying MicroProfile Rest Client integration with JAX-RS</description>
+    <url>http://cxf.apache.org</url>
+    <properties>
+        <cxf.module.name>org.apache.cxf.systests.microprofile.jaxrs</cxf.module.name>
+        <cxf.geronimo.config.version>1.0</cxf.geronimo.config.version>
+        <cxf.microprofile.rest.client.version>1.2-RC1</cxf.microprofile.rest.client.version>
+    </properties>
+        <dependencies>
+            <dependency>
+                <groupId>org.eclipse.microprofile.rest.client</groupId>
+                <artifactId>microprofile-rest-client-api</artifactId>
+                <version>${cxf.microprofile.rest.client.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.geronimo.config</groupId>
+                <artifactId>geronimo-config-impl</artifactId>
+                <version>${cxf.geronimo.config.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.cxf</groupId>
+                <artifactId>cxf-rt-rs-mp-client</artifactId>
+                <version>${project.version}</version>
+                <scope>test</scope>
+            </dependency>
+        <dependency>
+            <groupId>org.apache.cxf</groupId>
+            <artifactId>cxf-rt-rs-service-description-swagger</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.cxf</groupId>
+            <artifactId>cxf-rt-rs-service-description-openapi-v3</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.webjars</groupId>
+            <artifactId>swagger-ui</artifactId>
+            <version>${cxf.swagger.ui.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.ant</groupId>
+            <artifactId>ant</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-server</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-io</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-security</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-plus</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-webapp</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>apache-jsp</artifactId>
+            <version>${cxf.jetty.version}</version>
+            <exclusions>
+              <exclusion>
+                <groupId>org.glassfish</groupId>
+                <artifactId>javax.el</artifactId>
+              </exclusion>
+              <exclusion>
+                <groupId>org.ow2.asm</groupId>
+                <artifactId>asm-commons</artifactId>
+              </exclusion>
+            </exclusions> 
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-util</artifactId>
+            <version>${cxf.jetty.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.cxf</groupId>
+            <artifactId>cxf-core</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.cxf</groupId>
+            <artifactId>cxf-rt-transports-http</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.cxf</groupId>
+            <artifactId>cxf-rt-transports-http-jetty</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.cxf</groupId>
+            <artifactId>cxf-rt-features-logging</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>        
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-jdk14</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.cxf</groupId>
+            <artifactId>cxf-rt-transports-local</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.cxf</groupId>
+            <artifactId>cxf-rt-frontend-jaxrs</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.cxf</groupId>
+            <artifactId>cxf-rt-rs-client</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.cxf</groupId>
+            <artifactId>cxf-testutils</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.cxf</groupId>
+            <artifactId>cxf-testutils</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+            <classifier>keys</classifier>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.cxf</groupId>
+            <artifactId>cxf-rt-transports-http-hc</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>javax.annotation</groupId>
+            <artifactId>jsr250-api</artifactId>
+            <version>1.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/systests/microprofile/client/jaxrs/src/test/java/org/apache/cxf/systest/microprofile/rest/client/JaxrsHeaderPropagationTest.java
+++ b/systests/microprofile/client/jaxrs/src/test/java/org/apache/cxf/systest/microprofile/rest/client/JaxrsHeaderPropagationTest.java
@@ -1,0 +1,118 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.cxf.systest.microprofile.rest.client;
+
+import java.util.Collections;
+import java.util.logging.ConsoleHandler;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.Status;
+
+import org.apache.cxf.jaxrs.JAXRSServerFactoryBean;
+import org.apache.cxf.jaxrs.client.WebClient;
+import org.apache.cxf.jaxrs.lifecycle.SingletonResourceProvider;
+import org.apache.cxf.jaxrs.model.AbstractResourceInfo;
+import org.apache.cxf.testutil.common.AbstractBusClientServerTestBase;
+import org.apache.cxf.testutil.common.AbstractBusTestServerBase;
+import org.eclipse.microprofile.config.spi.ConfigProviderResolver;
+
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Ignore;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class JaxrsHeaderPropagationTest extends AbstractBusClientServerTestBase {
+    public static final String PORT = allocatePort(JaxrsHeaderPropagationTest.class);
+
+    WebClient client;
+    @Ignore
+    public static class Server extends AbstractBusTestServerBase {
+        protected void run() {
+            final JAXRSServerFactoryBean sf = new JAXRSServerFactoryBean();
+            sf.setResourceClasses(JaxrsResource.class);
+            sf.setResourceProvider(JaxrsResource.class,
+                new SingletonResourceProvider(new JaxrsResource()));
+            sf.setAddress("http://localhost:" + PORT + "/");
+            sf.setPublishedEndpointUrl("/");
+            sf.create();
+        }
+
+        public static void main(String[] args) {
+            try {
+                Server s = new Server();
+                s.start();
+            } catch (Exception ex) {
+                ex.printStackTrace();
+                System.exit(-1);
+            } finally {
+                System.out.println("done!");
+            }
+        }
+    }
+
+    @BeforeClass
+    public static void startServers() throws Exception {
+        
+        AbstractResourceInfo.clearAllMaps();
+        //keep out of process due to stack traces testing failures
+        assertTrue("server did not launch correctly", launchServer(Server.class, true));
+        createStaticBus();
+        System.out.println("Listening on port " + PORT);
+    }
+
+    @Before
+    public void setUp() {
+        final Response r = createWebClient("/jaxrs/check").get();
+        assertEquals(Status.OK.getStatusCode(), r.getStatus());
+    }
+
+    @Test
+    public void testHeadersArePropagated() throws Exception {
+        ConfigProviderResolver.setInstance(
+            new MockConfigProviderResolver(Collections.singletonMap(
+                "org.eclipse.microprofile.rest.client.propagateHeaders", "Header1,MultiHeader")));
+        Logger logger = 
+            Logger.getLogger("org.eclipse.microprofile.rest.client.ext.DefaultClientHeadersFactoryImpl"); //NOPMD
+        logger.setLevel(Level.ALL);
+        ConsoleHandler h = new ConsoleHandler();
+        h.setLevel(Level.ALL);
+        logger.addHandler(new ConsoleHandler());
+        final Response r = createWebClient("/jaxrs/propagate")
+            .header("Header1", "Single")
+            .header("MultiHeader", "value1", "value2", "value3")
+            .get();
+        assertEquals(Status.OK.getStatusCode(), r.getStatus());
+        String propagatedHeaderContent = r.readEntity(String.class);
+        System.out.println("propagatedHeaderContent: " + propagatedHeaderContent);
+        assertTrue(propagatedHeaderContent.contains("Header1=Single"));
+        assertTrue(propagatedHeaderContent.contains("MultiHeader=value1,value2,value3"));
+    }
+
+    private static WebClient createWebClient(final String url) {
+        return WebClient
+            .create("http://localhost:" + PORT + url)
+            .accept(MediaType.TEXT_PLAIN);
+    }
+}

--- a/systests/microprofile/client/jaxrs/src/test/java/org/apache/cxf/systest/microprofile/rest/client/JaxrsResource.java
+++ b/systests/microprofile/client/jaxrs/src/test/java/org/apache/cxf/systest/microprofile/rest/client/JaxrsResource.java
@@ -1,0 +1,49 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.cxf.systest.microprofile.rest.client;
+
+import java.net.URI;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.Response;
+
+import org.eclipse.microprofile.rest.client.RestClientBuilder;
+
+@Path("/jaxrs")
+@Produces("text/plain")
+public class JaxrsResource {
+
+    @Path("/check")
+    @GET
+    public Response statusCheck() {
+        return Response.ok("up").build();
+    }
+
+    @Path("/propagate")
+    @GET
+    public String propagateHeadersToRestClient() {
+        RestClient client = RestClientBuilder.newBuilder()
+                                             .baseUri(URI.create("http://localhost:8080/ignored"))
+                                             .register(ReturnAllOutboundHeadersFilter.class)
+                                             .build(RestClient.class);
+        return client.getAllHeadersToBeSent();
+    }
+}

--- a/systests/microprofile/client/jaxrs/src/test/java/org/apache/cxf/systest/microprofile/rest/client/MockConfigProviderResolver.java
+++ b/systests/microprofile/client/jaxrs/src/test/java/org/apache/cxf/systest/microprofile/rest/client/MockConfigProviderResolver.java
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.cxf.microprofile.client.mock;
+package org.apache.cxf.systest.microprofile.rest.client;
 
 import java.util.Arrays;
 import java.util.HashMap;

--- a/systests/microprofile/client/jaxrs/src/test/java/org/apache/cxf/systest/microprofile/rest/client/RestClient.java
+++ b/systests/microprofile/client/jaxrs/src/test/java/org/apache/cxf/systest/microprofile/rest/client/RestClient.java
@@ -1,0 +1,32 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.cxf.systest.microprofile.rest.client;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+
+import org.eclipse.microprofile.rest.client.annotation.RegisterClientHeaders;
+
+@Path("/remote")
+@RegisterClientHeaders
+public interface RestClient {
+
+    @GET
+    String getAllHeadersToBeSent();
+}

--- a/systests/microprofile/client/jaxrs/src/test/java/org/apache/cxf/systest/microprofile/rest/client/ReturnAllOutboundHeadersFilter.java
+++ b/systests/microprofile/client/jaxrs/src/test/java/org/apache/cxf/systest/microprofile/rest/client/ReturnAllOutboundHeadersFilter.java
@@ -1,0 +1,40 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.cxf.systest.microprofile.rest.client;
+
+import java.io.IOException;
+import java.util.stream.Collectors;
+
+import javax.ws.rs.client.ClientRequestContext;
+import javax.ws.rs.client.ClientRequestFilter;
+import javax.ws.rs.core.Response;
+
+public class ReturnAllOutboundHeadersFilter implements ClientRequestFilter {
+
+    @Override
+    public void filter(ClientRequestContext requestContext) throws IOException {
+        StringBuilder sb = new StringBuilder();
+        requestContext.getStringHeaders().forEach((k, v) -> {
+            sb.append(k).append("=").append(v.stream().collect(Collectors.joining(",")))
+                .append(System.lineSeparator());
+        });
+        requestContext.abortWith(Response.ok(sb.toString()).build());
+    }
+
+}

--- a/systests/microprofile/client/weld/testng.xml
+++ b/systests/microprofile/client/weld/testng.xml
@@ -6,6 +6,7 @@
             <package name="org.eclipse.microprofile.rest.client.tck" />
             <package name="org.eclipse.microprofile.rest.client.tck.asynctests" />
             <package name="org.eclipse.microprofile.rest.client.tck.cditests" />
+            <package name="org.eclipse.microprofile.rest.client.tck.timeout" />
         </packages>
     </test>
 </suite>

--- a/systests/microprofile/pom.xml
+++ b/systests/microprofile/pom.xml
@@ -33,7 +33,7 @@
     <url>http://cxf.apache.org</url>
     <properties>
         <cxf.geronimo.config.version>1.0</cxf.geronimo.config.version>
-        <cxf.microprofile.rest.client.version>1.2-m2</cxf.microprofile.rest.client.version>
+        <cxf.microprofile.rest.client.version>1.2-RC1</cxf.microprofile.rest.client.version>
         <cxf.wiremock.params>--port=8765</cxf.wiremock.params>
         <cxf.weld.se.version>2.4.5.Final</cxf.weld.se.version>
         <cxf.arquillian.weld.container.version>2.0.0.Final</cxf.arquillian.weld.container.version>
@@ -133,6 +133,7 @@
     </dependencyManagement>
     <modules>
         <module>client/async</module>
+        <module>client/jaxrs</module>
         <module>client/weld</module>
     </modules>
 </project>


### PR DESCRIPTION
* This includes generation and propagation of HTTPHeaders via @ClientHeaderParam annotations and ClientHeadersFactory.
* Ensuring that timeout props only have effect when using CDI.
* Related unit and system tests.
* Updates from the milestone 2 release to release candidate 1 of the API and TCK (1.2 final release is expected late next week).