### PR TITLE
CXF-7957: Swagger2Feature Doesn't Work With Swagger Versions Above 1.…

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -164,7 +164,7 @@
         <cxf.spring.osgi.version>1.2.1</cxf.spring.osgi.version>
         <cxf.spring.ldap.version>2.3.2.RELEASE</cxf.spring.ldap.version>
         <cxf.spring.mock>spring-test</cxf.spring.mock>
-        <cxf.swagger2.version>1.5.21</cxf.swagger2.version><!-- updating to 1.5.18 will cause systest failures -->
+        <cxf.swagger2.version>1.5.21</cxf.swagger2.version>
         <cxf.swagger.v3.version>2.0.6</cxf.swagger.v3.version>
         <cxf.swagger.ui.version>3.20.5</cxf.swagger.ui.version>
         <cxf.tomcat.version>8.5.37</cxf.tomcat.version>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -164,7 +164,7 @@
         <cxf.spring.osgi.version>1.2.1</cxf.spring.osgi.version>
         <cxf.spring.ldap.version>2.3.2.RELEASE</cxf.spring.ldap.version>
         <cxf.spring.mock>spring-test</cxf.spring.mock>
-        <cxf.swagger2.version>1.5.17</cxf.swagger2.version><!-- updating to 1.5.18 will cause systest failures -->
+        <cxf.swagger2.version>1.5.21</cxf.swagger2.version><!-- updating to 1.5.18 will cause systest failures -->
         <cxf.swagger.v3.version>2.0.6</cxf.swagger.v3.version>
         <cxf.swagger.ui.version>3.20.5</cxf.swagger.ui.version>
         <cxf.tomcat.version>8.5.37</cxf.tomcat.version>

--- a/rt/rs/description-swagger/src/main/java/org/apache/cxf/jaxrs/swagger/Swagger2Feature.java
+++ b/rt/rs/description-swagger/src/main/java/org/apache/cxf/jaxrs/swagger/Swagger2Feature.java
@@ -40,7 +40,6 @@ import javax.ws.rs.core.Context;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriInfo;
 
-import io.swagger.jaxrs.listing.SwaggerSerializers;
 import org.apache.cxf.Bus;
 import org.apache.cxf.annotations.Provider;
 import org.apache.cxf.annotations.Provider.Scope;
@@ -64,6 +63,7 @@ import io.swagger.jaxrs.config.DefaultReaderConfig;
 import io.swagger.jaxrs.config.ReaderConfig;
 import io.swagger.jaxrs.config.SwaggerContextService;
 import io.swagger.jaxrs.listing.ApiListingResource;
+import io.swagger.jaxrs.listing.SwaggerSerializers;
 import io.swagger.models.Swagger;
 import io.swagger.models.auth.SecuritySchemeDefinition;
 

--- a/rt/rs/description-swagger/src/main/java/org/apache/cxf/jaxrs/swagger/Swagger2Feature.java
+++ b/rt/rs/description-swagger/src/main/java/org/apache/cxf/jaxrs/swagger/Swagger2Feature.java
@@ -40,6 +40,7 @@ import javax.ws.rs.core.Context;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriInfo;
 
+import io.swagger.jaxrs.listing.SwaggerSerializers;
 import org.apache.cxf.Bus;
 import org.apache.cxf.annotations.Provider;
 import org.apache.cxf.annotations.Provider.Scope;
@@ -151,6 +152,8 @@ public class Swagger2Feature extends AbstractSwaggerFeature implements SwaggerUi
         swaggerResources.add(apiListingResource);
 
         List<Object> providers = new ArrayList<>();
