### PR TITLE
If there is no inMessage use the inFaultMessage

### DIFF
--- a/rt/frontend/jaxrs/src/main/java/org/apache/cxf/jaxrs/impl/ReaderInterceptorMBR.java
+++ b/rt/frontend/jaxrs/src/main/java/org/apache/cxf/jaxrs/impl/ReaderInterceptorMBR.java
@@ -18,9 +18,11 @@
  */
 package org.apache.cxf.jaxrs.impl;
 
-import org.apache.cxf.jaxrs.provider.ProviderFactory;
-import org.apache.cxf.jaxrs.utils.JAXRSUtils;
-import org.apache.cxf.message.Message;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.Reader;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
 
 import javax.ws.rs.ProcessingException;
 import javax.ws.rs.WebApplicationException;
@@ -29,11 +31,10 @@ import javax.ws.rs.ext.MessageBodyReader;
 import javax.ws.rs.ext.ReaderInterceptor;
 import javax.ws.rs.ext.ReaderInterceptorContext;
 import javax.xml.stream.XMLStreamReader;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.Reader;
-import java.lang.annotation.Annotation;
-import java.lang.reflect.Type;
+
+import org.apache.cxf.jaxrs.provider.ProviderFactory;
+import org.apache.cxf.jaxrs.utils.JAXRSUtils;
+import org.apache.cxf.message.Message;
 
 public class ReaderInterceptorMBR implements ReaderInterceptor {
 

--- a/rt/frontend/jaxrs/src/main/java/org/apache/cxf/jaxrs/impl/ReaderInterceptorMBR.java
+++ b/rt/frontend/jaxrs/src/main/java/org/apache/cxf/jaxrs/impl/ReaderInterceptorMBR.java
@@ -18,11 +18,9 @@
  */
 package org.apache.cxf.jaxrs.impl;
 
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.Reader;
-import java.lang.annotation.Annotation;
-import java.lang.reflect.Type;
+import org.apache.cxf.jaxrs.provider.ProviderFactory;
+import org.apache.cxf.jaxrs.utils.JAXRSUtils;
+import org.apache.cxf.message.Message;
 
 import javax.ws.rs.ProcessingException;
 import javax.ws.rs.WebApplicationException;
@@ -31,10 +29,11 @@ import javax.ws.rs.ext.MessageBodyReader;
 import javax.ws.rs.ext.ReaderInterceptor;
 import javax.ws.rs.ext.ReaderInterceptorContext;
 import javax.xml.stream.XMLStreamReader;
-
-import org.apache.cxf.jaxrs.provider.ProviderFactory;
-import org.apache.cxf.jaxrs.utils.JAXRSUtils;
-import org.apache.cxf.message.Message;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.Reader;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
 
 public class ReaderInterceptorMBR implements ReaderInterceptor {
 
@@ -43,6 +42,10 @@ public class ReaderInterceptorMBR implements ReaderInterceptor {
 
     public ReaderInterceptorMBR(MessageBodyReader<?> reader,
                                 Message m) {
+        if (null == m) {
+            throw new IllegalArgumentException("Message not allowed to be null");
+        }
+
         this.reader = reader;
         this.m = m;
     }

--- a/rt/frontend/jaxrs/src/main/java/org/apache/cxf/jaxrs/provider/ProviderFactory.java
+++ b/rt/frontend/jaxrs/src/main/java/org/apache/cxf/jaxrs/provider/ProviderFactory.java
@@ -370,7 +370,7 @@ public abstract class ProviderFactory {
                                                       m);
         int size = readerInterceptors.size();
         if (mr != null || size > 0) {
-            ReaderInterceptor mbrReader = new ReaderInterceptorMBR(mr, m.getExchange().getInMessage());
+            ReaderInterceptor mbrReader = new ReaderInterceptorMBR(mr, getResponseMessage(m));
 
             List<ReaderInterceptor> interceptors = null;
             if (size > 0) {
@@ -389,6 +389,15 @@ public abstract class ProviderFactory {
             return interceptors;
         }
         return null;
+    }
+
+    private Message getResponseMessage(Message message) {
+        Message responseMessage = message.getExchange().getInMessage();
+        if (responseMessage == null) {
+            responseMessage = message.getExchange().getInFaultMessage();
+        }
+
+        return responseMessage;
     }
 
     public <T> List<WriterInterceptor> createMessageBodyWriterInterceptor(Class<T> bodyType,

--- a/rt/frontend/jaxrs/src/test/java/org/apache/cxf/jaxrs/impl/ReaderInterceptorMBRTest.java
+++ b/rt/frontend/jaxrs/src/test/java/org/apache/cxf/jaxrs/impl/ReaderInterceptorMBRTest.java
@@ -1,3 +1,21 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.apache.cxf.jaxrs.impl;
 
 import org.junit.Test;

--- a/rt/frontend/jaxrs/src/test/java/org/apache/cxf/jaxrs/impl/ReaderInterceptorMBRTest.java
+++ b/rt/frontend/jaxrs/src/test/java/org/apache/cxf/jaxrs/impl/ReaderInterceptorMBRTest.java
@@ -1,0 +1,11 @@
+package org.apache.cxf.jaxrs.impl;
+
+import org.junit.Test;
+
+public class ReaderInterceptorMBRTest {
+    @Test(expected = IllegalArgumentException.class)
+    public void testReaderInterceptorMBRWithNullMessage() {
+        new ReaderInterceptorMBR(null, null);
+    }
+
+}

--- a/rt/frontend/jaxrs/src/test/java/org/apache/cxf/jaxrs/provider/ProviderFactoryTest.java
+++ b/rt/frontend/jaxrs/src/test/java/org/apache/cxf/jaxrs/provider/ProviderFactoryTest.java
@@ -19,28 +19,20 @@
 
 package org.apache.cxf.jaxrs.provider;
 
-import org.apache.cxf.Bus;
-import org.apache.cxf.BusFactory;
-import org.apache.cxf.endpoint.Endpoint;
-import org.apache.cxf.helpers.IOUtils;
-import org.apache.cxf.jaxrs.Customer;
-import org.apache.cxf.jaxrs.CustomerParameterHandler;
-import org.apache.cxf.jaxrs.JAXBContextProvider;
-import org.apache.cxf.jaxrs.JAXBContextProvider2;
-import org.apache.cxf.jaxrs.impl.MetadataMap;
-import org.apache.cxf.jaxrs.impl.WebApplicationExceptionMapper;
-import org.apache.cxf.jaxrs.model.AbstractResourceInfo;
-import org.apache.cxf.jaxrs.model.ProviderInfo;
-import org.apache.cxf.jaxrs.resources.Book;
-import org.apache.cxf.jaxrs.resources.SuperBook;
-import org.apache.cxf.message.Exchange;
-import org.apache.cxf.message.ExchangeImpl;
-import org.apache.cxf.message.Message;
-import org.apache.cxf.message.MessageImpl;
-import org.easymock.EasyMock;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
 
 import javax.activation.DataHandler;
 import javax.activation.DataSource;
@@ -66,20 +58,31 @@ import javax.ws.rs.ext.WriterInterceptorContext;
 import javax.xml.bind.JAXBContext;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.validation.Schema;
-import java.io.File;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
-import java.lang.annotation.Annotation;
-import java.lang.reflect.Type;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
+
+import org.apache.cxf.Bus;
+import org.apache.cxf.BusFactory;
+import org.apache.cxf.endpoint.Endpoint;
+import org.apache.cxf.helpers.IOUtils;
+import org.apache.cxf.jaxrs.Customer;
+import org.apache.cxf.jaxrs.CustomerParameterHandler;
+import org.apache.cxf.jaxrs.JAXBContextProvider;
+import org.apache.cxf.jaxrs.JAXBContextProvider2;
+import org.apache.cxf.jaxrs.impl.MetadataMap;
+import org.apache.cxf.jaxrs.impl.WebApplicationExceptionMapper;
+import org.apache.cxf.jaxrs.model.AbstractResourceInfo;
+import org.apache.cxf.jaxrs.model.ProviderInfo;
+import org.apache.cxf.jaxrs.resources.Book;
+import org.apache.cxf.jaxrs.resources.SuperBook;
+import org.apache.cxf.message.Exchange;
+import org.apache.cxf.message.ExchangeImpl;
+import org.apache.cxf.message.Message;
+import org.apache.cxf.message.MessageImpl;
+
+import org.easymock.EasyMock;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
 
 public class ProviderFactoryTest extends Assert {
 
@@ -1464,7 +1467,8 @@ public class ProviderFactoryTest extends Assert {
         ServerProviderFactory spf = ServerProviderFactory.getInstance();
         final Message message = prepareMessage(MediaType.APPLICATION_XML, MediaType.APPLICATION_XML);
 
-        List<ReaderInterceptor> interceptors = spf.createMessageBodyReaderInterceptor(Book.class, Book.class, new Annotation[0],MediaType.APPLICATION_XML_TYPE,
+        List<ReaderInterceptor> interceptors = spf.createMessageBodyReaderInterceptor(Book.class, Book.class,
+                new Annotation[0], MediaType.APPLICATION_XML_TYPE,
                 message, true, null);
         assertSame(1, interceptors.size());
     }
@@ -1474,7 +1478,8 @@ public class ProviderFactoryTest extends Assert {
         ServerProviderFactory spf = ServerProviderFactory.getInstance();
         final Message message = prepareFaultMessage(MediaType.APPLICATION_XML, MediaType.APPLICATION_XML);
 
-        List<ReaderInterceptor> interceptors = spf.createMessageBodyReaderInterceptor(Book.class, Book.class, new Annotation[0],MediaType.APPLICATION_XML_TYPE,
+        List<ReaderInterceptor> interceptors = spf.createMessageBodyReaderInterceptor(Book.class, Book.class,
+                new Annotation[0], MediaType.APPLICATION_XML_TYPE,
                 message, true, null);
         assertSame(1, interceptors.size());
     }
@@ -1489,7 +1494,8 @@ public class ProviderFactoryTest extends Assert {
 
         final Message message = prepareMessage(MediaType.APPLICATION_XML, MediaType.APPLICATION_XML);
 
-        List<ReaderInterceptor> interceptors = spf.createMessageBodyReaderInterceptor(Book.class, Book.class, new Annotation[0],MediaType.APPLICATION_XML_TYPE,
+        List<ReaderInterceptor> interceptors = spf.createMessageBodyReaderInterceptor(Book.class, Book.class,
+                new Annotation[0], MediaType.APPLICATION_XML_TYPE,
                 message, true, null);
         assertSame(2, interceptors.size());
     }
@@ -1503,7 +1509,8 @@ public class ProviderFactoryTest extends Assert {
         spf.readerInterceptors.put(new ProviderFactory.NameKey("org.apache.cxf.filter.binding", 1, ri.getClass()), pi);
 
         final Message message = prepareFaultMessage(MediaType.APPLICATION_XML, MediaType.APPLICATION_XML);
-        List<ReaderInterceptor> interceptors = spf.createMessageBodyReaderInterceptor(Book.class, Book.class, new Annotation[0],MediaType.APPLICATION_XML_TYPE,
+        List<ReaderInterceptor> interceptors = spf.createMessageBodyReaderInterceptor(Book.class, Book.class,
+                new Annotation[0], MediaType.APPLICATION_XML_TYPE,
                 message, true, null);
         assertSame(2, interceptors.size());
     }

--- a/systests/jaxrs/src/test/java/org/apache/cxf/systest/jaxrs/JAXRSClientServerBookTest.java
+++ b/systests/jaxrs/src/test/java/org/apache/cxf/systest/jaxrs/JAXRSClientServerBookTest.java
@@ -19,6 +19,7 @@
 
 package org.apache.cxf.systest.jaxrs;
 
+import java.io.BufferedInputStream;
 import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.IOException;
@@ -50,6 +51,7 @@ import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ReaderInterceptor;
 import javax.xml.bind.JAXBElement;
 import javax.xml.namespace.QName;
 
@@ -2737,6 +2739,36 @@ public class JAXRSClientServerBookTest extends AbstractBusClientServerTestBase {
         assertEquals("text", r3values.get(2));
         assertEquals("blah", r3values.get(3));
 
+    }
+
+    @Test
+    public void testGetBookWithReaderInterceptor() throws Exception {
+        BookStore client = JAXRSClientFactory
+                .create("http://localhost:" + PORT, BookStore.class, Collections.singletonList(getReaderInterceptor()));
+        Book book = client.getBook(0);
+        assertEquals(123, book.getId());
+    }
+
+    @Test
+    public void testGetBookWithServerWebApplicationExceptionAndReaderInterceptor() throws Exception {
+        BookStore client = JAXRSClientFactory
+                .create("http://localhost:" + PORT, BookStore.class, Collections.singletonList(getReaderInterceptor()));
+        try {
+            client.throwException();
+            fail("Exception expected");
+        } catch (ServerErrorException ex) {
+            assertEquals(500, ex.getResponse().getStatus());
+            assertEquals("This is a WebApplicationException", ex.getResponse().readEntity(String.class));
+        }
+    }
+
+
+    private ReaderInterceptor getReaderInterceptor() {
+        return readerInterceptorContext -> {
+            InputStream is = new BufferedInputStream(readerInterceptorContext.getInputStream());
+            readerInterceptorContext.setInputStream(is);
+            return readerInterceptorContext.proceed();
+        };
     }
 
 


### PR DESCRIPTION
I observed that when reading an entity from a response of a failed rest call the CXF throws a NullPointer exception.

I tracked this down to specific case where a JAXRS ReaderInterceptor is present on the chain and the response fails. When parsing the response this condition triggers a different path in JAXRSUtils.readFromMessageBodyReader which eventually results in a call to ProviderFactory.createMessageBodyReaderInterceptor which will throw a NullPointerException when there is no inMessage.

This fix tries to load  an inFaultMessage if there is no inMessage available which prevents the NPE and allows the code to execute successfully.

To reproduce create a JAX-RS Proxy client with a ReaderInterceptor. Then trigger a request that returns a 403 status code and try to 'readEntity' on the resulting ForbiddenException response.