### PR TITLE
Get rid of IndexArrayOutOfBounds

### DIFF
--- a/core/src/main/java/org/apache/cxf/helpers/JavaUtils.java
+++ b/core/src/main/java/org/apache/cxf/helpers/JavaUtils.java
@@ -53,7 +53,7 @@ public final class JavaUtils {
     static {
         String version = System.getProperty("java.version");
         try {
-            isJava8Before161 = version != null && version.startsWith("1.8.0")
+            isJava8Before161 = version != null && version.startsWith("1.8.0_")
                 && Integer.parseInt(version.substring(6)) < 161;
         } catch (NumberFormatException ex) {
             isJava8Before161 = false;


### PR DESCRIPTION
If an environment defines the java.version with 1.8.0 this code will die with an ArrayIndexOutOfBoundsEx. 

To evade this either the length of the version should be checked for being >6 or, as proposed in the pr, the 1.8.0 version format should be checked for an additional underscore - if its not there then the environment uses something different than the expected value like 1.8.0_161. But it should never die with an AIOB-Ex. Thank you.