### PR TITLE
Set jaxb-xjc back to scope test

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -178,6 +178,7 @@
         <dependency>
             <groupId>org.glassfish.jaxb</groupId>
             <artifactId>jaxb-xjc</artifactId>
+	    <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.osgi</groupId>


### PR DESCRIPTION
Was switched in commit 5544a990e1272bf72fbbb7bb5104409d020328e3

https://github.com/apache/cxf/commit/5544a990e1272bf72fbbb7bb5104409d020328e3#diff-357e4854869b2e21c38b1b437f11095a

This was likely by mistake.  The result is the `maven-war-plugin` and `maven-assembly-plugin` is pulling `jaxb-xjc` and all dependencies such as `ant` into war files, etc.