+        providers.add(new SwaggerSerializers());
+
         if (isRunAsFilter()) {
             providers.add(new SwaggerContainerRequestFilter(appInfo == null ? null : appInfo.getProvider(),
                                                             customizer));

--- a/rt/rs/description-swagger/src/main/java/org/apache/cxf/jaxrs/swagger/openapi/SwaggerToOpenApiConversionFilter.java
+++ b/rt/rs/description-swagger/src/main/java/org/apache/cxf/jaxrs/swagger/openapi/SwaggerToOpenApiConversionFilter.java
@@ -56,7 +56,7 @@ public final class SwaggerToOpenApiConversionFilter implements ContainerRequestF
     @Override
     public void filter(ContainerRequestContext reqCtx, ContainerResponseContext respCtx) throws IOException {
         if (Boolean.TRUE == reqCtx.getProperty(OPEN_API_PROPERTY)) {
-            String swaggerJson = Json.pretty(respCtx.getEntity());
+            String swaggerJson = respCtx.getEntity() instanceof String ? (String)respCtx.getEntity() : Json.pretty(respCtx.getEntity());
             String openApiJson = SwaggerToOpenApiConversionUtils.getOpenApiFromSwaggerJson(
                     createMessageContext(), swaggerJson, openApiConfig);
             respCtx.setEntity(openApiJson);

--- a/rt/rs/description-swagger/src/main/java/org/apache/cxf/jaxrs/swagger/openapi/SwaggerToOpenApiConversionFilter.java
+++ b/rt/rs/description-swagger/src/main/java/org/apache/cxf/jaxrs/swagger/openapi/SwaggerToOpenApiConversionFilter.java
@@ -28,9 +28,10 @@ import javax.ws.rs.container.ContainerResponseFilter;
 import javax.ws.rs.container.PreMatching;
 import javax.ws.rs.ext.Provider;
 
-import io.swagger.util.Json;
 import org.apache.cxf.jaxrs.ext.MessageContext;
 import org.apache.cxf.jaxrs.utils.JAXRSUtils;
+
+import io.swagger.util.Json;
 
 @Provider
 @PreMatching
@@ -56,7 +57,8 @@ public final class SwaggerToOpenApiConversionFilter implements ContainerRequestF
     @Override
     public void filter(ContainerRequestContext reqCtx, ContainerResponseContext respCtx) throws IOException {
         if (Boolean.TRUE == reqCtx.getProperty(OPEN_API_PROPERTY)) {
-            String swaggerJson = respCtx.getEntity() instanceof String ? (String)respCtx.getEntity() : Json.pretty(respCtx.getEntity());
+            String swaggerJson = respCtx.getEntity() instanceof String ? (String)respCtx.getEntity()
+                    : Json.pretty(respCtx.getEntity());
             String openApiJson = SwaggerToOpenApiConversionUtils.getOpenApiFromSwaggerJson(
                     createMessageContext(), swaggerJson, openApiConfig);
             respCtx.setEntity(openApiJson);

--- a/rt/rs/description-swagger/src/main/java/org/apache/cxf/jaxrs/swagger/openapi/SwaggerToOpenApiConversionFilter.java
+++ b/rt/rs/description-swagger/src/main/java/org/apache/cxf/jaxrs/swagger/openapi/SwaggerToOpenApiConversionFilter.java
@@ -28,6 +28,7 @@ import javax.ws.rs.container.ContainerResponseFilter;
 import javax.ws.rs.container.PreMatching;
 import javax.ws.rs.ext.Provider;
 
+import io.swagger.util.Json;
 import org.apache.cxf.jaxrs.ext.MessageContext;
 import org.apache.cxf.jaxrs.utils.JAXRSUtils;
 
@@ -55,7 +56,7 @@ public final class SwaggerToOpenApiConversionFilter implements ContainerRequestF
     @Override
     public void filter(ContainerRequestContext reqCtx, ContainerResponseContext respCtx) throws IOException {
         if (Boolean.TRUE == reqCtx.getProperty(OPEN_API_PROPERTY)) {
-            String swaggerJson = (String)respCtx.getEntity();
+            String swaggerJson = Json.pretty(respCtx.getEntity());
             String openApiJson = SwaggerToOpenApiConversionUtils.getOpenApiFromSwaggerJson(
                     createMessageContext(), swaggerJson, openApiConfig);
             respCtx.setEntity(openApiJson);

--- a/rt/rs/description-swagger/src/main/java/org/apache/cxf/jaxrs/swagger/parse/SwaggerParseUtils.java
+++ b/rt/rs/description-swagger/src/main/java/org/apache/cxf/jaxrs/swagger/parse/SwaggerParseUtils.java
@@ -131,7 +131,7 @@ public final class SwaggerParseUtils {
                 userOp.setVerb(operEntry.getKey().toUpperCase());
 
                 Map<String, Object> oper = CastUtils.cast((Map<?, ?>)operEntry.getValue());
-                if(oper != null) {
+                if (oper != null) {
                     userOp.setPath(operPath);
 
                     userOp.setName((String) oper.get("operationId"));

--- a/rt/rs/description-swagger/src/main/java/org/apache/cxf/jaxrs/swagger/parse/SwaggerParseUtils.java
+++ b/rt/rs/description-swagger/src/main/java/org/apache/cxf/jaxrs/swagger/parse/SwaggerParseUtils.java
@@ -131,41 +131,41 @@ public final class SwaggerParseUtils {
                 userOp.setVerb(operEntry.getKey().toUpperCase());
 
                 Map<String, Object> oper = CastUtils.cast((Map<?, ?>)operEntry.getValue());
-                
-                userOp.setPath(operPath);
+                if(oper != null) {
+                    userOp.setPath(operPath);
 
-                userOp.setName((String)oper.get("operationId"));
-                List<String> opProduces = CastUtils.cast((List<?>)oper.get("produces"));
-                userOp.setProduces(listToString(opProduces));
+                    userOp.setName((String) oper.get("operationId"));
+                    List<String> opProduces = CastUtils.cast((List<?>) oper.get("produces"));
+                    userOp.setProduces(listToString(opProduces));
 
-                List<String> opConsumes = CastUtils.cast((List<?>)oper.get("consumes"));
-                userOp.setConsumes(listToString(opConsumes));
+                    List<String> opConsumes = CastUtils.cast((List<?>) oper.get("consumes"));
+                    userOp.setConsumes(listToString(opConsumes));
 
-                List<Parameter> userOpParams = new LinkedList<>();
-                List<Map<String, Object>> params = CastUtils.cast((List<?>)oper.get("parameters"));
-                for (Map<String, Object> param : params) {
-                    String name = (String)param.get("name");
-                    //"query", "header", "path", "formData" or "body"
-                    String paramType = (String)param.get("in");
-                    ParameterType pType = "body".equals(paramType) ? ParameterType.REQUEST_BODY
-                        : "formData".equals(paramType)
-                        ? ParameterType.FORM : ParameterType.valueOf(paramType.toUpperCase());
-                    Parameter userParam = new Parameter(pType, name);
+                    List<Parameter> userOpParams = new LinkedList<>();
+                    List<Map<String, Object>> params = CastUtils.cast((List<?>) oper.get("parameters"));
+                    for (Map<String, Object> param : params) {
+                        String name = (String) param.get("name");
+                        //"query", "header", "path", "formData" or "body"
+                        String paramType = (String) param.get("in");
+                        ParameterType pType = "body".equals(paramType) ? ParameterType.REQUEST_BODY
+                                : "formData".equals(paramType)
+                                ? ParameterType.FORM : ParameterType.valueOf(paramType.toUpperCase());
+                        Parameter userParam = new Parameter(pType, name);
 
-                    setJavaType(userParam, (String)param.get("type"));
-                    userOpParams.add(userParam);
+                        setJavaType(userParam, (String) param.get("type"));
+                        userOpParams.add(userParam);
+                    }
+                    if (!userOpParams.isEmpty()) {
+                        userOp.setParameters(userOpParams);
+                    }
+                    List<String> opTags = CastUtils.cast((List<?>) oper.get("tags"));
+                    if (opTags == null) {
+                        opTags = Collections.singletonList("");
+                    }
+                    for (String opTag : opTags) {
+                        userOpsMap.get(opTag).add(userOp);
+                    }
                 }
-                if (!userOpParams.isEmpty()) {
-                    userOp.setParameters(userOpParams);
-                }
-                List<String> opTags = CastUtils.cast((List<?>)oper.get("tags"));
-                if (opTags == null) {
-                    opTags = Collections.singletonList("");
-                }
-                for (String opTag : opTags) {
-                    userOpsMap.get(opTag).add(userOp);
-                }
-
             }
         }
 

--- a/rt/rs/description-swagger/src/test/java/org/apache/cxf/jaxrs/swagger/parse/SwaggerParseUtilsTest.java
+++ b/rt/rs/description-swagger/src/test/java/org/apache/cxf/jaxrs/swagger/parse/SwaggerParseUtilsTest.java
@@ -490,4 +490,10 @@ public class SwaggerParseUtilsTest {
         assertEquals(String.class, param2.getJavaType());
 
     }
+
+    @Test
+    public void testConvertSwaggerWithNullValuesForOperations() {
+        UserApplication ap = SwaggerParseUtils.getUserApplication("/swagger2petShopWithNullOperations.json");
+        assertNotNull(ap);
+    }
 }

--- a/rt/rs/description-swagger/src/test/resources/swagger2petShopWithNullOperations.json
+++ b/rt/rs/description-swagger/src/test/resources/swagger2petShopWithNullOperations.json
@@ -1,0 +1,742 @@
+{"swagger":"2.0",
+  "info":{
+    "description":"This is a sample server Petstore server.  You can find out more about Swagger at [http://swagger.io](http://swagger.io) or on [irc.freenode.net, #swagger](http://swagger.io/irc/).  For this sample, you can use the api key `special-key` to test the authorization filters.",
+    "version":"1.0.0","title":"Swagger Petstore",
+    "termsOfService":"http://swagger.io/terms/",
+    "contact":{
+      "email":"apiteam@swagger.io"
+    },
+    "license":{
+      "name":"Apache 2.0",
+      "url":"http://www.apache.org/licenses/LICENSE-2.0.html"
+    }
+  },
+  "host":"petstore.swagger.io",
+  "basePath":"/v2",
+  "tags":[
+    {
+      "name":"pet",
+      "description":"Everything about your Pets",
+      "externalDocs":{
+        "description":"Find out more",
+        "url":"http://swagger.io"
+      }
+    },
+    {
+      "name":"store",
+      "description":"Access to Petstore orders"
+    },
+    {
+      "name":"user",
+      "description":"Operations about user",
+      "externalDocs":{
+        "description": "Find out more about our store",
+        "url":"http://swagger.io"
+      }
+    }
+  ],
+  "schemes":["http"],
+  "paths":{
+    "/pet":{
+      "head": null,
+      "post":{
+        "tags":["pet"],
+        "summary":"Add a new pet to the store",
+        "description":"",
+        "operationId":"addPet",
+        "consumes":["application/json","application/xml"],
+        "produces":["application/xml","application/json"],
+        "parameters":[
+          {
+            "in":"body",
+            "name":"body",
+            "description":"Pet object that needs to be added to the store",
+            "required":true,
+            "schema":{"$ref":"#/definitions/Pet"}
+          }
+        ],
+        "responses":{
+          "405":{"description":"Invalid input"}
+        },
+        "security":[
+          {
+            "petstore_auth":[
+              "write:pets",
+              "read:pets"
+            ]
+          }
+        ]
+      },
+      "put":{
+        "tags":["pet"],
+        "summary":"Update an existing pet",
+        "description":"",
+        "operationId":"updatePet",
+        "consumes":["application/json","application/xml"],
+        "produces":["application/xml","application/json"],
+        "parameters":[
+          {
+            "in":"body",
+            "name":"body",
+            "description":"Pet object that needs to be added to the store",
+            "required":true,
+            "schema":{"$ref":"#/definitions/Pet"}
+          }
+        ],
+        "responses":{
+          "400":{"description":"Invalid ID supplied"},
+          "404":{"description":"Pet not found"},
+          "405":{"description":"Validation exception"}
+        },
+        "security":[
+          {
+            "petstore_auth":["write:pets","read:pets"]
+          }
+        ]
+      }
+    },
+
+    "/pet/findByStatus":{
+      "get":{
+        "tags":["pet"],
+        "summary":"Finds Pets by status",
+        "description":"Multiple status values can be provided with comma separated strings",
+        "operationId":"findPetsByStatus",
+        "produces":["application/xml","application/json"],
+        "parameters":[
+          {
+            "name":"status",
+            "in":"query",
+            "description":"Status values that need to be considered for filter",
+            "required":true,
+            "type":"array",
+            "items":{
+              "type":"string",
+              "enum":["available","pending","sold"],
+              "default":"available"
+            },
+            "collectionFormat":"multi"
+          }
+        ],
+        "responses":{
+          "200":{
+            "description":"successful operation",
+            "schema":{"type":"array","items":{"$ref":"#/definitions/Pet"}}
+          },
+          "400":{"description":"Invalid status value"}
+        },
+        "security":[
+          {"petstore_auth":["write:pets","read:pets"]}
+        ]
+      }
+    },
+    "/pet/findByTags":{
+      "get":{
+        "tags":["pet"],
+        "summary":"Finds Pets by tags",
+        "description":"Muliple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.",
+        "operationId":"findPetsByTags",
+        "produces":["application/xml","application/json"],
+        "parameters":[
+          {
+            "name":"tags",
+            "in":"query",
+            "description":"Tags to filter by",
+            "required":true,
+            "type":"array",
+            "items":{
+              "type":"string"
+            },
+            "collectionFormat":"multi"
+          }
+        ],
+        "responses":{
+          "200":{
+            "description":"successful operation",
+            "schema":{"type":"array","items":{"$ref":"#/definitions/Pet"}}},
+          "400":{
+            "description":"Invalid tag value"}
+        },
+        "security":[
+          {"petstore_auth":["write:pets","read:pets"]}
+        ],
+        "deprecated":true
+      }
+    },
+    "/pet/{petId}":{
+      "get":{
+        "tags":["pet"],
+        "summary":"Find pet by ID",
+        "description":"Returns a single pet",
+        "operationId":"getPetById",
+        "produces":["application/xml","application/json"],
+        "parameters":[
+          {
+            "name":"petId",
+            "in":"path",
+            "description":"ID of pet to return",
+            "required":true,
+            "type":"integer",
+            "format":"int64"
+          }
+        ],
+        "responses":{
+          "200":{
+            "description":"successful operation",
+            "schema":{"$ref":"#/definitions/Pet"}
+          },
+          "400":{
+            "description":"Invalid ID supplied"
+          },
+          "404":{
+            "description":"Pet not found"}
+        },
+        "security":[
+          {"api_key":[]}
+        ]
+      },
+      "post":{
+        "tags":["pet"],
+        "summary":"Updates a pet in the store with form data",
+        "description":"",
+        "operationId":"updatePetWithForm",
+        "consumes":["application/x-www-form-urlencoded"],
+        "produces":["application/xml","application/json"],
+        "parameters":[
+          {
+            "name":"petId",
+            "in":"path",
+            "description":"ID of pet that needs to be updated",
+            "required":true,
+            "type":"integer",
+            "format":"int64"
+          },
+          {
+            "name":"name",
+            "in":"formData",
+            "description":"Updated name of the pet",
+            "required":false,
+            "type":"string"
+          },
+          {
+            "name":"status",
+            "in":"formData",
+            "description":"Updated status of the pet",
+            "required":false,
+            "type":"string"
+          }
+        ],
+        "responses":{
+          "405":{
+            "description":"Invalid input"}
+        },
+        "security":[
+          {"petstore_auth":["write:pets","read:pets"]}
+        ]
+      },
+      "delete":{
+        "tags":["pet"],
+        "summary":"Deletes a pet",
+        "description":"",
+        "operationId":"deletePet",
+        "produces":["application/xml","application/json"],
+        "parameters":[
+          {
+            "name":"api_key",
+            "in":"header",
+            "required":false,
+            "type":"string"
+          },
+          {
+            "name":"petId",
+            "in":"path",
+            "description":"Pet id to delete",
+            "required":true,
+            "type":"integer",
+            "format":"int64"
+          }
+        ],
+        "responses":{
+          "400":{
+            "description":"Invalid ID supplied"
+          },
+          "404":{
+            "description":"Pet not found"
+          }
+        },
+        "security":[
+          {"petstore_auth":["write:pets","read:pets"]}
+        ]
+      }
+    },
+    "/pet/{petId}/uploadImage":{
+      "post":{
+        "tags":["pet"],
+        "summary":"uploads an image",
+        "description":"",
+        "operationId":"uploadFile",
+        "consumes":["multipart/form-data"],
+        "produces":["application/json"],
+        "parameters":[
+          {
+            "name":"petId",
+            "in":"path",
+            "description":"ID of pet to update",
+            "required":true,
+            "type":"integer",
+            "format":"int64"
+          },
+          {
+            "name":"additionalMetadata",
+            "in":"formData",
+            "description":"Additional data to pass to server",
+            "required":false,
+            "type":"string"
+          },
+          {
+            "name":"file",
+            "in":"formData",
+            "description":"file to upload",
+            "required":false,
+            "type":"file"
+          }
+        ],
+        "responses":{
+          "200":{
+            "description":"successful operation",
+            "schema":{"$ref":"#/definitions/ApiResponse"}
+          }
+        },
+        "security":[{"petstore_auth":["write:pets","read:pets"]}]
+      }
+    },
+    "/store/inventory":{
+      "get":{
+        "tags":["store"],
+        "summary":"Returns pet inventories by status",
+        "description":"Returns a map of status codes to quantities",
+        "operationId":"getInventory",
+        "produces":["application/json"],
+        "parameters":[],
+        "responses":{
+          "200":{
+            "description":"successful operation",
+            "schema":{
+              "type":"object",
+              "additionalProperties":{"type":"integer","format":"int32"}
+            }
+          }
+        },
+        "security":[{"api_key":[]}]
+      }
+    },
+    "/store/order":{
+      "post":{
+        "tags":["store"],
+        "summary":"Place an order for a pet",
+        "description":"",
+        "operationId":"placeOrder",
+        "produces":["application/xml","application/json"],
+        "parameters":[
+          {
+            "in":"body",
+            "name":"body",
+            "description":"order placed for purchasing the pet",
+            "required":true,
+            "schema":{"$ref":"#/definitions/Order"}
+          }
+        ],
+        "responses":{
+          "200":{
+            "description":"successful operation",
+            "schema":{"$ref":"#/definitions/Order"}
+          },
+          "400":{
+            "description":"Invalid Order"
+          }
+        }
+      }
+    },
+    "/store/order/{orderId}":{
+      "get":{
+        "tags":["store"],
+        "summary":"Find purchase order by ID",
+        "description":"For valid response try integer IDs with value >= 1 and <= 10. Other values will generated exceptions",
+        "operationId":"getOrderById",
+        "produces":["application/xml","application/json"],
+        "parameters":[
+          {
+            "name":"orderId",
+            "in":"path",
+            "description":"ID of pet that needs to be fetched",
+            "required":true,
+            "type":"integer",
+            "maximum":10.0,
+            "minimum":1.0,
+            "format":"int64"
+          }
+        ],
+        "responses":{
+          "200":{
+            "description":"successful operation",
+            "schema":{"$ref":"#/definitions/Order"}
+          },
+          "400":{
+            "description":"Invalid ID supplied"
+          },
+          "404":{
+            "description":"Order not found"
+          }
+        }
+      },
+      "delete":{
+        "tags":["store"],
+        "summary":"Delete purchase order by ID",
+        "description":"For valid response try integer IDs with positive integer value. Negative or non-integer values will generate API errors",
+        "operationId":"deleteOrder",
+        "produces":["application/xml","application/json"],
+        "parameters":[
+          {
+            "name":"orderId",
+            "in":"path",
+            "description":"ID of the order that needs to be deleted",
+            "required":true,
+            "type":"integer",
+            "minimum":1.0,
+            "format":"int64"
+          }
+        ],
+        "responses":
+        {
+          "400":{
+            "description":"Invalid ID supplied"
+          },
+          "404":{
+            "description":"Order not found"}
+        }
+      }
+    },
+    "/user":{
+      "post":{
+        "tags":["user"],
+        "summary":"Create user",
+        "description":"This can only be done by the logged in user.",
+        "operationId":"createUser",
+        "produces":["application/xml","application/json"],
+        "parameters":[
+          {
+            "in":"body",
+            "name":"body",
+            "description":"Created user object",
+            "required":true,
+            "schema":{"$ref":"#/definitions/User"}
+          }
+        ],
+        "responses":{
+          "default":{
+            "description":"successful operation"}
+        }
+      }
+    },
+    "/user/createWithArray":{
+      "post":{
+        "tags":["user"],
+        "summary":"Creates list of users with given input array",
+        "description":"",
+        "operationId":"createUsersWithArrayInput",
+        "produces":["application/xml","application/json"],
+        "parameters":[
+          {
+            "in":"body",
+            "name":"body",
+            "description":"List of user object",
+            "required":true,
+            "schema":{
+              "type":"array",
+              "items":{"$ref":"#/definitions/User"}
+            }
+          }
+        ],
+        "responses":{
+          "default":{"description":"successful operation"}
+        }
+      }
+    },
+    "/user/createWithList":{
+      "post":{
+        "tags":["user"],
+        "summary":"Creates list of users with given input array",
+        "description":"",
+        "operationId":"createUsersWithListInput",
+        "produces":["application/xml","application/json"],
+        "parameters":[
+          {
+            "in":"body",
+            "name":"body",
+            "description":"List of user object",
+            "required":true,
+            "schema":{
+              "type":"array",
+              "items":{"$ref":"#/definitions/User"}
+            }
+          }
+        ],
+        "responses":{
+          "default":{"description":"successful operation"}
+        }
+      }
+    },
+    "/user/login":{
+      "get":{
+        "tags":["user"],
+        "summary":"Logs user into the system",
+        "description":"",
+        "operationId":"loginUser",
+        "produces":["application/xml","application/json"],
+        "parameters":[
+          {
+            "name":"username",
+            "in":"query",
+            "description":"The user name for login",
+            "required":true,
+            "type":"string"
+          },
+          {
+            "name":"password",
+            "in":"query",
+            "description":"The password for login in clear text",
+            "required":true,
+            "type":"string"
+          }
+        ],
+        "responses":{
+          "200":{
+            "description":"successful operation",
+            "schema":{"type":"string"},
+            "headers":{
+              "X-Rate-Limit":{
+                "type":"integer",
+                "format":"int32",
+                "description":"calls per hour allowed by the user"
+              },
+              "X-Expires-After":{
+                "type":"string",
+                "format":"date-time",
+                "description":"date in UTC when token expires"
+              }
+            }
+          },
+          "400":{"description":"Invalid username/password supplied"}
+        }
+      }
+    },
+    "/user/logout":{
+      "get":{
+        "tags":["user"],
+        "summary":"Logs out current logged in user session",
+        "description":"",
+        "operationId":"logoutUser",
+        "produces":["application/xml","application/json"],
+        "parameters":[],
+        "responses":{
+          "default":{"description":"successful operation"}
+        }
+      }
+    },
+    "/user/{username}":{
+      "get":{
+        "tags":["user"],
+        "summary":"Get user by user name",
+        "description":"",
+        "operationId":"getUserByName",
+        "produces":["application/xml","application/json"],
+        "parameters":[
+          {
+            "name":"username",
+            "in":"path",
+            "description":"The name that needs to be fetched. Use user1 for testing. ",
+            "required":true,
+            "type":"string"
+          }
+        ],
+        "responses":{
+          "200":{
+            "description":"successful operation",
+            "schema":{"$ref":"#/definitions/User"}
+          },
+          "400":{"description":"Invalid username supplied"},
+          "404":{"description":"User not found"}
+        }
+      },
+      "put":{
+        "tags":["user"],
+        "summary":"Updated user",
+        "description":"This can only be done by the logged in user.",
+        "operationId":"updateUser",
+        "produces":["application/xml","application/json"],
+        "parameters":[
+          {
+            "name":"username",
+            "in":"path",
+            "description":"name that need to be updated",
+            "required":true,
+            "type":"string"
+          },
+          {
+            "in":"body",
+            "name":"body",
+            "description":"Updated user object",
+            "required":true,
+            "schema":{"$ref":"#/definitions/User"}
+          }
+        ],
+        "responses":{
+          "400":{"description":"Invalid user supplied"},
+          "404":{"description":"User not found"}
+        }
+      },
+      "delete":{
+        "tags":["user"],
+        "summary":"Delete user",
+        "description":"This can only be done by the logged in user.",
+        "operationId":"deleteUser",
+        "produces":["application/xml","application/json"],
+        "parameters":[
+          {
+            "name":"username",
+            "in":"path",
+            "description":"The name that needs to be deleted",
+            "required":true,"type":"string"
+          }
+        ],
+        "responses":{
+          "400":{"description":"Invalid username supplied"},
+          "404":{"description":"User not found"}
+        }
+      }
+    }
+  },
+  "securityDefinitions":{
+    "petstore_auth":{
+      "type":"oauth2",
+      "authorizationUrl":"http://petstore.swagger.io/oauth/dialog",
+      "flow":"implicit",
+      "scopes":{
+        "write:pets":"modify pets in your account",
+        "read:pets":"read your pets"
+      }
+    },
+    "api_key":{
+      "type":"apiKey",
+      "name":"api_key",
+      "in":"header"
+    }
+  },
+  "definitions":{
+    "Order":{
+      "type":"object",
+      "properties":{
+        "id":{
+          "type":"integer",
+          "format":"int64"
+        },
+        "petId":{
+          "type":"integer",
+          "format":"int64"
+        },
+        "quantity":{
+          "type":"integer",
+          "format":"int32"
+        },
+        "shipDate":{
+          "type":"string",
+          "format":"date-time"
+        },
+        "status":{
+          "type":"string",
+          "description":"Order Status",
+          "enum":["placed","approved","delivered"]
+        },
+        "complete":{
+          "type":"boolean",
+          "default":false
+        }
+      },
+      "xml":{
+        "name":"Order"
+      }
+    },
+    "Category":{
+      "type":"object",
+      "properties":{
+        "id":{
+          "type":"integer","format":"int64"
+        },
+        "name":{
+          "type":"string"}
+      },
+      "xml":{"name":"Category"}
+    },
+    "User":{
+      "type":"object",
+      "properties":{
+        "id":{
+          "type":"integer",
+          "format":"int64"
+        },
+        "username":{"type":"string"},
+        "firstName":{"type":"string"},
+        "lastName":{"type":"string"},
+        "email":{"type":"string"},
+        "password":{"type":"string"},
+        "phone":{"type":"string"},
+        "userStatus":{
+          "type":"integer",
+          "format":"int32",
+          "description":"User Status"
+        }
+      },
+      "xml":{"name":"User"}
+    },
+    "Tag":{
+      "type":"object",
+      "properties":{
+        "id":{"type":"integer","format":"int64"},
+        "name":{"type":"string"}
+      },
+      "xml":{"name":"Tag"}
+    },
+    "Pet":{
+      "type":"object",
+      "required":["name","photoUrls"],
+      "properties":{
+        "id":{"type":"integer","format":"int64"},
+        "category":{"$ref":"#/definitions/Category"},
+        "name":{"type":"string","example":"doggie"},
+        "photoUrls":{
+          "type":"array",
+          "xml":{"name":"photoUrl","wrapped":true},
+          "items":{"type":"string"}
+        },
+        "tags":{
+          "type":"array",
+          "xml":{"name":"tag","wrapped":true},
+          "items":{"$ref":"#/definitions/Tag"}
+        },
+        "status":{"type":"string","description":"pet status in the store","enum":["available","pending","sold"]}},
+      "xml":{"name":"Pet"}
+    },
+    "ApiResponse":{
+      "type":"object",
+      "properties":{
+        "code":{
+          "type":"integer",
+          "format":"int32"
+        },
+        "type":{"type":"string"},
+        "message":{"type":"string"}
+      }
+    }
+  },
+  "externalDocs":{"description":"Find out more about Swagger","url":"http://swagger.io"}
+}


### PR DESCRIPTION
This patch compensates for the Swagger library's change in behavior.  They are now using a Swagger object as the entity in their responses and relying upon the SwaggerSerializers (a MessageBodyWriter<Swagger>) to take care of the serialization (they were previously just converting to a JSON string and using that as the entity).  The JSON serialization causes there to be null values in the JSON, which was breaking our SwaggerParseUtils method (there's an included test case for it).  