### PR TITLE
CXF-7974 <library> defined in cxf-jaxws causes trouble (jdk11)

### DIFF
--- a/osgi/karaf/features/src/main/resources/features.xml
+++ b/osgi/karaf/features/src/main/resources/features.xml
@@ -230,7 +230,6 @@
         <feature version="${project.version}">cxf-http</feature>
         <bundle start-level="40">mvn:org.apache.cxf/cxf-rt-frontend-simple/${project.version}</bundle>
         <bundle start-level="40">mvn:org.apache.cxf/cxf-rt-frontend-jaxws/${project.version}</bundle>
-        <library type="endorsed" export="true">mvn:org.apache.servicemix.specs/org.apache.servicemix.specs.jaxws-api-2.2/${cxf.servicemix.specs.version}</library>
     </feature>
     <feature name="cxf-jaxrs" version="${project.version}">
         <feature version="${project.version}">cxf-core</feature>


### PR DESCRIPTION
Issue: https://issues.apache.org/jira/browse/CXF-7974

Removal of <library ....jaxws-api.. > from cxf-jaxws. Library is already defined in cxf-specs, so it could be removed -> solves problems on jdk11.