### PR TITLE
More details when woodstox is not present and a XMLInputFactory can't be created

### DIFF
--- a/core/src/main/java/org/apache/cxf/staxutils/StaxUtils.java
+++ b/core/src/main/java/org/apache/cxf/staxutils/StaxUtils.java
@@ -335,7 +335,9 @@ public final class StaxUtils {
                 if (allowInsecureParser) {
                     LOG.log(Level.WARNING, "INSECURE_PARSER_DETECTED", factory.getClass().getName());
                 } else {
-                    throw new RuntimeException("Cannot create a secure XMLInputFactory");
+                    throw new RuntimeException("Cannot create a secure XMLInputFactory, "
+                        + "you should either add woodstox or set " + ALLOW_INSECURE_PARSER
+                        + " system property to true if an unsafe mode is acceptable.");
                 }
             }
         }


### PR DESCRIPTION

Rational is that people don't understand why JAXB does not work when woodstox is excluded, goal is to ensure the error is explicit about that.