### PR TITLE
CXF-7980 Fixing bean leak

### DIFF
--- a/rt/rs/microprofile-client/src/main/java/org/apache/cxf/microprofile/client/cdi/RestClientExtension.java
+++ b/rt/rs/microprofile-client/src/main/java/org/apache/cxf/microprofile/client/cdi/RestClientExtension.java
@@ -32,8 +32,8 @@ import javax.enterprise.inject.spi.WithAnnotations;
 import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
 
 public class RestClientExtension implements Extension {
-    private static Set<Class<?>> restClientClasses = new LinkedHashSet<>();
-    private static Set<Throwable> errors = new LinkedHashSet<>();
+    private Set<Class<?>> restClientClasses = new LinkedHashSet<>();
+    private Set<Throwable> errors = new LinkedHashSet<>();
     public void findClients(@Observes @WithAnnotations({RegisterRestClient.class}) ProcessAnnotatedType<?> pat) {
         Class<?> restClient = pat.getAnnotatedType().getJavaClass();
         if (restClient.isInterface()) {


### PR DESCRIPTION
This PR fixes the error below. Basically it will avoid beans to leak and cause issues when there are multiple apps using the same classes.

Error
Caused by: org.apache.webbeans.exception.WebBeansException: org.apache.webbeans.exception.DuplicateDefinitionException: PassivationCapable bean id is not unique: br.com.gbrsistemas.crvirtual.classificacao.SiemClassificacaoServiceClient bean:SiemClassificacaoServiceClient, WebBeansType:THIRDPARTY, Name:br.com.gbrsistemas.crvirtual.classificacao.SiemClassificacaoServiceClient, API Types:[br.com.gbrsistemas.crvirtual.classificacao.SiemClassificacaoServiceClient], Qualifiers:[javax.enterprise.inject.Default,org.eclipse.microprofile.rest.client.inject.RestClient,javax.enterprise.inject.Any], existing: SiemClassificacaoServiceClient, WebBeansType:THIRDPARTY, Name:br.com.gbrsistemas.crvirtual.classificacao.SiemClassificacaoServiceClient, API Types:[br.com.gbrsistemas.crvirtual.classificacao.SiemClassificacaoServiceClient], Qualifiers:[javax.enterprise.inject.Default,org.eclipse.microprofile.rest.client.inject.RestClient,javax.enterprise.inject.Any]
	at org.apache.webbeans.event.ObserverMethodImpl.notify(ObserverMethodImpl.java:371)
	at org.apache.webbeans.event.NotificationManager.invokeObserverMethod(NotificationManager.java:818)
	at org.apache.webbeans.event.NotificationManager.fireEvent(NotificationManager.java:714)
	... 42 more