### PR TITLE
Fix Spring 5 OSGi version constraints

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -57,7 +57,7 @@
         <cxf.osgi.import />
         <cxf.osgi.symbolic.name>${project.groupId}.${project.artifactId}</cxf.osgi.symbolic.name>
         <cxf.osgi.dynamic.import />
-        <cxf.osgi.spring.version>[3.1,5)</cxf.osgi.spring.version>
+        <cxf.osgi.spring.version>[3.1,6)</cxf.osgi.spring.version>
         <cxf.osgi.spring.osgi.version>[1.2.0,2)</cxf.osgi.spring.osgi.version>
         <cxf.osgi.slf4j.version>[1.5,2)</cxf.osgi.slf4j.version>
         <cxf.osgi.javax.annotation.version>[1.2,2)</cxf.osgi.javax.annotation.version>


### PR DESCRIPTION
Commit 424591420b052a2b557d3f1dd48609c9858d9809 bumped Spring to version 5 however the OSGi version constraints still only allowed max version 4 of Spring.