### PR TITLE
CXF-8022: Thread hangs using Reactor Flux when Exception is Thrown

### DIFF
--- a/rt/rs/extensions/reactor/src/main/java/org/apache/cxf/jaxrs/reactor/client/ReactorInvokerImpl.java
+++ b/rt/rs/extensions/reactor/src/main/java/org/apache/cxf/jaxrs/reactor/client/ReactorInvokerImpl.java
@@ -25,6 +25,7 @@ import java.util.concurrent.CompletionException;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
+import java.util.stream.StreamSupport;
 
 import javax.ws.rs.HttpMethod;
 import javax.ws.rs.client.Entity;
@@ -201,13 +202,15 @@ public class ReactorInvokerImpl implements ReactorInvoker {
     @Override
     public <T> Flux<T> flux(String name, Entity<?> entity, Class<T> responseType) {
         Future<Response> futureResponse = webClient.async().method(name, entity);
-        return Flux.fromIterable(toIterable(futureResponse, responseType));
+        return Flux.fromStream(() -> 
+            StreamSupport.stream(toIterable(futureResponse, responseType).spliterator(), false));
     }
 
     @Override
     public <T> Flux<T> flux(String name, Class<T> responseType) {
         Future<Response> futureResponse = webClient.async().method(name);
-        return Flux.fromIterable(toIterable(futureResponse, responseType));
+        return Flux.fromStream(() -> 
+            StreamSupport.stream(toIterable(futureResponse, responseType).spliterator(), false));
     }
 
     @Override

--- a/systests/jaxrs/pom.xml
+++ b/systests/jaxrs/pom.xml
@@ -531,6 +531,12 @@
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.projectreactor</groupId>
+            <artifactId>reactor-test</artifactId>
+            <version>${cxf.reactor.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/systests/jaxrs/src/test/java/org/apache/cxf/systest/jaxrs/reactor/FluxReactorTest.java
+++ b/systests/jaxrs/src/test/java/org/apache/cxf/systest/jaxrs/reactor/FluxReactorTest.java
@@ -32,6 +32,7 @@ import org.apache.cxf.jaxrs.model.AbstractResourceInfo;
 import org.apache.cxf.jaxrs.reactor.client.ReactorInvoker;
 import org.apache.cxf.jaxrs.reactor.client.ReactorInvokerProvider;
 import org.apache.cxf.testutil.common.AbstractBusClientServerTestBase;
+import reactor.test.StepVerifier;
 
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -78,6 +79,113 @@ public class FluxReactorTest extends AbstractBusClientServerTestBase {
         String address = "http://localhost:" + PORT + "/reactor2/flux/textJsonImplicitListAsyncStream2";
         doTestTextJsonImplicitListAsyncStream(address);
     }
+    
+    @Test
+    public void testFluxEmpty() throws Exception {
+        String address = "http://localhost:" + PORT + "/reactor2/flux/empty";
+        
+        StepVerifier
+            .create(ClientBuilder
+                .newClient()
+                .register(new JacksonJsonProvider())
+                .register(new ReactorInvokerProvider())
+                .target(address)
+                .request(MediaType.APPLICATION_JSON)
+                .rx(ReactorInvoker.class)
+                .getFlux(HelloWorldBean.class))
+            .expectComplete()
+            .verify();
+    }
+    
+    @Test
+    public void testFluxErrors() throws Exception {
+        String address = "http://localhost:" + PORT + "/reactor2/flux/errors";
+        
+        StepVerifier
+            .create(ClientBuilder
+                .newClient()
+                .register(new JacksonJsonProvider())
+                .register(new ReactorInvokerProvider())
+                .target(address)
+                .request(MediaType.APPLICATION_JSON)
+                .rx(ReactorInvoker.class)
+                .getFlux(HelloWorldBean.class))
+            .expectNextMatches(b -> b.getGreeting().equalsIgnoreCase("Person 1"))
+            .expectComplete()
+            .verify();
+    }
+    
+    @Test
+    public void testFluxErrorsResponse() throws Exception {
+        String address = "http://localhost:" + PORT + "/reactor2/flux/errors";
+        
+        StepVerifier
+            .create(ClientBuilder
+                .newClient()
+                .register(new JacksonJsonProvider())
+                .register(new ReactorInvokerProvider())
+                .target(address)
+                .request(MediaType.APPLICATION_JSON)
+                .rx(ReactorInvoker.class)
+                .get())
+            .expectNextMatches(r -> r.getStatus() == 500)
+            .expectComplete()
+            .verify();
+    }
+    
+    @Test
+    public void testFluxErrorsResponseWithMapper() throws Exception {
+        String address = "http://localhost:" + PORT + "/reactor2/flux/mapper/errors";
+        
+        StepVerifier
+            .create(ClientBuilder
+                .newClient()
+                .register(new JacksonJsonProvider())
+                .register(new ReactorInvokerProvider())
+                .target(address)
+                .request(MediaType.APPLICATION_JSON)
+                .rx(ReactorInvoker.class)
+                .get())
+            .expectNextMatches(r -> r.getStatus() == 400)
+            .expectComplete()
+            .verify();
+    }
+    
+    @Test
+    public void testFluxImmediateErrors() throws Exception {
+        String address = "http://localhost:" + PORT + "/reactor2/flux/immediate/errors";
+        
+        StepVerifier
+            .create(ClientBuilder
+                .newClient()
+                .register(new JacksonJsonProvider())
+                .register(new ReactorInvokerProvider())
+                .target(address)
+                .request(MediaType.APPLICATION_JSON)
+                .rx(ReactorInvoker.class)
+                .getFlux(HelloWorldBean.class))
+            .expectError()
+            .verify();
+    }
+
+    @Test
+    public void testFluxImmediateErrorsResponse() throws Exception {
+        String address = "http://localhost:" + PORT + "/reactor2/flux/immediate/errors";
+        
+        StepVerifier
+            .create(ClientBuilder
+                .newClient()
+                .register(new JacksonJsonProvider())
+                .register(new ReactorInvokerProvider())
+                .target(address)
+                .request(MediaType.APPLICATION_JSON)
+                .rx(ReactorInvoker.class)
+                .get())
+            .expectNextMatches(r -> r.getStatus() == 500)
+            .expectComplete()
+            .verify();
+    }
+
     private void doTestTextJsonImplicitListAsyncStream(String address) throws Exception {
         final BlockingQueue<HelloWorldBean> holder = new LinkedBlockingQueue<>();
         ClientBuilder.newClient()

--- a/systests/jaxrs/src/test/java/org/apache/cxf/systest/jaxrs/reactor/FluxService.java
+++ b/systests/jaxrs/src/test/java/org/apache/cxf/systest/jaxrs/reactor/FluxService.java
@@ -24,9 +24,11 @@ import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.container.AsyncResponse;
 import javax.ws.rs.container.Suspended;
+import javax.ws.rs.core.MediaType;
 
 import org.apache.cxf.jaxrs.reactivestreams.server.JsonStreamingAsyncSubscriber;
 import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
 import reactor.core.scheduler.Schedulers;
 
 @Path("/flux")
@@ -56,5 +58,51 @@ public class FluxService {
         return Flux.just("Hello", "Ciao")
                 .map(HelloWorldBean::new)
                 .subscribeOn(Schedulers.parallel());
+    }
+
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    @Path("errors")
+    public Flux<HelloWorldBean> errors() { 
+        return Flux 
+            .range(1, 2) 
+            .flatMap(item -> { 
+                if (item < 2) { 
+                    return Mono.just(new HelloWorldBean("Person " + item)); 
+                } else { 
+                    return Mono.error(new RuntimeException("Oops")); 
+                } 
+            }); 
+    }
+    
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    @Path("/mapper/errors")
+    public Flux<HelloWorldBean> mapperErrors() { 
+        return Flux 
+            .range(1, 3) 
+            .flatMap(item -> { 
+                if (item < 3) { 
+                    return Mono.just(new HelloWorldBean("Person " + item)); 
+                } else { 
+                    return Mono.error(new IllegalArgumentException("Oops")); 
+                } 
+            }); 
+    }
+    
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    @Path("/immediate/errors")
+    public Flux<HelloWorldBean> immediateErrors() { 
+        return Flux 
+            .range(1, 2) 
+            .flatMap(item -> Mono.error(new RuntimeException("Oops"))); 
+    }
+    
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    @Path("/empty")
+    public Flux<HelloWorldBean> empty() { 
+        return Flux.empty(); 
     }
 }

--- a/systests/jaxrs/src/test/java/org/apache/cxf/systest/jaxrs/reactor/IllegalArgumentExceptionMapper.java
+++ b/systests/jaxrs/src/test/java/org/apache/cxf/systest/jaxrs/reactor/IllegalArgumentExceptionMapper.java
@@ -1,0 +1,32 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.cxf.systest.jaxrs.reactor;
+
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+import javax.ws.rs.ext.Provider;
+
+@Provider
+public class IllegalArgumentExceptionMapper implements ExceptionMapper<IllegalArgumentException> {
+    @Override
+    public Response toResponse(IllegalArgumentException exception) {
+        return Response.status(400).build();
+    }
+}

--- a/systests/jaxrs/src/test/java/org/apache/cxf/systest/jaxrs/reactor/ReactorServer.java
+++ b/systests/jaxrs/src/test/java/org/apache/cxf/systest/jaxrs/reactor/ReactorServer.java
@@ -55,6 +55,7 @@ public class ReactorServer extends AbstractBusTestServerBase {
         
         JAXRSServerFactoryBean sf2 = new JAXRSServerFactoryBean();
         sf2.setProvider(new JacksonJsonProvider());
+        sf2.setProvider(new IllegalArgumentExceptionMapper());
         new ReactorCustomizer().customize(sf2);
         sf2.getOutInterceptors().add(new LoggingOutInterceptor());
         sf2.setResourceClasses(FluxService.class);


### PR DESCRIPTION
Indeed, there is an issue in case of error, opening the PR to get some feedback while working on the test cases. According to Reactive Streams spec (https://github.com/reactive-streams/reactive-streams-jvm), the `onError` is the terminal state:

> For a Publisher: When onComplete or onError has been signalled. For a Subscriber: When an onComplete   or onError has been received.

However, `StreamingAsyncSubscriber` does not treat it as that.

@coheigea @rmannibucau @davidkarlsen if you guys can validate my assumptions here, thanks.