### PR TITLE
SSLUtils: move tests and update due to JDK-8211883

### DIFF
--- a/core/src/test/java/org/apache/cxf/configuration/jsse/SSLUtilsTest.java
+++ b/core/src/test/java/org/apache/cxf/configuration/jsse/SSLUtilsTest.java
@@ -1,0 +1,90 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.cxf.configuration.jsse;
+
+import java.util.Arrays;
+
+import javax.net.ssl.SSLContext;
+
+import org.apache.cxf.common.logging.LogUtils;
+import org.apache.cxf.configuration.security.FiltersType;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+
+public class SSLUtilsTest {
+
+    @Test
+    public void testDefaultCipherSuitesFilterExcluded() throws Exception {
+        SSLContext sslContext = SSLContext.getInstance("TLS");
+        sslContext.init(null, null, new java.security.SecureRandom());
+
+        FiltersType filtersType = new FiltersType();
+        filtersType.getInclude().add(".*_AES_.*");
+        String[] supportedCipherSuites = sslContext.getSocketFactory().getSupportedCipherSuites();
+        String[] filteredCipherSuites = SSLUtils.getFilteredCiphersuites(filtersType, supportedCipherSuites,
+                                         LogUtils.getL7dLogger(SSLUtilsTest.class), false);
+
+        assertTrue(filteredCipherSuites.length > 0);
+        // Check we have no anon/EXPORT/NULL/etc ciphersuites
+        assertFalse(Arrays.stream(
+            filteredCipherSuites).anyMatch(c -> c.matches(".*NULL|anon|EXPORT|DES|MD5|CBC|RC4.*")));
+    }
+
+    @Test
+    public void testExclusionFilter() throws Exception {
+        SSLContext sslContext = SSLContext.getInstance("TLS");
+        sslContext.init(null, null, new java.security.SecureRandom());
+
+        FiltersType filtersType = new FiltersType();
+        filtersType.getInclude().add(".*_SHA384");
+        filtersType.getExclude().add(".*_SHA256");
+        String[] supportedCipherSuites = sslContext.getSocketFactory().getSupportedCipherSuites();
+        String[] filteredCipherSuites = SSLUtils.getFilteredCiphersuites(filtersType, supportedCipherSuites,
+                                         LogUtils.getL7dLogger(SSLUtilsTest.class), false);
+
+        assertTrue(filteredCipherSuites.length > 0);
+        // Check we have no SHA-256 ciphersuites
+        assertFalse(Arrays.stream(
+            filteredCipherSuites).anyMatch(c -> c.matches(".*_SHA256")));
+    }
+
+    @Test
+    public void testInclusionFilter() throws Exception {
+        SSLContext sslContext = SSLContext.getInstance("TLS");
+        sslContext.init(null, null, new java.security.SecureRandom());
+
+        FiltersType filtersType = new FiltersType();
+        filtersType.getInclude().add(".*_SHA256");
+        String[] supportedCipherSuites = sslContext.getSocketFactory().getSupportedCipherSuites();
+        String[] filteredCipherSuites = SSLUtils.getFilteredCiphersuites(filtersType, supportedCipherSuites,
+                                         LogUtils.getL7dLogger(SSLUtilsTest.class), false);
+
+        assertTrue(filteredCipherSuites.length > 0);
+        // Check we have SHA-256 ciphersuites
+        assertTrue(Arrays.stream(
+            filteredCipherSuites).anyMatch(c -> c.matches(".*_SHA256")));
+    }
+
+
+}

--- a/systests/transports/src/test/java/org/apache/cxf/systest/https/ciphersuites/CipherSuitesTest.java
+++ b/systests/transports/src/test/java/org/apache/cxf/systest/https/ciphersuites/CipherSuitesTest.java
@@ -22,13 +22,11 @@ package org.apache.cxf.systest.https.ciphersuites;
 import java.net.URL;
 import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
-import java.util.Arrays;
 import java.util.Collections;
 
 import javax.crypto.Cipher;
 import javax.crypto.SecretKey;
 import javax.crypto.spec.SecretKeySpec;
