### PR TITLE
CXF-8009: CXF should not rely on ClassUtils for CGLIB proxy checks

### DIFF
--- a/core/src/main/java/org/apache/cxf/common/util/ClassUnwrapper.java
+++ b/core/src/main/java/org/apache/cxf/common/util/ClassUnwrapper.java
@@ -18,8 +18,29 @@
  */
 package org.apache.cxf.common.util;
 
-public interface ClassUnwrapper {
+import java.lang.reflect.Proxy;
 
+public interface ClassUnwrapper {
+    /**
+     * Return a real class for the instance, possibly a proxy.
+     * @param o instance to get real class for
+     * @return real class for the instance
+     */
     Class<?> getRealClass(Object o);
 
+    /**
+     * Return a real class for the class, possibly a proxy class.
+     * @param clazz class to get real class for
+     * @return real class for the class
+     */
+    Class<?> getRealClassFromClass(Class<?> clazz);
+    
+    /**
+     * Return a real class for the instance, possibly a proxy.
+     * @param o instance to get real class for
+     * @return real class for the instance
+     */
+    default Object getRealObject(Object o) {
+        return (o instanceof Proxy) ? Proxy.getInvocationHandler(o) : o;
+    }
 }

--- a/integration/cdi/src/main/java/org/apache/cxf/cdi/CdiClassUnwrapper.java
+++ b/integration/cdi/src/main/java/org/apache/cxf/cdi/CdiClassUnwrapper.java
@@ -42,6 +42,11 @@ class CdiClassUnwrapper implements ClassUnwrapper {
     @Override
     public Class<?> getRealClass(Object o) {
         Class<?> clazz = o.getClass();
+        return getRealClassFromClass(clazz);
+    }
+    
+    @Override
+    public Class<?> getRealClassFromClass(Class<?> clazz) {
         if (PROXY_PATTERN.matcher(clazz.getSimpleName()).matches()) {
             return clazz.getSuperclass();
         }


### PR DESCRIPTION
This is a tricky one. So the `ClassUtils.isCglibProxyClass`, which is used by `SpringAopClassHelper`, does check if the class name has `$$` to disambiguate CGLIB proxies from regular classes. The typical examples of CGLIB proxy class names are:
```
SpringProxy$$EnhancerBySpringCGLIB$$d8e73a30
Function$$EnhancerByCGLIB$$53576dae
```
However, the classes generated for lambda expressions do contain `$$` as well, tricking `SpringAopClassHelper` to believe it is a CGLIB proxy, here is an example:
```
org.apache.cxf.common.util.ClassHelperTest$$Lambda$10/846254484@32b260fa
```
It turned out to be difficult to come up with efficient and bullet-proof check (based on class name only) to determine if it is CGLIB generated proxy or not. The cheapest but not 100% reliable way seems to be to check the presence of the `CGLIB` in the class name (this PR).

Alternatively, using the reflection it is possible to achieve more reliable outcomes by inspecting the class, looking for CGLIB generated methods / fields (`CGLIB$BIND_CALLBACKS`). I am not sure it is worth it actually.

@dkulp @coheigea what do you think, guys?


