### PR TITLE
cxf-rt-ws-security: fix PVS-Studio errors/warnings

### DIFF
--- a/rt/ws/security/src/main/java/org/apache/cxf/ws/security/policy/interceptors/KerberosTokenInterceptorProvider.java
+++ b/rt/ws/security/src/main/java/org/apache/cxf/ws/security/policy/interceptors/KerberosTokenInterceptorProvider.java
@@ -178,7 +178,7 @@ public class KerberosTokenInterceptorProvider extends AbstractPolicyInterceptorP
                     List<WSHandlerResult> results =
                         CastUtils.cast((List<?>)message.get(WSHandlerConstants.RECV_RESULTS));
                     if (results != null && !results.isEmpty()) {
-                        parseHandlerResults(results.get(0), message, aim, ais);
+                        parseHandlerResults(results.get(0), message, ais);
                     }
                 } else {
                     //client side should be checked on the way out
@@ -195,7 +195,6 @@ public class KerberosTokenInterceptorProvider extends AbstractPolicyInterceptorP
         private void parseHandlerResults(
             WSHandlerResult rResult,
             Message message,
-            AssertionInfoMap aim,
             Collection<AssertionInfo> ais
         ) {
 

--- a/rt/ws/security/src/main/java/org/apache/cxf/ws/security/policy/interceptors/STSInvoker.java
+++ b/rt/ws/security/src/main/java/org/apache/cxf/ws/security/policy/interceptors/STSInvoker.java
@@ -184,7 +184,7 @@ abstract class STSInvoker implements Invoker {
 
     private SecurityToken findCancelOrRenewToken(Exchange exchange, Element el) throws WSSecurityException {
         Element childElement = DOMUtils.getFirstElement(el);
-        String uri = "";
+        final String uri;
         if ("SecurityContextToken".equals(childElement.getLocalName())) {
             SecurityContextToken sct = new SecurityContextToken(childElement);
             uri = sct.getIdentifier();

--- a/rt/ws/security/src/main/java/org/apache/cxf/ws/security/policy/interceptors/SecureConversationInInterceptor.java
+++ b/rt/ws/security/src/main/java/org/apache/cxf/ws/security/policy/interceptors/SecureConversationInInterceptor.java
@@ -302,7 +302,7 @@ class SecureConversationInInterceptor extends AbstractPhaseInterceptor<SoapMessa
             String prefix,
             String namespace
         ) throws Exception {
-            doIssueOrRenew(requestEl, exchange, binaryExchange, writer, prefix, namespace, null);
+            doIssueOrRenew(requestEl, exchange, writer, prefix, namespace, null);
         }
 
         void doRenew(Element requestEl,
@@ -312,14 +312,13 @@ class SecureConversationInInterceptor extends AbstractPhaseInterceptor<SoapMessa
                      W3CDOMStreamWriter writer,
                      String prefix,
                      String namespace) throws Exception {
-            doIssueOrRenew(requestEl, exchange, binaryExchange, writer, prefix, namespace,
+            doIssueOrRenew(requestEl, exchange, writer, prefix, namespace,
                     renewToken.getId());
         }
 
 
         private void doIssueOrRenew(Element requestEl,
                                Exchange exchange,
-                               Element binaryExchange,
                                W3CDOMStreamWriter writer,
                                String prefix,
                                String namespace,

--- a/rt/ws/security/src/main/java/org/apache/cxf/ws/security/policy/interceptors/SpnegoContextTokenOutInterceptor.java
+++ b/rt/ws/security/src/main/java/org/apache/cxf/ws/security/policy/interceptors/SpnegoContextTokenOutInterceptor.java
@@ -74,14 +74,12 @@ class SpnegoContextTokenOutInterceptor extends AbstractPhaseInterceptor<SoapMess
                 if (tok == null) {
                     tok = issueToken(message, aim);
                 }
-                if (tok != null) {
-                    for (AssertionInfo ai : ais) {
-                        ai.setAsserted(true);
-                    }
-                    message.getExchange().getEndpoint().put(SecurityConstants.TOKEN_ID, tok.getId());
-                    message.getExchange().put(SecurityConstants.TOKEN_ID, tok.getId());
-                    TokenStoreUtils.getTokenStore(message).add(tok);
+                for (AssertionInfo ai : ais) {
+                    ai.setAsserted(true);
                 }
+                message.getExchange().getEndpoint().put(SecurityConstants.TOKEN_ID, tok.getId());
+                message.getExchange().put(SecurityConstants.TOKEN_ID, tok.getId());
+                TokenStoreUtils.getTokenStore(message).add(tok);
             } else {
                 // server side should be checked on the way in
                 for (AssertionInfo ai : ais) {

--- a/rt/ws/security/src/main/java/org/apache/cxf/ws/security/tokenstore/MemoryTokenStore.java
+++ b/rt/ws/security/src/main/java/org/apache/cxf/ws/security/tokenstore/MemoryTokenStore.java
@@ -38,19 +38,13 @@ public class MemoryTokenStore implements TokenStore {
 
     public void add(SecurityToken token) {
         if (token != null && !StringUtils.isEmpty(token.getId())) {
-            CacheEntry cacheEntry = createCacheEntry(token);
-            if (cacheEntry != null) {
-                tokens.put(token.getId(), cacheEntry);
-            }
+            tokens.put(token.getId(), createCacheEntry(token));
         }
     }
 
     public void add(String identifier, SecurityToken token) {
         if (token != null && !StringUtils.isEmpty(identifier)) {
-            CacheEntry cacheEntry = createCacheEntry(token);
-            if (cacheEntry != null) {
-                tokens.put(identifier, cacheEntry);
-            }
+            tokens.put(identifier, createCacheEntry(token));
         }
     }
 

--- a/rt/ws/security/src/main/java/org/apache/cxf/ws/security/trust/STSLoginModule.java
+++ b/rt/ws/security/src/main/java/org/apache/cxf/ws/security/trust/STSLoginModule.java
@@ -334,16 +334,11 @@ public class STSLoginModule implements LoginModule {
     private TokenStore configureTokenStore() throws MalformedURLException {
         if (TokenStoreFactory.isEhCacheInstalled()) {
             String cfg = "cxf-ehcache.xml";
-            URL url = null;
-            if (url == null) {
-                url = ClassLoaderUtils.getResource(cfg, STSLoginModule.class);
-            }
+            URL url = ClassLoaderUtils.getResource(cfg, STSLoginModule.class);
             if (url == null) {
                 url = new URL(cfg);
             }
-            if (url != null) {
-                return new EHCacheTokenStore(TOKEN_STORE_KEY, BusFactory.getDefaultBus(), url);
-            }
+            return new EHCacheTokenStore(TOKEN_STORE_KEY, BusFactory.getDefaultBus(), url);
         }
         return null;
     }
@@ -402,7 +397,7 @@ public class STSLoginModule implements LoginModule {
     public boolean abort() throws LoginException {
         if (!succeeded) {
             return false;
-        } else if (succeeded && commitSucceeded) {
+        } else if (commitSucceeded) {
             // we succeeded, but another required module failed
             logout();
         } else {

--- a/rt/ws/security/src/main/java/org/apache/cxf/ws/security/trust/STSTokenRetriever.java
+++ b/rt/ws/security/src/main/java/org/apache/cxf/ws/security/trust/STSTokenRetriever.java
@@ -87,7 +87,7 @@ public final class STSTokenRetriever {
                 Element actAsToken = client.getActAsToken();
 
                 String key = appliesTo;
-                if (!enableAppliesTo || key == null || "".equals(key)) {
+                if (!enableAppliesTo || key == null || key.isEmpty()) {
                     key = ASSOCIATED_TOKEN;
                 }
                 

--- a/rt/ws/security/src/main/java/org/apache/cxf/ws/security/wss4j/CryptoCoverageUtil.java
+++ b/rt/ws/security/src/main/java/org/apache/cxf/ws/security/wss4j/CryptoCoverageUtil.java
@@ -127,7 +127,7 @@ public final class CryptoCoverageUtil {
         CoverageType type,
         CoverageScope scope
     ) throws WSSecurityException {
-        if (!CryptoCoverageUtil.matchElement(refs, type, scope, soapBody)) {
+        if (!CryptoCoverageUtil.matchElement(refs, scope, soapBody)) {
             Exception ex = new Exception("The " + getCoverageTypeString(type)
                     + " does not cover the required elements (soap:Body).");
             throw new WSSecurityException(WSSecurityException.ErrorCode.FAILURE, ex);
@@ -216,7 +216,7 @@ public final class CryptoCoverageUtil {
         }
 
         for (Element el : elements) {
-            if (!CryptoCoverageUtil.matchElement(refs, type, scope, el)) {
+            if (!CryptoCoverageUtil.matchElement(refs, scope, el)) {
                 throw new WSSecurityException(WSSecurityException.ErrorCode.FAILURE,
                         new Exception("The " + getCoverageTypeString(type)
                         + " does not cover the required elements ({"
@@ -344,7 +344,7 @@ public final class CryptoCoverageUtil {
 
                     final Element el = (Element)list.item(x);
 
-                    boolean instanceMatched = CryptoCoverageUtil.matchElement(refs, type, scope, el);
+                    boolean instanceMatched = CryptoCoverageUtil.matchElement(refs, scope, el);
 
                     // We looked through all of the refs, but the element was
                     // not signed.
@@ -359,8 +359,7 @@ public final class CryptoCoverageUtil {
         }
     }
 
-    private static boolean matchElement(Collection<WSDataRef> refs,
-            CoverageType type, CoverageScope scope, Element el) {
+    private static boolean matchElement(Collection<WSDataRef> refs, CoverageScope scope, Element el) {
         final boolean content;
 
         switch (scope) {

--- a/rt/ws/security/src/main/java/org/apache/cxf/ws/security/wss4j/PolicyBasedWSS4JInInterceptor.java
+++ b/rt/ws/security/src/main/java/org/apache/cxf/ws/security/wss4j/PolicyBasedWSS4JInInterceptor.java
@@ -155,7 +155,7 @@ public class PolicyBasedWSS4JInInterceptor extends WSS4JInInterceptor {
     }
 
     private String checkDefaultBinding(
-        AssertionInfoMap aim, String action, SoapMessage message, RequestData data
+        String action, SoapMessage message, RequestData data
     ) throws WSSecurityException {
         action = addToAction(action, "Signature", true);
         action = addToAction(action, "Encrypt", true);
@@ -396,7 +396,7 @@ public class PolicyBasedWSS4JInInterceptor extends WSS4JInInterceptor {
             action = checkSymmetricBinding(aim, action, message, data);
             Collection<AssertionInfo> ais = aim.get(SP12Constants.TRANSPORT_BINDING);
             if ("".equals(action) || (ais != null && !ais.isEmpty())) {
-                action = checkDefaultBinding(aim, action, message, data);
+                action = checkDefaultBinding(action, message, data);
             }
 
             // Allow for setting non-standard asymmetric signature algorithms
@@ -407,7 +407,7 @@ public class PolicyBasedWSS4JInInterceptor extends WSS4JInInterceptor {
             if (asymSignatureAlgorithm != null || symSignatureAlgorithm != null) {
                 Collection<AssertionInfo> algorithmSuites =
                     PolicyUtils.getAllAssertionsByLocalname(aim, SPConstants.ALGORITHM_SUITE);
-                if (algorithmSuites != null && !algorithmSuites.isEmpty()) {
+                if (!algorithmSuites.isEmpty()) {
                     for (AssertionInfo algorithmSuite : algorithmSuites) {
                         AlgorithmSuite algSuite = (AlgorithmSuite)algorithmSuite.getAssertion();
                         if (asymSignatureAlgorithm != null) {

--- a/rt/ws/security/src/main/java/org/apache/cxf/ws/security/wss4j/SamlTokenInterceptor.java
+++ b/rt/ws/security/src/main/java/org/apache/cxf/ws/security/wss4j/SamlTokenInterceptor.java
@@ -183,7 +183,7 @@ public class SamlTokenInterceptor extends AbstractTokenInterceptor {
         data.setMsgContext(message);
         data.setWssConfig(WSSConfig.getNewInstance());
 
-        data.setSigVerCrypto(getCrypto(null, SecurityConstants.SIGNATURE_CRYPTO,
+        data.setSigVerCrypto(getCrypto(SecurityConstants.SIGNATURE_CRYPTO,
                                      SecurityConstants.SIGNATURE_PROPERTIES, message));
 
         WSDocInfo wsDocInfo = new WSDocInfo(tokenElement.getOwnerDocument());
@@ -286,7 +286,7 @@ public class SamlTokenInterceptor extends AbstractTokenInterceptor {
             Crypto crypto = samlCallback.getIssuerCrypto();
             if (crypto == null) {
                 crypto =
-                    getCrypto(token, SecurityConstants.SIGNATURE_CRYPTO,
+                    getCrypto(SecurityConstants.SIGNATURE_CRYPTO,
                               SecurityConstants.SIGNATURE_PROPERTIES, message);
             }
 
@@ -304,7 +304,6 @@ public class SamlTokenInterceptor extends AbstractTokenInterceptor {
     }
 
     private Crypto getCrypto(
-        SamlToken samlToken,
         String cryptoKey,
         String propKey,
         SoapMessage message

--- a/rt/ws/security/src/main/java/org/apache/cxf/ws/security/wss4j/UsernameTokenInterceptor.java
+++ b/rt/ws/security/src/main/java/org/apache/cxf/ws/security/wss4j/UsernameTokenInterceptor.java
@@ -345,7 +345,7 @@ public class UsernameTokenInterceptor extends AbstractTokenInterceptor {
                 PolicyUtils.assertPolicy(aim, SPConstants.NO_PASSWORD);
             }
 
-            if (tok.isCreated() && princ.getCreatedTime() == null) {
+            if (tok.isCreated() && (princ == null || princ.getCreatedTime() == null)) {
                 ai.setNotAsserted("No Created Time");
             } else {
                 PolicyUtils.assertPolicy(aim, SP13Constants.CREATED);

--- a/rt/ws/security/src/main/java/org/apache/cxf/ws/security/wss4j/policyhandlers/AbstractBindingBuilder.java
+++ b/rt/ws/security/src/main/java/org/apache/cxf/ws/security/wss4j/policyhandlers/AbstractBindingBuilder.java
@@ -1956,8 +1956,7 @@ public abstract class AbstractBindingBuilder extends AbstractCommonBindingHandle
                         doSymmSignatureDerived(supportingToken.getToken(), token, sigParts,
                                                isTokenProtection, isSigProtect);
                     } else {
-                        doSymmSignature(supportingToken.getToken(), token, sigParts,
-                                        isTokenProtection, isSigProtect);
+                        doSymmSignature(supportingToken.getToken(), token, sigParts, isSigProtect);
                     }
                 } catch (Exception e) {
                     LOG.log(Level.FINE, e.getMessage(), e);
@@ -1985,8 +1984,7 @@ public abstract class AbstractBindingBuilder extends AbstractCommonBindingHandle
                         doSymmSignatureDerived(supportingToken.getToken(), secToken, sigParts,
                                                isTokenProtection, isSigProtect);
                     } else {
-                        doSymmSignature(supportingToken.getToken(), secToken, sigParts,
-                                        isTokenProtection, isSigProtect);
+                        doSymmSignature(supportingToken.getToken(), secToken, sigParts, isSigProtect);
                     }
                 } catch (Exception e) {
                     LOG.log(Level.FINE, e.getMessage(), e);
@@ -2085,7 +2083,7 @@ public abstract class AbstractBindingBuilder extends AbstractCommonBindingHandle
     }
 
     private void doSymmSignature(AbstractToken policyToken, SecurityToken tok,
-                                         List<WSEncryptionPart> sigParts, boolean isTokenProtection,
+                                         List<WSEncryptionPart> sigParts,
                                          boolean isSigProtect)
         throws WSSecurityException {
 

--- a/rt/ws/security/src/main/java/org/apache/cxf/ws/security/wss4j/policyhandlers/AsymmetricBindingHandler.java
+++ b/rt/ws/security/src/main/java/org/apache/cxf/ws/security/wss4j/policyhandlers/AsymmetricBindingHandler.java
@@ -572,7 +572,7 @@ public class AsymmetricBindingHandler extends AbstractBindingBuilder {
             }
 
             if (encrKey == null) {
-                setupEncryptedKey(recToken, encrToken);
+                setupEncryptedKey(encrToken);
             }
 
             dkEncr.setExternalKey(this.encryptedKeyValue, this.encryptedKeyId);
@@ -644,7 +644,7 @@ public class AsymmetricBindingHandler extends AbstractBindingBuilder {
         }
         if (sigToken.getDerivedKeys() == DerivedKeys.RequireDerivedKeys) {
             // Set up the encrypted key to use
-            setupEncryptedKey(wrapper, sigToken);
+            setupEncryptedKey(sigToken);
 
             WSSecDKSign dkSign = new WSSecDKSign(secHeader);
             dkSign.setIdAllocator(wssConfig.getIdAllocator());
@@ -760,7 +760,7 @@ public class AsymmetricBindingHandler extends AbstractBindingBuilder {
         }
     }
 
-    private void setupEncryptedKey(AbstractTokenWrapper wrapper, AbstractToken token) throws WSSecurityException {
+    private void setupEncryptedKey(AbstractToken token) throws WSSecurityException {
         if (!isRequestor() && token.getDerivedKeys() == DerivedKeys.RequireDerivedKeys) {
             //If we already have them, simply return
             if (encryptedKeyId != null && encryptedKeyValue != null) {
@@ -784,17 +784,17 @@ public class AsymmetricBindingHandler extends AbstractBindingBuilder {
                 //message by a listener created for an async client
                 //Therefore we will create a new EncryptedKey
                 if (encryptedKeyId == null && encryptedKeyValue == null) {
-                    createEncryptedKey(wrapper, token);
+                    createEncryptedKey(token);
                 }
             } else {
                 unassertPolicy(token, "No security results found");
             }
         } else {
-            createEncryptedKey(wrapper, token);
+            createEncryptedKey(token);
         }
     }
 
-    private void createEncryptedKey(AbstractTokenWrapper wrapper, AbstractToken token)
+    private void createEncryptedKey(AbstractToken token)
         throws WSSecurityException {
         //Set up the encrypted key to use
         encrKey = this.getEncryptedKeyBuilder(token);

--- a/rt/ws/security/src/main/java/org/apache/cxf/ws/security/wss4j/policyhandlers/StaxAsymmetricBindingHandler.java
+++ b/rt/ws/security/src/main/java/org/apache/cxf/ws/security/wss4j/policyhandlers/StaxAsymmetricBindingHandler.java
@@ -217,7 +217,7 @@ public class StaxAsymmetricBindingHandler extends AbstractStaxBindingHandler {
                 assertTokenWrapper(encToken);
                 assertToken(encToken.getToken());
             }
-            doEncryption(encToken, enc, false);
+            doEncryption(encToken, enc);
 
             putCustomTokenAfterSignature();
         } catch (Exception e) {
@@ -311,7 +311,7 @@ public class StaxAsymmetricBindingHandler extends AbstractStaxBindingHandler {
                         new QName(abinding.getName().getNamespaceURI(), SPConstants.ENCRYPT_SIGNATURE));
                 }
 
-                doEncryption(wrapper, encrParts, true);
+                doEncryption(wrapper, encrParts);
             }
 
             if (timestampAdded) {
@@ -348,8 +348,7 @@ public class StaxAsymmetricBindingHandler extends AbstractStaxBindingHandler {
     }
 
     private void doEncryption(AbstractTokenWrapper recToken,
-                                    List<SecurePart> encrParts,
-                                    boolean externalRef) throws SOAPException {
+                                    List<SecurePart> encrParts) throws SOAPException {
         //Do encryption
         if (recToken != null && recToken.getToken() != null && !encrParts.isEmpty()) {
             AbstractToken encrToken = recToken.getToken();

--- a/rt/ws/security/src/main/java/org/apache/cxf/ws/security/wss4j/policyhandlers/StaxSymmetricBindingHandler.java
+++ b/rt/ws/security/src/main/java/org/apache/cxf/ws/security/wss4j/policyhandlers/StaxSymmetricBindingHandler.java
@@ -192,7 +192,7 @@ public class StaxSymmetricBindingHandler extends AbstractStaxBindingHandler {
                 }
             } else if (encryptionToken instanceof X509Token) {
                 if (isRequestor()) {
-                    tokenId = setupEncryptedKey(encryptionWrapper, encryptionToken);
+                    tokenId = setupEncryptedKey();
                 } else {
                     org.apache.xml.security.stax.securityToken.SecurityToken securityToken =
                         findEncryptedKeyToken();
@@ -246,7 +246,7 @@ public class StaxSymmetricBindingHandler extends AbstractStaxBindingHandler {
                         new QName(sbinding.getName().getNamespaceURI(), SPConstants.ENCRYPT_SIGNATURE));
                 }
 
-                doEncryption(encryptionWrapper, encrParts, true);
+                doEncryption(encryptionWrapper, encrParts);
             }
 
             if (timestampAdded) {
@@ -261,10 +261,10 @@ public class StaxSymmetricBindingHandler extends AbstractStaxBindingHandler {
                 if (sigAbstractTokenWrapper != null) {
                     AbstractToken sigToken = sigAbstractTokenWrapper.getToken();
                     if (isRequestor()) {
-                        doSignature(sigAbstractTokenWrapper, sigToken, tok, sigParts);
+                        doSignature(sigAbstractTokenWrapper, sigToken, sigParts);
                     } else {
                         addSignatureConfirmation(sigParts);
-                        doSignature(sigAbstractTokenWrapper, sigToken, tok, sigParts);
+                        doSignature(sigAbstractTokenWrapper, sigToken, sigParts);
                     }
                 }
             }
@@ -318,7 +318,7 @@ public class StaxSymmetricBindingHandler extends AbstractStaxBindingHandler {
                     }
                 } else if (sigToken instanceof X509Token) {
                     if (isRequestor()) {
-                        sigTokId = setupEncryptedKey(sigAbstractTokenWrapper, sigToken);
+                        sigTokId = setupEncryptedKey();
                     } else {
                         org.apache.xml.security.stax.securityToken.SecurityToken securityToken =
                             findEncryptedKeyToken();
@@ -361,7 +361,7 @@ public class StaxSymmetricBindingHandler extends AbstractStaxBindingHandler {
             }
 
             if (!sigs.isEmpty()) {
-                doSignature(sigAbstractTokenWrapper, sigToken, sigTok, sigs);
+                doSignature(sigAbstractTokenWrapper, sigToken, sigs);
             }
 
             addSupportingTokens();
@@ -389,7 +389,7 @@ public class StaxSymmetricBindingHandler extends AbstractStaxBindingHandler {
                 enc.addAll(encryptedTokensList);
             }
             AbstractTokenWrapper encrAbstractTokenWrapper = getEncryptionToken();
-            doEncryption(encrAbstractTokenWrapper, enc, false);
+            doEncryption(encrAbstractTokenWrapper, enc);
 
             putCustomTokenAfterSignature();
         } catch (Exception e) {
@@ -398,8 +398,7 @@ public class StaxSymmetricBindingHandler extends AbstractStaxBindingHandler {
     }
 
     private void doEncryption(AbstractTokenWrapper recToken,
-                              List<SecurePart> encrParts,
-                              boolean externalRef) throws SOAPException {
+                              List<SecurePart> encrParts) throws SOAPException {
         //Do encryption
         if (recToken != null && recToken.getToken() != null) {
             AbstractToken encrToken = recToken.getToken();
@@ -501,8 +500,7 @@ public class StaxSymmetricBindingHandler extends AbstractStaxBindingHandler {
         }
     }
 
-    private void doSignature(AbstractTokenWrapper wrapper, AbstractToken policyToken,
-                             SecurityToken tok, List<SecurePart> sigParts)
+    private void doSignature(AbstractTokenWrapper wrapper, AbstractToken policyToken, List<SecurePart> sigParts)
         throws WSSecurityException, SOAPException {
 
         // Action
@@ -599,7 +597,7 @@ public class StaxSymmetricBindingHandler extends AbstractStaxBindingHandler {
         }
     }
 
-    private String setupEncryptedKey(AbstractTokenWrapper wrapper, AbstractToken sigToken) throws WSSecurityException {
+    private String setupEncryptedKey() throws WSSecurityException {
 
         Instant created = Instant.now();
         Instant expires = created.plusSeconds(WSS4JUtils.getSecurityTokenLifetime(message) / 1000L);

--- a/rt/ws/security/src/main/java/org/apache/cxf/ws/security/wss4j/policyhandlers/TransportBindingHandler.java
+++ b/rt/ws/security/src/main/java/org/apache/cxf/ws/security/wss4j/policyhandlers/TransportBindingHandler.java
@@ -448,7 +448,7 @@ public class TransportBindingHandler extends AbstractBindingBuilder {
         if (token.getDerivedKeys() == DerivedKeys.RequireDerivedKeys) {
             return doDerivedKeySignature(tokenIncluded, secTok, token, sigParts);
         }
-        return doSignature(tokenIncluded, secTok, token, wrapper, sigParts);
+        return doSignature(tokenIncluded, secTok, token, sigParts);
     }
 
     private byte[] doDerivedKeySignature(
@@ -510,7 +510,6 @@ public class TransportBindingHandler extends AbstractBindingBuilder {
         boolean tokenIncluded,
         SecurityToken secTok,
         AbstractToken token,
-        SupportingTokens wrapper,
         List<WSEncryptionPart> sigParts
     ) throws Exception {
         WSSecSignature sig = new WSSecSignature(secHeader);

--- a/rt/ws/security/src/main/java/org/apache/cxf/ws/security/wss4j/policyvalidators/AbstractSupportingTokenPolicyValidator.java
+++ b/rt/ws/security/src/main/java/org/apache/cxf/ws/security/wss4j/policyvalidators/AbstractSupportingTokenPolicyValidator.java
@@ -112,8 +112,7 @@ public abstract class AbstractSupportingTokenPolicyValidator extends AbstractSec
                                            parameters.getMessage())) {
             return false;
         }
-        if (isEncrypted() && !areTokensEncrypted(tokenResults, parameters.getEncryptedResults(),
-                                                 parameters.getMessage())) {
+        if (isEncrypted() && !areTokensEncrypted(tokenResults, parameters.getEncryptedResults())) {
             return false;
         }
 
@@ -157,8 +156,7 @@ public abstract class AbstractSupportingTokenPolicyValidator extends AbstractSec
             return false;
         }
         if (isEncrypted() && !areTokensEncrypted(tokenResults,
-                                                 parameters.getEncryptedResults(),
-                                                 parameters.getMessage())) {
+                                                 parameters.getEncryptedResults())) {
             return false;
         }
 
@@ -218,8 +216,7 @@ public abstract class AbstractSupportingTokenPolicyValidator extends AbstractSec
                                            parameters.getMessage())) {
             return false;
         }
-        if (isEncrypted() && !areTokensEncrypted(tokenResults, parameters.getEncryptedResults(),
-                                                 parameters.getMessage())) {
+        if (isEncrypted() && !areTokensEncrypted(tokenResults, parameters.getEncryptedResults())) {
             return false;
         }
 
@@ -274,8 +271,7 @@ public abstract class AbstractSupportingTokenPolicyValidator extends AbstractSec
                                            parameters.getMessage())) {
             return false;
         }
-        if (isEncrypted() && !areTokensEncrypted(tokenResults, parameters.getEncryptedResults(),
-                                                 parameters.getMessage())) {
+        if (isEncrypted() && !areTokensEncrypted(tokenResults, parameters.getEncryptedResults())) {
             return false;
         }
 
@@ -327,8 +323,7 @@ public abstract class AbstractSupportingTokenPolicyValidator extends AbstractSec
                                            parameters.getMessage())) {
             return false;
         }
-        if (isEncrypted() && !areTokensEncrypted(tokenResults, parameters.getEncryptedResults(),
-                                                 parameters.getMessage())) {
+        if (isEncrypted() && !areTokensEncrypted(tokenResults, parameters.getEncryptedResults())) {
             return false;
         }
         if (isEndorsing() && !checkEndorsed(tokenResults, parameters.getSignedResults(),
@@ -358,11 +353,11 @@ public abstract class AbstractSupportingTokenPolicyValidator extends AbstractSec
             return false;
         }
 
-        if (!validateSignedEncryptedElements(signedElements, false, signedResults, tokenResults, message)) {
+        if (!validateSignedEncryptedElements(signedElements, signedResults, tokenResults, message)) {
             return false;
         }
 
-        return validateSignedEncryptedElements(encryptedElements, false, encryptedResults, tokenResults, message);
+        return validateSignedEncryptedElements(encryptedElements, encryptedResults, tokenResults, message);
     }
 
 
@@ -381,8 +376,7 @@ public abstract class AbstractSupportingTokenPolicyValidator extends AbstractSec
                                            parameters.getMessage())) {
             return false;
         }
-        if (isEncrypted() && !areTokensEncrypted(tokenResults, parameters.getEncryptedResults(),
-                                                 parameters.getMessage())) {
+        if (isEncrypted() && !areTokensEncrypted(tokenResults, parameters.getEncryptedResults())) {
             return false;
         }
 
@@ -510,8 +504,7 @@ public abstract class AbstractSupportingTokenPolicyValidator extends AbstractSec
      * Return true if a list of tokens were encrypted, false otherwise.
      */
     private boolean areTokensEncrypted(List<WSSecurityEngineResult> tokens,
-                                       List<WSSecurityEngineResult> encryptedResults,
-                                       Message message) {
+                                       List<WSSecurityEngineResult> encryptedResults) {
         if (enforceEncryptedTokens) {
             for (WSSecurityEngineResult wser : tokens) {
                 Element tokenElement = (Element)wser.get(WSSecurityEngineResult.TAG_TOKEN_ELEMENT);
@@ -726,7 +719,6 @@ public abstract class AbstractSupportingTokenPolicyValidator extends AbstractSec
      */
     private boolean validateSignedEncryptedElements(
         RequiredElements elements,
-        boolean content,
         List<WSSecurityEngineResult> protResults,
         List<WSSecurityEngineResult> tokenResults,
         Message message

--- a/rt/ws/security/src/main/java/org/apache/cxf/ws/security/wss4j/policyvalidators/AlgorithmSuitePolicyValidator.java
+++ b/rt/ws/security/src/main/java/org/apache/cxf/ws/security/wss4j/policyvalidators/AlgorithmSuitePolicyValidator.java
@@ -83,7 +83,7 @@ public class AlgorithmSuitePolicyValidator extends AbstractSecurityPolicyValidat
                 PolicyUtils.assertPolicy(parameters.getAssertionInfoMap(),
                                          new QName(algorithmSuite.getName().getNamespaceURI(),
                                                    algorithmSuite.getC14n().name()));
-            } else if (!valid && ai.isAsserted()) {
+            } else if (ai.isAsserted()) {
                 ai.setNotAsserted("Error in validating AlgorithmSuite policy");
             }
         }

--- a/rt/ws/security/src/main/java/org/apache/cxf/ws/security/wss4j/policyvalidators/AsymmetricBindingPolicyValidator.java
+++ b/rt/ws/security/src/main/java/org/apache/cxf/ws/security/wss4j/policyvalidators/AsymmetricBindingPolicyValidator.java
@@ -96,27 +96,27 @@ public class AsymmetricBindingPolicyValidator extends AbstractBindingPolicyValid
     ) {
         boolean result = true;
         if (binding.getInitiatorToken() != null) {
-            result &= checkInitiatorTokens(binding.getInitiatorToken(), binding, ai, aim, hasDerivedKeys,
+            result &= checkInitiatorTokens(binding.getInitiatorToken(), ai, aim, hasDerivedKeys,
                                         signedResults, encryptedResults);
         }
         if (binding.getInitiatorSignatureToken() != null) {
-            result &= checkInitiatorTokens(binding.getInitiatorSignatureToken(), binding, ai, aim,
+            result &= checkInitiatorTokens(binding.getInitiatorSignatureToken(), ai, aim,
                                         hasDerivedKeys, signedResults, encryptedResults);
         }
         if (binding.getInitiatorEncryptionToken() != null) {
-            result &= checkInitiatorTokens(binding.getInitiatorEncryptionToken(), binding, ai, aim,
+            result &= checkInitiatorTokens(binding.getInitiatorEncryptionToken(), ai, aim,
                                         hasDerivedKeys, signedResults, encryptedResults);
         }
         if (binding.getRecipientToken() != null) {
-            result &= checkRecipientTokens(binding.getRecipientToken(), binding, ai, aim, hasDerivedKeys,
+            result &= checkRecipientTokens(binding.getRecipientToken(), ai, aim, hasDerivedKeys,
                                         signedResults, encryptedResults);
         }
         if (binding.getRecipientSignatureToken() != null) {
-            result &= checkRecipientTokens(binding.getRecipientSignatureToken(), binding, ai, aim,
+            result &= checkRecipientTokens(binding.getRecipientSignatureToken(), ai, aim,
                                         hasDerivedKeys, signedResults, encryptedResults);
         }
         if (binding.getRecipientEncryptionToken() != null) {
-            result &= checkRecipientTokens(binding.getRecipientEncryptionToken(), binding, ai, aim,
+            result &= checkRecipientTokens(binding.getRecipientEncryptionToken(), ai, aim,
                                         hasDerivedKeys, signedResults, encryptedResults);
         }
 
@@ -125,7 +125,6 @@ public class AsymmetricBindingPolicyValidator extends AbstractBindingPolicyValid
 
     private boolean checkInitiatorTokens(
         AbstractTokenWrapper wrapper,
-        AsymmetricBinding binding,
         AssertionInfo ai,
         AssertionInfoMap aim,
         boolean hasDerivedKeys,
@@ -171,7 +170,6 @@ public class AsymmetricBindingPolicyValidator extends AbstractBindingPolicyValid
 
     private boolean checkRecipientTokens(
         AbstractTokenWrapper wrapper,
-        AsymmetricBinding binding,
         AssertionInfo ai,
         AssertionInfoMap aim,
         boolean hasDerivedKeys,

--- a/rt/ws/security/src/test/java/org/apache/cxf/ws/security/wss4j/StaxToDOMRoundTripTest.java
+++ b/rt/ws/security/src/test/java/org/apache/cxf/ws/security/wss4j/StaxToDOMRoundTripTest.java
@@ -391,10 +391,6 @@ public class StaxToDOMRoundTripTest extends AbstractSecurityTest {
             ConfigurationConstants.ENC_KEY_TRANSPORT,
             "http://www.w3.org/2001/04/xmlenc#rsa-1_5"
         );
-        outConfig.put(
-             ConfigurationConstants.ENC_SYM_ALGO,
-             "http://www.w3.org/2001/04/xmlenc#tripledes-cbc"
-        );
         outConfig.put(ConfigurationConstants.ENC_SYM_ALGO, XMLSecurityConstants.NS_XENC_AES128);
         outConfig.put(ConfigurationConstants.ENC_PROP_FILE, "outsecurity.properties");
         WSS4JStaxOutInterceptor ohandler = new WSS4JStaxOutInterceptor(outConfig);

--- a/rt/ws/security/src/test/java/org/apache/cxf/ws/security/wss4j/saml/StaxToDOMSamlTest.java
+++ b/rt/ws/security/src/test/java/org/apache/cxf/ws/security/wss4j/saml/StaxToDOMSamlTest.java
@@ -471,7 +471,6 @@ public class StaxToDOMSamlTest extends AbstractSecurityTest {
         outConfig.put(ConfigurationConstants.SIGNATURE_USER, "alice");
         outConfig.put(ConfigurationConstants.SIG_PROP_FILE, "alice.properties");
         outConfig.put(ConfigurationConstants.SIG_KEY_ID, "DirectReference");
-        outConfig.put(ConfigurationConstants.PW_CALLBACK_REF, new PasswordCallbackHandler());
         WSS4JStaxOutInterceptor ohandler = new WSS4JStaxOutInterceptor(outConfig);
 
         client.getOutInterceptors().add(ohandler);
@@ -592,7 +591,6 @@ public class StaxToDOMSamlTest extends AbstractSecurityTest {
         outConfig.put(ConfigurationConstants.SIGNATURE_USER, "alice");
         outConfig.put(ConfigurationConstants.SIG_PROP_FILE, "alice.properties");
         outConfig.put(ConfigurationConstants.SIG_KEY_ID, "DirectReference");
-        outConfig.put(ConfigurationConstants.PW_CALLBACK_REF, new PasswordCallbackHandler());
         WSS4JStaxOutInterceptor ohandler = new WSS4JStaxOutInterceptor(outConfig);
 
         client.getOutInterceptors().add(ohandler);


### PR DESCRIPTION
https://www.viva64.com/en/m/0044/

The rest of report:
```
Low: V6008 [CWE-690] Potential null dereference of 'ai'. [cxf\rt\ws\security\src\main\java\org\apache\cxf\ws\security\wss4j\policyhandlers\AbstractBindingBuilder.java:374]
Low: V6008 [CWE-690] Potential null dereference of 'tok'. [cxf\rt\ws\security\src\main\java\org\apache\cxf\ws\security\policy\interceptors\SecureConversationInInterceptor.java:536]
Low: V6008 [CWE-690] Potential null dereference of 'origBinding'. [cxf\rt\ws\security\src\main\java\org\apache\cxf\ws\security\policy\interceptors\SecureConversationInInterceptor.java:196]
Medium: V6008 [CWE-690] Potential null dereference of 'secToken'. [cxf\rt\ws\security\src\main\java\org\apache\cxf\ws\security\wss4j\policyhandlers\AbstractStaxBindingHandler.java:219, cxf\rt\ws\security\src\main\java\org\apache\cxf\ws\security\wss4j\policyhandlers\AbstractStaxBindingHandler.java:213]
Medium: V6008 [CWE-690] Potential null dereference of 'secToken'. [cxf\rt\ws\security\src\main\java\org\apache\cxf\ws\security\wss4j\policyhandlers\AbstractBindingBuilder.java:483, cxf\rt\ws\security\src\main\java\org\apache\cxf\ws\security\wss4j\policyhandlers\AbstractBindingBuilder.java:480]
Low: V6008 [CWE-690] Potential null dereference of '(WSSecDKEncrypt) encr)'. [cxf\rt\ws\security\src\main\java\org\apache\cxf\ws\security\wss4j\policyhandlers\SymmetricBindingHandler.java:255]
Low: V6008 [CWE-690] Potential null dereference of 'utPrincipal'. [cxf\rt\ws\security\src\main\java\org\apache\cxf\ws\security\wss4j\UsernameTokenInterceptor.java:133]
High: V6060 [CWE-476] The 'key' reference was utilized before it was verified against null. [cxf\rt\ws\security\src\main\java\org\apache\cxf\ws\security\trust\STSTokenRetriever.java:90, cxf\rt\ws\security\src\main\java\org\apache\cxf\ws\security\trust\STSTokenRetriever.java:60]
Medium: V6032 It is odd that the body of method 'checkAsymmetricBinding' is fully equivalent to the body of another method 'checkTransportBinding'. [cxf\rt\ws\security\src\main\java\org\apache\cxf\ws\security\wss4j\PolicyBasedWSS4JStaxOutInterceptor.java:61, cxf\rt\ws\security\src\main\java\org\apache\cxf\ws\security\wss4j\PolicyBasedWSS4JStaxOutInterceptor.java:92]
High: V6007 [CWE-571] Expression '!foundSCT' is always true. [cxf\rt\ws\security\src\main\java\org\apache\cxf\ws\security\policy\interceptors\SecureConversationInInterceptor.java:471]
Medium: V6022 Parameter 'type' is not used inside method body. [cxf\rt\ws\security\src\main\java\org\apache\cxf\ws\security\kerberos\KerberosUtils.java:39]
High: V6037 [CWE-670] An unconditional 'return' within a loop. [cxf\rt\ws\security\src\main\java\org\apache\cxf\ws\security\wss4j\policyhandlers\SymmetricBindingHandler.java:1018]
Medium: V6008 [CWE-690] Potential null dereference of 'princ'. [cxf\rt\ws\security\src\main\java\org\apache\cxf\ws\security\wss4j\UsernameTokenInterceptor.java:354, cxf\rt\ws\security\src\main\java\org\apache\cxf\ws\security\wss4j\UsernameTokenInterceptor.java:340]
```