-import javax.net.ssl.SSLContext;
 import javax.net.ssl.TrustManager;
 import javax.net.ssl.X509TrustManager;
 import javax.xml.ws.BindingProvider;
@@ -36,10 +34,7 @@ import javax.xml.ws.BindingProvider;
 import org.apache.cxf.Bus;
 import org.apache.cxf.BusFactory;
 import org.apache.cxf.bus.spring.SpringBusFactory;
-import org.apache.cxf.common.logging.LogUtils;
-import org.apache.cxf.configuration.jsse.SSLUtils;
 import org.apache.cxf.configuration.jsse.TLSClientParameters;
-import org.apache.cxf.configuration.security.FiltersType;
 import org.apache.cxf.endpoint.Client;
 import org.apache.cxf.frontend.ClientProxy;
 import org.apache.cxf.helpers.JavaUtils;
@@ -53,7 +48,6 @@ import org.junit.Assume;
 import org.junit.BeforeClass;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -679,55 +673,6 @@ public class CipherSuitesTest extends AbstractBusClientServerTestBase {
 
         ((java.io.Closeable)port).close();
         bus.shutdown(true);
-    }
-
-    @org.junit.Test
-    public void testDefaultCipherSuitesFilterExcluded() throws Exception {
-        SSLContext sslContext = SSLContext.getInstance("TLS");
-        sslContext.init(null, null, new java.security.SecureRandom());
-
-        FiltersType filtersType = new FiltersType();
-        filtersType.getInclude().add(".*_AES_.*");
-        String[] supportedCipherSuites = sslContext.getSocketFactory().getSupportedCipherSuites();
-        String[] filteredCipherSuites = SSLUtils.getFilteredCiphersuites(filtersType, supportedCipherSuites,
-                                         LogUtils.getL7dLogger(CipherSuitesTest.class), false);
-
-        // Check we have no anon/EXPORT/NULL/etc ciphersuites
-        assertFalse(Arrays.stream(
-            filteredCipherSuites).anyMatch(c -> c.matches(".*NULL|anon|EXPORT|DES|MD5|CBC|RC4.*")));
-    }
-
-    @org.junit.Test
-    public void testExclusionFilter() throws Exception {
-        SSLContext sslContext = SSLContext.getInstance("TLS");
-        sslContext.init(null, null, new java.security.SecureRandom());
-
-        FiltersType filtersType = new FiltersType();
-        filtersType.getInclude().add(".*_AES_.*");
-        filtersType.getExclude().add(".*anon.*");
-        String[] supportedCipherSuites = sslContext.getSocketFactory().getSupportedCipherSuites();
-        String[] filteredCipherSuites = SSLUtils.getFilteredCiphersuites(filtersType, supportedCipherSuites,
-                                         LogUtils.getL7dLogger(CipherSuitesTest.class), false);
-
-        // Check we have no anon ciphersuites
-        assertFalse(Arrays.stream(
-            filteredCipherSuites).anyMatch(c -> c.matches(".*anon.*")));
-    }
-
-    @org.junit.Test
-    public void testInclusionFilter() throws Exception {
-        SSLContext sslContext = SSLContext.getInstance("TLS");
-        sslContext.init(null, null, new java.security.SecureRandom());
-
-        FiltersType filtersType = new FiltersType();
-        filtersType.getInclude().add(".*anon.*");
-        String[] supportedCipherSuites = sslContext.getSocketFactory().getSupportedCipherSuites();
-        String[] filteredCipherSuites = SSLUtils.getFilteredCiphersuites(filtersType, supportedCipherSuites,
-                                         LogUtils.getL7dLogger(CipherSuitesTest.class), false);
-
-        // Check we have anon ciphersuites
-        assertTrue(Arrays.stream(
-            filteredCipherSuites).anyMatch(c -> c.matches(".*anon.*")));
     }
 
     private static class NoOpX509TrustManager implements X509TrustManager {


### PR DESCRIPTION
https://bugs.openjdk.java.net/browse/JDK-8211883 Disable anon and NULL cipher suites
Backported to 7u211, 8u201, 11.0.2