### PR TITLE
add more generic interface which allows to use a sharedKey/Key

### DIFF
--- a/rt/rs/security/http-signature/src/main/java/org/apache/cxf/rs/security/httpsignature/TomitribeSignatureValidator.java
+++ b/rt/rs/security/http-signature/src/main/java/org/apache/cxf/rs/security/httpsignature/TomitribeSignatureValidator.java
@@ -30,7 +30,7 @@ import org.apache.cxf.rs.security.httpsignature.exception.InvalidDataToVerifySig
 import org.apache.cxf.rs.security.httpsignature.exception.InvalidSignatureException;
 import org.apache.cxf.rs.security.httpsignature.exception.InvalidSignatureHeaderException;
 import org.apache.cxf.rs.security.httpsignature.provider.AlgorithmProvider;
-import org.apache.cxf.rs.security.httpsignature.provider.PublicKeyProvider;
+import org.apache.cxf.rs.security.httpsignature.provider.KeyProvider;
 import org.apache.cxf.rs.security.httpsignature.provider.SecurityProvider;
 import org.apache.cxf.rs.security.httpsignature.utils.SignatureHeaderUtils;
 import org.tomitribe.auth.signatures.Signature;
@@ -47,7 +47,7 @@ public class TomitribeSignatureValidator implements SignatureValidator {
     @Override
     public void validate(Map<String, List<String>> messageHeaders,
                          AlgorithmProvider algorithmProvider,
-                         PublicKeyProvider publicKeyProvider,
+                         KeyProvider keyProvider,
                          SecurityProvider securityProvider,
                          String method,
                          String uri) {
@@ -60,7 +60,7 @@ public class TomitribeSignatureValidator implements SignatureValidator {
             throw new DifferentAlgorithmsException("signature algorithm from header and provided are different");
         }
 
-        Key key = publicKeyProvider.getKey(signature.getKeyId());
+        Key key = keyProvider.getKey(signature.getKeyId());
 
         java.security.Provider provider = securityProvider.getProvider(signature.getKeyId());
 

--- a/rt/rs/security/http-signature/src/main/java/org/apache/cxf/rs/security/httpsignature/provider/KeyProvider.java
+++ b/rt/rs/security/http-signature/src/main/java/org/apache/cxf/rs/security/httpsignature/provider/KeyProvider.java
@@ -16,21 +16,17 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.cxf.rs.security.httpsignature;
+package org.apache.cxf.rs.security.httpsignature.provider;
 
-import java.util.List;
-import java.util.Map;
+import java.security.Key;
 
-import org.apache.cxf.rs.security.httpsignature.provider.AlgorithmProvider;
-import org.apache.cxf.rs.security.httpsignature.provider.KeyProvider;
-import org.apache.cxf.rs.security.httpsignature.provider.SecurityProvider;
+@FunctionalInterface
+public interface KeyProvider {
 
-public interface SignatureValidator {
-    void validate(Map<String, List<String>> messageHeaders,
-                  AlgorithmProvider algorithmProvider,
-                  KeyProvider keyProvider,
-                  SecurityProvider securityProvider,
-                  String method,
-                  String uri);
-
+    /**
+     * Resolve a Key based on the keyId
+     * @param keyId in question, not null or empty.
+     * @return a Key, never null.
+     */
+    Key getKey(String keyId);
 }

--- a/rt/rs/security/http-signature/src/main/java/org/apache/cxf/rs/security/httpsignature/provider/PrivateKeyProvider.java
+++ b/rt/rs/security/http-signature/src/main/java/org/apache/cxf/rs/security/httpsignature/provider/PrivateKeyProvider.java
@@ -21,7 +21,7 @@ package org.apache.cxf.rs.security.httpsignature.provider;
 import java.security.PrivateKey;
 
 @FunctionalInterface
-public interface PrivateKeyProvider {
+public interface PrivateKeyProvider extends KeyProvider {
     /**
      * @param keyId is used as lookup to find the correct configured private key for this keyId
      *              The keyId is sent in the message together with the signature

--- a/rt/rs/security/http-signature/src/main/java/org/apache/cxf/rs/security/httpsignature/provider/PublicKeyProvider.java
+++ b/rt/rs/security/http-signature/src/main/java/org/apache/cxf/rs/security/httpsignature/provider/PublicKeyProvider.java
@@ -21,7 +21,7 @@ package org.apache.cxf.rs.security.httpsignature.provider;
 import java.security.PublicKey;
 
 @FunctionalInterface
-public interface PublicKeyProvider {
+public interface PublicKeyProvider extends KeyProvider {
     /**
      * @param keyId is used as lookup to find the correct configured public key for this keyId
      *              The keyId is sent in the message together with the signature


### PR DESCRIPTION
We're looking into a scheme where the keys involved can be HMAC keys which are not asymmetrical - hence use simply an interface which resolves and uses Key instead of PublicKey.

Signed-off-by: David J. M. Karlsen <david@davidkarlsen.com>
@coheigea 