### PR TITLE
CXF-7989: org.apache.cxf.jaxrs.JAXRSInvoker should handle CompletionException

### DIFF
--- a/rt/frontend/jaxrs/src/main/java/org/apache/cxf/jaxrs/JAXRSInvoker.java
+++ b/rt/frontend/jaxrs/src/main/java/org/apache/cxf/jaxrs/JAXRSInvoker.java
@@ -27,6 +27,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.ResourceBundle;
 import java.util.concurrent.CancellationException;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.CompletionStage;
 import java.util.logging.Logger;
 
@@ -127,7 +128,14 @@ public class JAXRSInvoker extends AbstractInvoker {
     private Object handleAsyncResponse(Exchange exchange, AsyncResponseImpl ar) {
         Object asyncObj = ar.getResponseObject();
         if (asyncObj instanceof Throwable) {
-            return handleAsyncFault(exchange, ar, (Throwable)asyncObj);
+            final Throwable throwable = (Throwable)asyncObj;
+            Throwable cause = throwable;
+
+            if (throwable instanceof CompletionException) {
+                cause = throwable.getCause();
+            }
+
+            return handleAsyncFault(exchange, ar, (cause != null) ? cause : throwable);
         }
         setResponseContentTypeIfNeeded(exchange.getInMessage(), asyncObj);
         return new MessageContentsList(asyncObj);

--- a/systests/jaxrs/src/test/java/org/apache/cxf/systest/jaxrs/reactive/CompletableFutureServer.java
+++ b/systests/jaxrs/src/test/java/org/apache/cxf/systest/jaxrs/reactive/CompletableFutureServer.java
@@ -54,6 +54,7 @@ public class CompletableFutureServer extends AbstractBusTestServerBase {
         sf.setResourceProvider(CompletableFutureService.class,
                                new SingletonResourceProvider(new CompletableFutureService(), true));
         sf.setAddress("http://localhost:" + PORT + "/");
+        sf.setProvider(new MappedExceptionMapper());
         server = sf.create();
         BusFactory.setDefaultBus(null);
         BusFactory.setThreadDefaultBus(null);

--- a/systests/jaxrs/src/test/java/org/apache/cxf/systest/jaxrs/reactive/CompletableFutureService.java
+++ b/systests/jaxrs/src/test/java/org/apache/cxf/systest/jaxrs/reactive/CompletableFutureService.java
@@ -27,6 +27,10 @@ import javax.ws.rs.NotFoundException;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.container.AsyncResponse;
+import javax.ws.rs.container.Suspended;
+import javax.ws.rs.core.Response.Status;
 
 import org.apache.cxf.systest.jaxrs.Book;
 
@@ -48,6 +52,72 @@ public class CompletableFutureService {
     @Path("booksAsync/{id}")
     public CompletableFuture<Book> getBookAsync(@PathParam("id") long id) {
         return CompletableFuture.supplyAsync(() -> new Book("cxf", 123L));
+    }
+
+    @GET
+    @Produces("text/xml")
+    @Path("badRequest/{id}")
+    public CompletableFuture<Book> getBookAsyncExceptionBadRequest(@PathParam("id") long id) {
+        return CompletableFuture.supplyAsync(() -> {
+            throw new WebApplicationException(Status.BAD_REQUEST);
+        });
+    }
+
+    @GET
+    @Produces("text/xml")
+    @Path("forbidden/{id}")
+    public CompletableFuture<Book> getBookAsyncExceptionForbidden(@PathParam("id") long id) {
+        final CompletableFuture<Book> future = new CompletableFuture<Book>();
+        future.completeExceptionally(new WebApplicationException(Status.FORBIDDEN));
+        return future;
+    }
+
+    @GET
+    @Produces("text/xml")
+    @Path("unauthorized/{id}")
+    public void getBookAsyncExceptionUnauthorized(@PathParam("id") long id, @Suspended AsyncResponse response) {
+        CompletableFuture.supplyAsync(() -> {
+            throw new WebApplicationException(Status.UNAUTHORIZED);
+        }).whenComplete((r, ex) -> {
+            if (ex != null) {
+                response.resume(ex);
+            } else {
+                response.resume(r);
+            }
+        });
+    }
+
+    @GET
+    @Produces("text/xml")
+    @Path("mapped/badRequest/{id}")
+    public CompletableFuture<Book> getBookAsyncExceptionBadRequestMapped(@PathParam("id") long id) {
+        return CompletableFuture.supplyAsync(() -> {
+            throw new MappedException(Status.BAD_REQUEST);
+        });
+    }
+
+    @GET
+    @Produces("text/xml")
+    @Path("mapped/forbidden/{id}")
+    public CompletableFuture<Book> getBookAsyncExceptionForbiddenMapped(@PathParam("id") long id) {
+        final CompletableFuture<Book> future = new CompletableFuture<Book>();
+        future.completeExceptionally(new MappedException(Status.FORBIDDEN));
+        return future;
+    }
+
+    @GET
+    @Produces("text/xml")
+    @Path("mapped/unauthorized/{id}")
+    public void getBookAsyncExceptionUnauthorizedMapped(@PathParam("id") long id, @Suspended AsyncResponse response) {
+        CompletableFuture.supplyAsync(() -> {
+            throw new MappedException(Status.UNAUTHORIZED);
+        }).whenComplete((r, ex) -> {
+            if (ex != null) {
+                response.resume(ex);
+            } else {
+                response.resume(r);
+            }
+        });
     }
 }
 

--- a/systests/jaxrs/src/test/java/org/apache/cxf/systest/jaxrs/reactive/JAXRSCompletionStageTest.java
+++ b/systests/jaxrs/src/test/java/org/apache/cxf/systest/jaxrs/reactive/JAXRSCompletionStageTest.java
@@ -22,6 +22,9 @@ package org.apache.cxf.systest.jaxrs.reactive;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ExecutionException;
 
+import javax.ws.rs.BadRequestException;
+import javax.ws.rs.ForbiddenException;
+import javax.ws.rs.NotAuthorizedException;
 import javax.ws.rs.NotFoundException;
 import javax.xml.ws.Holder;
 
@@ -33,7 +36,9 @@ import org.apache.cxf.testutil.common.AbstractBusClientServerTestBase;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
+import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -91,8 +96,86 @@ public class JAXRSCompletionStageTest extends AbstractBusClientServerTestBase {
         } catch (ExecutionException ex) {
             assertTrue(ex.getCause() instanceof NotFoundException);
         }
-
     }
+
+    @Test
+    public void testGetBookAsyncStageThrowsBadRequestException() throws Exception {
+        String address = "http://localhost:" + PORT + "/completable/badRequest";
+        WebClient wc = createWebClient(address);
+        CompletionStage<Book> stage = wc.path("123").rx().get(Book.class);
+        try {
+            stage.toCompletableFuture().get();
+            fail("Exception expected");
+        } catch (ExecutionException ex) {
+            assertThat(ex.getCause(), instanceOf(BadRequestException.class));
+        }
+    }
+
+    @Test
+    public void testGetBookAsyncStageThrowsForbiddenException() throws Exception {
+        String address = "http://localhost:" + PORT + "/completable/forbidden";
+        WebClient wc = createWebClient(address);
+        CompletionStage<Book> stage = wc.path("123").rx().get(Book.class);
+        try {
+            stage.toCompletableFuture().get();
+            fail("Exception expected");
+        } catch (ExecutionException ex) {
+            assertThat(ex.getCause(), instanceOf(ForbiddenException.class));
+        }
+    }
+
+    @Test
+    public void testGetBookAsyncStageThrowsNotAuthorizedException() throws Exception {
+        String address = "http://localhost:" + PORT + "/completable/unauthorized";
+        WebClient wc = createWebClient(address);
+        CompletionStage<Book> stage = wc.path("123").rx().get(Book.class);
+        try {
+            stage.toCompletableFuture().get();
+            fail("Exception expected");
+        } catch (ExecutionException ex) {
+            assertThat(ex.getCause(), instanceOf(NotAuthorizedException.class));
+        }
+    }
+
+    @Test
+    public void testGetBookAsyncStageThrowsBadRequestMappedException() throws Exception {
+        String address = "http://localhost:" + PORT + "/completable/mapped/badRequest";
+        WebClient wc = createWebClient(address);
+        CompletionStage<Book> stage = wc.path("123").rx().get(Book.class);
+        try {
+            stage.toCompletableFuture().get();
+            fail("Exception expected");
+        } catch (ExecutionException ex) {
+            assertThat(ex.getCause(), instanceOf(BadRequestException.class));
+        }
+    }
+
+    @Test
+    public void testGetBookAsyncStageThrowsForbiddenMappedException() throws Exception {
+        String address = "http://localhost:" + PORT + "/completable/mapped/forbidden";
+        WebClient wc = createWebClient(address);
+        CompletionStage<Book> stage = wc.path("123").rx().get(Book.class);
+        try {
+            stage.toCompletableFuture().get();
+            fail("Exception expected");
+        } catch (ExecutionException ex) {
+            assertThat(ex.getCause(), instanceOf(ForbiddenException.class));
+        }
+    }
+
+    @Test
+    public void testGetBookAsyncStageThrowsNotAuthorizedMappedException() throws Exception {
+        String address = "http://localhost:" + PORT + "/completable/mapped/unauthorized";
+        WebClient wc = createWebClient(address);
+        CompletionStage<Book> stage = wc.path("123").rx().get(Book.class);
+        try {
+            stage.toCompletableFuture().get();
+            fail("Exception expected");
+        } catch (ExecutionException ex) {
+            assertThat(ex.getCause(), instanceOf(NotAuthorizedException.class));
+        }
+    }
+
     private WebClient createWebClient(String address) {
         return WebClient.create(address);
     }

--- a/systests/jaxrs/src/test/java/org/apache/cxf/systest/jaxrs/reactive/MappedException.java
+++ b/systests/jaxrs/src/test/java/org/apache/cxf/systest/jaxrs/reactive/MappedException.java
@@ -1,0 +1,35 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.cxf.systest.jaxrs.reactive;
+
+import javax.ws.rs.core.Response;
+
+public class MappedException extends RuntimeException {
+    private static final long serialVersionUID = -1208379323354179764L;
+    private final Response.Status status;
+
+    public MappedException(Response.Status status) {
+        this.status = status;
+    }
+
+    public Response.Status getStatus() {
+        return status;
+    }
+}

--- a/systests/jaxrs/src/test/java/org/apache/cxf/systest/jaxrs/reactive/MappedExceptionMapper.java
+++ b/systests/jaxrs/src/test/java/org/apache/cxf/systest/jaxrs/reactive/MappedExceptionMapper.java
@@ -1,0 +1,32 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.cxf.systest.jaxrs.reactive;
+
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+import javax.ws.rs.ext.Provider;
+
+@Provider
+public class MappedExceptionMapper implements ExceptionMapper<MappedException> {
+    @Override
+    public Response toResponse(MappedException exception) {
+        return Response.status(exception.getStatus()).build();
+    }
+}


### PR DESCRIPTION
The Problem
===

In case when CXF is used along with `CompletionStage` / `CompletableFuture`, in most cases the error handling is propagated back through `CompletionException` instance (http://cs.oswego.edu/pipermail/concurrency-interest/2014-August/012911.html). It works but it forces users to introduce own implementations of `ExceptionMapper`s and manually unwrap the `CompletionException` into something more meaningful.

Use cases
===
There are 3 leading use cases which cover most typical usage of the `CompletionStage` / `CompletableFuture`.

1. `@Suspended AsyncResponse`
```
public void get(@PathParam("isbn") String isbn, @Suspended final AsyncResponse resp) {
        client.target("http://localhost:19092/services/catalog/" + isbn)
            .request()
            .rx()
            .get(Book.class)
            .whenComplete((r, ex) -> {
                if (ex != null) {
                    resp.resume(ex);
                } else {
                    resp.resume(r);
                }
            });
    }
```
2. Return `CompletableFuture<Book>`

```
public CompletableFuture<Book> get(@PathParam("isbn") String isbn) {
        return client
            .target("http://localhost:19092/services/catalog/" + isbn)
            .request()
            .rx()
            .get(Book.class)
            .toCompletableFuture();
    }
```

3. Return constructed instance of the `CompletableFuture<Book>` 

```
public CompletableFuture<Book> get(@PathParam("isbn") String isbn) {
    final CompletableFuture<Book> future = new CompletableFuture<Book>();
    future.completeExceptionally(...);
    return future;
}
```

Suggested Solution
===
Instrument `JAXRSInvoker::handleAsyncResponse` to distinguish `CompletionException`, unwrap the cause and use it to select the appropriate `ExceptionMapper` (if any).

@rmannibucau why `JAXRSInvoker::handleAsyncResponse` and not `JAXRSInvoker::checkFutureResponse`, the 1st use case which uses suspended async response does not flow through `JAXRSInvoker::checkFutureResponse` but all three use cases run through `JAXRSInvoker::handleAsyncResponse`

@coheigea @dkulp guys would really appreciate if you could take a quick look, small change but may introduce undesired side effects, thanks a lot.
