### PR TITLE
[CXF-8053] portable feature to avoid jaxws for jaxrs apps

### DIFF
--- a/core/src/main/java/org/apache/cxf/databinding/stax/StaxDataBindingFeature.java
+++ b/core/src/main/java/org/apache/cxf/databinding/stax/StaxDataBindingFeature.java
@@ -25,31 +25,44 @@ import org.apache.cxf.Bus;
 import org.apache.cxf.endpoint.Client;
 import org.apache.cxf.endpoint.Server;
 import org.apache.cxf.feature.AbstractFeature;
+import org.apache.cxf.feature.AbstractPortableFeature;
 import org.apache.cxf.interceptor.AbstractInDatabindingInterceptor;
 import org.apache.cxf.interceptor.Interceptor;
 import org.apache.cxf.message.Message;
 
 public class StaxDataBindingFeature extends AbstractFeature {
-
+    private Portable delegate = new Portable();
 
     @Override
     public void initialize(Client client, Bus bus) {
-        removeDatabindingInterceptor(client.getEndpoint().getBinding().getInInterceptors());
+        delegate.initialize(client, bus);
     }
 
     @Override
     public void initialize(Server server, Bus bus) {
-        removeDatabindingInterceptor(server.getEndpoint().getBinding().getInInterceptors());
+        delegate.initialize(server, bus);
     }
 
-    private void removeDatabindingInterceptor(List<Interceptor<? extends Message>> inInterceptors) {
-        List<Interceptor<? extends Message>> remove = new LinkedList<>();
-        for (Interceptor<? extends Message> i : inInterceptors) {
-            if (i instanceof AbstractInDatabindingInterceptor) {
-                remove.add(i);
-            }
+    public static class Portable implements AbstractPortableFeature {
+        @Override
+        public void initialize(Client client, Bus bus) {
+            removeDatabindingInterceptor(client.getEndpoint().getBinding().getInInterceptors());
         }
-        inInterceptors.removeAll(remove);
-        inInterceptors.add(new StaxDataBindingInterceptor());
+
+        @Override
+        public void initialize(Server server, Bus bus) {
+            removeDatabindingInterceptor(server.getEndpoint().getBinding().getInInterceptors());
+        }
+
+        private void removeDatabindingInterceptor(List<Interceptor<? extends Message>> inInterceptors) {
+            List<Interceptor<? extends Message>> remove = new LinkedList<>();
+            for (Interceptor<? extends Message> i : inInterceptors) {
+                if (i instanceof AbstractInDatabindingInterceptor) {
+                    remove.add(i);
+                }
+            }
+            inInterceptors.removeAll(remove);
+            inInterceptors.add(new StaxDataBindingInterceptor());
+        }
     }
 }

--- a/core/src/main/java/org/apache/cxf/databinding/stax/StaxDataBindingFeature.java
+++ b/core/src/main/java/org/apache/cxf/databinding/stax/StaxDataBindingFeature.java
@@ -28,6 +28,7 @@ import org.apache.cxf.feature.AbstractFeature;
 import org.apache.cxf.feature.AbstractPortableFeature;
 import org.apache.cxf.interceptor.AbstractInDatabindingInterceptor;
 import org.apache.cxf.interceptor.Interceptor;
+import org.apache.cxf.interceptor.InterceptorProvider;
 import org.apache.cxf.message.Message;
 
 public class StaxDataBindingFeature extends AbstractFeature {
@@ -41,6 +42,16 @@ public class StaxDataBindingFeature extends AbstractFeature {
     @Override
     public void initialize(Server server, Bus bus) {
         delegate.initialize(server, bus);
+    }
+
+    @Override
+    public void initialize(InterceptorProvider interceptorProvider, Bus bus) {
+        delegate.initialize(interceptorProvider, bus);
+    }
+
+    @Override
+    public void initialize(Bus bus) {
+        delegate.initialize(bus);
     }
 
     public static class Portable implements AbstractPortableFeature {

--- a/core/src/main/java/org/apache/cxf/databinding/stax/StaxDataBindingFeature.java
+++ b/core/src/main/java/org/apache/cxf/databinding/stax/StaxDataBindingFeature.java
@@ -24,34 +24,16 @@ import java.util.List;
 import org.apache.cxf.Bus;
 import org.apache.cxf.endpoint.Client;
 import org.apache.cxf.endpoint.Server;
-import org.apache.cxf.feature.AbstractFeature;
 import org.apache.cxf.feature.AbstractPortableFeature;
+import org.apache.cxf.feature.DelegatingFeature;
 import org.apache.cxf.interceptor.AbstractInDatabindingInterceptor;
 import org.apache.cxf.interceptor.Interceptor;
-import org.apache.cxf.interceptor.InterceptorProvider;
 import org.apache.cxf.message.Message;
 
-public class StaxDataBindingFeature extends AbstractFeature {
-    private Portable delegate = new Portable();
+public class StaxDataBindingFeature extends DelegatingFeature<StaxDataBindingFeature.Portable> {
 
-    @Override
-    public void initialize(Client client, Bus bus) {
-        delegate.initialize(client, bus);
-    }
-
-    @Override
-    public void initialize(Server server, Bus bus) {
-        delegate.initialize(server, bus);
-    }
-
-    @Override
-    public void initialize(InterceptorProvider interceptorProvider, Bus bus) {
-        delegate.initialize(interceptorProvider, bus);
-    }
-
-    @Override
-    public void initialize(Bus bus) {
-        delegate.initialize(bus);
+    public StaxDataBindingFeature() {
+        super(new Portable());
     }
 
     public static class Portable implements AbstractPortableFeature {

--- a/core/src/main/java/org/apache/cxf/feature/AbstractFeature.java
+++ b/core/src/main/java/org/apache/cxf/feature/AbstractFeature.java
@@ -45,10 +45,10 @@ public abstract class AbstractFeature extends WebServiceFeature implements Abstr
 
     @Override
     public void doInitializeProvider(InterceptorProvider provider, Bus bus) {
-        // no-op
+        initializeProvider(provider, bus);
     }
 
     protected void initializeProvider(InterceptorProvider provider, Bus bus) {
-        doInitializeProvider(provider, bus);
+        // no-op
     }
 }

--- a/core/src/main/java/org/apache/cxf/feature/AbstractFeature.java
+++ b/core/src/main/java/org/apache/cxf/feature/AbstractFeature.java
@@ -18,6 +18,8 @@
  */
 package org.apache.cxf.feature;
 
+import java.util.List;
+
 import javax.xml.ws.WebServiceFeature;
 
 import org.apache.cxf.Bus;
@@ -50,5 +52,9 @@ public abstract class AbstractFeature extends WebServiceFeature implements Abstr
 
     protected void initializeProvider(InterceptorProvider provider, Bus bus) {
         // no-op
+    }
+
+    public static <T> T getActive(List<? extends Feature> features, Class<T> type) {
+        return AbstractPortableFeature.getActive(features, type);
     }
 }

--- a/core/src/main/java/org/apache/cxf/feature/AbstractPortableFeature.java
+++ b/core/src/main/java/org/apache/cxf/feature/AbstractPortableFeature.java
@@ -26,8 +26,9 @@ import org.apache.cxf.endpoint.Server;
 import org.apache.cxf.interceptor.InterceptorProvider;
 
 /**
- * A Feature is something that is able to customize a Server, Client, or Bus, typically
- * adding capabilities. For instance, there may be a LoggingFeature which configures
+ * A portable - i.e. for jaxws and jaxrs - Feature is something that is able to customize
+ * a Server, Client, or Bus, typically adding capabilities.
+ * For instance, there may be a LoggingFeature which configures
  * one of the above to log each of their messages.
  * <p>
  * By default the initialize methods all delegate to doInitializeProvider(InterceptorProvider).

--- a/core/src/main/java/org/apache/cxf/feature/AbstractPortableFeature.java
+++ b/core/src/main/java/org/apache/cxf/feature/AbstractPortableFeature.java
@@ -62,8 +62,7 @@ public interface AbstractPortableFeature extends Feature {
      * @param type the feature type required
      * @return the feature of the specified type if active
      */
-    static <T> T getActive(List<? extends Feature> features,
-                                  Class<T> type) {
+    static <T> T getActive(List<? extends Feature> features, Class<T> type) {
         T active = null;
         if (features != null) {
             for (Feature feature : features) {

--- a/core/src/main/java/org/apache/cxf/feature/AbstractPortableFeature.java
+++ b/core/src/main/java/org/apache/cxf/feature/AbstractPortableFeature.java
@@ -30,7 +30,7 @@ import org.apache.cxf.interceptor.InterceptorProvider;
  * adding capabilities. For instance, there may be a LoggingFeature which configures
  * one of the above to log each of their messages.
  * <p>
- * By default the initialize methods all delegate to initializeProvider(InterceptorProvider).
+ * By default the initialize methods all delegate to doInitializeProvider(InterceptorProvider).
  * If you're simply adding interceptors to a Server, Client, or Bus, this allows you to add
  * them easily.
  */

--- a/core/src/main/java/org/apache/cxf/feature/DelegatingFeature.java
+++ b/core/src/main/java/org/apache/cxf/feature/DelegatingFeature.java
@@ -1,0 +1,70 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.cxf.feature;
+
+import org.apache.cxf.Bus;
+import org.apache.cxf.endpoint.Client;
+import org.apache.cxf.endpoint.Server;
+import org.apache.cxf.interceptor.InterceptorProvider;
+
+/**
+ * Enable to convert a {@link AbstractPortableFeature} to a {@link AbstractFeature}.
+ *
+ * @param <T> the "portable" feature.
+ */
+public class DelegatingFeature<T extends AbstractPortableFeature> extends AbstractFeature {
+    protected T delegate;
+
+    protected DelegatingFeature(final T d) {
+        delegate = d == null ? getDelegate() : d;
+    }
+
+    protected T getDelegate() { // useful for inheritance
+        return delegate;
+    }
+
+    public void setDelegate(T delegate) {
+        this.delegate = delegate;
+    }
+
+    @Override
+    public void initialize(final Server server, final Bus bus) {
+        delegate.initialize(server, bus);
+    }
+
+    @Override
+    public void initialize(final Client client, final Bus bus) {
+        delegate.initialize(client, bus);
+    }
+
+    @Override
+    public void initialize(final InterceptorProvider interceptorProvider, final Bus bus) {
+        delegate.initialize(interceptorProvider, bus);
+    }
+
+    @Override
+    public void initialize(final Bus bus) {
+        delegate.initialize(bus);
+    }
+
+    @Override
+    protected void initializeProvider(final InterceptorProvider interceptorProvider, final Bus bus) {
+        delegate.doInitializeProvider(interceptorProvider, bus);
+    }
+}

--- a/core/src/main/java/org/apache/cxf/feature/FastInfosetFeature.java
+++ b/core/src/main/java/org/apache/cxf/feature/FastInfosetFeature.java
@@ -38,65 +38,76 @@ import org.apache.cxf.interceptor.InterceptorProvider;
  */
 @NoJSR250Annotations
 public class FastInfosetFeature extends AbstractFeature {
-
-    boolean force;
-    private Integer serializerAttributeValueMapMemoryLimit;
-    private Integer serializerMinAttributeValueSize;
-    private Integer serializerMaxAttributeValueSize;
-    private Integer serializerCharacterContentChunkMapMemoryLimit;
-    private Integer serializerMinCharacterContentChunkSize;
-    private Integer serializerMaxCharacterContentChunkSize;
-
-    public FastInfosetFeature() {
-        //
-    }
-
+    private Portable delegate = new Portable();
 
     @Override
-    protected void initializeProvider(InterceptorProvider provider, Bus bus) {
-
-        FIStaxInInterceptor in = new FIStaxInInterceptor();
-
-        FIStaxOutInterceptor out = new FIStaxOutInterceptor(force);
-        if (serializerAttributeValueMapMemoryLimit != null && serializerAttributeValueMapMemoryLimit.intValue() > 0) {
-            out.setSerializerAttributeValueMapMemoryLimit(serializerAttributeValueMapMemoryLimit);
-        }
-        if (serializerMinAttributeValueSize != null && serializerMinAttributeValueSize.intValue() > 0) {
-            out.setSerializerMinAttributeValueSize(serializerMinAttributeValueSize);
-        }
-        if (serializerMaxAttributeValueSize != null && serializerMaxAttributeValueSize.intValue() > 0) {
-            out.setSerializerMaxAttributeValueSize(serializerMaxAttributeValueSize);
-        }
-        if (serializerCharacterContentChunkMapMemoryLimit != null
-                && serializerCharacterContentChunkMapMemoryLimit.intValue() > 0) {
-            out.setSerializerCharacterContentChunkMapMemoryLimit(
-                    serializerCharacterContentChunkMapMemoryLimit);
-        }
-        if (serializerMinCharacterContentChunkSize != null && serializerMinCharacterContentChunkSize.intValue() > 0) {
-            out.setSerializerMinCharacterContentChunkSize(serializerMinCharacterContentChunkSize);
-        }
-        if (serializerMaxCharacterContentChunkSize != null && serializerMaxCharacterContentChunkSize.intValue() > 0) {
-            out.setSerializerMaxCharacterContentChunkSize(serializerMaxCharacterContentChunkSize);
-        }
-
-        provider.getInInterceptors().add(in);
-        provider.getInFaultInterceptors().add(in);
-        provider.getOutInterceptors().add(out);
-        provider.getOutFaultInterceptors().add(out);
+    public void initializeProvider(InterceptorProvider provider, Bus bus) {
+        delegate.doInitializeProvider(provider, bus);
     }
 
-    /**
-     * Set if FastInfoset is always used without negotiation
-     * @param b
-     */
     public void setForce(boolean b) {
-        force = b;
+        delegate.setForce(b);
     }
 
-    /**
-     * Retrieve the value set with {@link #setForce(boolean)}.
-     */
     public boolean getForce() {
-        return force;
+        return delegate.getForce();
+    }
+
+    public static class Portable implements AbstractPortableFeature {
+        boolean force;
+        private Integer serializerAttributeValueMapMemoryLimit;
+        private Integer serializerMinAttributeValueSize;
+        private Integer serializerMaxAttributeValueSize;
+        private Integer serializerCharacterContentChunkMapMemoryLimit;
+        private Integer serializerMinCharacterContentChunkSize;
+        private Integer serializerMaxCharacterContentChunkSize;
+
+        @Override
+        public void doInitializeProvider(InterceptorProvider provider, Bus bus) {
+
+            FIStaxInInterceptor in = new FIStaxInInterceptor();
+
+            FIStaxOutInterceptor out = new FIStaxOutInterceptor(force);
+            if (serializerAttributeValueMapMemoryLimit != null && serializerAttributeValueMapMemoryLimit.intValue() > 0) {
+                out.setSerializerAttributeValueMapMemoryLimit(serializerAttributeValueMapMemoryLimit);
+            }
+            if (serializerMinAttributeValueSize != null && serializerMinAttributeValueSize.intValue() > 0) {
+                out.setSerializerMinAttributeValueSize(serializerMinAttributeValueSize);
+            }
+            if (serializerMaxAttributeValueSize != null && serializerMaxAttributeValueSize.intValue() > 0) {
+                out.setSerializerMaxAttributeValueSize(serializerMaxAttributeValueSize);
+            }
+            if (serializerCharacterContentChunkMapMemoryLimit != null
+                    && serializerCharacterContentChunkMapMemoryLimit.intValue() > 0) {
+                out.setSerializerCharacterContentChunkMapMemoryLimit(
+                        serializerCharacterContentChunkMapMemoryLimit);
+            }
+            if (serializerMinCharacterContentChunkSize != null && serializerMinCharacterContentChunkSize.intValue() > 0) {
+                out.setSerializerMinCharacterContentChunkSize(serializerMinCharacterContentChunkSize);
+            }
+            if (serializerMaxCharacterContentChunkSize != null && serializerMaxCharacterContentChunkSize.intValue() > 0) {
+                out.setSerializerMaxCharacterContentChunkSize(serializerMaxCharacterContentChunkSize);
+            }
+
+            provider.getInInterceptors().add(in);
+            provider.getInFaultInterceptors().add(in);
+            provider.getOutInterceptors().add(out);
+            provider.getOutFaultInterceptors().add(out);
+        }
+
+        /**
+         * Set if FastInfoset is always used without negotiation
+         * @param b
+         */
+        public void setForce(boolean b) {
+            force = b;
+        }
+
+        /**
+         * Retrieve the value set with {@link #setForce(boolean)}.
+         */
+        public boolean getForce() {
+            return force;
+        }
     }
 }

--- a/core/src/main/java/org/apache/cxf/feature/FastInfosetFeature.java
+++ b/core/src/main/java/org/apache/cxf/feature/FastInfosetFeature.java
@@ -20,6 +20,8 @@ package org.apache.cxf.feature;
 
 import org.apache.cxf.Bus;
 import org.apache.cxf.common.injection.NoJSR250Annotations;
+import org.apache.cxf.endpoint.Client;
+import org.apache.cxf.endpoint.Server;
 import org.apache.cxf.interceptor.FIStaxInInterceptor;
 import org.apache.cxf.interceptor.FIStaxOutInterceptor;
 import org.apache.cxf.interceptor.InterceptorProvider;
@@ -45,6 +47,26 @@ public class FastInfosetFeature extends AbstractFeature {
         delegate.doInitializeProvider(provider, bus);
     }
 
+    @Override
+    public void initialize(Server server, Bus bus) {
+        delegate.initialize(server, bus);
+    }
+
+    @Override
+    public void initialize(Client client, Bus bus) {
+        delegate.initialize(client, bus);
+    }
+
+    @Override
+    public void initialize(InterceptorProvider interceptorProvider, Bus bus) {
+        delegate.initialize(interceptorProvider, bus);
+    }
+
+    @Override
+    public void initialize(Bus bus) {
+        delegate.initialize(bus);
+    }
+
     public void setForce(boolean b) {
         delegate.setForce(b);
     }
@@ -68,24 +90,24 @@ public class FastInfosetFeature extends AbstractFeature {
             FIStaxInInterceptor in = new FIStaxInInterceptor();
 
             FIStaxOutInterceptor out = new FIStaxOutInterceptor(force);
-            if (serializerAttributeValueMapMemoryLimit != null && serializerAttributeValueMapMemoryLimit.intValue() > 0) {
+            if (serializerAttributeValueMapMemoryLimit != null && serializerAttributeValueMapMemoryLimit > 0) {
                 out.setSerializerAttributeValueMapMemoryLimit(serializerAttributeValueMapMemoryLimit);
             }
-            if (serializerMinAttributeValueSize != null && serializerMinAttributeValueSize.intValue() > 0) {
+            if (serializerMinAttributeValueSize != null && serializerMinAttributeValueSize > 0) {
                 out.setSerializerMinAttributeValueSize(serializerMinAttributeValueSize);
             }
-            if (serializerMaxAttributeValueSize != null && serializerMaxAttributeValueSize.intValue() > 0) {
+            if (serializerMaxAttributeValueSize != null && serializerMaxAttributeValueSize > 0) {
                 out.setSerializerMaxAttributeValueSize(serializerMaxAttributeValueSize);
             }
             if (serializerCharacterContentChunkMapMemoryLimit != null
-                    && serializerCharacterContentChunkMapMemoryLimit.intValue() > 0) {
+                    && serializerCharacterContentChunkMapMemoryLimit > 0) {
                 out.setSerializerCharacterContentChunkMapMemoryLimit(
                         serializerCharacterContentChunkMapMemoryLimit);
             }
-            if (serializerMinCharacterContentChunkSize != null && serializerMinCharacterContentChunkSize.intValue() > 0) {
+            if (serializerMinCharacterContentChunkSize != null && serializerMinCharacterContentChunkSize > 0) {
                 out.setSerializerMinCharacterContentChunkSize(serializerMinCharacterContentChunkSize);
             }
-            if (serializerMaxCharacterContentChunkSize != null && serializerMaxCharacterContentChunkSize.intValue() > 0) {
+            if (serializerMaxCharacterContentChunkSize != null && serializerMaxCharacterContentChunkSize > 0) {
                 out.setSerializerMaxCharacterContentChunkSize(serializerMaxCharacterContentChunkSize);
             }
 

--- a/core/src/main/java/org/apache/cxf/feature/FastInfosetFeature.java
+++ b/core/src/main/java/org/apache/cxf/feature/FastInfosetFeature.java
@@ -20,8 +20,6 @@ package org.apache.cxf.feature;
 
 import org.apache.cxf.Bus;
 import org.apache.cxf.common.injection.NoJSR250Annotations;
-import org.apache.cxf.endpoint.Client;
-import org.apache.cxf.endpoint.Server;
 import org.apache.cxf.interceptor.FIStaxInInterceptor;
 import org.apache.cxf.interceptor.FIStaxOutInterceptor;
 import org.apache.cxf.interceptor.InterceptorProvider;
@@ -39,32 +37,9 @@ import org.apache.cxf.interceptor.InterceptorProvider;
   </pre>
  */
 @NoJSR250Annotations
-public class FastInfosetFeature extends AbstractFeature {
-    private Portable delegate = new Portable();
-
-    @Override
-    public void initializeProvider(InterceptorProvider provider, Bus bus) {
-        delegate.doInitializeProvider(provider, bus);
-    }
-
-    @Override
-    public void initialize(Server server, Bus bus) {
-        delegate.initialize(server, bus);
-    }
-
-    @Override
-    public void initialize(Client client, Bus bus) {
-        delegate.initialize(client, bus);
-    }
-
-    @Override
-    public void initialize(InterceptorProvider interceptorProvider, Bus bus) {
-        delegate.initialize(interceptorProvider, bus);
-    }
-
-    @Override
-    public void initialize(Bus bus) {
-        delegate.initialize(bus);
+public class FastInfosetFeature extends DelegatingFeature<FastInfosetFeature.Portable> {
+    public FastInfosetFeature() {
+        super(new Portable());
     }
 
     public void setForce(boolean b) {

--- a/core/src/main/java/org/apache/cxf/feature/LoggingFeature.java
+++ b/core/src/main/java/org/apache/cxf/feature/LoggingFeature.java
@@ -23,8 +23,6 @@ import org.apache.cxf.annotations.Logging;
 import org.apache.cxf.annotations.Provider;
 import org.apache.cxf.annotations.Provider.Type;
 import org.apache.cxf.common.injection.NoJSR250Annotations;
-import org.apache.cxf.endpoint.Client;
-import org.apache.cxf.endpoint.Server;
 import org.apache.cxf.interceptor.AbstractLoggingInterceptor;
 import org.apache.cxf.interceptor.InterceptorProvider;
 import org.apache.cxf.interceptor.LoggingInInterceptor;
@@ -51,37 +49,30 @@ import org.apache.cxf.interceptor.LoggingOutInterceptor;
 @NoJSR250Annotations
 @Deprecated
 @Provider(value = Type.Feature)
-public class LoggingFeature extends AbstractFeature {
-    private Portable delegate;
-
+public class LoggingFeature extends DelegatingFeature<LoggingFeature.Portable> {
     public LoggingFeature() {
-        delegate = new Portable();
+        super(new Portable());
     }
     public LoggingFeature(int lim) {
-        delegate = new Portable(lim);
+        super(new Portable(lim));
     }
     public LoggingFeature(String in, String out) {
-        delegate = new Portable(in, out);
+        super(new Portable(in, out));
     }
     public LoggingFeature(String in, String out, int lim) {
-        delegate = new Portable(in, out, lim);
+        super(new Portable(in, out, lim));
     }
 
     public LoggingFeature(String in, String out, int lim, boolean p) {
-        delegate = new Portable(in, out, lim, p);
+        super(new Portable(in, out, lim, p));
     }
 
     public LoggingFeature(String in, String out, int lim, boolean p, boolean showBinary) {
-        delegate = new Portable(in, out, lim, p, showBinary);
+        super(new Portable(in, out, lim, p, showBinary));
     }
 
     public LoggingFeature(Logging annotation) {
-        delegate = new Portable(annotation);
-    }
-
-    @Override
-    protected void initializeProvider(InterceptorProvider provider, Bus bus) {
-        delegate.doInitializeProvider(provider, bus);
+        super(new Portable(annotation));
     }
 
     public void setLimit(int lim) {
@@ -98,26 +89,6 @@ public class LoggingFeature extends AbstractFeature {
 
     public void setPrettyLogging(boolean prettyLogging) {
         delegate.setPrettyLogging(prettyLogging);
-    }
-
-    @Override
-    public void initialize(Server server, Bus bus) {
-        delegate.initialize(server, bus);
-    }
-
-    @Override
-    public void initialize(Client client, Bus bus) {
-        delegate.initialize(client, bus);
-    }
-
-    @Override
-    public void initialize(InterceptorProvider interceptorProvider, Bus bus) {
-        delegate.initialize(interceptorProvider, bus);
-    }
-
-    @Override
-    public void initialize(Bus bus) {
-        delegate.initialize(bus);
     }
 
     @Provider(Type.Feature)

--- a/core/src/main/java/org/apache/cxf/feature/LoggingFeature.java
+++ b/core/src/main/java/org/apache/cxf/feature/LoggingFeature.java
@@ -50,104 +50,155 @@ import org.apache.cxf.interceptor.LoggingOutInterceptor;
 @Deprecated
 @Provider(value = Type.Feature)
 public class LoggingFeature extends AbstractFeature {
-    private static final int DEFAULT_LIMIT = AbstractLoggingInterceptor.DEFAULT_LIMIT;
-    private static final LoggingInInterceptor IN = new LoggingInInterceptor(DEFAULT_LIMIT);
-    private static final LoggingOutInterceptor OUT = new LoggingOutInterceptor(DEFAULT_LIMIT);
-
-
-    String inLocation;
-    String outLocation;
-    boolean prettyLogging;
-    boolean showBinary;
-
-    int limit = DEFAULT_LIMIT;
+    private Portable delegate = new Portable();
 
     public LoggingFeature() {
-
+        delegate = new Portable();
     }
     public LoggingFeature(int lim) {
-        limit = lim;
+        delegate = new Portable(lim);
     }
     public LoggingFeature(String in, String out) {
-        inLocation = in;
-        outLocation = out;
+        delegate = new Portable(in, out);
     }
     public LoggingFeature(String in, String out, int lim) {
-        inLocation = in;
-        outLocation = out;
-        limit = lim;
+        delegate = new Portable(in, out, lim);
     }
 
     public LoggingFeature(String in, String out, int lim, boolean p) {
-        inLocation = in;
-        outLocation = out;
-        limit = lim;
-        prettyLogging = p;
+        delegate = new Portable(in, out, lim, p);
     }
 
     public LoggingFeature(String in, String out, int lim, boolean p, boolean showBinary) {
-        this(in, out, lim, p);
-        this.showBinary = showBinary;
+        delegate = new Portable(in, out, lim, p, showBinary);
     }
 
     public LoggingFeature(Logging annotation) {
-        inLocation = annotation.inLocation();
-        outLocation = annotation.outLocation();
-        limit = annotation.limit();
-        prettyLogging = annotation.pretty();
-        showBinary = annotation.showBinary();
+        delegate = new Portable(annotation);
     }
 
     @Override
     protected void initializeProvider(InterceptorProvider provider, Bus bus) {
-        if (limit == DEFAULT_LIMIT && inLocation == null
-            && outLocation == null && !prettyLogging) {
-            provider.getInInterceptors().add(IN);
-            provider.getInFaultInterceptors().add(IN);
-            provider.getOutInterceptors().add(OUT);
-            provider.getOutFaultInterceptors().add(OUT);
-        } else {
-            LoggingInInterceptor in = new LoggingInInterceptor(limit);
-            in.setOutputLocation(inLocation);
-            in.setPrettyLogging(prettyLogging);
-            in.setShowBinaryContent(showBinary);
-            LoggingOutInterceptor out = new LoggingOutInterceptor(limit);
-            out.setOutputLocation(outLocation);
-            out.setPrettyLogging(prettyLogging);
-            out.setShowBinaryContent(showBinary);
-
-            provider.getInInterceptors().add(in);
-            provider.getInFaultInterceptors().add(in);
-            provider.getOutInterceptors().add(out);
-            provider.getOutFaultInterceptors().add(out);
-        }
+        delegate.doInitializeProvider(provider, bus);
     }
 
-    /**
-     * Set a limit on how much content can be logged
-     * @param lim
-     */
     public void setLimit(int lim) {
-        limit = lim;
+        delegate.setLimit(lim);
     }
 
-    /**
-     * Retrieve the value set with {@link #setLimit(int)}.
-     */
     public int getLimit() {
-        return limit;
+        return delegate.getLimit();
     }
 
-    /**
-     */
     public boolean isPrettyLogging() {
-        return prettyLogging;
+        return delegate.isPrettyLogging();
     }
-    /**
-     * Turn pretty logging of XML content on/off
-     * @param prettyLogging
-     */
+
     public void setPrettyLogging(boolean prettyLogging) {
-        this.prettyLogging = prettyLogging;
+        delegate.setPrettyLogging(prettyLogging);
+    }
+
+    @Provider(Type.Feature)
+    public static class Portable implements AbstractPortableFeature {
+        private static final int DEFAULT_LIMIT = AbstractLoggingInterceptor.DEFAULT_LIMIT;
+        private static final LoggingInInterceptor IN = new LoggingInInterceptor(DEFAULT_LIMIT);
+        private static final LoggingOutInterceptor OUT = new LoggingOutInterceptor(DEFAULT_LIMIT);
+
+
+        String inLocation;
+        String outLocation;
+        boolean prettyLogging;
+        boolean showBinary;
+
+        int limit = DEFAULT_LIMIT;
+
+        public Portable() {
+
+        }
+        public Portable(int lim) {
+            limit = lim;
+        }
+        public Portable(String in, String out) {
+            inLocation = in;
+            outLocation = out;
+        }
+        public Portable(String in, String out, int lim) {
+            inLocation = in;
+            outLocation = out;
+            limit = lim;
+        }
+
+        public Portable(String in, String out, int lim, boolean p) {
+            inLocation = in;
+            outLocation = out;
+            limit = lim;
+            prettyLogging = p;
+        }
+
+        public Portable(String in, String out, int lim, boolean p, boolean showBinary) {
+            this(in, out, lim, p);
+            this.showBinary = showBinary;
+        }
+
+        public Portable(Logging annotation) {
+            inLocation = annotation.inLocation();
+            outLocation = annotation.outLocation();
+            limit = annotation.limit();
+            prettyLogging = annotation.pretty();
+            showBinary = annotation.showBinary();
+        }
+
+        @Override
+        public void doInitializeProvider(InterceptorProvider provider, Bus bus) {
+            if (limit == DEFAULT_LIMIT && inLocation == null
+                    && outLocation == null && !prettyLogging) {
+                provider.getInInterceptors().add(IN);
+                provider.getInFaultInterceptors().add(IN);
+                provider.getOutInterceptors().add(OUT);
+                provider.getOutFaultInterceptors().add(OUT);
+            } else {
+                LoggingInInterceptor in = new LoggingInInterceptor(limit);
+                in.setOutputLocation(inLocation);
+                in.setPrettyLogging(prettyLogging);
+                in.setShowBinaryContent(showBinary);
+                LoggingOutInterceptor out = new LoggingOutInterceptor(limit);
+                out.setOutputLocation(outLocation);
+                out.setPrettyLogging(prettyLogging);
+                out.setShowBinaryContent(showBinary);
+
+                provider.getInInterceptors().add(in);
+                provider.getInFaultInterceptors().add(in);
+                provider.getOutInterceptors().add(out);
+                provider.getOutFaultInterceptors().add(out);
+            }
+        }
+
+        /**
+         * Set a limit on how much content can be logged
+         * @param lim
+         */
+        public void setLimit(int lim) {
+            limit = lim;
+        }
+
+        /**
+         * Retrieve the value set with {@link #setLimit(int)}.
+         */
+        public int getLimit() {
+            return limit;
+        }
+
+        /**
+         */
+        public boolean isPrettyLogging() {
+            return prettyLogging;
+        }
+        /**
+         * Turn pretty logging of XML content on/off
+         * @param prettyLogging
+         */
+        public void setPrettyLogging(boolean prettyLogging) {
+            this.prettyLogging = prettyLogging;
+        }
     }
 }

--- a/core/src/main/java/org/apache/cxf/feature/LoggingFeature.java
+++ b/core/src/main/java/org/apache/cxf/feature/LoggingFeature.java
@@ -23,6 +23,8 @@ import org.apache.cxf.annotations.Logging;
 import org.apache.cxf.annotations.Provider;
 import org.apache.cxf.annotations.Provider.Type;
 import org.apache.cxf.common.injection.NoJSR250Annotations;
+import org.apache.cxf.endpoint.Client;
+import org.apache.cxf.endpoint.Server;
 import org.apache.cxf.interceptor.AbstractLoggingInterceptor;
 import org.apache.cxf.interceptor.InterceptorProvider;
 import org.apache.cxf.interceptor.LoggingInInterceptor;
@@ -50,7 +52,7 @@ import org.apache.cxf.interceptor.LoggingOutInterceptor;
 @Deprecated
 @Provider(value = Type.Feature)
 public class LoggingFeature extends AbstractFeature {
-    private Portable delegate = new Portable();
+    private Portable delegate;
 
     public LoggingFeature() {
         delegate = new Portable();
@@ -96,6 +98,26 @@ public class LoggingFeature extends AbstractFeature {
 
     public void setPrettyLogging(boolean prettyLogging) {
         delegate.setPrettyLogging(prettyLogging);
+    }
+
+    @Override
+    public void initialize(Server server, Bus bus) {
+        delegate.initialize(server, bus);
+    }
+
+    @Override
+    public void initialize(Client client, Bus bus) {
+        delegate.initialize(client, bus);
+    }
+
+    @Override
+    public void initialize(InterceptorProvider interceptorProvider, Bus bus) {
+        delegate.initialize(interceptorProvider, bus);
+    }
+
+    @Override
+    public void initialize(Bus bus) {
+        delegate.initialize(bus);
     }
 
     @Provider(Type.Feature)

--- a/core/src/main/java/org/apache/cxf/feature/StaxTransformFeature.java
+++ b/core/src/main/java/org/apache/cxf/feature/StaxTransformFeature.java
@@ -40,68 +40,124 @@ import org.apache.cxf.interceptor.transform.TransformOutInterceptor;
  */
 @NoJSR250Annotations
 public class StaxTransformFeature extends AbstractFeature {
-
-    private TransformInInterceptor in = new TransformInInterceptor();
-    private TransformOutInterceptor out = new TransformOutInterceptor();
-
-    public StaxTransformFeature() {
-        //
-    }
-
-    @Override
-    protected void initializeProvider(InterceptorProvider provider, Bus bus) {
-
-        provider.getInInterceptors().add(in);
-        provider.getOutInterceptors().add(out);
-        provider.getOutFaultInterceptors().add(out);
-    }
+    private Portable delegate = new Portable();
 
     public void setOutTransformElements(Map<String, String> outElements) {
-        out.setOutTransformElements(outElements);
+        delegate.setOutTransformElements(outElements);
     }
 
     public void setOutTransformAttributes(Map<String, String> outAttributes) {
-        out.setOutTransformAttributes(outAttributes);
+        delegate.setOutTransformAttributes(outAttributes);
     }
 
     public void setAttributesToElements(boolean value) {
-        out.setAttributesToElements(value);
+        delegate.setAttributesToElements(value);
     }
 
     public void setSkipOnFault(boolean value) {
-        out.setSkipOnFault(value);
+        delegate.setSkipOnFault(value);
     }
 
     public void setOutAppendElements(Map<String, String> map) {
-        out.setOutAppendElements(map);
+        delegate.setOutAppendElements(map);
     }
 
     public void setOutDropElements(List<String> dropElementsSet) {
-        out.setOutDropElements(dropElementsSet);
+        delegate.setOutDropElements(dropElementsSet);
     }
 
     public void setInAppendElements(Map<String, String> inElements) {
-        in.setInAppendElements(inElements);
+        delegate.setInAppendElements(inElements);
     }
 
     public void setInDropElements(List<String> dropElementsSet) {
-        in.setInDropElements(dropElementsSet);
+        delegate.setInDropElements(dropElementsSet);
     }
 
     public void setInTransformElements(Map<String, String> inElements) {
-        in.setInTransformElements(inElements);
+        delegate.setInTransformElements(inElements);
     }
 
     public void setInTransformAttributes(Map<String, String> inAttributes) {
-        in.setInTransformAttributes(inAttributes);
+        delegate.setInTransformAttributes(inAttributes);
     }
 
     public void setOutDefaultNamespace(String ns) {
-        out.setDefaultNamespace(ns);
+        delegate.setOutDefaultNamespace(ns);
     }
 
     public void setContextPropertyName(String propertyName) {
-        in.setContextPropertyName(propertyName);
-        out.setContextPropertyName(propertyName);
+        delegate.setContextPropertyName(propertyName);
+    }
+
+    @Override
+    protected void initializeProvider(InterceptorProvider interceptorProvider, Bus bus) {
+        delegate.doInitializeProvider(interceptorProvider, bus);
+    }
+
+    public static class Portable implements AbstractPortableFeature {
+        private TransformInInterceptor in = new TransformInInterceptor();
+        private TransformOutInterceptor out = new TransformOutInterceptor();
+
+        public Portable() {
+            //
+        }
+
+        @Override
+        public void doInitializeProvider(InterceptorProvider provider, Bus bus) {
+
+            provider.getInInterceptors().add(in);
+            provider.getOutInterceptors().add(out);
+            provider.getOutFaultInterceptors().add(out);
+        }
+
+        public void setOutTransformElements(Map<String, String> outElements) {
+            out.setOutTransformElements(outElements);
+        }
+
+        public void setOutTransformAttributes(Map<String, String> outAttributes) {
+            out.setOutTransformAttributes(outAttributes);
+        }
+
+        public void setAttributesToElements(boolean value) {
+            out.setAttributesToElements(value);
+        }
+
+        public void setSkipOnFault(boolean value) {
+            out.setSkipOnFault(value);
+        }
+
+        public void setOutAppendElements(Map<String, String> map) {
+            out.setOutAppendElements(map);
+        }
+
+        public void setOutDropElements(List<String> dropElementsSet) {
+            out.setOutDropElements(dropElementsSet);
+        }
+
+        public void setInAppendElements(Map<String, String> inElements) {
+            in.setInAppendElements(inElements);
+        }
+
+        public void setInDropElements(List<String> dropElementsSet) {
+            in.setInDropElements(dropElementsSet);
+        }
+
+        public void setInTransformElements(Map<String, String> inElements) {
+            in.setInTransformElements(inElements);
+        }
+
+        public void setInTransformAttributes(Map<String, String> inAttributes) {
+            in.setInTransformAttributes(inAttributes);
+        }
+
+        public void setOutDefaultNamespace(String ns) {
+            out.setDefaultNamespace(ns);
+        }
+
+        public void setContextPropertyName(String propertyName) {
+            in.setContextPropertyName(propertyName);
+            out.setContextPropertyName(propertyName);
+        }
     }
 }

--- a/core/src/main/java/org/apache/cxf/feature/StaxTransformFeature.java
+++ b/core/src/main/java/org/apache/cxf/feature/StaxTransformFeature.java
@@ -23,6 +23,8 @@ import java.util.Map;
 
 import org.apache.cxf.Bus;
 import org.apache.cxf.common.injection.NoJSR250Annotations;
+import org.apache.cxf.endpoint.Client;
+import org.apache.cxf.endpoint.Server;
 import org.apache.cxf.interceptor.InterceptorProvider;
 import org.apache.cxf.interceptor.transform.TransformInInterceptor;
 import org.apache.cxf.interceptor.transform.TransformOutInterceptor;
@@ -93,6 +95,26 @@ public class StaxTransformFeature extends AbstractFeature {
     @Override
     protected void initializeProvider(InterceptorProvider interceptorProvider, Bus bus) {
         delegate.doInitializeProvider(interceptorProvider, bus);
+    }
+
+    @Override
+    public void initialize(Server server, Bus bus) {
+        delegate.initialize(server, bus);
+    }
+
+    @Override
+    public void initialize(Client client, Bus bus) {
+        delegate.initialize(client, bus);
+    }
+
+    @Override
+    public void initialize(InterceptorProvider interceptorProvider, Bus bus) {
+        delegate.initialize(interceptorProvider, bus);
+    }
+
+    @Override
+    public void initialize(Bus bus) {
+        delegate.initialize(bus);
     }
 
     public static class Portable implements AbstractPortableFeature {

--- a/core/src/main/java/org/apache/cxf/feature/StaxTransformFeature.java
+++ b/core/src/main/java/org/apache/cxf/feature/StaxTransformFeature.java
@@ -23,8 +23,6 @@ import java.util.Map;
 
 import org.apache.cxf.Bus;
 import org.apache.cxf.common.injection.NoJSR250Annotations;
-import org.apache.cxf.endpoint.Client;
-import org.apache.cxf.endpoint.Server;
 import org.apache.cxf.interceptor.InterceptorProvider;
 import org.apache.cxf.interceptor.transform.TransformInInterceptor;
 import org.apache.cxf.interceptor.transform.TransformOutInterceptor;
@@ -41,8 +39,11 @@ import org.apache.cxf.interceptor.transform.TransformOutInterceptor;
   </pre>
  */
 @NoJSR250Annotations
-public class StaxTransformFeature extends AbstractFeature {
-    private Portable delegate = new Portable();
+public class StaxTransformFeature extends DelegatingFeature<StaxTransformFeature.Portable> {
+
+    public StaxTransformFeature() {
+        super(new Portable());
+    }
 
     public void setOutTransformElements(Map<String, String> outElements) {
         delegate.setOutTransformElements(outElements);
@@ -90,31 +91,6 @@ public class StaxTransformFeature extends AbstractFeature {
 
     public void setContextPropertyName(String propertyName) {
         delegate.setContextPropertyName(propertyName);
-    }
-
-    @Override
-    protected void initializeProvider(InterceptorProvider interceptorProvider, Bus bus) {
-        delegate.doInitializeProvider(interceptorProvider, bus);
-    }
-
-    @Override
-    public void initialize(Server server, Bus bus) {
-        delegate.initialize(server, bus);
-    }
-
-    @Override
-    public void initialize(Client client, Bus bus) {
-        delegate.initialize(client, bus);
-    }
-
-    @Override
-    public void initialize(InterceptorProvider interceptorProvider, Bus bus) {
-        delegate.initialize(interceptorProvider, bus);
-    }
-
-    @Override
-    public void initialize(Bus bus) {
-        delegate.initialize(bus);
     }
 
     public static class Portable implements AbstractPortableFeature {

--- a/core/src/main/java/org/apache/cxf/feature/transform/XSLTFeature.java
+++ b/core/src/main/java/org/apache/cxf/feature/transform/XSLTFeature.java
@@ -21,6 +21,7 @@ package org.apache.cxf.feature.transform;
 import org.apache.cxf.Bus;
 import org.apache.cxf.common.injection.NoJSR250Annotations;
 import org.apache.cxf.feature.AbstractFeature;
+import org.apache.cxf.feature.AbstractPortableFeature;
 import org.apache.cxf.interceptor.InterceptorProvider;
 
 /**
@@ -32,29 +33,45 @@ import org.apache.cxf.interceptor.InterceptorProvider;
  */
 @NoJSR250Annotations
 public class XSLTFeature extends AbstractFeature {
-    private String inXSLTPath;
-    private String outXSLTPath;
-
-    @Override
-    protected void initializeProvider(InterceptorProvider provider, Bus bus) {
-        if (inXSLTPath != null) {
-            XSLTInInterceptor in = new XSLTInInterceptor(inXSLTPath);
-            provider.getInInterceptors().add(in);
-        }
-
-        if (outXSLTPath != null) {
-            XSLTOutInterceptor out = new XSLTOutInterceptor(outXSLTPath);
-            provider.getOutInterceptors().add(out);
-            provider.getOutFaultInterceptors().add(out);
-        }
-    }
+    private final Portable portable = new Portable();
 
     public void setInXSLTPath(String inXSLTPath) {
-        this.inXSLTPath = inXSLTPath;
+        portable.setInXSLTPath(inXSLTPath);
     }
 
     public void setOutXSLTPath(String outXSLTPath) {
-        this.outXSLTPath = outXSLTPath;
+        portable.setOutXSLTPath(outXSLTPath);
     }
 
+    @Override
+    protected void initializeProvider(InterceptorProvider interceptorProvider, Bus bus) {
+        portable.doInitializeProvider(interceptorProvider, bus);
+    }
+
+    public static class Portable implements AbstractPortableFeature {
+        private String inXSLTPath;
+        private String outXSLTPath;
+
+        @Override
+        public void doInitializeProvider(InterceptorProvider provider, Bus bus) {
+            if (inXSLTPath != null) {
+                XSLTInInterceptor in = new XSLTInInterceptor(inXSLTPath);
+                provider.getInInterceptors().add(in);
+            }
+
+            if (outXSLTPath != null) {
+                XSLTOutInterceptor out = new XSLTOutInterceptor(outXSLTPath);
+                provider.getOutInterceptors().add(out);
+                provider.getOutFaultInterceptors().add(out);
+            }
+        }
+
+        public void setInXSLTPath(String inXSLTPath) {
+            this.inXSLTPath = inXSLTPath;
+        }
+
+        public void setOutXSLTPath(String outXSLTPath) {
+            this.outXSLTPath = outXSLTPath;
+        }
+    }
 }

--- a/core/src/main/java/org/apache/cxf/feature/transform/XSLTFeature.java
+++ b/core/src/main/java/org/apache/cxf/feature/transform/XSLTFeature.java
@@ -20,10 +20,8 @@ package org.apache.cxf.feature.transform;
 
 import org.apache.cxf.Bus;
 import org.apache.cxf.common.injection.NoJSR250Annotations;
-import org.apache.cxf.endpoint.Client;
-import org.apache.cxf.endpoint.Server;
-import org.apache.cxf.feature.AbstractFeature;
 import org.apache.cxf.feature.AbstractPortableFeature;
+import org.apache.cxf.feature.DelegatingFeature;
 import org.apache.cxf.interceptor.InterceptorProvider;
 
 /**
@@ -34,8 +32,10 @@ import org.apache.cxf.interceptor.InterceptorProvider;
  * (can be fixed in further versions when XSLT engine supports XML stream).
  */
 @NoJSR250Annotations
-public class XSLTFeature extends AbstractFeature {
-    private final Portable delegate = new Portable();
+public class XSLTFeature extends DelegatingFeature<XSLTFeature.Portable> {
+    public XSLTFeature() {
+        super(new Portable());
+    }
 
     public void setInXSLTPath(String inXSLTPath) {
         delegate.setInXSLTPath(inXSLTPath);
@@ -43,31 +43,6 @@ public class XSLTFeature extends AbstractFeature {
 
     public void setOutXSLTPath(String outXSLTPath) {
         delegate.setOutXSLTPath(outXSLTPath);
-    }
-
-    @Override
-    protected void initializeProvider(InterceptorProvider interceptorProvider, Bus bus) {
-        delegate.doInitializeProvider(interceptorProvider, bus);
-    }
-
-    @Override
-    public void initialize(Server server, Bus bus) {
-        delegate.initialize(server, bus);
-    }
-
-    @Override
-    public void initialize(Client client, Bus bus) {
-        delegate.initialize(client, bus);
-    }
-
-    @Override
-    public void initialize(InterceptorProvider interceptorProvider, Bus bus) {
-        delegate.initialize(interceptorProvider, bus);
-    }
-
-    @Override
-    public void initialize(Bus bus) {
-        delegate.initialize(bus);
     }
 
     public static class Portable implements AbstractPortableFeature {

--- a/core/src/main/java/org/apache/cxf/feature/transform/XSLTFeature.java
+++ b/core/src/main/java/org/apache/cxf/feature/transform/XSLTFeature.java
@@ -20,6 +20,8 @@ package org.apache.cxf.feature.transform;
 
 import org.apache.cxf.Bus;
 import org.apache.cxf.common.injection.NoJSR250Annotations;
+import org.apache.cxf.endpoint.Client;
+import org.apache.cxf.endpoint.Server;
 import org.apache.cxf.feature.AbstractFeature;
 import org.apache.cxf.feature.AbstractPortableFeature;
 import org.apache.cxf.interceptor.InterceptorProvider;
@@ -33,19 +35,39 @@ import org.apache.cxf.interceptor.InterceptorProvider;
  */
 @NoJSR250Annotations
 public class XSLTFeature extends AbstractFeature {
-    private final Portable portable = new Portable();
+    private final Portable delegate = new Portable();
 
     public void setInXSLTPath(String inXSLTPath) {
-        portable.setInXSLTPath(inXSLTPath);
+        delegate.setInXSLTPath(inXSLTPath);
     }
 
     public void setOutXSLTPath(String outXSLTPath) {
-        portable.setOutXSLTPath(outXSLTPath);
+        delegate.setOutXSLTPath(outXSLTPath);
     }
 
     @Override
     protected void initializeProvider(InterceptorProvider interceptorProvider, Bus bus) {
-        portable.doInitializeProvider(interceptorProvider, bus);
+        delegate.doInitializeProvider(interceptorProvider, bus);
+    }
+
+    @Override
+    public void initialize(Server server, Bus bus) {
+        delegate.initialize(server, bus);
+    }
+
+    @Override
+    public void initialize(Client client, Bus bus) {
+        delegate.initialize(client, bus);
+    }
+
+    @Override
+    public void initialize(InterceptorProvider interceptorProvider, Bus bus) {
+        delegate.initialize(interceptorProvider, bus);
+    }
+
+    @Override
+    public void initialize(Bus bus) {
+        delegate.initialize(bus);
     }
 
     public static class Portable implements AbstractPortableFeature {

--- a/core/src/main/java/org/apache/cxf/feature/validation/SchemaValidationFeature.java
+++ b/core/src/main/java/org/apache/cxf/feature/validation/SchemaValidationFeature.java
@@ -24,8 +24,8 @@ import org.apache.cxf.annotations.SchemaValidation.SchemaValidationType;
 import org.apache.cxf.endpoint.Client;
 import org.apache.cxf.endpoint.Endpoint;
 import org.apache.cxf.endpoint.Server;
-import org.apache.cxf.feature.AbstractFeature;
 import org.apache.cxf.feature.AbstractPortableFeature;
+import org.apache.cxf.feature.DelegatingFeature;
 import org.apache.cxf.interceptor.InterceptorProvider;
 import org.apache.cxf.message.Message;
 import org.apache.cxf.service.model.BindingOperationInfo;
@@ -34,33 +34,9 @@ import org.apache.cxf.service.model.BindingOperationInfo;
  * A feature to configure schema validation at the operation level, as an alternative to
  * using the @SchemaValidation annotation.
  */
-public class SchemaValidationFeature extends AbstractFeature {
-    private final Portable delegate;
-
+public class SchemaValidationFeature extends DelegatingFeature<SchemaValidationFeature.Portable> {
     public SchemaValidationFeature(final SchemaValidationTypeProvider provider) {
-        this.delegate = new Portable(provider);
-    }
-
-    public void initialize(Server server, Bus bus) {
-        delegate.initialize(server, bus);
-    }
-
-    public void initialize(Client client, Bus bus) {
-        delegate.initialize(client, bus);
-    }
-
-    public void initialise(Endpoint endpoint) {
-        delegate.initialise(endpoint);
-    }
-
-    @Override
-    public void initialize(InterceptorProvider interceptorProvider, Bus bus) {
-        delegate.initialize(interceptorProvider, bus);
-    }
-
-    @Override
-    public void initialize(Bus bus) {
-        delegate.initialize(bus);
+        super(new Portable(provider));
     }
 
     public static class Portable implements AbstractPortableFeature {

--- a/core/src/main/java/org/apache/cxf/feature/validation/SchemaValidationFeature.java
+++ b/core/src/main/java/org/apache/cxf/feature/validation/SchemaValidationFeature.java
@@ -49,6 +49,20 @@ public class SchemaValidationFeature extends AbstractFeature {
         delegate.initialize(client, bus);
     }
 
+    public void initialise(Endpoint endpoint) {
+        delegate.initialise(endpoint);
+    }
+
+    @Override
+    public void initialize(InterceptorProvider interceptorProvider, Bus bus) {
+        delegate.initialize(interceptorProvider, bus);
+    }
+
+    @Override
+    public void initialize(Bus bus) {
+        delegate.initialize(bus);
+    }
+
     public static class Portable implements AbstractPortableFeature {
         private final SchemaValidationTypeProvider provider;
 
@@ -65,7 +79,7 @@ public class SchemaValidationFeature extends AbstractFeature {
         }
 
         @Override
-        public void doInitializeProvider(InterceptorProvider provider, Bus bus) {
+        public void doInitializeProvider(InterceptorProvider interceptorProvider, Bus bus) {
             // no-op
         }
 

--- a/core/src/main/java/org/apache/cxf/interceptor/security/JAASAuthenticationFeature.java
+++ b/core/src/main/java/org/apache/cxf/interceptor/security/JAASAuthenticationFeature.java
@@ -19,43 +19,18 @@
 package org.apache.cxf.interceptor.security;
 
 import org.apache.cxf.Bus;
-import org.apache.cxf.endpoint.Client;
-import org.apache.cxf.endpoint.Server;
-import org.apache.cxf.feature.AbstractFeature;
 import org.apache.cxf.feature.AbstractPortableFeature;
+import org.apache.cxf.feature.DelegatingFeature;
 import org.apache.cxf.interceptor.InterceptorProvider;
 
 /**
  * Feature to do JAAS authentication with defaults for karaf integration
  */
-public class JAASAuthenticationFeature extends AbstractFeature {
+public class JAASAuthenticationFeature extends DelegatingFeature<JAASAuthenticationFeature.Portable> {
     public static final String ID = "jaas";
 
-    private Portable delegate = new Portable();
-
-    @Override
-    public void initializeProvider(InterceptorProvider provider, Bus bus) {
-        delegate.doInitializeProvider(provider, bus);
-    }
-
-    @Override
-    public void initialize(Server server, Bus bus) {
-        delegate.initialize(server, bus);
-    }
-
-    @Override
-    public void initialize(Client client, Bus bus) {
-        delegate.initialize(client, bus);
-    }
-
-    @Override
-    public void initialize(InterceptorProvider interceptorProvider, Bus bus) {
-        delegate.initialize(interceptorProvider, bus);
-    }
-
-    @Override
-    public void initialize(Bus bus) {
-        delegate.initialize(bus);
+    public JAASAuthenticationFeature() {
+        super(new Portable());
     }
 
     public void setContextName(String contextName) {
@@ -70,7 +45,6 @@ public class JAASAuthenticationFeature extends AbstractFeature {
     public String getID() {
         return ID;
     }
-
 
     public static class Portable implements AbstractPortableFeature {
         private String contextName = "karaf";

--- a/core/src/main/java/org/apache/cxf/interceptor/security/JAASAuthenticationFeature.java
+++ b/core/src/main/java/org/apache/cxf/interceptor/security/JAASAuthenticationFeature.java
@@ -20,6 +20,7 @@ package org.apache.cxf.interceptor.security;
 
 import org.apache.cxf.Bus;
 import org.apache.cxf.feature.AbstractFeature;
+import org.apache.cxf.feature.AbstractPortableFeature;
 import org.apache.cxf.interceptor.InterceptorProvider;
 
 /**
@@ -28,31 +29,48 @@ import org.apache.cxf.interceptor.InterceptorProvider;
 public class JAASAuthenticationFeature extends AbstractFeature {
     public static final String ID = "jaas";
 
-    private String contextName = "karaf";
-    private boolean reportFault;
+    private Portable delegate = new Portable();
+
+    @Override
+    public void initializeProvider(InterceptorProvider provider, Bus bus) {
+        delegate.doInitializeProvider(provider, bus);
+    }
+
+    public void setContextName(String contextName) {
+        delegate.setContextName(contextName);
+    }
+
+    public void setReportFault(boolean reportFault) {
+        delegate.setReportFault(reportFault);
+    }
 
     @Override
     public String getID() {
         return ID;
     }
 
-    @Override
-    protected void initializeProvider(InterceptorProvider provider, Bus bus) {
-        JAASLoginInterceptor jaasLoginInterceptor = new JAASLoginInterceptor();
-        jaasLoginInterceptor.setRoleClassifierType(JAASLoginInterceptor.ROLE_CLASSIFIER_CLASS_NAME);
-        jaasLoginInterceptor.setRoleClassifier("org.apache.karaf.jaas.boot.principal.RolePrincipal");
-        jaasLoginInterceptor.setContextName(contextName);
-        jaasLoginInterceptor.setReportFault(reportFault);
-        provider.getInInterceptors().add(jaasLoginInterceptor);
-        super.initializeProvider(provider, bus);
-    }
 
-    public void setContextName(String contextName) {
-        this.contextName = contextName;
-    }
+    public static class Portable implements AbstractPortableFeature {
+        private String contextName = "karaf";
+        private boolean reportFault;
 
-    public void setReportFault(boolean reportFault) {
-        this.reportFault = reportFault;
+        @Override
+        public void doInitializeProvider(InterceptorProvider provider, Bus bus) {
+            JAASLoginInterceptor jaasLoginInterceptor = new JAASLoginInterceptor();
+            jaasLoginInterceptor.setRoleClassifierType(JAASLoginInterceptor.ROLE_CLASSIFIER_CLASS_NAME);
+            jaasLoginInterceptor.setRoleClassifier("org.apache.karaf.jaas.boot.principal.RolePrincipal");
+            jaasLoginInterceptor.setContextName(contextName);
+            jaasLoginInterceptor.setReportFault(reportFault);
+            provider.getInInterceptors().add(jaasLoginInterceptor);
+        }
+
+        public void setContextName(String contextName) {
+            this.contextName = contextName;
+        }
+
+        public void setReportFault(boolean reportFault) {
+            this.reportFault = reportFault;
+        }
     }
 
 }

--- a/core/src/main/java/org/apache/cxf/interceptor/security/JAASAuthenticationFeature.java
+++ b/core/src/main/java/org/apache/cxf/interceptor/security/JAASAuthenticationFeature.java
@@ -19,6 +19,8 @@
 package org.apache.cxf.interceptor.security;
 
 import org.apache.cxf.Bus;
+import org.apache.cxf.endpoint.Client;
+import org.apache.cxf.endpoint.Server;
 import org.apache.cxf.feature.AbstractFeature;
 import org.apache.cxf.feature.AbstractPortableFeature;
 import org.apache.cxf.interceptor.InterceptorProvider;
@@ -34,6 +36,26 @@ public class JAASAuthenticationFeature extends AbstractFeature {
     @Override
     public void initializeProvider(InterceptorProvider provider, Bus bus) {
         delegate.doInitializeProvider(provider, bus);
+    }
+
+    @Override
+    public void initialize(Server server, Bus bus) {
+        delegate.initialize(server, bus);
+    }
+
+    @Override
+    public void initialize(Client client, Bus bus) {
+        delegate.initialize(client, bus);
+    }
+
+    @Override
+    public void initialize(InterceptorProvider interceptorProvider, Bus bus) {
+        delegate.initialize(interceptorProvider, bus);
+    }
+
+    @Override
+    public void initialize(Bus bus) {
+        delegate.initialize(bus);
     }
 
     public void setContextName(String contextName) {

--- a/core/src/main/java/org/apache/cxf/transport/common/gzip/GZIPFeature.java
+++ b/core/src/main/java/org/apache/cxf/transport/common/gzip/GZIPFeature.java
@@ -23,6 +23,8 @@ import java.util.List;
 import org.apache.cxf.Bus;
 import org.apache.cxf.annotations.Provider;
 import org.apache.cxf.common.injection.NoJSR250Annotations;
+import org.apache.cxf.endpoint.Client;
+import org.apache.cxf.endpoint.Server;
 import org.apache.cxf.feature.AbstractFeature;
 import org.apache.cxf.feature.AbstractPortableFeature;
 import org.apache.cxf.interceptor.Interceptor;
@@ -77,6 +79,26 @@ public class GZIPFeature extends AbstractFeature {
     @Override
     protected void initializeProvider(InterceptorProvider interceptorProvider, Bus bus) {
         delegate.doInitializeProvider(interceptorProvider, bus);
+    }
+
+    @Override
+    public void initialize(Server server, Bus bus) {
+        delegate.initialize(server, bus);
+    }
+
+    @Override
+    public void initialize(Client client, Bus bus) {
+        delegate.initialize(client, bus);
+    }
+
+    @Override
+    public void initialize(InterceptorProvider interceptorProvider, Bus bus) {
+        delegate.initialize(interceptorProvider, bus);
+    }
+
+    @Override
+    public void initialize(Bus bus) {
+        delegate.initialize(bus);
     }
 
     @Provider(value = Provider.Type.Feature)

--- a/core/src/main/java/org/apache/cxf/transport/common/gzip/GZIPFeature.java
+++ b/core/src/main/java/org/apache/cxf/transport/common/gzip/GZIPFeature.java
@@ -23,10 +23,8 @@ import java.util.List;
 import org.apache.cxf.Bus;
 import org.apache.cxf.annotations.Provider;
 import org.apache.cxf.common.injection.NoJSR250Annotations;
-import org.apache.cxf.endpoint.Client;
-import org.apache.cxf.endpoint.Server;
-import org.apache.cxf.feature.AbstractFeature;
 import org.apache.cxf.feature.AbstractPortableFeature;
+import org.apache.cxf.feature.DelegatingFeature;
 import org.apache.cxf.interceptor.Interceptor;
 import org.apache.cxf.interceptor.InterceptorProvider;
 import org.apache.cxf.message.Message;
@@ -53,8 +51,11 @@ import org.apache.cxf.message.Message;
  */
 @NoJSR250Annotations
 @Provider(value = Provider.Type.Feature)
-public class GZIPFeature extends AbstractFeature {
-    private Portable delegate = new Portable();
+public class GZIPFeature extends DelegatingFeature<GZIPFeature.Portable> {
+
+    public GZIPFeature() {
+        super(new Portable());
+    }
 
     public void remove(List<Interceptor<? extends Message>> outInterceptors) {
         delegate.remove(outInterceptors);
@@ -74,31 +75,6 @@ public class GZIPFeature extends AbstractFeature {
 
     public boolean getForce() {
         return delegate.getForce();
-    }
-
-    @Override
-    protected void initializeProvider(InterceptorProvider interceptorProvider, Bus bus) {
-        delegate.doInitializeProvider(interceptorProvider, bus);
-    }
-
-    @Override
-    public void initialize(Server server, Bus bus) {
-        delegate.initialize(server, bus);
-    }
-
-    @Override
-    public void initialize(Client client, Bus bus) {
-        delegate.initialize(client, bus);
-    }
-
-    @Override
-    public void initialize(InterceptorProvider interceptorProvider, Bus bus) {
-        delegate.initialize(interceptorProvider, bus);
-    }
-
-    @Override
-    public void initialize(Bus bus) {
-        delegate.initialize(bus);
     }
 
     @Provider(value = Provider.Type.Feature)

--- a/core/src/main/java/org/apache/cxf/transport/common/gzip/GZIPFeature.java
+++ b/core/src/main/java/org/apache/cxf/transport/common/gzip/GZIPFeature.java
@@ -24,6 +24,7 @@ import org.apache.cxf.Bus;
 import org.apache.cxf.annotations.Provider;
 import org.apache.cxf.common.injection.NoJSR250Annotations;
 import org.apache.cxf.feature.AbstractFeature;
+import org.apache.cxf.feature.AbstractPortableFeature;
 import org.apache.cxf.interceptor.Interceptor;
 import org.apache.cxf.interceptor.InterceptorProvider;
 import org.apache.cxf.message.Message;
@@ -51,68 +52,98 @@ import org.apache.cxf.message.Message;
 @NoJSR250Annotations
 @Provider(value = Provider.Type.Feature)
 public class GZIPFeature extends AbstractFeature {
-    private static final GZIPInInterceptor IN = new GZIPInInterceptor();
-    private static final GZIPOutInterceptor OUT = new GZIPOutInterceptor();
+    private Portable delegate = new Portable();
 
-    /**
-     * The compression threshold to pass to the outgoing interceptor.
-     */
-    int threshold = -1;
-
-    /**
-     * Force GZIP instead of negotiate
-     */
-    boolean force;
-
-
-    @Override
-    protected void initializeProvider(InterceptorProvider provider, Bus bus) {
-        provider.getInInterceptors().add(IN);
-        if (threshold == -1 && !force) {
-            provider.getOutInterceptors().add(OUT);
-            provider.getOutFaultInterceptors().add(OUT);
-        } else {
-            GZIPOutInterceptor out = new GZIPOutInterceptor();
-            out.setThreshold(threshold);
-            out.setForce(force);
-            remove(provider.getOutInterceptors());
-            remove(provider.getOutFaultInterceptors());
-            provider.getOutInterceptors().add(out);
-            provider.getOutFaultInterceptors().add(out);
-        }
-    }
-
-    private void remove(List<Interceptor<? extends Message>> outInterceptors) {
-        int x = outInterceptors.size();
-        while (x > 0) {
-            --x;
-            if (outInterceptors.get(x) instanceof GZIPOutInterceptor) {
-                outInterceptors.remove(x);
-            }
-        }
+    public void remove(List<Interceptor<? extends Message>> outInterceptors) {
+        delegate.remove(outInterceptors);
     }
 
     public void setThreshold(int threshold) {
-        this.threshold = threshold;
+        delegate.setThreshold(threshold);
     }
 
     public int getThreshold() {
-        return threshold;
+        return delegate.getThreshold();
     }
 
-
-    /**
-     * Set if GZIP is always used without negotiation
-     * @param b
-     */
     public void setForce(boolean b) {
-        force = b;
+        delegate.setForce(b);
     }
 
-    /**
-     * Retrieve the value set with {@link #setForce(boolean)}.
-     */
     public boolean getForce() {
-        return force;
+        return delegate.getForce();
+    }
+
+    @Override
+    protected void initializeProvider(InterceptorProvider interceptorProvider, Bus bus) {
+        delegate.doInitializeProvider(interceptorProvider, bus);
+    }
+
+    @Provider(value = Provider.Type.Feature)
+    public static class Portable implements AbstractPortableFeature {
+        private static final GZIPInInterceptor IN = new GZIPInInterceptor();
+        private static final GZIPOutInterceptor OUT = new GZIPOutInterceptor();
+
+        /**
+         * The compression threshold to pass to the outgoing interceptor.
+         */
+        int threshold = -1;
+
+        /**
+         * Force GZIP instead of negotiate
+         */
+        boolean force;
+
+
+        @Override
+        public void doInitializeProvider(InterceptorProvider provider, Bus bus) {
+            provider.getInInterceptors().add(IN);
+            if (threshold == -1 && !force) {
+                provider.getOutInterceptors().add(OUT);
+                provider.getOutFaultInterceptors().add(OUT);
+            } else {
+                GZIPOutInterceptor out = new GZIPOutInterceptor();
+                out.setThreshold(threshold);
+                out.setForce(force);
+                remove(provider.getOutInterceptors());
+                remove(provider.getOutFaultInterceptors());
+                provider.getOutInterceptors().add(out);
+                provider.getOutFaultInterceptors().add(out);
+            }
+        }
+
+        private void remove(List<Interceptor<? extends Message>> outInterceptors) {
+            int x = outInterceptors.size();
+            while (x > 0) {
+                --x;
+                if (outInterceptors.get(x) instanceof GZIPOutInterceptor) {
+                    outInterceptors.remove(x);
+                }
+            }
+        }
+
+        public void setThreshold(int threshold) {
+            this.threshold = threshold;
+        }
+
+        public int getThreshold() {
+            return threshold;
+        }
+
+
+        /**
+         * Set if GZIP is always used without negotiation
+         * @param b
+         */
+        public void setForce(boolean b) {
+            force = b;
+        }
+
+        /**
+         * Retrieve the value set with {@link #setForce(boolean)}.
+         */
+        public boolean getForce() {
+            return force;
+        }
     }
 }

--- a/core/src/main/java/org/apache/cxf/validation/BeanValidationFeature.java
+++ b/core/src/main/java/org/apache/cxf/validation/BeanValidationFeature.java
@@ -22,6 +22,8 @@ import org.apache.cxf.Bus;
 import org.apache.cxf.annotations.Provider;
 import org.apache.cxf.annotations.Provider.Scope;
 import org.apache.cxf.annotations.Provider.Type;
+import org.apache.cxf.endpoint.Client;
+import org.apache.cxf.endpoint.Server;
 import org.apache.cxf.feature.AbstractFeature;
 import org.apache.cxf.feature.AbstractPortableFeature;
 import org.apache.cxf.interceptor.InterceptorProvider;
@@ -34,6 +36,26 @@ public class BeanValidationFeature extends AbstractFeature {
     @Override
     protected void initializeProvider(InterceptorProvider interceptorProvider, Bus bus) {
         delegate.doInitializeProvider(interceptorProvider, bus);
+    }
+
+    @Override
+    public void initialize(Server server, Bus bus) {
+        delegate.initialize(server, bus);
+    }
+
+    @Override
+    public void initialize(Client client, Bus bus) {
+        delegate.initialize(client, bus);
+    }
+
+    @Override
+    public void initialize(InterceptorProvider interceptorProvider, Bus bus) {
+        delegate.initialize(interceptorProvider, bus);
+    }
+
+    @Override
+    public void initialize(Bus bus) {
+        delegate.initialize(bus);
     }
 
     public void setProvider(BeanValidationProvider provider) {

--- a/core/src/main/java/org/apache/cxf/validation/BeanValidationFeature.java
+++ b/core/src/main/java/org/apache/cxf/validation/BeanValidationFeature.java
@@ -22,40 +22,15 @@ import org.apache.cxf.Bus;
 import org.apache.cxf.annotations.Provider;
 import org.apache.cxf.annotations.Provider.Scope;
 import org.apache.cxf.annotations.Provider.Type;
-import org.apache.cxf.endpoint.Client;
-import org.apache.cxf.endpoint.Server;
-import org.apache.cxf.feature.AbstractFeature;
 import org.apache.cxf.feature.AbstractPortableFeature;
+import org.apache.cxf.feature.DelegatingFeature;
 import org.apache.cxf.interceptor.InterceptorProvider;
 
 @Provider(value = Type.Feature, scope = Scope.Server)
-public class BeanValidationFeature extends AbstractFeature {
+public class BeanValidationFeature extends DelegatingFeature<BeanValidationFeature.Portable> {
 
-    private Portable delegate = new Portable();
-
-    @Override
-    protected void initializeProvider(InterceptorProvider interceptorProvider, Bus bus) {
-        delegate.doInitializeProvider(interceptorProvider, bus);
-    }
-
-    @Override
-    public void initialize(Server server, Bus bus) {
-        delegate.initialize(server, bus);
-    }
-
-    @Override
-    public void initialize(Client client, Bus bus) {
-        delegate.initialize(client, bus);
-    }
-
-    @Override
-    public void initialize(InterceptorProvider interceptorProvider, Bus bus) {
-        delegate.initialize(interceptorProvider, bus);
-    }
-
-    @Override
-    public void initialize(Bus bus) {
-        delegate.initialize(bus);
+    public BeanValidationFeature() {
+        super(new Portable());
     }
 
     public void setProvider(BeanValidationProvider provider) {

--- a/core/src/main/java/org/apache/cxf/validation/BeanValidationFeature.java
+++ b/core/src/main/java/org/apache/cxf/validation/BeanValidationFeature.java
@@ -23,26 +23,43 @@ import org.apache.cxf.annotations.Provider;
 import org.apache.cxf.annotations.Provider.Scope;
 import org.apache.cxf.annotations.Provider.Type;
 import org.apache.cxf.feature.AbstractFeature;
+import org.apache.cxf.feature.AbstractPortableFeature;
 import org.apache.cxf.interceptor.InterceptorProvider;
 
 @Provider(value = Type.Feature, scope = Scope.Server)
 public class BeanValidationFeature extends AbstractFeature {
 
-    private BeanValidationProvider validationProvider;
+    private Portable delegate = new Portable();
 
     @Override
     protected void initializeProvider(InterceptorProvider interceptorProvider, Bus bus) {
-        BeanValidationInInterceptor in = new BeanValidationInInterceptor();
-        BeanValidationOutInterceptor out = new BeanValidationOutInterceptor();
-        if (validationProvider != null) {
-            in.setProvider(validationProvider);
-            out.setProvider(validationProvider);
-        }
-        interceptorProvider.getInInterceptors().add(in);
-        interceptorProvider.getOutInterceptors().add(out);
+        delegate.doInitializeProvider(interceptorProvider, bus);
     }
 
     public void setProvider(BeanValidationProvider provider) {
-        this.validationProvider = provider;
+        delegate.setProvider(provider);
     }
+
+    @Provider(value = Type.Feature, scope = Scope.Server)
+    public static class Portable implements AbstractPortableFeature {
+
+        private BeanValidationProvider validationProvider;
+
+        @Override
+        public void doInitializeProvider(InterceptorProvider interceptorProvider, Bus bus) {
+            BeanValidationInInterceptor in = new BeanValidationInInterceptor();
+            BeanValidationOutInterceptor out = new BeanValidationOutInterceptor();
+            if (validationProvider != null) {
+                in.setProvider(validationProvider);
+                out.setProvider(validationProvider);
+            }
+            interceptorProvider.getInInterceptors().add(in);
+            interceptorProvider.getOutInterceptors().add(out);
+        }
+
+        public void setProvider(BeanValidationProvider provider) {
+            this.validationProvider = provider;
+        }
+    }
+
 }

--- a/core/src/main/java/org/apache/cxf/validation/ClientBeanValidationFeature.java
+++ b/core/src/main/java/org/apache/cxf/validation/ClientBeanValidationFeature.java
@@ -23,28 +23,50 @@ import org.apache.cxf.annotations.Provider;
 import org.apache.cxf.annotations.Provider.Scope;
 import org.apache.cxf.annotations.Provider.Type;
 import org.apache.cxf.feature.AbstractFeature;
+import org.apache.cxf.feature.AbstractPortableFeature;
 import org.apache.cxf.interceptor.InterceptorProvider;
 
 @Provider(value = Type.Feature, scope = Scope.Client)
 public class ClientBeanValidationFeature extends AbstractFeature {
+    private final Portable delegate = getDelegate();
 
-    private BeanValidationProvider validationProvider;
-
-    @Override
-    protected void initializeProvider(InterceptorProvider interceptorProvider, Bus bus) {
-        ClientBeanValidationOutInterceptor out = new ClientBeanValidationOutInterceptor();
-        addInterceptor(interceptorProvider, out);
+    protected Portable getDelegate() {
+        return new Portable();
     }
 
-    protected void addInterceptor(InterceptorProvider interceptorProvider, ClientBeanValidationOutInterceptor out) {
-        if (validationProvider != null) {
-            out.setProvider(validationProvider);
-        }
-        interceptorProvider.getOutInterceptors().add(out);
-
+    public void addInterceptor(InterceptorProvider interceptorProvider, ClientBeanValidationOutInterceptor out) {
+        delegate.addInterceptor(interceptorProvider, out);
     }
 
     public void setProvider(BeanValidationProvider provider) {
-        this.validationProvider = provider;
+        delegate.setProvider(provider);
+    }
+
+    @Override
+    protected void initializeProvider(InterceptorProvider interceptorProvider, Bus bus) {
+        delegate.doInitializeProvider(interceptorProvider, bus);
+    }
+
+    @Provider(value = Type.Feature, scope = Scope.Client)
+    public static class Portable implements AbstractPortableFeature {
+        private BeanValidationProvider validationProvider;
+
+        @Override
+        public void doInitializeProvider(InterceptorProvider interceptorProvider, Bus bus) {
+            ClientBeanValidationOutInterceptor out = new ClientBeanValidationOutInterceptor();
+            addInterceptor(interceptorProvider, out);
+        }
+
+        protected void addInterceptor(InterceptorProvider interceptorProvider, ClientBeanValidationOutInterceptor out) {
+            if (validationProvider != null) {
+                out.setProvider(validationProvider);
+            }
+            interceptorProvider.getOutInterceptors().add(out);
+
+        }
+
+        public void setProvider(BeanValidationProvider provider) {
+            this.validationProvider = provider;
+        }
     }
 }

--- a/core/src/main/java/org/apache/cxf/validation/ClientBeanValidationFeature.java
+++ b/core/src/main/java/org/apache/cxf/validation/ClientBeanValidationFeature.java
@@ -22,6 +22,8 @@ import org.apache.cxf.Bus;
 import org.apache.cxf.annotations.Provider;
 import org.apache.cxf.annotations.Provider.Scope;
 import org.apache.cxf.annotations.Provider.Type;
+import org.apache.cxf.endpoint.Client;
+import org.apache.cxf.endpoint.Server;
 import org.apache.cxf.feature.AbstractFeature;
 import org.apache.cxf.feature.AbstractPortableFeature;
 import org.apache.cxf.interceptor.InterceptorProvider;
@@ -40,6 +42,26 @@ public class ClientBeanValidationFeature extends AbstractFeature {
 
     public void setProvider(BeanValidationProvider provider) {
         delegate.setProvider(provider);
+    }
+
+    @Override
+    public void initialize(Server server, Bus bus) {
+        delegate.initialize(server, bus);
+    }
+
+    @Override
+    public void initialize(Client client, Bus bus) {
+        delegate.initialize(client, bus);
+    }
+
+    @Override
+    public void initialize(InterceptorProvider interceptorProvider, Bus bus) {
+        delegate.initialize(interceptorProvider, bus);
+    }
+
+    @Override
+    public void initialize(Bus bus) {
+        delegate.initialize(bus);
     }
 
     @Override

--- a/core/src/main/java/org/apache/cxf/validation/ClientBeanValidationFeature.java
+++ b/core/src/main/java/org/apache/cxf/validation/ClientBeanValidationFeature.java
@@ -22,18 +22,18 @@ import org.apache.cxf.Bus;
 import org.apache.cxf.annotations.Provider;
 import org.apache.cxf.annotations.Provider.Scope;
 import org.apache.cxf.annotations.Provider.Type;
-import org.apache.cxf.endpoint.Client;
-import org.apache.cxf.endpoint.Server;
-import org.apache.cxf.feature.AbstractFeature;
 import org.apache.cxf.feature.AbstractPortableFeature;
+import org.apache.cxf.feature.DelegatingFeature;
 import org.apache.cxf.interceptor.InterceptorProvider;
 
 @Provider(value = Type.Feature, scope = Scope.Client)
-public class ClientBeanValidationFeature extends AbstractFeature {
-    private final Portable delegate = getDelegate();
+public class ClientBeanValidationFeature extends DelegatingFeature<ClientBeanValidationFeature.Portable> {
+    public ClientBeanValidationFeature() {
+        super(new Portable());
+    }
 
-    protected Portable getDelegate() {
-        return new Portable();
+    protected ClientBeanValidationFeature(final Portable d) {
+        super(d);
     }
 
     public void addInterceptor(InterceptorProvider interceptorProvider, ClientBeanValidationOutInterceptor out) {
@@ -42,31 +42,6 @@ public class ClientBeanValidationFeature extends AbstractFeature {
 
     public void setProvider(BeanValidationProvider provider) {
         delegate.setProvider(provider);
-    }
-
-    @Override
-    public void initialize(Server server, Bus bus) {
-        delegate.initialize(server, bus);
-    }
-
-    @Override
-    public void initialize(Client client, Bus bus) {
-        delegate.initialize(client, bus);
-    }
-
-    @Override
-    public void initialize(InterceptorProvider interceptorProvider, Bus bus) {
-        delegate.initialize(interceptorProvider, bus);
-    }
-
-    @Override
-    public void initialize(Bus bus) {
-        delegate.initialize(bus);
-    }
-
-    @Override
-    protected void initializeProvider(InterceptorProvider interceptorProvider, Bus bus) {
-        delegate.doInitializeProvider(interceptorProvider, bus);
     }
 
     @Provider(value = Type.Feature, scope = Scope.Client)

--- a/integration/tracing/tracing-brave/src/main/java/org/apache/cxf/tracing/brave/BraveClientFeature.java
+++ b/integration/tracing/tracing-brave/src/main/java/org/apache/cxf/tracing/brave/BraveClientFeature.java
@@ -25,48 +25,19 @@ import org.apache.cxf.annotations.Provider;
 import org.apache.cxf.annotations.Provider.Scope;
 import org.apache.cxf.annotations.Provider.Type;
 import org.apache.cxf.common.injection.NoJSR250Annotations;
-import org.apache.cxf.endpoint.Client;
-import org.apache.cxf.endpoint.Server;
-import org.apache.cxf.feature.AbstractFeature;
 import org.apache.cxf.feature.AbstractPortableFeature;
+import org.apache.cxf.feature.DelegatingFeature;
 import org.apache.cxf.interceptor.InterceptorProvider;
 
 @NoJSR250Annotations
 @Provider(value = Type.Feature, scope = Scope.Client)
-public class BraveClientFeature extends AbstractFeature {
-    private Portable delegate;
-
+public class BraveClientFeature extends DelegatingFeature<BraveClientFeature.Portable> {
     public BraveClientFeature(final Tracing tracing) {
-        delegate = new Portable(tracing);
+        super(new Portable(tracing));
     }
 
     public BraveClientFeature(HttpTracing brave) {
-        delegate = new Portable(brave);
-    }
-
-    @Override
-    protected void initializeProvider(InterceptorProvider provider, Bus bus) {
-        delegate.doInitializeProvider(provider, bus);
-    }
-
-    @Override
-    public void initialize(Server server, Bus bus) {
-        delegate.initialize(server, bus);
-    }
-
-    @Override
-    public void initialize(Client client, Bus bus) {
-        delegate.initialize(client, bus);
-    }
-
-    @Override
-    public void initialize(InterceptorProvider interceptorProvider, Bus bus) {
-        delegate.initialize(interceptorProvider, bus);
-    }
-
-    @Override
-    public void initialize(Bus bus) {
-        delegate.initialize(bus);
+        super(new Portable(brave));
     }
 
     @Provider(value = Type.Feature, scope = Scope.Client)

--- a/integration/tracing/tracing-brave/src/main/java/org/apache/cxf/tracing/brave/BraveClientFeature.java
+++ b/integration/tracing/tracing-brave/src/main/java/org/apache/cxf/tracing/brave/BraveClientFeature.java
@@ -25,6 +25,8 @@ import org.apache.cxf.annotations.Provider;
 import org.apache.cxf.annotations.Provider.Scope;
 import org.apache.cxf.annotations.Provider.Type;
 import org.apache.cxf.common.injection.NoJSR250Annotations;
+import org.apache.cxf.endpoint.Client;
+import org.apache.cxf.endpoint.Server;
 import org.apache.cxf.feature.AbstractFeature;
 import org.apache.cxf.feature.AbstractPortableFeature;
 import org.apache.cxf.interceptor.InterceptorProvider;
@@ -45,6 +47,26 @@ public class BraveClientFeature extends AbstractFeature {
     @Override
     protected void initializeProvider(InterceptorProvider provider, Bus bus) {
         delegate.doInitializeProvider(provider, bus);
+    }
+
+    @Override
+    public void initialize(Server server, Bus bus) {
+        delegate.initialize(server, bus);
+    }
+
+    @Override
+    public void initialize(Client client, Bus bus) {
+        delegate.initialize(client, bus);
+    }
+
+    @Override
+    public void initialize(InterceptorProvider interceptorProvider, Bus bus) {
+        delegate.initialize(interceptorProvider, bus);
+    }
+
+    @Override
+    public void initialize(Bus bus) {
+        delegate.initialize(bus);
     }
 
     @Provider(value = Type.Feature, scope = Scope.Client)

--- a/integration/tracing/tracing-brave/src/main/java/org/apache/cxf/tracing/brave/BraveFeature.java
+++ b/integration/tracing/tracing-brave/src/main/java/org/apache/cxf/tracing/brave/BraveFeature.java
@@ -27,6 +27,8 @@ import org.apache.cxf.annotations.Provider;
 import org.apache.cxf.annotations.Provider.Scope;
 import org.apache.cxf.annotations.Provider.Type;
 import org.apache.cxf.common.injection.NoJSR250Annotations;
+import org.apache.cxf.endpoint.Client;
+import org.apache.cxf.endpoint.Server;
 import org.apache.cxf.feature.AbstractFeature;
 import org.apache.cxf.feature.AbstractPortableFeature;
 import org.apache.cxf.interceptor.InterceptorProvider;
@@ -55,6 +57,26 @@ public class BraveFeature extends AbstractFeature {
     @Override
     protected void initializeProvider(InterceptorProvider provider, Bus bus) {
         delegate.doInitializeProvider(provider, bus);
+    }
+
+    @Override
+    public void initialize(Server server, Bus bus) {
+        delegate.initialize(server, bus);
+    }
+
+    @Override
+    public void initialize(Client client, Bus bus) {
+        delegate.initialize(client, bus);
+    }
+
+    @Override
+    public void initialize(InterceptorProvider interceptorProvider, Bus bus) {
+        delegate.initialize(interceptorProvider, bus);
+    }
+
+    @Override
+    public void initialize(Bus bus) {
+        delegate.initialize(bus);
     }
 
     @Provider(value = Type.Feature, scope = Scope.Server)

--- a/integration/tracing/tracing-brave/src/main/java/org/apache/cxf/tracing/brave/BraveFeature.java
+++ b/integration/tracing/tracing-brave/src/main/java/org/apache/cxf/tracing/brave/BraveFeature.java
@@ -28,47 +28,75 @@ import org.apache.cxf.annotations.Provider.Scope;
 import org.apache.cxf.annotations.Provider.Type;
 import org.apache.cxf.common.injection.NoJSR250Annotations;
 import org.apache.cxf.feature.AbstractFeature;
+import org.apache.cxf.feature.AbstractPortableFeature;
 import org.apache.cxf.interceptor.InterceptorProvider;
 
 @NoJSR250Annotations
 @Provider(value = Type.Feature, scope = Scope.Server)
 public class BraveFeature extends AbstractFeature {
-    private BraveStartInterceptor in;
-    private BraveStopInterceptor out;
+    private Portable delegate;
 
     public BraveFeature() {
         this("cxf-svc-" + UUID.randomUUID().toString());
     }
 
-    public BraveFeature(final String name) {
-        this(
-            HttpTracing
-                .newBuilder(Tracing.newBuilder().localServiceName(name).build())
-                .serverParser(new HttpServerSpanParser())
-                .build()
-        );
-    }
-    
     public BraveFeature(final Tracing tracing) {
-        this(
-          HttpTracing
-              .newBuilder(tracing)
-              .serverParser(new HttpServerSpanParser())
-              .build()
-        );
+        this(Portable.newTracer(tracing));
+    }
+
+    public BraveFeature(final String name) {
+        this(Portable.newTracer(Portable.newTracing(name)));
     }
 
     public BraveFeature(HttpTracing brave) {
-        in = new BraveStartInterceptor(brave);
-        out = new BraveStopInterceptor(brave);
+        delegate = new Portable(brave);
     }
 
     @Override
     protected void initializeProvider(InterceptorProvider provider, Bus bus) {
-        provider.getInInterceptors().add(in);
-        provider.getInFaultInterceptors().add(in);
+        delegate.doInitializeProvider(provider, bus);
+    }
 
-        provider.getOutInterceptors().add(out);
-        provider.getOutFaultInterceptors().add(out);
+    @Provider(value = Type.Feature, scope = Scope.Server)
+    public static class Portable implements AbstractPortableFeature {
+        private BraveStartInterceptor in;
+        private BraveStopInterceptor out;
+
+        public Portable() {
+            this("cxf-svc-" + UUID.randomUUID().toString());
+        }
+
+        public Portable(final String name) {
+            this(newTracer(newTracing(name)));
+        }
+
+        public Portable(final Tracing tracing) {
+            this(newTracer(tracing));
+        }
+
+        public Portable(HttpTracing brave) {
+            in = new BraveStartInterceptor(brave);
+            out = new BraveStopInterceptor(brave);
+        }
+
+        @Override
+        public void doInitializeProvider(InterceptorProvider provider, Bus bus) {
+            provider.getInInterceptors().add(in);
+            provider.getInFaultInterceptors().add(in);
+
+            provider.getOutInterceptors().add(out);
+            provider.getOutFaultInterceptors().add(out);
+        }
+
+        private static HttpTracing newTracer(Tracing tracing) {
+            return HttpTracing
+                    .newBuilder(tracing)
+                    .serverParser(new HttpServerSpanParser())
+                    .build();
+        }
+
+        private static Tracing newTracing(String name) {
+            return Tracing.newBuilder().localServiceName(name).build();
+        }
     }
 }

--- a/integration/tracing/tracing-brave/src/main/java/org/apache/cxf/tracing/brave/BraveFeature.java
+++ b/integration/tracing/tracing-brave/src/main/java/org/apache/cxf/tracing/brave/BraveFeature.java
@@ -27,17 +27,13 @@ import org.apache.cxf.annotations.Provider;
 import org.apache.cxf.annotations.Provider.Scope;
 import org.apache.cxf.annotations.Provider.Type;
 import org.apache.cxf.common.injection.NoJSR250Annotations;
-import org.apache.cxf.endpoint.Client;
-import org.apache.cxf.endpoint.Server;
-import org.apache.cxf.feature.AbstractFeature;
 import org.apache.cxf.feature.AbstractPortableFeature;
+import org.apache.cxf.feature.DelegatingFeature;
 import org.apache.cxf.interceptor.InterceptorProvider;
 
 @NoJSR250Annotations
 @Provider(value = Type.Feature, scope = Scope.Server)
-public class BraveFeature extends AbstractFeature {
-    private Portable delegate;
-
+public class BraveFeature extends DelegatingFeature<BraveFeature.Portable> {
     public BraveFeature() {
         this("cxf-svc-" + UUID.randomUUID().toString());
     }
@@ -51,32 +47,7 @@ public class BraveFeature extends AbstractFeature {
     }
 
     public BraveFeature(HttpTracing brave) {
-        delegate = new Portable(brave);
-    }
-
-    @Override
-    protected void initializeProvider(InterceptorProvider provider, Bus bus) {
-        delegate.doInitializeProvider(provider, bus);
-    }
-
-    @Override
-    public void initialize(Server server, Bus bus) {
-        delegate.initialize(server, bus);
-    }
-
-    @Override
-    public void initialize(Client client, Bus bus) {
-        delegate.initialize(client, bus);
-    }
-
-    @Override
-    public void initialize(InterceptorProvider interceptorProvider, Bus bus) {
-        delegate.initialize(interceptorProvider, bus);
-    }
-
-    @Override
-    public void initialize(Bus bus) {
-        delegate.initialize(bus);
+        super(new Portable(brave));
     }
 
     @Provider(value = Type.Feature, scope = Scope.Server)

--- a/integration/tracing/tracing-opentracing/src/main/java/org/apache/cxf/tracing/opentracing/OpenTracingClientFeature.java
+++ b/integration/tracing/tracing-opentracing/src/main/java/org/apache/cxf/tracing/opentracing/OpenTracingClientFeature.java
@@ -23,6 +23,8 @@ import org.apache.cxf.annotations.Provider;
 import org.apache.cxf.annotations.Provider.Scope;
 import org.apache.cxf.annotations.Provider.Type;
 import org.apache.cxf.common.injection.NoJSR250Annotations;
+import org.apache.cxf.endpoint.Client;
+import org.apache.cxf.endpoint.Server;
 import org.apache.cxf.feature.AbstractFeature;
 import org.apache.cxf.feature.AbstractPortableFeature;
 import org.apache.cxf.interceptor.InterceptorProvider;
@@ -41,6 +43,26 @@ public class OpenTracingClientFeature extends AbstractFeature {
     @Override
     protected void initializeProvider(InterceptorProvider provider, Bus bus) {
         delegate.doInitializeProvider(provider, bus);
+    }
+
+    @Override
+    public void initialize(Server server, Bus bus) {
+        delegate.initialize(server, bus);
+    }
+
+    @Override
+    public void initialize(Client client, Bus bus) {
+        delegate.initialize(client, bus);
+    }
+
+    @Override
+    public void initialize(InterceptorProvider interceptorProvider, Bus bus) {
+        delegate.initialize(interceptorProvider, bus);
+    }
+
+    @Override
+    public void initialize(Bus bus) {
+        delegate.initialize(bus);
     }
 
     @Provider(value = Type.Feature, scope = Scope.Client)

--- a/integration/tracing/tracing-opentracing/src/main/java/org/apache/cxf/tracing/opentracing/OpenTracingClientFeature.java
+++ b/integration/tracing/tracing-opentracing/src/main/java/org/apache/cxf/tracing/opentracing/OpenTracingClientFeature.java
@@ -23,46 +23,17 @@ import org.apache.cxf.annotations.Provider;
 import org.apache.cxf.annotations.Provider.Scope;
 import org.apache.cxf.annotations.Provider.Type;
 import org.apache.cxf.common.injection.NoJSR250Annotations;
-import org.apache.cxf.endpoint.Client;
-import org.apache.cxf.endpoint.Server;
-import org.apache.cxf.feature.AbstractFeature;
 import org.apache.cxf.feature.AbstractPortableFeature;
+import org.apache.cxf.feature.DelegatingFeature;
 import org.apache.cxf.interceptor.InterceptorProvider;
 
 import io.opentracing.Tracer;
 
 @NoJSR250Annotations
 @Provider(value = Type.Feature, scope = Scope.Client)
-public class OpenTracingClientFeature extends AbstractFeature {
-    private Portable delegate;
-
+public class OpenTracingClientFeature extends DelegatingFeature<OpenTracingClientFeature.Portable> {
     public OpenTracingClientFeature(Tracer tracer) {
-        this.delegate = new Portable(tracer);
-    }
-
-    @Override
-    protected void initializeProvider(InterceptorProvider provider, Bus bus) {
-        delegate.doInitializeProvider(provider, bus);
-    }
-
-    @Override
-    public void initialize(Server server, Bus bus) {
-        delegate.initialize(server, bus);
-    }
-
-    @Override
-    public void initialize(Client client, Bus bus) {
-        delegate.initialize(client, bus);
-    }
-
-    @Override
-    public void initialize(InterceptorProvider interceptorProvider, Bus bus) {
-        delegate.initialize(interceptorProvider, bus);
-    }
-
-    @Override
-    public void initialize(Bus bus) {
-        delegate.initialize(bus);
+        super(new Portable(tracer));
     }
 
     @Provider(value = Type.Feature, scope = Scope.Client)

--- a/integration/tracing/tracing-opentracing/src/main/java/org/apache/cxf/tracing/opentracing/OpenTracingFeature.java
+++ b/integration/tracing/tracing-opentracing/src/main/java/org/apache/cxf/tracing/opentracing/OpenTracingFeature.java
@@ -23,10 +23,8 @@ import org.apache.cxf.annotations.Provider;
 import org.apache.cxf.annotations.Provider.Scope;
 import org.apache.cxf.annotations.Provider.Type;
 import org.apache.cxf.common.injection.NoJSR250Annotations;
-import org.apache.cxf.endpoint.Client;
-import org.apache.cxf.endpoint.Server;
-import org.apache.cxf.feature.AbstractFeature;
 import org.apache.cxf.feature.AbstractPortableFeature;
+import org.apache.cxf.feature.DelegatingFeature;
 import org.apache.cxf.interceptor.InterceptorProvider;
 
 import io.opentracing.Tracer;
@@ -34,40 +32,13 @@ import io.opentracing.util.GlobalTracer;
 
 @NoJSR250Annotations
 @Provider(value = Type.Feature, scope = Scope.Server)
-public class OpenTracingFeature extends AbstractFeature {
-    private Portable delegate;
-
+public class OpenTracingFeature extends DelegatingFeature<OpenTracingFeature.Portable> {
     public OpenTracingFeature() {
-        delegate = new Portable();
+        super(new Portable());
     }
 
     public OpenTracingFeature(final Tracer tracer) {
-        delegate = new Portable(tracer);
-    }
-
-    @Override
-    public void initializeProvider(InterceptorProvider provider, Bus bus) {
-        delegate.doInitializeProvider(provider, bus);
-    }
-
-    @Override
-    public void initialize(Server server, Bus bus) {
-        delegate.initialize(server, bus);
-    }
-
-    @Override
-    public void initialize(Client client, Bus bus) {
-        delegate.initialize(client, bus);
-    }
-
-    @Override
-    public void initialize(InterceptorProvider interceptorProvider, Bus bus) {
-        delegate.initialize(interceptorProvider, bus);
-    }
-
-    @Override
-    public void initialize(Bus bus) {
-        delegate.initialize(bus);
+        super(new Portable(tracer));
     }
 
     @Provider(value = Type.Feature, scope = Scope.Server)

--- a/integration/tracing/tracing-opentracing/src/main/java/org/apache/cxf/tracing/opentracing/OpenTracingFeature.java
+++ b/integration/tracing/tracing-opentracing/src/main/java/org/apache/cxf/tracing/opentracing/OpenTracingFeature.java
@@ -23,6 +23,8 @@ import org.apache.cxf.annotations.Provider;
 import org.apache.cxf.annotations.Provider.Scope;
 import org.apache.cxf.annotations.Provider.Type;
 import org.apache.cxf.common.injection.NoJSR250Annotations;
+import org.apache.cxf.endpoint.Client;
+import org.apache.cxf.endpoint.Server;
 import org.apache.cxf.feature.AbstractFeature;
 import org.apache.cxf.feature.AbstractPortableFeature;
 import org.apache.cxf.interceptor.InterceptorProvider;
@@ -46,6 +48,26 @@ public class OpenTracingFeature extends AbstractFeature {
     @Override
     public void initializeProvider(InterceptorProvider provider, Bus bus) {
         delegate.doInitializeProvider(provider, bus);
+    }
+
+    @Override
+    public void initialize(Server server, Bus bus) {
+        delegate.initialize(server, bus);
+    }
+
+    @Override
+    public void initialize(Client client, Bus bus) {
+        delegate.initialize(client, bus);
+    }
+
+    @Override
+    public void initialize(InterceptorProvider interceptorProvider, Bus bus) {
+        delegate.initialize(interceptorProvider, bus);
+    }
+
+    @Override
+    public void initialize(Bus bus) {
+        delegate.initialize(bus);
     }
 
     @Provider(value = Type.Feature, scope = Scope.Server)

--- a/integration/tracing/tracing-opentracing/src/main/java/org/apache/cxf/tracing/opentracing/OpenTracingFeature.java
+++ b/integration/tracing/tracing-opentracing/src/main/java/org/apache/cxf/tracing/opentracing/OpenTracingFeature.java
@@ -24,6 +24,7 @@ import org.apache.cxf.annotations.Provider.Scope;
 import org.apache.cxf.annotations.Provider.Type;
 import org.apache.cxf.common.injection.NoJSR250Annotations;
 import org.apache.cxf.feature.AbstractFeature;
+import org.apache.cxf.feature.AbstractPortableFeature;
 import org.apache.cxf.interceptor.InterceptorProvider;
 
 import io.opentracing.Tracer;
@@ -32,24 +33,42 @@ import io.opentracing.util.GlobalTracer;
 @NoJSR250Annotations
 @Provider(value = Type.Feature, scope = Scope.Server)
 public class OpenTracingFeature extends AbstractFeature {
-    private OpenTracingStartInterceptor in;
-    private OpenTracingStopInterceptor out;
+    private Portable delegate;
 
     public OpenTracingFeature() {
-        this(GlobalTracer.get());
+        delegate = new Portable();
     }
-    
+
     public OpenTracingFeature(final Tracer tracer) {
-        in = new OpenTracingStartInterceptor(tracer);
-        out = new OpenTracingStopInterceptor(tracer);
+        delegate = new Portable(tracer);
     }
 
     @Override
-    protected void initializeProvider(InterceptorProvider provider, Bus bus) {
-        provider.getInInterceptors().add(in);
-        provider.getInFaultInterceptors().add(in);
+    public void initializeProvider(InterceptorProvider provider, Bus bus) {
+        delegate.doInitializeProvider(provider, bus);
+    }
 
-        provider.getOutInterceptors().add(out);
-        provider.getOutFaultInterceptors().add(out);
+    @Provider(value = Type.Feature, scope = Scope.Server)
+    public static class Portable implements AbstractPortableFeature {
+        private OpenTracingStartInterceptor in;
+        private OpenTracingStopInterceptor out;
+
+        public Portable() {
+            this(GlobalTracer.get());
+        }
+
+        public Portable(final Tracer tracer) {
+            in = new OpenTracingStartInterceptor(tracer);
+            out = new OpenTracingStopInterceptor(tracer);
+        }
+
+        @Override
+        public void doInitializeProvider(InterceptorProvider provider, Bus bus) {
+            provider.getInInterceptors().add(in);
+            provider.getInFaultInterceptors().add(in);
+
+            provider.getOutInterceptors().add(out);
+            provider.getOutFaultInterceptors().add(out);
+        }
     }
 }

--- a/rt/bindings/coloc/src/main/java/org/apache/cxf/binding/coloc/feature/ColocFeature.java
+++ b/rt/bindings/coloc/src/main/java/org/apache/cxf/binding/coloc/feature/ColocFeature.java
@@ -25,6 +25,7 @@ import org.apache.cxf.common.injection.NoJSR250Annotations;
 import org.apache.cxf.endpoint.Client;
 import org.apache.cxf.endpoint.ConduitSelector;
 import org.apache.cxf.endpoint.DeferredConduitSelector;
+import org.apache.cxf.endpoint.Server;
 import org.apache.cxf.feature.AbstractFeature;
 import org.apache.cxf.feature.AbstractPortableFeature;
 import org.apache.cxf.interceptor.InterceptorProvider;
@@ -41,6 +42,21 @@ public class ColocFeature extends AbstractFeature {
     @Override
     public void initializeProvider(InterceptorProvider provider, Bus bus) {
         delegate.doInitializeProvider(provider, bus);
+    }
+
+    @Override
+    public void initialize(Server server, Bus bus) {
+        delegate.initialize(server, bus);
+    }
+
+    @Override
+    public void initialize(InterceptorProvider interceptorProvider, Bus bus) {
+        delegate.initialize(interceptorProvider, bus);
+    }
+
+    @Override
+    public void initialize(Bus bus) {
+        delegate.initialize(bus);
     }
 
     public static class Portable implements AbstractPortableFeature {

--- a/rt/bindings/coloc/src/main/java/org/apache/cxf/binding/coloc/feature/ColocFeature.java
+++ b/rt/bindings/coloc/src/main/java/org/apache/cxf/binding/coloc/feature/ColocFeature.java
@@ -26,22 +26,36 @@ import org.apache.cxf.endpoint.Client;
 import org.apache.cxf.endpoint.ConduitSelector;
 import org.apache.cxf.endpoint.DeferredConduitSelector;
 import org.apache.cxf.feature.AbstractFeature;
+import org.apache.cxf.feature.AbstractPortableFeature;
 import org.apache.cxf.interceptor.InterceptorProvider;
 
 @NoJSR250Annotations
 public class ColocFeature extends AbstractFeature {
+    private final Portable delegate = new Portable();
 
     @Override
     public void initialize(Client client, Bus bus) {
-        ConduitSelector selector = new DeferredConduitSelector();
-        selector.setEndpoint(client.getEndpoint());
-        client.setConduitSelector(selector);
-        initializeProvider(client, bus);
+        delegate.initialize(client, bus);
     }
 
     @Override
-    protected void initializeProvider(InterceptorProvider provider, Bus bus) {
-        provider.getInInterceptors().add(new ColocInInterceptor());
-        provider.getOutInterceptors().add(new ColocOutInterceptor(bus));
+    public void initializeProvider(InterceptorProvider provider, Bus bus) {
+        delegate.doInitializeProvider(provider, bus);
+    }
+
+    public static class Portable implements AbstractPortableFeature {
+        @Override
+        public void initialize(Client client, Bus bus) {
+            ConduitSelector selector = new DeferredConduitSelector();
+            selector.setEndpoint(client.getEndpoint());
+            client.setConduitSelector(selector);
+            doInitializeProvider(client, bus);
+        }
+
+        @Override
+        public void doInitializeProvider(InterceptorProvider provider, Bus bus) {
+            provider.getInInterceptors().add(new ColocInInterceptor());
+            provider.getOutInterceptors().add(new ColocOutInterceptor(bus));
+        }
     }
 }

--- a/rt/bindings/coloc/src/main/java/org/apache/cxf/binding/coloc/feature/ColocFeature.java
+++ b/rt/bindings/coloc/src/main/java/org/apache/cxf/binding/coloc/feature/ColocFeature.java
@@ -25,38 +25,15 @@ import org.apache.cxf.common.injection.NoJSR250Annotations;
 import org.apache.cxf.endpoint.Client;
 import org.apache.cxf.endpoint.ConduitSelector;
 import org.apache.cxf.endpoint.DeferredConduitSelector;
-import org.apache.cxf.endpoint.Server;
-import org.apache.cxf.feature.AbstractFeature;
 import org.apache.cxf.feature.AbstractPortableFeature;
+import org.apache.cxf.feature.DelegatingFeature;
 import org.apache.cxf.interceptor.InterceptorProvider;
 
 @NoJSR250Annotations
-public class ColocFeature extends AbstractFeature {
-    private final Portable delegate = new Portable();
+public class ColocFeature extends DelegatingFeature<ColocFeature.Portable> {
 
-    @Override
-    public void initialize(Client client, Bus bus) {
-        delegate.initialize(client, bus);
-    }
-
-    @Override
-    public void initializeProvider(InterceptorProvider provider, Bus bus) {
-        delegate.doInitializeProvider(provider, bus);
-    }
-
-    @Override
-    public void initialize(Server server, Bus bus) {
-        delegate.initialize(server, bus);
-    }
-
-    @Override
-    public void initialize(InterceptorProvider interceptorProvider, Bus bus) {
-        delegate.initialize(interceptorProvider, bus);
-    }
-
-    @Override
-    public void initialize(Bus bus) {
-        delegate.initialize(bus);
+    public ColocFeature() {
+        super(new Portable());
     }
 
     public static class Portable implements AbstractPortableFeature {

--- a/rt/features/clustering/src/main/java/org/apache/cxf/clustering/FailoverFeature.java
+++ b/rt/features/clustering/src/main/java/org/apache/cxf/clustering/FailoverFeature.java
@@ -42,8 +42,11 @@ import org.apache.cxf.interceptor.InterceptorProvider;
 @EvaluateAllEndpoints
 @Provider(value = Type.Feature, scope = Scope.Client)
 public class FailoverFeature extends AbstractFeature {
-    private Portable delegate;
+    protected Portable delegate;
 
+    protected FailoverFeature(Portable portable) {
+        delegate = portable;
+    }
     public FailoverFeature() {
         delegate = new Portable();
     }

--- a/rt/features/clustering/src/main/java/org/apache/cxf/clustering/FailoverFeature.java
+++ b/rt/features/clustering/src/main/java/org/apache/cxf/clustering/FailoverFeature.java
@@ -29,6 +29,7 @@ import org.apache.cxf.endpoint.ConduitSelector;
 import org.apache.cxf.endpoint.ConduitSelectorHolder;
 import org.apache.cxf.endpoint.Endpoint;
 import org.apache.cxf.feature.AbstractFeature;
+import org.apache.cxf.feature.AbstractPortableFeature;
 import org.apache.cxf.interceptor.InterceptorProvider;
 
 /**
@@ -40,67 +41,115 @@ import org.apache.cxf.interceptor.InterceptorProvider;
 @EvaluateAllEndpoints
 @Provider(value = Type.Feature, scope = Scope.Client)
 public class FailoverFeature extends AbstractFeature {
-
-    private FailoverStrategy failoverStrategy;
-    private FailoverTargetSelector targetSelector;
-    private String clientBootstrapAddress;
+    private Portable delegate;
 
     public FailoverFeature() {
-
+        delegate = new Portable();
     }
     public FailoverFeature(String clientBootstrapAddress) {
-        this.clientBootstrapAddress = clientBootstrapAddress;
+        delegate = new Portable(clientBootstrapAddress);
     }
 
     @Override
     protected void initializeProvider(InterceptorProvider provider, Bus bus) {
-        if (provider instanceof ConduitSelectorHolder) {
-            ConduitSelectorHolder csHolder = (ConduitSelectorHolder) provider;
-            Endpoint endpoint = csHolder.getConduitSelector().getEndpoint();
-            ConduitSelector conduitSelector = initTargetSelector(endpoint);
-            csHolder.setConduitSelector(conduitSelector);
-        }
+        delegate.doInitializeProvider(provider, bus);
     }
 
     @Override
     public void initialize(Client client, Bus bus) {
-        ConduitSelector selector = initTargetSelector(client.getConduitSelector().getEndpoint());
-        client.setConduitSelector(selector);
+        delegate.initialize(client, bus);
     }
 
-    protected ConduitSelector initTargetSelector(Endpoint endpoint) {
-        FailoverTargetSelector selector = getTargetSelector();
-        selector.setEndpoint(endpoint);
-        if (getStrategy() != null) {
-            selector.setStrategy(getStrategy());
-        }
-        return selector;
+    public ConduitSelector initTargetSelector(Endpoint endpoint) {
+        return delegate.initTargetSelector(endpoint);
     }
 
     public FailoverTargetSelector getTargetSelector() {
-        if (this.targetSelector == null) {
-            this.targetSelector = new FailoverTargetSelector(clientBootstrapAddress);
-        }
-        return this.targetSelector;
+        return delegate.getTargetSelector();
     }
 
     public void setTargetSelector(FailoverTargetSelector selector) {
-        this.targetSelector = selector;
+        delegate.setTargetSelector(selector);
     }
 
     public void setStrategy(FailoverStrategy strategy) {
-        failoverStrategy = strategy;
+        delegate.setStrategy(strategy);
     }
 
-    public FailoverStrategy getStrategy()  {
-        return failoverStrategy;
+    public FailoverStrategy getStrategy() {
+        return delegate.getStrategy();
     }
 
     public String getClientBootstrapAddress() {
-        return clientBootstrapAddress;
+        return delegate.getClientBootstrapAddress();
     }
 
     public void setClientBootstrapAddress(String clientBootstrapAddress) {
-        this.clientBootstrapAddress = clientBootstrapAddress;
+        delegate.setClientBootstrapAddress(clientBootstrapAddress);
+    }
+
+    public static class Portable implements AbstractPortableFeature {
+        private FailoverStrategy failoverStrategy;
+        private FailoverTargetSelector targetSelector;
+        private String clientBootstrapAddress;
+
+        public Portable() {
+
+        }
+        public Portable(String clientBootstrapAddress) {
+            this.clientBootstrapAddress = clientBootstrapAddress;
+        }
+
+        @Override
+        public void doInitializeProvider(InterceptorProvider provider, Bus bus) {
+            if (provider instanceof ConduitSelectorHolder) {
+                ConduitSelectorHolder csHolder = (ConduitSelectorHolder) provider;
+                Endpoint endpoint = csHolder.getConduitSelector().getEndpoint();
+                ConduitSelector conduitSelector = initTargetSelector(endpoint);
+                csHolder.setConduitSelector(conduitSelector);
+            }
+        }
+
+        @Override
+        public void initialize(Client client, Bus bus) {
+            ConduitSelector selector = initTargetSelector(client.getConduitSelector().getEndpoint());
+            client.setConduitSelector(selector);
+        }
+
+        protected ConduitSelector initTargetSelector(Endpoint endpoint) {
+            FailoverTargetSelector selector = getTargetSelector();
+            selector.setEndpoint(endpoint);
+            if (getStrategy() != null) {
+                selector.setStrategy(getStrategy());
+            }
+            return selector;
+        }
+
+        public FailoverTargetSelector getTargetSelector() {
+            if (this.targetSelector == null) {
+                this.targetSelector = new FailoverTargetSelector(clientBootstrapAddress);
+            }
+            return this.targetSelector;
+        }
+
+        public void setTargetSelector(FailoverTargetSelector selector) {
+            this.targetSelector = selector;
+        }
+
+        public void setStrategy(FailoverStrategy strategy) {
+            failoverStrategy = strategy;
+        }
+
+        public FailoverStrategy getStrategy()  {
+            return failoverStrategy;
+        }
+
+        public String getClientBootstrapAddress() {
+            return clientBootstrapAddress;
+        }
+
+        public void setClientBootstrapAddress(String clientBootstrapAddress) {
+            this.clientBootstrapAddress = clientBootstrapAddress;
+        }
     }
 }

--- a/rt/features/clustering/src/main/java/org/apache/cxf/clustering/FailoverFeature.java
+++ b/rt/features/clustering/src/main/java/org/apache/cxf/clustering/FailoverFeature.java
@@ -28,9 +28,8 @@ import org.apache.cxf.endpoint.Client;
 import org.apache.cxf.endpoint.ConduitSelector;
 import org.apache.cxf.endpoint.ConduitSelectorHolder;
 import org.apache.cxf.endpoint.Endpoint;
-import org.apache.cxf.endpoint.Server;
-import org.apache.cxf.feature.AbstractFeature;
 import org.apache.cxf.feature.AbstractPortableFeature;
+import org.apache.cxf.feature.DelegatingFeature;
 import org.apache.cxf.interceptor.InterceptorProvider;
 
 /**
@@ -41,42 +40,15 @@ import org.apache.cxf.interceptor.InterceptorProvider;
 @NoJSR250Annotations
 @EvaluateAllEndpoints
 @Provider(value = Type.Feature, scope = Scope.Client)
-public class FailoverFeature extends AbstractFeature {
-    protected Portable delegate;
-
+public class FailoverFeature extends DelegatingFeature<FailoverFeature.Portable> {
     protected FailoverFeature(Portable portable) {
-        delegate = portable;
+        super(portable);
     }
     public FailoverFeature() {
-        delegate = new Portable();
+        super(new Portable());
     }
     public FailoverFeature(String clientBootstrapAddress) {
-        delegate = new Portable(clientBootstrapAddress);
-    }
-
-    @Override
-    protected void initializeProvider(InterceptorProvider provider, Bus bus) {
-        delegate.doInitializeProvider(provider, bus);
-    }
-
-    @Override
-    public void initialize(Server server, Bus bus) {
-        delegate.initialize(server, bus);
-    }
-
-    @Override
-    public void initialize(InterceptorProvider interceptorProvider, Bus bus) {
-        delegate.initialize(interceptorProvider, bus);
-    }
-
-    @Override
-    public void initialize(Bus bus) {
-        delegate.initialize(bus);
-    }
-
-    @Override
-    public void initialize(Client client, Bus bus) {
-        delegate.initialize(client, bus);
+        super(new Portable(clientBootstrapAddress));
     }
 
     public ConduitSelector initTargetSelector(Endpoint endpoint) {

--- a/rt/features/clustering/src/main/java/org/apache/cxf/clustering/FailoverFeature.java
+++ b/rt/features/clustering/src/main/java/org/apache/cxf/clustering/FailoverFeature.java
@@ -28,6 +28,7 @@ import org.apache.cxf.endpoint.Client;
 import org.apache.cxf.endpoint.ConduitSelector;
 import org.apache.cxf.endpoint.ConduitSelectorHolder;
 import org.apache.cxf.endpoint.Endpoint;
+import org.apache.cxf.endpoint.Server;
 import org.apache.cxf.feature.AbstractFeature;
 import org.apache.cxf.feature.AbstractPortableFeature;
 import org.apache.cxf.interceptor.InterceptorProvider;
@@ -53,6 +54,21 @@ public class FailoverFeature extends AbstractFeature {
     @Override
     protected void initializeProvider(InterceptorProvider provider, Bus bus) {
         delegate.doInitializeProvider(provider, bus);
+    }
+
+    @Override
+    public void initialize(Server server, Bus bus) {
+        delegate.initialize(server, bus);
+    }
+
+    @Override
+    public void initialize(InterceptorProvider interceptorProvider, Bus bus) {
+        delegate.initialize(interceptorProvider, bus);
+    }
+
+    @Override
+    public void initialize(Bus bus) {
+        delegate.initialize(bus);
     }
 
     @Override

--- a/rt/features/clustering/src/main/java/org/apache/cxf/clustering/LoadDistributorFeature.java
+++ b/rt/features/clustering/src/main/java/org/apache/cxf/clustering/LoadDistributorFeature.java
@@ -30,10 +30,10 @@ import org.apache.cxf.common.injection.NoJSR250Annotations;
 public class LoadDistributorFeature extends FailoverFeature {
 
     public LoadDistributorFeature() {
-
+        super(new Portable());
     }
     public LoadDistributorFeature(String clientBootstrapAddress) {
-        super(clientBootstrapAddress);
+        super(new FailoverFeature.Portable(clientBootstrapAddress));
     }
 
     @Override

--- a/rt/features/clustering/src/main/java/org/apache/cxf/clustering/LoadDistributorFeature.java
+++ b/rt/features/clustering/src/main/java/org/apache/cxf/clustering/LoadDistributorFeature.java
@@ -29,7 +29,6 @@ import org.apache.cxf.common.injection.NoJSR250Annotations;
 @NoJSR250Annotations
 public class LoadDistributorFeature extends FailoverFeature {
 
-
     public LoadDistributorFeature() {
 
     }
@@ -40,5 +39,19 @@ public class LoadDistributorFeature extends FailoverFeature {
     @Override
     public FailoverTargetSelector getTargetSelector() {
         return new LoadDistributorTargetSelector(getClientBootstrapAddress());
+    }
+
+    public static class Portable extends FailoverFeature.Portable {
+        public Portable() {
+
+        }
+        public Portable(String clientBootstrapAddress) {
+            super(clientBootstrapAddress);
+        }
+
+        @Override
+        public FailoverTargetSelector getTargetSelector() {
+            return new LoadDistributorTargetSelector(getClientBootstrapAddress());
+        }
     }
 }

--- a/rt/features/clustering/src/main/java/org/apache/cxf/clustering/circuitbreaker/CircuitBreakerFailoverFeature.java
+++ b/rt/features/clustering/src/main/java/org/apache/cxf/clustering/circuitbreaker/CircuitBreakerFailoverFeature.java
@@ -25,59 +25,108 @@ import org.apache.cxf.clustering.FailoverFeature;
 import org.apache.cxf.clustering.FailoverTargetSelector;
 
 public class CircuitBreakerFailoverFeature extends FailoverFeature {
-    private int threshold;
-    private long timeout;
-    private FailoverTargetSelector targetSelector;
-
+    private Portable config;
     public CircuitBreakerFailoverFeature() {
         this(CircuitBreakerTargetSelector.DEFAULT_THESHOLD,
-             CircuitBreakerTargetSelector.DEFAULT_TIMEOUT);
+                CircuitBreakerTargetSelector.DEFAULT_TIMEOUT);
     }
 
     public CircuitBreakerFailoverFeature(String clientBootstrapAddress) {
         this(CircuitBreakerTargetSelector.DEFAULT_THESHOLD,
-             CircuitBreakerTargetSelector.DEFAULT_TIMEOUT,
-             clientBootstrapAddress);
+                CircuitBreakerTargetSelector.DEFAULT_TIMEOUT,
+                clientBootstrapAddress);
     }
 
     public CircuitBreakerFailoverFeature(int threshold, long timeout) {
-        this.threshold = threshold;
-        this.timeout = timeout;
+        config = new Portable(threshold, timeout);
     }
 
     public CircuitBreakerFailoverFeature(int threshold, long timeout, String clientBootstrapAddress) {
         super(clientBootstrapAddress);
-        this.threshold = threshold;
-        this.timeout = timeout;
+        config = new Portable(threshold, timeout);
     }
 
     @Override
     public FailoverTargetSelector getTargetSelector() {
-        if (this.targetSelector == null) {
-            this.targetSelector = new CircuitBreakerTargetSelector(threshold, timeout,
-                                                                   super.getClientBootstrapAddress());
-        }
-        return this.targetSelector;
+        return config.getTargetSelector();
     }
 
     @Override
     public void setTargetSelector(FailoverTargetSelector targetSelector) {
-        this.targetSelector = targetSelector;
+        config.setTargetSelector(targetSelector);
     }
 
     public int getThreshold() {
-        return threshold;
+        return config.getThreshold();
     }
 
     public long getTimeout() {
-        return timeout;
+        return config.getTimeout();
     }
 
     public void setThreshold(int threshold) {
-        this.threshold = threshold;
+        config.setThreshold(threshold);
     }
 
     public void setTimeout(long timeout) {
-        this.timeout = timeout;
+        config.setTimeout(timeout);
+    }
+
+    public static class Portable extends FailoverFeature.Portable {
+        private int threshold;
+        private long timeout;
+        private FailoverTargetSelector targetSelector;
+
+        public Portable() {
+            this(CircuitBreakerTargetSelector.DEFAULT_THESHOLD,
+                    CircuitBreakerTargetSelector.DEFAULT_TIMEOUT);
+        }
+
+        public Portable(String clientBootstrapAddress) {
+            this(CircuitBreakerTargetSelector.DEFAULT_THESHOLD,
+                    CircuitBreakerTargetSelector.DEFAULT_TIMEOUT,
+                    clientBootstrapAddress);
+        }
+
+        public Portable(int threshold, long timeout) {
+            this.threshold = threshold;
+            this.timeout = timeout;
+        }
+
+        public Portable(int threshold, long timeout, String clientBootstrapAddress) {
+            super(clientBootstrapAddress);
+            this.threshold = threshold;
+            this.timeout = timeout;
+        }
+
+        @Override
+        public FailoverTargetSelector getTargetSelector() {
+            if (this.targetSelector == null) {
+                this.targetSelector = new CircuitBreakerTargetSelector(threshold, timeout,
+                        super.getClientBootstrapAddress());
+            }
+            return this.targetSelector;
+        }
+
+        @Override
+        public void setTargetSelector(FailoverTargetSelector targetSelector) {
+            this.targetSelector = targetSelector;
+        }
+
+        public int getThreshold() {
+            return threshold;
+        }
+
+        public long getTimeout() {
+            return timeout;
+        }
+
+        public void setThreshold(int threshold) {
+            this.threshold = threshold;
+        }
+
+        public void setTimeout(long timeout) {
+            this.timeout = timeout;
+        }
     }
 }

--- a/rt/features/clustering/src/main/java/org/apache/cxf/clustering/circuitbreaker/CircuitBreakerFailoverFeature.java
+++ b/rt/features/clustering/src/main/java/org/apache/cxf/clustering/circuitbreaker/CircuitBreakerFailoverFeature.java
@@ -25,8 +25,6 @@ import org.apache.cxf.clustering.FailoverFeature;
 import org.apache.cxf.clustering.FailoverTargetSelector;
 
 public class CircuitBreakerFailoverFeature extends FailoverFeature {
-    private Portable config;
-
     public CircuitBreakerFailoverFeature() {
         this(CircuitBreakerTargetSelector.DEFAULT_THESHOLD,
                 CircuitBreakerTargetSelector.DEFAULT_TIMEOUT);
@@ -39,38 +37,37 @@ public class CircuitBreakerFailoverFeature extends FailoverFeature {
     }
 
     public CircuitBreakerFailoverFeature(int threshold, long timeout) {
-        config = new Portable(threshold, timeout);
+        super(new Portable(threshold, timeout));
     }
 
     public CircuitBreakerFailoverFeature(int threshold, long timeout, String clientBootstrapAddress) {
-        super(clientBootstrapAddress);
-        config = new Portable(threshold, timeout);
+        super(new Portable(threshold, timeout, clientBootstrapAddress));
     }
 
     @Override
     public FailoverTargetSelector getTargetSelector() {
-        return config.getTargetSelector();
+        return delegate.getTargetSelector();
     }
 
     @Override
     public void setTargetSelector(FailoverTargetSelector targetSelector) {
-        config.setTargetSelector(targetSelector);
+        delegate.setTargetSelector(targetSelector);
     }
 
     public int getThreshold() {
-        return config.getThreshold();
+        return Portable.class.cast(delegate).getThreshold();
     }
 
     public long getTimeout() {
-        return config.getTimeout();
+        return Portable.class.cast(delegate).getTimeout();
     }
 
     public void setThreshold(int threshold) {
-        config.setThreshold(threshold);
+        Portable.class.cast(delegate).setThreshold(threshold);
     }
 
     public void setTimeout(long timeout) {
-        config.setTimeout(timeout);
+        Portable.class.cast(delegate).setTimeout(timeout);
     }
 
     public static class Portable extends FailoverFeature.Portable {

--- a/rt/features/clustering/src/main/java/org/apache/cxf/clustering/circuitbreaker/CircuitBreakerFailoverFeature.java
+++ b/rt/features/clustering/src/main/java/org/apache/cxf/clustering/circuitbreaker/CircuitBreakerFailoverFeature.java
@@ -26,6 +26,7 @@ import org.apache.cxf.clustering.FailoverTargetSelector;
 
 public class CircuitBreakerFailoverFeature extends FailoverFeature {
     private Portable config;
+
     public CircuitBreakerFailoverFeature() {
         this(CircuitBreakerTargetSelector.DEFAULT_THESHOLD,
                 CircuitBreakerTargetSelector.DEFAULT_TIMEOUT);

--- a/rt/features/logging/src/main/java/org/apache/cxf/ext/logging/LoggingFeature.java
+++ b/rt/features/logging/src/main/java/org/apache/cxf/ext/logging/LoggingFeature.java
@@ -22,14 +22,12 @@ import org.apache.cxf.Bus;
 import org.apache.cxf.annotations.Provider;
 import org.apache.cxf.annotations.Provider.Type;
 import org.apache.cxf.common.injection.NoJSR250Annotations;
-import org.apache.cxf.endpoint.Client;
-import org.apache.cxf.endpoint.Server;
 import org.apache.cxf.ext.logging.event.LogEventSender;
 import org.apache.cxf.ext.logging.event.PrettyLoggingFilter;
 import org.apache.cxf.ext.logging.slf4j.Slf4jEventSender;
 import org.apache.cxf.ext.logging.slf4j.Slf4jVerboseEventSender;
-import org.apache.cxf.feature.AbstractFeature;
 import org.apache.cxf.feature.AbstractPortableFeature;
+import org.apache.cxf.feature.DelegatingFeature;
 import org.apache.cxf.interceptor.InterceptorProvider;
 
 /**
@@ -49,8 +47,10 @@ import org.apache.cxf.interceptor.InterceptorProvider;
  */
 @NoJSR250Annotations
 @Provider(value = Type.Feature)
-public class LoggingFeature extends AbstractFeature {
-    private Portable delegate = new Portable();
+public class LoggingFeature extends DelegatingFeature<LoggingFeature.Portable> {
+    public LoggingFeature() {
+        super(new Portable());
+    }
 
     public void setLimit(int limit) {
         delegate.setLimit(limit);
@@ -86,31 +86,6 @@ public class LoggingFeature extends AbstractFeature {
 
     public void setVerbose(boolean verbose) {
         delegate.setVerbose(verbose);
-    }
-
-    @Override
-    public void initializeProvider(InterceptorProvider interceptorProvider, Bus bus) {
-        delegate.doInitializeProvider(interceptorProvider, bus);
-    }
-
-    @Override
-    public void initialize(Server server, Bus bus) {
-        delegate.initialize(server, bus);
-    }
-
-    @Override
-    public void initialize(Client client, Bus bus) {
-        delegate.initialize(client, bus);
-    }
-
-    @Override
-    public void initialize(InterceptorProvider interceptorProvider, Bus bus) {
-        delegate.initialize(interceptorProvider, bus);
-    }
-
-    @Override
-    public void initialize(Bus bus) {
-        delegate.initialize(bus);
     }
 
     public void addInBinaryContentMediaTypes(String mediaTypes) {

--- a/rt/features/logging/src/main/java/org/apache/cxf/ext/logging/LoggingFeature.java
+++ b/rt/features/logging/src/main/java/org/apache/cxf/ext/logging/LoggingFeature.java
@@ -27,6 +27,7 @@ import org.apache.cxf.ext.logging.event.PrettyLoggingFilter;
 import org.apache.cxf.ext.logging.slf4j.Slf4jEventSender;
 import org.apache.cxf.ext.logging.slf4j.Slf4jVerboseEventSender;
 import org.apache.cxf.feature.AbstractFeature;
+import org.apache.cxf.feature.AbstractPortableFeature;
 import org.apache.cxf.interceptor.InterceptorProvider;
 
 /**
@@ -47,75 +48,121 @@ import org.apache.cxf.interceptor.InterceptorProvider;
 @NoJSR250Annotations
 @Provider(value = Type.Feature)
 public class LoggingFeature extends AbstractFeature {
-    private LoggingInInterceptor in;
-    private LoggingOutInterceptor out;
-    private PrettyLoggingFilter inPrettyFilter;
-    private PrettyLoggingFilter outPrettyFilter;
-
-    public LoggingFeature() {
-        LogEventSender sender = new Slf4jVerboseEventSender();
-        inPrettyFilter = new PrettyLoggingFilter(sender);
-        outPrettyFilter = new PrettyLoggingFilter(sender);
-        in = new LoggingInInterceptor(inPrettyFilter);
-        out = new LoggingOutInterceptor(outPrettyFilter);
-    }
-
-    @Override
-    protected void initializeProvider(InterceptorProvider provider, Bus bus) {
-
-        provider.getInInterceptors().add(in);
-        provider.getInFaultInterceptors().add(in);
-
-        provider.getOutInterceptors().add(out);
-        provider.getOutFaultInterceptors().add(out);
-    }
+    private Portable delegate = new Portable();
 
     public void setLimit(int limit) {
-        in.setLimit(limit);
-        out.setLimit(limit);
+        delegate.setLimit(limit);
     }
 
     public void setInMemThreshold(long inMemThreshold) {
-        in.setInMemThreshold(inMemThreshold);
-        out.setInMemThreshold(inMemThreshold);
+        delegate.setInMemThreshold(inMemThreshold);
     }
 
     public void setSender(LogEventSender sender) {
-        this.inPrettyFilter.setNext(sender);
-        this.outPrettyFilter.setNext(sender);
+        delegate.setSender(sender);
     }
+
     public void setInSender(LogEventSender s) {
-        this.inPrettyFilter.setNext(s);
+        delegate.setInSender(s);
     }
+
     public void setOutSender(LogEventSender s) {
-        this.outPrettyFilter.setNext(s);
+        delegate.setOutSender(s);
     }
 
     public void setPrettyLogging(boolean prettyLogging) {
-        this.inPrettyFilter.setPrettyLogging(prettyLogging);
-        this.outPrettyFilter.setPrettyLogging(prettyLogging);
+        delegate.setPrettyLogging(prettyLogging);
     }
 
-    /**
-     * Log binary content?
-     * @param logBinary defaults to false
-     */
     public void setLogBinary(boolean logBinary) {
-        in.setLogBinary(logBinary);
-        out.setLogBinary(logBinary);
+        delegate.setLogBinary(logBinary);
     }
 
-    /**
-     * Log multipart content?
-     * @param logMultipart defaults to true
-     */
     public void setLogMultipart(boolean logMultipart) {
-        in.setLogMultipart(logMultipart);
-        out.setLogMultipart(logMultipart);
+        delegate.setLogMultipart(logMultipart);
     }
 
     public void setVerbose(boolean verbose) {
-        setSender(verbose ? new Slf4jVerboseEventSender() : new Slf4jEventSender());
+        delegate.setVerbose(verbose);
+    }
+
+    @Override
+    public void initializeProvider(InterceptorProvider interceptorProvider, Bus bus) {
+        delegate.doInitializeProvider(interceptorProvider, bus);
+    }
+
+    @Provider(value = Type.Feature)
+    public static class Portable implements AbstractPortableFeature {
+        private LoggingInInterceptor in;
+        private LoggingOutInterceptor out;
+        private PrettyLoggingFilter inPrettyFilter;
+        private PrettyLoggingFilter outPrettyFilter;
+
+        public Portable() {
+            LogEventSender sender = new Slf4jVerboseEventSender();
+            inPrettyFilter = new PrettyLoggingFilter(sender);
+            outPrettyFilter = new PrettyLoggingFilter(sender);
+            in = new LoggingInInterceptor(inPrettyFilter);
+            out = new LoggingOutInterceptor(outPrettyFilter);
+        }
+
+        @Override
+        public void doInitializeProvider(InterceptorProvider provider, Bus bus) {
+
+            provider.getInInterceptors().add(in);
+            provider.getInFaultInterceptors().add(in);
+
+            provider.getOutInterceptors().add(out);
+            provider.getOutFaultInterceptors().add(out);
+        }
+
+        public void setLimit(int limit) {
+            in.setLimit(limit);
+            out.setLimit(limit);
+        }
+
+        public void setInMemThreshold(long inMemThreshold) {
+            in.setInMemThreshold(inMemThreshold);
+            out.setInMemThreshold(inMemThreshold);
+        }
+
+        public void setSender(LogEventSender sender) {
+            this.inPrettyFilter.setNext(sender);
+            this.outPrettyFilter.setNext(sender);
+        }
+        public void setInSender(LogEventSender s) {
+            this.inPrettyFilter.setNext(s);
+        }
+        public void setOutSender(LogEventSender s) {
+            this.outPrettyFilter.setNext(s);
+        }
+
+        public void setPrettyLogging(boolean prettyLogging) {
+            this.inPrettyFilter.setPrettyLogging(prettyLogging);
+            this.outPrettyFilter.setPrettyLogging(prettyLogging);
+        }
+
+        /**
+         * Log binary content?
+         * @param logBinary defaults to false
+         */
+        public void setLogBinary(boolean logBinary) {
+            in.setLogBinary(logBinary);
+            out.setLogBinary(logBinary);
+        }
+
+        /**
+         * Log multipart content?
+         * @param logMultipart defaults to true
+         */
+        public void setLogMultipart(boolean logMultipart) {
+            in.setLogMultipart(logMultipart);
+            out.setLogMultipart(logMultipart);
+        }
+
+        public void setVerbose(boolean verbose) {
+            setSender(verbose ? new Slf4jVerboseEventSender() : new Slf4jEventSender());
+        }
     }
 
     /**

--- a/rt/features/logging/src/main/java/org/apache/cxf/ext/logging/LoggingFeature.java
+++ b/rt/features/logging/src/main/java/org/apache/cxf/ext/logging/LoggingFeature.java
@@ -22,6 +22,8 @@ import org.apache.cxf.Bus;
 import org.apache.cxf.annotations.Provider;
 import org.apache.cxf.annotations.Provider.Type;
 import org.apache.cxf.common.injection.NoJSR250Annotations;
+import org.apache.cxf.endpoint.Client;
+import org.apache.cxf.endpoint.Server;
 import org.apache.cxf.ext.logging.event.LogEventSender;
 import org.apache.cxf.ext.logging.event.PrettyLoggingFilter;
 import org.apache.cxf.ext.logging.slf4j.Slf4jEventSender;
@@ -89,6 +91,38 @@ public class LoggingFeature extends AbstractFeature {
     @Override
     public void initializeProvider(InterceptorProvider interceptorProvider, Bus bus) {
         delegate.doInitializeProvider(interceptorProvider, bus);
+    }
+
+    @Override
+    public void initialize(Server server, Bus bus) {
+        delegate.initialize(server, bus);
+    }
+
+    @Override
+    public void initialize(Client client, Bus bus) {
+        delegate.initialize(client, bus);
+    }
+
+    @Override
+    public void initialize(InterceptorProvider interceptorProvider, Bus bus) {
+        delegate.initialize(interceptorProvider, bus);
+    }
+
+    @Override
+    public void initialize(Bus bus) {
+        delegate.initialize(bus);
+    }
+
+    public void addInBinaryContentMediaTypes(String mediaTypes) {
+        delegate.addInBinaryContentMediaTypes(mediaTypes);
+    }
+
+    public void addOutBinaryContentMediaTypes(String mediaTypes) {
+        delegate.addOutBinaryContentMediaTypes(mediaTypes);
+    }
+
+    public void addBinaryContentMediaTypes(String mediaTypes) {
+        delegate.addBinaryContentMediaTypes(mediaTypes);
     }
 
     @Provider(value = Type.Feature)
@@ -163,51 +197,51 @@ public class LoggingFeature extends AbstractFeature {
         public void setVerbose(boolean verbose) {
             setSender(verbose ? new Slf4jVerboseEventSender() : new Slf4jEventSender());
         }
-    }
 
-    /**
-     * Add additional binary media types to the default values in the LoggingInInterceptor.
-     * Content for these types will not be logged.
-     * For example:
-     * <pre>
-     * &lt;bean id="loggingFeature" class="org.apache.cxf.ext.logging.LoggingFeature"&gt;
-     *   &lt;property name="addInBinaryContentMediaTypes" value="audio/mpeg;application/zip"/&gt;
-     * &lt;/bean&gt;
-     * </pre>
-     * @param mediaTypes list of mediaTypes. symbol ; - delimeter
-     */
-    public void addInBinaryContentMediaTypes(String mediaTypes) {
-        in.addBinaryContentMediaTypes(mediaTypes);
-    }
+        /**
+         * Add additional binary media types to the default values in the LoggingInInterceptor.
+         * Content for these types will not be logged.
+         * For example:
+         * <pre>
+         * &lt;bean id="loggingFeature" class="org.apache.cxf.ext.logging.LoggingFeature"&gt;
+         *   &lt;property name="addInBinaryContentMediaTypes" value="audio/mpeg;application/zip"/&gt;
+         * &lt;/bean&gt;
+         * </pre>
+         * @param mediaTypes list of mediaTypes. symbol ; - delimeter
+         */
+        public void addInBinaryContentMediaTypes(String mediaTypes) {
+            in.addBinaryContentMediaTypes(mediaTypes);
+        }
 
-    /**
-     * Add additional binary media types to the default values in the LoggingOutInterceptor.
-     * Content for these types will not be logged.
-     * For example:
-     * <pre>
-     * &lt;bean id="loggingFeature" class="org.apache.cxf.ext.logging.LoggingFeature"&gt;
-     *   &lt;property name="addOutBinaryContentMediaTypes" value="audio/mpeg;application/zip"/&gt;
-     * &lt;/bean&gt;
-     * </pre>
-     * @param mediaTypes list of mediaTypes. symbol ; - delimeter
-     */
-    public void addOutBinaryContentMediaTypes(String mediaTypes) {
-        out.addBinaryContentMediaTypes(mediaTypes);
-    }
+        /**
+         * Add additional binary media types to the default values in the LoggingOutInterceptor.
+         * Content for these types will not be logged.
+         * For example:
+         * <pre>
+         * &lt;bean id="loggingFeature" class="org.apache.cxf.ext.logging.LoggingFeature"&gt;
+         *   &lt;property name="addOutBinaryContentMediaTypes" value="audio/mpeg;application/zip"/&gt;
+         * &lt;/bean&gt;
+         * </pre>
+         * @param mediaTypes list of mediaTypes. symbol ; - delimeter
+         */
+        public void addOutBinaryContentMediaTypes(String mediaTypes) {
+            out.addBinaryContentMediaTypes(mediaTypes);
+        }
 
-    /**
-     * Add additional binary media types to the default values for both logging interceptors
-     * Content for these types will not be logged.
-     * For example:
-     * <pre>
-     * &lt;bean id="loggingFeature" class="org.apache.cxf.ext.logging.LoggingFeature"&gt;
-     *   &lt;property name="addBinaryContentMediaTypes" value="audio/mpeg;application/zip"/&gt;
-     * &lt;/bean&gt;
-     * </pre>
-     * @param mediaTypes list of mediaTypes. symbol ; - delimeter
-     */
-    public void addBinaryContentMediaTypes(String mediaTypes) {
-        addInBinaryContentMediaTypes(mediaTypes);
-        addOutBinaryContentMediaTypes(mediaTypes);
+        /**
+         * Add additional binary media types to the default values for both logging interceptors
+         * Content for these types will not be logged.
+         * For example:
+         * <pre>
+         * &lt;bean id="loggingFeature" class="org.apache.cxf.ext.logging.LoggingFeature"&gt;
+         *   &lt;property name="addBinaryContentMediaTypes" value="audio/mpeg;application/zip"/&gt;
+         * &lt;/bean&gt;
+         * </pre>
+         * @param mediaTypes list of mediaTypes. symbol ; - delimeter
+         */
+        public void addBinaryContentMediaTypes(String mediaTypes) {
+            addInBinaryContentMediaTypes(mediaTypes);
+            addOutBinaryContentMediaTypes(mediaTypes);
+        }
     }
 }

--- a/rt/features/metrics/src/main/java/org/apache/cxf/metrics/MetricsFeature.java
+++ b/rt/features/metrics/src/main/java/org/apache/cxf/metrics/MetricsFeature.java
@@ -31,8 +31,8 @@ import org.apache.cxf.configuration.ConfiguredBeanLocator;
 import org.apache.cxf.endpoint.Client;
 import org.apache.cxf.endpoint.Endpoint;
 import org.apache.cxf.endpoint.Server;
-import org.apache.cxf.feature.AbstractFeature;
 import org.apache.cxf.feature.AbstractPortableFeature;
+import org.apache.cxf.feature.DelegatingFeature;
 import org.apache.cxf.interceptor.InterceptorProvider;
 import org.apache.cxf.metrics.interceptors.CountingOutInterceptor;
 import org.apache.cxf.metrics.interceptors.MetricsMessageClientOutInterceptor;
@@ -47,42 +47,15 @@ import org.apache.cxf.metrics.interceptors.MetricsMessageOutInterceptor;
  */
 @NoJSR250Annotations
 @Provider(Type.Feature)
-public class MetricsFeature extends AbstractFeature {
-    private Portable delegate;
-
+public class MetricsFeature extends DelegatingFeature<MetricsFeature.Portable> {
     public MetricsFeature() {
-        delegate = new Portable();
+        super(new Portable());
     }
     public MetricsFeature(MetricsProvider provider) {
-        delegate = new Portable(provider);
+        super(new Portable(provider));
     }
     public MetricsFeature(MetricsProvider ... providers) {
-        delegate = new Portable(providers);
-    }
-
-    @Override
-    public void initialize(Server server, Bus bus) {
-        delegate.initialize(server, bus);
-    }
-
-    @Override
-    public void initialize(Client client, Bus bus) {
-        delegate.initialize(client, bus);
-    }
-
-    @Override
-    protected void initializeProvider(InterceptorProvider provider, Bus bus) {
-        delegate.doInitializeProvider(provider, bus);
-    }
-
-    @Override
-    public void initialize(InterceptorProvider interceptorProvider, Bus bus) {
-        delegate.initialize(interceptorProvider, bus);
-    }
-
-    @Override
-    public void initialize(Bus bus) {
-        delegate.initialize(bus);
+        super(new Portable(providers));
     }
 
     @Provider(Type.Feature)

--- a/rt/features/metrics/src/main/java/org/apache/cxf/metrics/MetricsFeature.java
+++ b/rt/features/metrics/src/main/java/org/apache/cxf/metrics/MetricsFeature.java
@@ -75,6 +75,16 @@ public class MetricsFeature extends AbstractFeature {
         delegate.doInitializeProvider(provider, bus);
     }
 
+    @Override
+    public void initialize(InterceptorProvider interceptorProvider, Bus bus) {
+        delegate.initialize(interceptorProvider, bus);
+    }
+
+    @Override
+    public void initialize(Bus bus) {
+        delegate.initialize(bus);
+    }
+
     @Provider(Type.Feature)
     public static class Portable implements AbstractPortableFeature {
         MetricsProvider[] providers;

--- a/rt/features/throttling/src/main/java/org/apache/cxf/throttling/ThrottlingFeature.java
+++ b/rt/features/throttling/src/main/java/org/apache/cxf/throttling/ThrottlingFeature.java
@@ -20,49 +20,20 @@
 package org.apache.cxf.throttling;
 
 import org.apache.cxf.Bus;
-import org.apache.cxf.endpoint.Client;
-import org.apache.cxf.endpoint.Server;
-import org.apache.cxf.feature.AbstractFeature;
 import org.apache.cxf.feature.AbstractPortableFeature;
+import org.apache.cxf.feature.DelegatingFeature;
 import org.apache.cxf.interceptor.InterceptorProvider;
 
 /**
  *
  */
-public class ThrottlingFeature extends AbstractFeature {
-    private final Portable delegate;
-
+public class ThrottlingFeature extends DelegatingFeature<ThrottlingFeature.Portable> {
     public ThrottlingFeature() {
-        delegate = new Portable();
+        super(new Portable());
     }
 
     public ThrottlingFeature(ThrottlingManager manager) {
-        delegate = new Portable(manager);
-    }
-
-    @Override
-    protected void initializeProvider(InterceptorProvider provider, Bus bus) {
-        delegate.doInitializeProvider(provider, bus);
-    }
-
-    @Override
-    public void initialize(Server server, Bus bus) {
-        delegate.initialize(server, bus);
-    }
-
-    @Override
-    public void initialize(Client client, Bus bus) {
-        delegate.initialize(client, bus);
-    }
-
-    @Override
-    public void initialize(InterceptorProvider interceptorProvider, Bus bus) {
-        delegate.initialize(interceptorProvider, bus);
-    }
-
-    @Override
-    public void initialize(Bus bus) {
-        delegate.initialize(bus);
+        super(new Portable(manager));
     }
 
     public static class Portable implements AbstractPortableFeature {

--- a/rt/features/throttling/src/main/java/org/apache/cxf/throttling/ThrottlingFeature.java
+++ b/rt/features/throttling/src/main/java/org/apache/cxf/throttling/ThrottlingFeature.java
@@ -21,35 +21,53 @@ package org.apache.cxf.throttling;
 
 import org.apache.cxf.Bus;
 import org.apache.cxf.feature.AbstractFeature;
+import org.apache.cxf.feature.AbstractPortableFeature;
 import org.apache.cxf.interceptor.InterceptorProvider;
 
 /**
  *
  */
 public class ThrottlingFeature extends AbstractFeature {
-    final ThrottlingManager manager;
+    private final Portable delegate;
 
     public ThrottlingFeature() {
-        manager = null;
+        delegate = new Portable();
     }
 
     public ThrottlingFeature(ThrottlingManager manager) {
-        this.manager = manager;
+        delegate = new Portable(manager);
     }
 
     @Override
     protected void initializeProvider(InterceptorProvider provider, Bus bus) {
-        ThrottlingManager m = manager;
-        if (m == null) {
-            m = bus.getExtension(ThrottlingManager.class);
+        delegate.doInitializeProvider(provider, bus);
+    }
+
+    public static class Portable implements AbstractPortableFeature {
+        final ThrottlingManager manager;
+
+        public Portable() {
+            manager = null;
         }
-        if (m == null) {
-            throw new IllegalArgumentException("ThrottlingManager must not be null");
+
+        public Portable(ThrottlingManager manager) {
+            this.manager = manager;
         }
-        for (String p : m.getDecisionPhases()) {
-            provider.getInInterceptors().add(new ThrottlingInterceptor(p, m));
+
+        @Override
+        public void doInitializeProvider(InterceptorProvider provider, Bus bus) {
+            ThrottlingManager m = manager;
+            if (m == null) {
+                m = bus.getExtension(ThrottlingManager.class);
+            }
+            if (m == null) {
+                throw new IllegalArgumentException("ThrottlingManager must not be null");
+            }
+            for (String p : m.getDecisionPhases()) {
+                provider.getInInterceptors().add(new ThrottlingInterceptor(p, m));
+            }
+            provider.getOutInterceptors().add(new ThrottlingResponseInterceptor());
+            provider.getOutFaultInterceptors().add(new ThrottlingResponseInterceptor());
         }
-        provider.getOutInterceptors().add(new ThrottlingResponseInterceptor());
-        provider.getOutFaultInterceptors().add(new ThrottlingResponseInterceptor());
     }
 }

--- a/rt/features/throttling/src/main/java/org/apache/cxf/throttling/ThrottlingFeature.java
+++ b/rt/features/throttling/src/main/java/org/apache/cxf/throttling/ThrottlingFeature.java
@@ -20,6 +20,8 @@
 package org.apache.cxf.throttling;
 
 import org.apache.cxf.Bus;
+import org.apache.cxf.endpoint.Client;
+import org.apache.cxf.endpoint.Server;
 import org.apache.cxf.feature.AbstractFeature;
 import org.apache.cxf.feature.AbstractPortableFeature;
 import org.apache.cxf.interceptor.InterceptorProvider;
@@ -41,6 +43,26 @@ public class ThrottlingFeature extends AbstractFeature {
     @Override
     protected void initializeProvider(InterceptorProvider provider, Bus bus) {
         delegate.doInitializeProvider(provider, bus);
+    }
+
+    @Override
+    public void initialize(Server server, Bus bus) {
+        delegate.initialize(server, bus);
+    }
+
+    @Override
+    public void initialize(Client client, Bus bus) {
+        delegate.initialize(client, bus);
+    }
+
+    @Override
+    public void initialize(InterceptorProvider interceptorProvider, Bus bus) {
+        delegate.initialize(interceptorProvider, bus);
+    }
+
+    @Override
+    public void initialize(Bus bus) {
+        delegate.initialize(bus);
     }
 
     public static class Portable implements AbstractPortableFeature {

--- a/rt/frontend/jaxrs/src/main/java/org/apache/cxf/jaxrs/validation/JAXRSBeanValidationFeature.java
+++ b/rt/frontend/jaxrs/src/main/java/org/apache/cxf/jaxrs/validation/JAXRSBeanValidationFeature.java
@@ -23,6 +23,7 @@ import org.apache.cxf.annotations.Provider;
 import org.apache.cxf.annotations.Provider.Scope;
 import org.apache.cxf.annotations.Provider.Type;
 import org.apache.cxf.feature.AbstractFeature;
+import org.apache.cxf.feature.AbstractPortableFeature;
 import org.apache.cxf.interceptor.InterceptorProvider;
 import org.apache.cxf.validation.BeanValidationInInterceptor;
 import org.apache.cxf.validation.BeanValidationProvider;
@@ -30,25 +31,44 @@ import org.apache.cxf.validation.BeanValidationProvider;
 @Provider(value = Type.Feature, scope = Scope.Server)
 public class JAXRSBeanValidationFeature extends AbstractFeature {
 
-    private BeanValidationProvider validationProvider;
-    private boolean supportMultipleValidations;
+    private Portable delegate = new Portable();
+
     @Override
     protected void initializeProvider(InterceptorProvider interceptorProvider, Bus bus) {
-        BeanValidationInInterceptor in = new JAXRSBeanValidationInInterceptor();
-        JAXRSBeanValidationOutInterceptor out = new JAXRSBeanValidationOutInterceptor();
-        out.setSupportMultipleValidations(supportMultipleValidations);
-        if (validationProvider != null) {
-            in.setProvider(validationProvider);
-            out.setProvider(validationProvider);
-        }
-        interceptorProvider.getInInterceptors().add(in);
-        interceptorProvider.getOutInterceptors().add(out);
+        delegate.doInitializeProvider(interceptorProvider, bus);
     }
 
     public void setProvider(BeanValidationProvider provider) {
-        this.validationProvider = provider;
+        delegate.setProvider(provider);
     }
+
     public void setSupportMultipleValidations(boolean supportMultipleValidations) {
-        this.supportMultipleValidations = supportMultipleValidations;
+        delegate.setSupportMultipleValidations(supportMultipleValidations);
+    }
+
+    @Provider(value = Type.Feature, scope = Scope.Server)
+    public static class Portable implements AbstractPortableFeature {
+
+        private BeanValidationProvider validationProvider;
+        private boolean supportMultipleValidations;
+        @Override
+        public void doInitializeProvider(InterceptorProvider interceptorProvider, Bus bus) {
+            BeanValidationInInterceptor in = new JAXRSBeanValidationInInterceptor();
+            JAXRSBeanValidationOutInterceptor out = new JAXRSBeanValidationOutInterceptor();
+            out.setSupportMultipleValidations(supportMultipleValidations);
+            if (validationProvider != null) {
+                in.setProvider(validationProvider);
+                out.setProvider(validationProvider);
+            }
+            interceptorProvider.getInInterceptors().add(in);
+            interceptorProvider.getOutInterceptors().add(out);
+        }
+
+        public void setProvider(BeanValidationProvider provider) {
+            this.validationProvider = provider;
+        }
+        public void setSupportMultipleValidations(boolean supportMultipleValidations) {
+            this.supportMultipleValidations = supportMultipleValidations;
+        }
     }
 }

--- a/rt/frontend/jaxrs/src/main/java/org/apache/cxf/jaxrs/validation/JAXRSBeanValidationFeature.java
+++ b/rt/frontend/jaxrs/src/main/java/org/apache/cxf/jaxrs/validation/JAXRSBeanValidationFeature.java
@@ -22,6 +22,8 @@ import org.apache.cxf.Bus;
 import org.apache.cxf.annotations.Provider;
 import org.apache.cxf.annotations.Provider.Scope;
 import org.apache.cxf.annotations.Provider.Type;
+import org.apache.cxf.endpoint.Client;
+import org.apache.cxf.endpoint.Server;
 import org.apache.cxf.feature.AbstractFeature;
 import org.apache.cxf.feature.AbstractPortableFeature;
 import org.apache.cxf.interceptor.InterceptorProvider;
@@ -36,6 +38,26 @@ public class JAXRSBeanValidationFeature extends AbstractFeature {
     @Override
     protected void initializeProvider(InterceptorProvider interceptorProvider, Bus bus) {
         delegate.doInitializeProvider(interceptorProvider, bus);
+    }
+
+    @Override
+    public void initialize(Server server, Bus bus) {
+        delegate.initialize(server, bus);
+    }
+
+    @Override
+    public void initialize(Client client, Bus bus) {
+        delegate.initialize(client, bus);
+    }
+
+    @Override
+    public void initialize(InterceptorProvider interceptorProvider, Bus bus) {
+        delegate.initialize(interceptorProvider, bus);
+    }
+
+    @Override
+    public void initialize(Bus bus) {
+        delegate.initialize(bus);
     }
 
     public void setProvider(BeanValidationProvider provider) {

--- a/rt/frontend/jaxrs/src/main/java/org/apache/cxf/jaxrs/validation/JAXRSBeanValidationFeature.java
+++ b/rt/frontend/jaxrs/src/main/java/org/apache/cxf/jaxrs/validation/JAXRSBeanValidationFeature.java
@@ -22,42 +22,17 @@ import org.apache.cxf.Bus;
 import org.apache.cxf.annotations.Provider;
 import org.apache.cxf.annotations.Provider.Scope;
 import org.apache.cxf.annotations.Provider.Type;
-import org.apache.cxf.endpoint.Client;
-import org.apache.cxf.endpoint.Server;
-import org.apache.cxf.feature.AbstractFeature;
 import org.apache.cxf.feature.AbstractPortableFeature;
+import org.apache.cxf.feature.DelegatingFeature;
 import org.apache.cxf.interceptor.InterceptorProvider;
 import org.apache.cxf.validation.BeanValidationInInterceptor;
 import org.apache.cxf.validation.BeanValidationProvider;
 
 @Provider(value = Type.Feature, scope = Scope.Server)
-public class JAXRSBeanValidationFeature extends AbstractFeature {
+public class JAXRSBeanValidationFeature extends DelegatingFeature<JAXRSBeanValidationFeature.Portable> {
 
-    private Portable delegate = new Portable();
-
-    @Override
-    protected void initializeProvider(InterceptorProvider interceptorProvider, Bus bus) {
-        delegate.doInitializeProvider(interceptorProvider, bus);
-    }
-
-    @Override
-    public void initialize(Server server, Bus bus) {
-        delegate.initialize(server, bus);
-    }
-
-    @Override
-    public void initialize(Client client, Bus bus) {
-        delegate.initialize(client, bus);
-    }
-
-    @Override
-    public void initialize(InterceptorProvider interceptorProvider, Bus bus) {
-        delegate.initialize(interceptorProvider, bus);
-    }
-
-    @Override
-    public void initialize(Bus bus) {
-        delegate.initialize(bus);
+    public JAXRSBeanValidationFeature() {
+        super(new Portable());
     }
 
     public void setProvider(BeanValidationProvider provider) {

--- a/rt/javascript/javascript-rt/src/main/java/org/apache/cxf/javascript/JavascriptOptionsFeature.java
+++ b/rt/javascript/javascript-rt/src/main/java/org/apache/cxf/javascript/JavascriptOptionsFeature.java
@@ -23,11 +23,9 @@ import java.util.Map;
 
 import org.apache.cxf.Bus;
 import org.apache.cxf.common.injection.NoJSR250Annotations;
-import org.apache.cxf.endpoint.Client;
 import org.apache.cxf.endpoint.Server;
-import org.apache.cxf.feature.AbstractFeature;
 import org.apache.cxf.feature.AbstractPortableFeature;
-import org.apache.cxf.interceptor.InterceptorProvider;
+import org.apache.cxf.feature.DelegatingFeature;
 
 /**
  * This class provides configuration options to the JavaScript client generator.
@@ -45,8 +43,11 @@ import org.apache.cxf.interceptor.InterceptorProvider;
   * At this time, there is no corresponding WSDL extension for this information.
  */
 @NoJSR250Annotations
-public class JavascriptOptionsFeature extends AbstractFeature {
-    private Portable delegate = new Portable();
+public class JavascriptOptionsFeature extends DelegatingFeature<JavascriptOptionsFeature.Portable> {
+
+    public JavascriptOptionsFeature() {
+        super(new Portable());
+    }
 
     public Map<String, String> getNamespacePrefixMap() {
         return delegate.getNamespacePrefixMap();
@@ -54,26 +55,6 @@ public class JavascriptOptionsFeature extends AbstractFeature {
 
     public void setNamespacePrefixMap(Map<String, String> namespacePrefixMap) {
         delegate.setNamespacePrefixMap(namespacePrefixMap);
-    }
-
-    @Override
-    public void initialize(Server server, Bus bus) {
-        delegate.initialize(server, bus);
-    }
-
-    @Override
-    public void initialize(Client client, Bus bus) {
-        delegate.initialize(client, bus);
-    }
-
-    @Override
-    public void initialize(InterceptorProvider interceptorProvider, Bus bus) {
-        delegate.initialize(interceptorProvider, bus);
-    }
-
-    @Override
-    public void initialize(Bus bus) {
-        delegate.initialize(bus);
     }
 
     public static class Portable implements AbstractPortableFeature {

--- a/rt/javascript/javascript-rt/src/main/java/org/apache/cxf/javascript/JavascriptOptionsFeature.java
+++ b/rt/javascript/javascript-rt/src/main/java/org/apache/cxf/javascript/JavascriptOptionsFeature.java
@@ -25,6 +25,7 @@ import org.apache.cxf.Bus;
 import org.apache.cxf.common.injection.NoJSR250Annotations;
 import org.apache.cxf.endpoint.Server;
 import org.apache.cxf.feature.AbstractFeature;
+import org.apache.cxf.feature.AbstractPortableFeature;
 
 /**
  * This class provides configuration options to the JavaScript client generator.
@@ -43,26 +44,43 @@ import org.apache.cxf.feature.AbstractFeature;
  */
 @NoJSR250Annotations
 public class JavascriptOptionsFeature extends AbstractFeature {
-    private Map<String, String> namespacePrefixMap;
+    private Portable delegate = new Portable();
 
-    /**
-     * Retrieve the map from namespace URI strings to JavaScript function prefixes.
-     * @return the map
-     */
     public Map<String, String> getNamespacePrefixMap() {
-        return namespacePrefixMap;
+        return delegate.getNamespacePrefixMap();
     }
 
-    /**
-     * Set the map from namespace URI strings to Javascript function prefixes.
-     * @param namespacePrefixMap the map from namespace URI strings to JavaScript function prefixes.
-     */
     public void setNamespacePrefixMap(Map<String, String> namespacePrefixMap) {
-        this.namespacePrefixMap = namespacePrefixMap;
+        delegate.setNamespacePrefixMap(namespacePrefixMap);
     }
 
     @Override
     public void initialize(Server server, Bus bus) {
-      //  server.getEndpoint().getActiveFeatures().add(this);
+        delegate.initialize(server, bus);
+    }
+
+    public static class Portable implements AbstractPortableFeature {
+        private Map<String, String> namespacePrefixMap;
+
+        /**
+         * Retrieve the map from namespace URI strings to JavaScript function prefixes.
+         * @return the map
+         */
+        public Map<String, String> getNamespacePrefixMap() {
+            return namespacePrefixMap;
+        }
+
+        /**
+         * Set the map from namespace URI strings to Javascript function prefixes.
+         * @param namespacePrefixMap the map from namespace URI strings to JavaScript function prefixes.
+         */
+        public void setNamespacePrefixMap(Map<String, String> namespacePrefixMap) {
+            this.namespacePrefixMap = namespacePrefixMap;
+        }
+
+        @Override
+        public void initialize(Server server, Bus bus) {
+            //  server.getEndpoint().getActiveFeatures().add(this);
+        }
     }
 }

--- a/rt/javascript/javascript-rt/src/main/java/org/apache/cxf/javascript/JavascriptOptionsFeature.java
+++ b/rt/javascript/javascript-rt/src/main/java/org/apache/cxf/javascript/JavascriptOptionsFeature.java
@@ -23,9 +23,11 @@ import java.util.Map;
 
 import org.apache.cxf.Bus;
 import org.apache.cxf.common.injection.NoJSR250Annotations;
+import org.apache.cxf.endpoint.Client;
 import org.apache.cxf.endpoint.Server;
 import org.apache.cxf.feature.AbstractFeature;
 import org.apache.cxf.feature.AbstractPortableFeature;
+import org.apache.cxf.interceptor.InterceptorProvider;
 
 /**
  * This class provides configuration options to the JavaScript client generator.
@@ -57,6 +59,21 @@ public class JavascriptOptionsFeature extends AbstractFeature {
     @Override
     public void initialize(Server server, Bus bus) {
         delegate.initialize(server, bus);
+    }
+
+    @Override
+    public void initialize(Client client, Bus bus) {
+        delegate.initialize(client, bus);
+    }
+
+    @Override
+    public void initialize(InterceptorProvider interceptorProvider, Bus bus) {
+        delegate.initialize(interceptorProvider, bus);
+    }
+
+    @Override
+    public void initialize(Bus bus) {
+        delegate.initialize(bus);
     }
 
     public static class Portable implements AbstractPortableFeature {

--- a/rt/management/src/main/java/org/apache/cxf/management/interceptor/ResponseTimeFeature.java
+++ b/rt/management/src/main/java/org/apache/cxf/management/interceptor/ResponseTimeFeature.java
@@ -21,24 +21,32 @@ package org.apache.cxf.management.interceptor;
 import org.apache.cxf.Bus;
 import org.apache.cxf.common.injection.NoJSR250Annotations;
 import org.apache.cxf.feature.AbstractFeature;
+import org.apache.cxf.feature.AbstractPortableFeature;
 import org.apache.cxf.interceptor.InterceptorProvider;
 
 @NoJSR250Annotations
 public class ResponseTimeFeature extends AbstractFeature {
-    private static final ResponseTimeMessageInInterceptor IN =
-        new ResponseTimeMessageInInterceptor();
-    private static final ResponseTimeMessageInvokerInterceptor INVOKER =
-        new ResponseTimeMessageInvokerInterceptor();
-    private static final ResponseTimeMessageOutInterceptor OUT =
-        new ResponseTimeMessageOutInterceptor();
+    private final Portable delegate = new Portable();
 
     @Override
     protected void initializeProvider(InterceptorProvider provider, Bus bus) {
-        provider.getInInterceptors().add(IN);
-        provider.getInFaultInterceptors().add(IN);
-        provider.getInInterceptors().add(INVOKER);
-        provider.getOutInterceptors().add(OUT);
-
+        delegate.doInitializeProvider(provider, bus);
     }
 
+    public static class Portable implements AbstractPortableFeature {
+        private static final ResponseTimeMessageInInterceptor IN =
+                new ResponseTimeMessageInInterceptor();
+        private static final ResponseTimeMessageInvokerInterceptor INVOKER =
+                new ResponseTimeMessageInvokerInterceptor();
+        private static final ResponseTimeMessageOutInterceptor OUT =
+                new ResponseTimeMessageOutInterceptor();
+
+        @Override
+        public void doInitializeProvider(InterceptorProvider provider, Bus bus) {
+            provider.getInInterceptors().add(IN);
+            provider.getInFaultInterceptors().add(IN);
+            provider.getInInterceptors().add(INVOKER);
+            provider.getOutInterceptors().add(OUT);
+        }
+    }
 }

--- a/rt/management/src/main/java/org/apache/cxf/management/interceptor/ResponseTimeFeature.java
+++ b/rt/management/src/main/java/org/apache/cxf/management/interceptor/ResponseTimeFeature.java
@@ -20,39 +20,14 @@ package org.apache.cxf.management.interceptor;
 
 import org.apache.cxf.Bus;
 import org.apache.cxf.common.injection.NoJSR250Annotations;
-import org.apache.cxf.endpoint.Client;
-import org.apache.cxf.endpoint.Server;
-import org.apache.cxf.feature.AbstractFeature;
 import org.apache.cxf.feature.AbstractPortableFeature;
+import org.apache.cxf.feature.DelegatingFeature;
 import org.apache.cxf.interceptor.InterceptorProvider;
 
 @NoJSR250Annotations
-public class ResponseTimeFeature extends AbstractFeature {
-    private final Portable delegate = new Portable();
-
-    @Override
-    protected void initializeProvider(InterceptorProvider provider, Bus bus) {
-        delegate.doInitializeProvider(provider, bus);
-    }
-
-    @Override
-    public void initialize(Server server, Bus bus) {
-        delegate.initialize(server, bus);
-    }
-
-    @Override
-    public void initialize(Client client, Bus bus) {
-        delegate.initialize(client, bus);
-    }
-
-    @Override
-    public void initialize(InterceptorProvider interceptorProvider, Bus bus) {
-        delegate.initialize(interceptorProvider, bus);
-    }
-
-    @Override
-    public void initialize(Bus bus) {
-        delegate.initialize(bus);
+public class ResponseTimeFeature extends DelegatingFeature<ResponseTimeFeature.Portable> {
+    public ResponseTimeFeature() {
+        super(new Portable());
     }
 
     public static class Portable implements AbstractPortableFeature {

--- a/rt/management/src/main/java/org/apache/cxf/management/interceptor/ResponseTimeFeature.java
+++ b/rt/management/src/main/java/org/apache/cxf/management/interceptor/ResponseTimeFeature.java
@@ -20,6 +20,8 @@ package org.apache.cxf.management.interceptor;
 
 import org.apache.cxf.Bus;
 import org.apache.cxf.common.injection.NoJSR250Annotations;
+import org.apache.cxf.endpoint.Client;
+import org.apache.cxf.endpoint.Server;
 import org.apache.cxf.feature.AbstractFeature;
 import org.apache.cxf.feature.AbstractPortableFeature;
 import org.apache.cxf.interceptor.InterceptorProvider;
@@ -31,6 +33,26 @@ public class ResponseTimeFeature extends AbstractFeature {
     @Override
     protected void initializeProvider(InterceptorProvider provider, Bus bus) {
         delegate.doInitializeProvider(provider, bus);
+    }
+
+    @Override
+    public void initialize(Server server, Bus bus) {
+        delegate.initialize(server, bus);
+    }
+
+    @Override
+    public void initialize(Client client, Bus bus) {
+        delegate.initialize(client, bus);
+    }
+
+    @Override
+    public void initialize(InterceptorProvider interceptorProvider, Bus bus) {
+        delegate.initialize(interceptorProvider, bus);
+    }
+
+    @Override
+    public void initialize(Bus bus) {
+        delegate.initialize(bus);
     }
 
     public static class Portable implements AbstractPortableFeature {

--- a/rt/rs/client/src/main/java/org/apache/cxf/jaxrs/client/validation/JAXRSClientBeanValidationFeature.java
+++ b/rt/rs/client/src/main/java/org/apache/cxf/jaxrs/client/validation/JAXRSClientBeanValidationFeature.java
@@ -27,14 +27,8 @@ import org.apache.cxf.validation.ClientBeanValidationFeature;
 
 @Provider(value = Type.Feature, scope = Scope.Client)
 public class JAXRSClientBeanValidationFeature extends ClientBeanValidationFeature {
-    @Override
-    protected void initializeProvider(InterceptorProvider interceptorProvider, Bus bus) {
-        super.initializeProvider(interceptorProvider, bus);
-    }
-
-    @Override
-    protected ClientBeanValidationFeature.Portable getDelegate() {
-        return new Portable();
+    public JAXRSClientBeanValidationFeature() {
+        super(new Portable());
     }
 
     public void setWrapInProcessingException(boolean wrapInProcessingException) {

--- a/rt/rs/client/src/main/java/org/apache/cxf/jaxrs/client/validation/JAXRSClientBeanValidationFeature.java
+++ b/rt/rs/client/src/main/java/org/apache/cxf/jaxrs/client/validation/JAXRSClientBeanValidationFeature.java
@@ -27,14 +27,30 @@ import org.apache.cxf.validation.ClientBeanValidationFeature;
 
 @Provider(value = Type.Feature, scope = Scope.Client)
 public class JAXRSClientBeanValidationFeature extends ClientBeanValidationFeature {
-    private boolean wrapInProcessingException;
     @Override
     protected void initializeProvider(InterceptorProvider interceptorProvider, Bus bus) {
-        JAXRSClientBeanValidationOutInterceptor out = new JAXRSClientBeanValidationOutInterceptor();
-        out.setWrapInProcessingException(wrapInProcessingException);
-        super.addInterceptor(interceptorProvider, out);
+        super.initializeProvider(interceptorProvider, bus);
     }
+
+    @Override
+    protected ClientBeanValidationFeature.Portable getDelegate() {
+        return new Portable();
+    }
+
     public void setWrapInProcessingException(boolean wrapInProcessingException) {
-        this.wrapInProcessingException = wrapInProcessingException;
+        Portable.class.cast(getDelegate()).setWrapInProcessingException(wrapInProcessingException);
+    }
+
+    public static class Portable extends ClientBeanValidationFeature.Portable {
+        private boolean wrapInProcessingException;
+        @Override
+        public void doInitializeProvider(InterceptorProvider interceptorProvider, Bus bus) {
+            JAXRSClientBeanValidationOutInterceptor out = new JAXRSClientBeanValidationOutInterceptor();
+            out.setWrapInProcessingException(wrapInProcessingException);
+            super.addInterceptor(interceptorProvider, out);
+        }
+        public void setWrapInProcessingException(boolean wrapInProcessingException) {
+            this.wrapInProcessingException = wrapInProcessingException;
+        }
     }
 }

--- a/rt/rs/description-openapi-v3/src/main/java/org/apache/cxf/jaxrs/openapi/OpenApiFeature.java
+++ b/rt/rs/description-openapi-v3/src/main/java/org/apache/cxf/jaxrs/openapi/OpenApiFeature.java
@@ -37,11 +37,9 @@ import org.apache.cxf.annotations.Provider.Scope;
 import org.apache.cxf.annotations.Provider.Type;
 import org.apache.cxf.common.util.PropertyUtils;
 import org.apache.cxf.common.util.StringUtils;
-import org.apache.cxf.endpoint.Client;
 import org.apache.cxf.endpoint.Server;
-import org.apache.cxf.feature.AbstractFeature;
 import org.apache.cxf.feature.AbstractPortableFeature;
-import org.apache.cxf.interceptor.InterceptorProvider;
+import org.apache.cxf.feature.DelegatingFeature;
 import org.apache.cxf.jaxrs.JAXRSServiceFactoryBean;
 import org.apache.cxf.jaxrs.common.openapi.DefaultApplicationFactory;
 import org.apache.cxf.jaxrs.common.openapi.SwaggerProperties;
@@ -64,27 +62,11 @@ import io.swagger.v3.oas.models.info.License;
 import io.swagger.v3.oas.models.security.SecurityScheme;
 
 @Provider(value = Type.Feature, scope = Scope.Server)
-public class OpenApiFeature extends AbstractFeature implements SwaggerUiSupport, SwaggerProperties {
-    private Portable delegate = new Portable();
+public class OpenApiFeature extends DelegatingFeature<OpenApiFeature.Portable>
+        implements SwaggerUiSupport, SwaggerProperties {
 
-    @Override
-    public void initialize(Server server, Bus bus) {
-        delegate.initialize(server, bus);
-    }
-
-    @Override
-    public void initialize(Client client, Bus bus) {
-        delegate.initialize(client, bus);
-    }
-
-    @Override
-    public void initialize(InterceptorProvider interceptorProvider, Bus bus) {
-        delegate.initialize(interceptorProvider, bus);
-    }
-
-    @Override
-    public void initialize(Bus bus) {
-        delegate.initialize(bus);
+    public OpenApiFeature() {
+        super(new Portable());
     }
 
     public boolean isScan() {

--- a/rt/rs/description-openapi-v3/src/main/java/org/apache/cxf/jaxrs/openapi/OpenApiFeature.java
+++ b/rt/rs/description-openapi-v3/src/main/java/org/apache/cxf/jaxrs/openapi/OpenApiFeature.java
@@ -39,6 +39,7 @@ import org.apache.cxf.common.util.PropertyUtils;
 import org.apache.cxf.common.util.StringUtils;
 import org.apache.cxf.endpoint.Server;
 import org.apache.cxf.feature.AbstractFeature;
+import org.apache.cxf.feature.AbstractPortableFeature;
 import org.apache.cxf.jaxrs.JAXRSServiceFactoryBean;
 import org.apache.cxf.jaxrs.common.openapi.DefaultApplicationFactory;
 import org.apache.cxf.jaxrs.common.openapi.SwaggerProperties;
@@ -62,514 +63,808 @@ import io.swagger.v3.oas.models.security.SecurityScheme;
 
 @Provider(value = Type.Feature, scope = Scope.Server)
 public class OpenApiFeature extends AbstractFeature implements SwaggerUiSupport, SwaggerProperties {
-    private String version;
-    private String title;
-    private String description;
-    private String contactName;
-    private String contactEmail;
-    private String contactUrl;
-    private String license;
-    private String licenseUrl;
-    private String termsOfServiceUrl;
-    // Read all operations also with no @Operation
-    private boolean readAllResources = true; 
-    // Scan all JAX-RS resources automatically
-    private boolean scan = true;
-    private boolean prettyPrint = true;
-    private boolean runAsFilter;
-    private Collection<String> ignoredRoutes;
-    private Set<String> resourcePackages;
-    private Set<String> resourceClasses;
-    private String filterClass;
-
-    private Boolean supportSwaggerUi;
-    private String swaggerUiVersion;
-    private String swaggerUiMavenGroupAndArtifact;
-    private Map<String, String> swaggerUiMediaTypes;
-    
-    // Additional components
-    private Map<String, SecurityScheme> securityDefinitions;
-    private OpenApiCustomizer customizer;
-    
-    // Allows to pass the configuration location, usually openapi-configuration.json
-    // or openapi-configuration.yml file.
-    private String configLocation;
-    // Allows to pass the properties location, by default swagger.properties
-    private String propertiesLocation = DEFAULT_PROPS_LOCATION;
-    // Allows to disable automatic scan of known configuration locations (enabled by default)
-    private boolean scanKnownConfigLocations = true;
-    // Swagger UI configuration parameters (to be passed as query string).
-    private SwaggerUiConfig swaggerUiConfig;
-    // Generates the Swagger Context ID (instead of using the default one). It is
-    // necessary when more than one JAXRS Server Factory Bean or OpenApiFeature instance
-    // are co-located in the same application.
-    private boolean useContextBasedConfig;
-    private String ctxId;
+    private Portable delegate = new Portable();
 
     @Override
     public void initialize(Server server, Bus bus) {
-        final JAXRSServiceFactoryBean sfb = (JAXRSServiceFactoryBean)server
-            .getEndpoint()
-            .get(JAXRSServiceFactoryBean.class.getName());
-
-        final ServerProviderFactory factory = (ServerProviderFactory)server
-            .getEndpoint()
-            .get(ServerProviderFactory.class.getName());
-
-        final Set<String> packages = new HashSet<>();
-        if (resourcePackages != null) {
-            packages.addAll(resourcePackages);
-        }
-        
-        // Generate random Context ID for Swagger
-        if (useContextBasedConfig) {
-            ctxId = UUID.randomUUID().toString();
-        }
-
-        Properties swaggerProps = null;
-        GenericOpenApiContextBuilder<?> openApiConfiguration; 
-        final Application application = DefaultApplicationFactory.createApplicationOrDefault(server, factory, 
-            sfb, bus, resourcePackages, isScan());
-        
-        String defaultConfigLocation = getConfigLocation();
-        if (scanKnownConfigLocations && StringUtils.isEmpty(defaultConfigLocation)) {
-            defaultConfigLocation = OpenApiDefaultConfigurationScanner.locateDefaultConfiguration().orElse(null);
-        }
-        
-        if (StringUtils.isEmpty(defaultConfigLocation)) {
-            swaggerProps = getSwaggerProperties(propertiesLocation, bus);
-            
-            if (isScan()) {
-                packages.addAll(scanResourcePackages(sfb));
-            }
-        
-            final OpenAPI oas = new OpenAPI().info(getInfo(swaggerProps));
-            registerComponents(securityDefinitions).ifPresent(oas::setComponents);
-            
-            final SwaggerConfiguration config = new SwaggerConfiguration()
-                .openAPI(oas)
-                .prettyPrint(getOrFallback(isPrettyPrint(), swaggerProps, PRETTY_PRINT_PROPERTY))
-                .readAllResources(isReadAllResources())
-                .ignoredRoutes(getIgnoredRoutes())
-                .filterClass(getOrFallback(getFilterClass(), swaggerProps, FILTER_CLASS_PROPERTY))
-                .resourceClasses(getResourceClasses())
-                .resourcePackages(getOrFallback(packages, swaggerProps, RESOURCE_PACKAGE_PROPERTY));
-
-            openApiConfiguration = new JaxrsOpenApiContextBuilder<>()
-                .application(application)
-                .openApiConfiguration(config)
-                .ctxId(ctxId); /* will be null if not used */
-        } else {
-            openApiConfiguration = new JaxrsOpenApiContextBuilder<>()
-                .application(application)
-                .configLocation(defaultConfigLocation)
-                .ctxId(ctxId); /* will be null if not used */
-        }
-
-        try {
-            final OpenApiContext context = openApiConfiguration.buildContext(true);
-            final Properties userProperties = getUserProperties(
-                context
-                    .getOpenApiConfiguration()
-                    .getUserDefinedOptions());
-            registerOpenApiResources(sfb, packages, context.getOpenApiConfiguration());
-            registerSwaggerUiResources(sfb, combine(swaggerProps, userProperties), factory, bus);
-            
-            if (useContextBasedConfig) {
-                registerServletConfigProvider(factory);
-            }
-            
-            if (customizer != null) {
-                customizer.setApplicationInfo(factory.getApplicationProvider());
-            }
-            
-            bus.setProperty("openapi.service.description.available", "true");
-        } catch (OpenApiConfigurationException ex) {
-            throw new RuntimeException("Unable to initialize OpenAPI context", ex);
-        }
+        delegate.initialize(server, bus);
     }
 
     public boolean isScan() {
-        return scan;
+        return delegate.isScan();
     }
 
     public void setScan(boolean scan) {
-        this.scan = scan;
+        delegate.setScan(scan);
     }
 
     public String getFilterClass() {
-        return filterClass;
+        return delegate.getFilterClass();
     }
 
     public void setFilterClass(String filterClass) {
-        this.filterClass = filterClass;
+        delegate.setFilterClass(filterClass);
     }
-    
+
     public Set<String> getResourcePackages() {
-        return resourcePackages;
+        return delegate.getResourcePackages();
     }
-    
+
     public void setResourcePackages(Set<String> resourcePackages) {
-        this.resourcePackages = (resourcePackages == null) ? null : new HashSet<>(resourcePackages);
+        delegate.setResourcePackages(resourcePackages);
     }
 
     public String getVersion() {
-        return version;
+        return delegate.getVersion();
     }
 
     public void setVersion(String version) {
-        this.version = version;
+        delegate.setVersion(version);
     }
 
     public String getTitle() {
-        return title;
+        return delegate.getTitle();
     }
 
     public void setTitle(String title) {
-        this.title = title;
+        delegate.setTitle(title);
     }
 
     public String getDescription() {
-        return description;
+        return delegate.getDescription();
     }
 
     public void setDescription(String description) {
-        this.description = description;
+        delegate.setDescription(description);
     }
 
     public String getContactName() {
-        return contactName;
+        return delegate.getContactName();
     }
 
     public void setContactName(String contactName) {
-        this.contactName = contactName;
+        delegate.setContactName(contactName);
     }
 
     public String getContactEmail() {
-        return contactEmail;
+        return delegate.getContactEmail();
     }
 
     public void setContactEmail(String contactEmail) {
-        this.contactEmail = contactEmail;
+        delegate.setContactEmail(contactEmail);
     }
 
     public String getContactUrl() {
-        return contactUrl;
+        return delegate.getContactUrl();
     }
 
     public void setContactUrl(String contactUrl) {
-        this.contactUrl = contactUrl;
+        delegate.setContactUrl(contactUrl);
     }
 
     public String getLicense() {
-        return license;
+        return delegate.getLicense();
     }
 
     public void setLicense(String license) {
-        this.license = license;
+        delegate.setLicense(license);
     }
 
     public String getLicenseUrl() {
-        return licenseUrl;
+        return delegate.getLicenseUrl();
     }
 
     public void setLicenseUrl(String licenseUrl) {
-        this.licenseUrl = licenseUrl;
+        delegate.setLicenseUrl(licenseUrl);
     }
 
     public String getTermsOfServiceUrl() {
-        return termsOfServiceUrl;
+        return delegate.getTermsOfServiceUrl();
     }
 
     public void setTermsOfServiceUrl(String termsOfServiceUrl) {
-        this.termsOfServiceUrl = termsOfServiceUrl;
+        delegate.setTermsOfServiceUrl(termsOfServiceUrl);
     }
 
     public boolean isReadAllResources() {
-        return readAllResources;
+        return delegate.isReadAllResources();
     }
 
     public void setReadAllResources(boolean readAllResources) {
-        this.readAllResources = readAllResources;
+        delegate.setReadAllResources(readAllResources);
     }
 
     public Set<String> getResourceClasses() {
-        return resourceClasses;
+        return delegate.getResourceClasses();
     }
 
     public void setResourceClasses(Set<String> resourceClasses) {
-        this.resourceClasses = (resourceClasses == null) ? null : new HashSet<>(resourceClasses);
+        delegate.setResourceClasses(resourceClasses);
     }
 
     public Collection<String> getIgnoredRoutes() {
-        return ignoredRoutes;
+        return delegate.getIgnoredRoutes();
     }
 
     public void setIgnoredRoutes(Collection<String> ignoredRoutes) {
-        this.ignoredRoutes = (ignoredRoutes == null) ? null : new HashSet<>(ignoredRoutes);
+        delegate.setIgnoredRoutes(ignoredRoutes);
     }
 
     public boolean isPrettyPrint() {
-        return prettyPrint;
+        return delegate.isPrettyPrint();
     }
 
     public void setPrettyPrint(boolean prettyPrint) {
-        this.prettyPrint = prettyPrint;
+        delegate.setPrettyPrint(prettyPrint);
     }
-    
+
     public boolean isRunAsFilter() {
-        return runAsFilter;
+        return delegate.isRunAsFilter();
     }
-    
+
     @Override
     public Boolean isSupportSwaggerUi() {
-        return supportSwaggerUi;
+        return delegate.isSupportSwaggerUi();
     }
 
     public void setSupportSwaggerUi(Boolean supportSwaggerUi) {
-        this.supportSwaggerUi = supportSwaggerUi;
+        delegate.setSupportSwaggerUi(supportSwaggerUi);
     }
 
     public String getSwaggerUiVersion() {
-        return swaggerUiVersion;
+        return delegate.getSwaggerUiVersion();
     }
 
     public void setSwaggerUiVersion(String swaggerUiVersion) {
-        this.swaggerUiVersion = swaggerUiVersion;
+        delegate.setSwaggerUiVersion(swaggerUiVersion);
     }
 
     public String getSwaggerUiMavenGroupAndArtifact() {
-        return swaggerUiMavenGroupAndArtifact;
+        return delegate.getSwaggerUiMavenGroupAndArtifact();
     }
 
-    public void setSwaggerUiMavenGroupAndArtifact(
-            String swaggerUiMavenGroupAndArtifact) {
-        this.swaggerUiMavenGroupAndArtifact = swaggerUiMavenGroupAndArtifact;
+    public void setSwaggerUiMavenGroupAndArtifact(String swaggerUiMavenGroupAndArtifact) {
+        delegate.setSwaggerUiMavenGroupAndArtifact(swaggerUiMavenGroupAndArtifact);
     }
 
     @Override
     public Map<String, String> getSwaggerUiMediaTypes() {
-        return swaggerUiMediaTypes;
+        return delegate.getSwaggerUiMediaTypes();
     }
 
     public void setSwaggerUiMediaTypes(Map<String, String> swaggerUiMediaTypes) {
-        this.swaggerUiMediaTypes = swaggerUiMediaTypes;
+        delegate.setSwaggerUiMediaTypes(swaggerUiMediaTypes);
     }
 
     public String getConfigLocation() {
-        return configLocation;
+        return delegate.getConfigLocation();
     }
 
     public void setConfigLocation(String configLocation) {
-        this.configLocation = configLocation;
+        delegate.setConfigLocation(configLocation);
     }
 
     public String getPropertiesLocation() {
-        return propertiesLocation;
+        return delegate.getPropertiesLocation();
     }
 
     public void setPropertiesLocation(String propertiesLocation) {
-        this.propertiesLocation = propertiesLocation;
+        delegate.setPropertiesLocation(propertiesLocation);
     }
 
     public void setRunAsFilter(boolean runAsFilter) {
-        this.runAsFilter = runAsFilter;
+        delegate.setRunAsFilter(runAsFilter);
     }
 
     public Map<String, SecurityScheme> getSecurityDefinitions() {
-        return securityDefinitions;
+        return delegate.getSecurityDefinitions();
     }
 
     public void setSecurityDefinitions(Map<String, SecurityScheme> securityDefinitions) {
-        this.securityDefinitions = securityDefinitions;
+        delegate.setSecurityDefinitions(securityDefinitions);
     }
-    
+
     public OpenApiCustomizer getCustomizer() {
-        return customizer;
+        return delegate.getCustomizer();
     }
-    
+
     public void setCustomizer(OpenApiCustomizer customizer) {
-        this.customizer = customizer;
+        delegate.setCustomizer(customizer);
     }
-    
+
     public void setScanKnownConfigLocations(boolean scanKnownConfigLocations) {
-        this.scanKnownConfigLocations = scanKnownConfigLocations;
+        delegate.setScanKnownConfigLocations(scanKnownConfigLocations);
     }
-    
+
     public boolean isScanKnownConfigLocations() {
-        return scanKnownConfigLocations;
+        return delegate.isScanKnownConfigLocations();
     }
-    
-    public void setSwaggerUiConfig(final SwaggerUiConfig swaggerUiConfig) {
-        this.swaggerUiConfig = swaggerUiConfig;
+
+    public void setSwaggerUiConfig(SwaggerUiConfig swaggerUiConfig) {
+        delegate.setSwaggerUiConfig(swaggerUiConfig);
     }
-    
-    public void setUseContextBasedConfig(final boolean useContextBasedConfig) {
-        this.useContextBasedConfig = useContextBasedConfig;
+
+    public void setUseContextBasedConfig(boolean useContextBasedConfig) {
+        delegate.setUseContextBasedConfig(useContextBasedConfig);
     }
-    
+
     public boolean isUseContextBasedConfig() {
-        return useContextBasedConfig;
+        return delegate.isUseContextBasedConfig();
     }
-    
+
     @Override
     public SwaggerUiConfig getSwaggerUiConfig() {
-        return swaggerUiConfig;
+        return delegate.getSwaggerUiConfig();
     }
 
     @Override
     public String findSwaggerUiRoot() {
-        return SwaggerUi.findSwaggerUiRoot(swaggerUiMavenGroupAndArtifact, swaggerUiVersion);
-    }
-    
-    protected Properties getUserProperties(final Map<String, Object> userDefinedOptions) {
-        final Properties properties = new Properties();
-        
-        if (userDefinedOptions != null) {
-            userDefinedOptions
-                .entrySet()
-                .stream()
-                .filter(entry -> entry.getValue() != null)
-                .forEach(entry -> properties.setProperty(entry.getKey(), entry.getValue().toString()));
-        }
-        
-        return properties;
+        return delegate.findSwaggerUiRoot();
     }
 
-    protected void registerOpenApiResources(
-            final JAXRSServiceFactoryBean sfb, 
-            final Set<String> packages, 
-            final OpenAPIConfiguration config) {
-
-        if (customizer != null) {
-            customizer.setClassResourceInfos(sfb.getClassResourceInfo());
-        }
-
-        sfb.setResourceClassesFromBeans(Arrays.asList(
-            createOpenApiResource()
-                .openApiConfiguration(config)
-                .configLocation(configLocation)
-                .resourcePackages(packages)));
+    public Properties getUserProperties(Map<String, Object> userDefinedOptions) {
+        return delegate.getUserProperties(userDefinedOptions);
     }
 
-    protected void registerServletConfigProvider(ServerProviderFactory factory) {
-        factory.setUserProviders(Arrays.asList(new ServletConfigProvider(ctxId)));
+    public void registerOpenApiResources(JAXRSServiceFactoryBean sfb, Set<String> packages, OpenAPIConfiguration config) {
+        delegate.registerOpenApiResources(sfb, packages, config);
     }
 
-    protected void registerSwaggerUiResources(JAXRSServiceFactoryBean sfb, Properties properties, 
-            ServerProviderFactory factory, Bus bus) {
-        
-        final Registration swaggerUiRegistration = getSwaggerUi(bus, properties, isRunAsFilter());
-        
-        if (!isRunAsFilter()) {
-            sfb.setResourceClassesFromBeans(swaggerUiRegistration.getResources());
-        } 
-
-        factory.setUserProviders(swaggerUiRegistration.getProviders());
+    public void registerServletConfigProvider(ServerProviderFactory factory) {
+        delegate.registerServletConfigProvider(factory);
     }
 
-    /**
-     * The info will be used only if there is no @OpenAPIDefinition annotation is present. 
-     */
-    private Info getInfo(final Properties properties) {
-        final Info info = new Info()
-            .title(getOrFallback(getTitle(), properties, TITLE_PROPERTY))
-            .version(getOrFallback(getVersion(), properties, VERSION_PROPERTY))
-            .description(getOrFallback(getDescription(), properties, DESCRIPTION_PROPERTY))
-            .termsOfService(getOrFallback(getTermsOfServiceUrl(), properties, TERMS_URL_PROPERTY))
-            .contact(new Contact()
-                .name(getOrFallback(getContactName(), properties, CONTACT_PROPERTY))
-                .email(getContactEmail())
-                .url(getContactUrl()))
-            .license(new License()
-                .name(getOrFallback(getLicense(), properties, LICENSE_PROPERTY))
-                .url(getOrFallback(getLicenseUrl(), properties, LICENSE_URL_PROPERTY)));
-        
-        if (info.getLicense().getName() == null) {
-            info.getLicense().setName(DEFAULT_LICENSE_VALUE);
-        }
-        
-        if (info.getLicense().getUrl() == null && DEFAULT_LICENSE_VALUE.equals(info.getLicense().getName())) {
-            info.getLicense().setUrl(DEFAULT_LICENSE_URL);
-        }
-        
-        return info;
+    public void registerSwaggerUiResources(JAXRSServiceFactoryBean sfb, Properties properties, ServerProviderFactory factory, Bus bus) {
+        delegate.registerSwaggerUiResources(sfb, properties, factory, bus);
     }
 
-    private String getOrFallback(String value, Properties properties, String property) {
-        if (value == null && properties != null) {
-            return properties.getProperty(property);
-        } else {
-            return value;
-        }
+    public Info getInfo(Properties properties) {
+        return delegate.getInfo(properties);
     }
 
-    private Boolean getOrFallback(Boolean value, Properties properties, String property) {
-        Boolean fallback = value;
-        if (value == null && properties != null) {
-            fallback = PropertyUtils.isTrue(properties.get(PRETTY_PRINT_PROPERTY));
-        }
-        
-        if (fallback == null) {
-            return false;
-        }
-        
-        return fallback;
+    public String getOrFallback(String value, Properties properties, String property) {
+        return delegate.getOrFallback(value, properties, property);
     }
-    
-    private Set<String> getOrFallback(Set<String> collection, Properties properties, String property) {
-        if (collection.isEmpty() && properties != null) {
-            final String value = properties.getProperty(property);
-            if (!StringUtils.isEmpty(value)) {
-                collection.add(value);
+
+    public Boolean getOrFallback(Boolean value, Properties properties, String property) {
+        return delegate.getOrFallback(value, properties, property);
+    }
+
+    public Set<String> getOrFallback(Set<String> collection, Properties properties, String property) {
+        return delegate.getOrFallback(collection, properties, property);
+    }
+
+    public Collection<String> scanResourcePackages(JAXRSServiceFactoryBean sfb) {
+        return delegate.scanResourcePackages(sfb);
+    }
+
+    public static Properties combine(Properties primary, Properties secondary) {
+        return Portable.combine(primary, secondary);
+    }
+
+    public static void setOrReplace(Properties source, Properties destination) {
+        Portable.setOrReplace(source, destination);
+    }
+
+    public static Optional<Components> registerComponents(Map<String, SecurityScheme> securityDefinitions) {
+        return Portable.registerComponents(securityDefinitions);
+    }
+
+    public OpenApiResource createOpenApiResource() {
+        return delegate.createOpenApiResource();
+    }
+
+    @Provider(value = Type.Feature, scope = Scope.Server)
+    public static class Portable implements AbstractPortableFeature, SwaggerUiSupport, SwaggerProperties {
+        private String version;
+        private String title;
+        private String description;
+        private String contactName;
+        private String contactEmail;
+        private String contactUrl;
+        private String license;
+        private String licenseUrl;
+        private String termsOfServiceUrl;
+        // Read all operations also with no @Operation
+        private boolean readAllResources = true;
+        // Scan all JAX-RS resources automatically
+        private boolean scan = true;
+        private boolean prettyPrint = true;
+        private boolean runAsFilter;
+        private Collection<String> ignoredRoutes;
+        private Set<String> resourcePackages;
+        private Set<String> resourceClasses;
+        private String filterClass;
+
+        private Boolean supportSwaggerUi;
+        private String swaggerUiVersion;
+        private String swaggerUiMavenGroupAndArtifact;
+        private Map<String, String> swaggerUiMediaTypes;
+
+        // Additional components
+        private Map<String, SecurityScheme> securityDefinitions;
+        private OpenApiCustomizer customizer;
+
+        // Allows to pass the configuration location, usually openapi-configuration.json
+        // or openapi-configuration.yml file.
+        private String configLocation;
+        // Allows to pass the properties location, by default swagger.properties
+        private String propertiesLocation = DEFAULT_PROPS_LOCATION;
+        // Allows to disable automatic scan of known configuration locations (enabled by default)
+        private boolean scanKnownConfigLocations = true;
+        // Swagger UI configuration parameters (to be passed as query string).
+        private SwaggerUiConfig swaggerUiConfig;
+        // Generates the Swagger Context ID (instead of using the default one). It is
+        // necessary when more than one JAXRS Server Factory Bean or OpenApiFeature instance
+        // are co-located in the same application.
+        private boolean useContextBasedConfig;
+        private String ctxId;
+
+        @Override
+        public void initialize(Server server, Bus bus) {
+            final JAXRSServiceFactoryBean sfb = (JAXRSServiceFactoryBean)server
+                    .getEndpoint()
+                    .get(JAXRSServiceFactoryBean.class.getName());
+
+            final ServerProviderFactory factory = (ServerProviderFactory)server
+                    .getEndpoint()
+                    .get(ServerProviderFactory.class.getName());
+
+            final Set<String> packages = new HashSet<>();
+            if (resourcePackages != null) {
+                packages.addAll(resourcePackages);
             }
-        } 
 
-        return collection;
-    }
+            // Generate random Context ID for Swagger
+            if (useContextBasedConfig) {
+                ctxId = UUID.randomUUID().toString();
+            }
 
-    private Collection<String> scanResourcePackages(JAXRSServiceFactoryBean sfb) {
-        return sfb
-            .getClassResourceInfo()
-            .stream()
-            .map(cri -> cri.getServiceClass().getPackage().getName())
-            .collect(Collectors.toSet());
-    }
-    
-    private static Properties combine(final Properties primary, final Properties secondary) {
-        if (primary == null) {
-            return secondary;
-        } else if (secondary == null) {
-            return primary;
-        } else {
-            final Properties combined = new Properties();
-            setOrReplace(secondary, combined);
-            setOrReplace(primary, combined);
-            return combined;
-        }
-    }
+            Properties swaggerProps = null;
+            GenericOpenApiContextBuilder<?> openApiConfiguration;
+            final Application application = DefaultApplicationFactory.createApplicationOrDefault(server, factory,
+                    sfb, bus, resourcePackages, isScan());
 
-    private static void setOrReplace(final Properties source, final Properties destination) {
-        final Enumeration<?> enumeration = source.propertyNames();
-        while (enumeration.hasMoreElements()) {
-            final String name = (String)enumeration.nextElement(); 
-            destination.setProperty(name, source.getProperty(name));
+            String defaultConfigLocation = getConfigLocation();
+            if (scanKnownConfigLocations && StringUtils.isEmpty(defaultConfigLocation)) {
+                defaultConfigLocation = OpenApiDefaultConfigurationScanner.locateDefaultConfiguration().orElse(null);
+            }
+
+            if (StringUtils.isEmpty(defaultConfigLocation)) {
+                swaggerProps = getSwaggerProperties(propertiesLocation, bus);
+
+                if (isScan()) {
+                    packages.addAll(scanResourcePackages(sfb));
+                }
+
+                final OpenAPI oas = new OpenAPI().info(getInfo(swaggerProps));
+                registerComponents(securityDefinitions).ifPresent(oas::setComponents);
+
+                final SwaggerConfiguration config = new SwaggerConfiguration()
+                        .openAPI(oas)
+                        .prettyPrint(getOrFallback(isPrettyPrint(), swaggerProps, PRETTY_PRINT_PROPERTY))
+                        .readAllResources(isReadAllResources())
+                        .ignoredRoutes(getIgnoredRoutes())
+                        .filterClass(getOrFallback(getFilterClass(), swaggerProps, FILTER_CLASS_PROPERTY))
+                        .resourceClasses(getResourceClasses())
+                        .resourcePackages(getOrFallback(packages, swaggerProps, RESOURCE_PACKAGE_PROPERTY));
+
+                openApiConfiguration = new JaxrsOpenApiContextBuilder<>()
+                        .application(application)
+                        .openApiConfiguration(config)
+                        .ctxId(ctxId); /* will be null if not used */
+            } else {
+                openApiConfiguration = new JaxrsOpenApiContextBuilder<>()
+                        .application(application)
+                        .configLocation(defaultConfigLocation)
+                        .ctxId(ctxId); /* will be null if not used */
+            }
+
+            try {
+                final OpenApiContext context = openApiConfiguration.buildContext(true);
+                final Properties userProperties = getUserProperties(
+                        context
+                                .getOpenApiConfiguration()
+                                .getUserDefinedOptions());
+                registerOpenApiResources(sfb, packages, context.getOpenApiConfiguration());
+                registerSwaggerUiResources(sfb, combine(swaggerProps, userProperties), factory, bus);
+
+                if (useContextBasedConfig) {
+                    registerServletConfigProvider(factory);
+                }
+
+                if (customizer != null) {
+                    customizer.setApplicationInfo(factory.getApplicationProvider());
+                }
+
+                bus.setProperty("openapi.service.description.available", "true");
+            } catch (OpenApiConfigurationException ex) {
+                throw new RuntimeException("Unable to initialize OpenAPI context", ex);
+            }
         }
-    }
-    
-    private static Optional<Components> registerComponents(Map<String, SecurityScheme> securityDefinitions) {
-        final Components components = new Components();
-    
-        boolean hasComponents = false;
-        if (securityDefinitions != null && !securityDefinitions.isEmpty()) {
-            securityDefinitions.forEach(components::addSecuritySchemes);
-            hasComponents |= true;
+
+        public boolean isScan() {
+            return scan;
         }
-        
-        return hasComponents ? Optional.of(components) : Optional.empty();
-    }
-    
-    private OpenApiResource createOpenApiResource() {
-        return (customizer == null) ? new OpenApiResource() : new OpenApiCustomizedResource(customizer);
+
+        public void setScan(boolean scan) {
+            this.scan = scan;
+        }
+
+        public String getFilterClass() {
+            return filterClass;
+        }
+
+        public void setFilterClass(String filterClass) {
+            this.filterClass = filterClass;
+        }
+
+        public Set<String> getResourcePackages() {
+            return resourcePackages;
+        }
+
+        public void setResourcePackages(Set<String> resourcePackages) {
+            this.resourcePackages = (resourcePackages == null) ? null : new HashSet<>(resourcePackages);
+        }
+
+        public String getVersion() {
+            return version;
+        }
+
+        public void setVersion(String version) {
+            this.version = version;
+        }
+
+        public String getTitle() {
+            return title;
+        }
+
+        public void setTitle(String title) {
+            this.title = title;
+        }
+
+        public String getDescription() {
+            return description;
+        }
+
+        public void setDescription(String description) {
+            this.description = description;
+        }
+
+        public String getContactName() {
+            return contactName;
+        }
+
+        public void setContactName(String contactName) {
+            this.contactName = contactName;
+        }
+
+        public String getContactEmail() {
+            return contactEmail;
+        }
+
+        public void setContactEmail(String contactEmail) {
+            this.contactEmail = contactEmail;
+        }
+
+        public String getContactUrl() {
+            return contactUrl;
+        }
+
+        public void setContactUrl(String contactUrl) {
+            this.contactUrl = contactUrl;
+        }
+
+        public String getLicense() {
+            return license;
+        }
+
+        public void setLicense(String license) {
+            this.license = license;
+        }
+
+        public String getLicenseUrl() {
+            return licenseUrl;
+        }
+
+        public void setLicenseUrl(String licenseUrl) {
+            this.licenseUrl = licenseUrl;
+        }
+
+        public String getTermsOfServiceUrl() {
+            return termsOfServiceUrl;
+        }
+
+        public void setTermsOfServiceUrl(String termsOfServiceUrl) {
+            this.termsOfServiceUrl = termsOfServiceUrl;
+        }
+
+        public boolean isReadAllResources() {
+            return readAllResources;
+        }
+
+        public void setReadAllResources(boolean readAllResources) {
+            this.readAllResources = readAllResources;
+        }
+
+        public Set<String> getResourceClasses() {
+            return resourceClasses;
+        }
+
+        public void setResourceClasses(Set<String> resourceClasses) {
+            this.resourceClasses = (resourceClasses == null) ? null : new HashSet<>(resourceClasses);
+        }
+
+        public Collection<String> getIgnoredRoutes() {
+            return ignoredRoutes;
+        }
+
+        public void setIgnoredRoutes(Collection<String> ignoredRoutes) {
+            this.ignoredRoutes = (ignoredRoutes == null) ? null : new HashSet<>(ignoredRoutes);
+        }
+
+        public boolean isPrettyPrint() {
+            return prettyPrint;
+        }
+
+        public void setPrettyPrint(boolean prettyPrint) {
+            this.prettyPrint = prettyPrint;
+        }
+
+        public boolean isRunAsFilter() {
+            return runAsFilter;
+        }
+
+        @Override
+        public Boolean isSupportSwaggerUi() {
+            return supportSwaggerUi;
+        }
+
+        public void setSupportSwaggerUi(Boolean supportSwaggerUi) {
+            this.supportSwaggerUi = supportSwaggerUi;
+        }
+
+        public String getSwaggerUiVersion() {
+            return swaggerUiVersion;
+        }
+
+        public void setSwaggerUiVersion(String swaggerUiVersion) {
+            this.swaggerUiVersion = swaggerUiVersion;
+        }
+
+        public String getSwaggerUiMavenGroupAndArtifact() {
+            return swaggerUiMavenGroupAndArtifact;
+        }
+
+        public void setSwaggerUiMavenGroupAndArtifact(
+                String swaggerUiMavenGroupAndArtifact) {
+            this.swaggerUiMavenGroupAndArtifact = swaggerUiMavenGroupAndArtifact;
+        }
+
+        @Override
+        public Map<String, String> getSwaggerUiMediaTypes() {
+            return swaggerUiMediaTypes;
+        }
+
+        public void setSwaggerUiMediaTypes(Map<String, String> swaggerUiMediaTypes) {
+            this.swaggerUiMediaTypes = swaggerUiMediaTypes;
+        }
+
+        public String getConfigLocation() {
+            return configLocation;
+        }
+
+        public void setConfigLocation(String configLocation) {
+            this.configLocation = configLocation;
+        }
+
+        public String getPropertiesLocation() {
+            return propertiesLocation;
+        }
+
+        public void setPropertiesLocation(String propertiesLocation) {
+            this.propertiesLocation = propertiesLocation;
+        }
+
+        public void setRunAsFilter(boolean runAsFilter) {
+            this.runAsFilter = runAsFilter;
+        }
+
+        public Map<String, SecurityScheme> getSecurityDefinitions() {
+            return securityDefinitions;
+        }
+
+        public void setSecurityDefinitions(Map<String, SecurityScheme> securityDefinitions) {
+            this.securityDefinitions = securityDefinitions;
+        }
+
+        public OpenApiCustomizer getCustomizer() {
+            return customizer;
+        }
+
+        public void setCustomizer(OpenApiCustomizer customizer) {
+            this.customizer = customizer;
+        }
+
+        public void setScanKnownConfigLocations(boolean scanKnownConfigLocations) {
+            this.scanKnownConfigLocations = scanKnownConfigLocations;
+        }
+
+        public boolean isScanKnownConfigLocations() {
+            return scanKnownConfigLocations;
+        }
+
+        public void setSwaggerUiConfig(final SwaggerUiConfig swaggerUiConfig) {
+            this.swaggerUiConfig = swaggerUiConfig;
+        }
+
+        public void setUseContextBasedConfig(final boolean useContextBasedConfig) {
+            this.useContextBasedConfig = useContextBasedConfig;
+        }
+
+        public boolean isUseContextBasedConfig() {
+            return useContextBasedConfig;
+        }
+
+        @Override
+        public SwaggerUiConfig getSwaggerUiConfig() {
+            return swaggerUiConfig;
+        }
+
+        @Override
+        public String findSwaggerUiRoot() {
+            return SwaggerUi.findSwaggerUiRoot(swaggerUiMavenGroupAndArtifact, swaggerUiVersion);
+        }
+
+        protected Properties getUserProperties(final Map<String, Object> userDefinedOptions) {
+            final Properties properties = new Properties();
+
+            if (userDefinedOptions != null) {
+                userDefinedOptions
+                        .entrySet()
+                        .stream()
+                        .filter(entry -> entry.getValue() != null)
+                        .forEach(entry -> properties.setProperty(entry.getKey(), entry.getValue().toString()));
+            }
+
+            return properties;
+        }
+
+        protected void registerOpenApiResources(
+                final JAXRSServiceFactoryBean sfb,
+                final Set<String> packages,
+                final OpenAPIConfiguration config) {
+
+            if (customizer != null) {
+                customizer.setClassResourceInfos(sfb.getClassResourceInfo());
+            }
+
+            sfb.setResourceClassesFromBeans(Arrays.asList(
+                    createOpenApiResource()
+                            .openApiConfiguration(config)
+                            .configLocation(configLocation)
+                            .resourcePackages(packages)));
+        }
+
+        protected void registerServletConfigProvider(ServerProviderFactory factory) {
+            factory.setUserProviders(Arrays.asList(new ServletConfigProvider(ctxId)));
+        }
+
+        protected void registerSwaggerUiResources(JAXRSServiceFactoryBean sfb, Properties properties,
+                                                  ServerProviderFactory factory, Bus bus) {
+
+            final Registration swaggerUiRegistration = getSwaggerUi(bus, properties, isRunAsFilter());
+
+            if (!isRunAsFilter()) {
+                sfb.setResourceClassesFromBeans(swaggerUiRegistration.getResources());
+            }
+
+            factory.setUserProviders(swaggerUiRegistration.getProviders());
+        }
+
+        /**
+         * The info will be used only if there is no @OpenAPIDefinition annotation is present.
+         */
+        private Info getInfo(final Properties properties) {
+            final Info info = new Info()
+                    .title(getOrFallback(getTitle(), properties, TITLE_PROPERTY))
+                    .version(getOrFallback(getVersion(), properties, VERSION_PROPERTY))
+                    .description(getOrFallback(getDescription(), properties, DESCRIPTION_PROPERTY))
+                    .termsOfService(getOrFallback(getTermsOfServiceUrl(), properties, TERMS_URL_PROPERTY))
+                    .contact(new Contact()
+                            .name(getOrFallback(getContactName(), properties, CONTACT_PROPERTY))
+                            .email(getContactEmail())
+                            .url(getContactUrl()))
+                    .license(new License()
+                            .name(getOrFallback(getLicense(), properties, LICENSE_PROPERTY))
+                            .url(getOrFallback(getLicenseUrl(), properties, LICENSE_URL_PROPERTY)));
+
+            if (info.getLicense().getName() == null) {
+                info.getLicense().setName(DEFAULT_LICENSE_VALUE);
+            }
+
+            if (info.getLicense().getUrl() == null && DEFAULT_LICENSE_VALUE.equals(info.getLicense().getName())) {
+                info.getLicense().setUrl(DEFAULT_LICENSE_URL);
+            }
+
+            return info;
+        }
+
+        private String getOrFallback(String value, Properties properties, String property) {
+            if (value == null && properties != null) {
+                return properties.getProperty(property);
+            } else {
+                return value;
+            }
+        }
+
+        private Boolean getOrFallback(Boolean value, Properties properties, String property) {
+            Boolean fallback = value;
+            if (value == null && properties != null) {
+                fallback = PropertyUtils.isTrue(properties.get(PRETTY_PRINT_PROPERTY));
+            }
+
+            if (fallback == null) {
+                return false;
+            }
+
+            return fallback;
+        }
+
+        private Set<String> getOrFallback(Set<String> collection, Properties properties, String property) {
+            if (collection.isEmpty() && properties != null) {
+                final String value = properties.getProperty(property);
+                if (!StringUtils.isEmpty(value)) {
+                    collection.add(value);
+                }
+            }
+
+            return collection;
+        }
+
+        private Collection<String> scanResourcePackages(JAXRSServiceFactoryBean sfb) {
+            return sfb
+                    .getClassResourceInfo()
+                    .stream()
+                    .map(cri -> cri.getServiceClass().getPackage().getName())
+                    .collect(Collectors.toSet());
+        }
+
+        private static Properties combine(final Properties primary, final Properties secondary) {
+            if (primary == null) {
+                return secondary;
+            } else if (secondary == null) {
+                return primary;
+            } else {
+                final Properties combined = new Properties();
+                setOrReplace(secondary, combined);
+                setOrReplace(primary, combined);
+                return combined;
+            }
+        }
+
+        private static void setOrReplace(final Properties source, final Properties destination) {
+            final Enumeration<?> enumeration = source.propertyNames();
+            while (enumeration.hasMoreElements()) {
+                final String name = (String)enumeration.nextElement();
+                destination.setProperty(name, source.getProperty(name));
+            }
+        }
+
+        private static Optional<Components> registerComponents(Map<String, SecurityScheme> securityDefinitions) {
+            final Components components = new Components();
+
+            boolean hasComponents = false;
+            if (securityDefinitions != null && !securityDefinitions.isEmpty()) {
+                securityDefinitions.forEach(components::addSecuritySchemes);
+                hasComponents |= true;
+            }
+
+            return hasComponents ? Optional.of(components) : Optional.empty();
+        }
+
+        private OpenApiResource createOpenApiResource() {
+            return (customizer == null) ? new OpenApiResource() : new OpenApiCustomizedResource(customizer);
+        }
     }
 }

--- a/rt/rs/description-openapi-v3/src/main/java/org/apache/cxf/jaxrs/openapi/OpenApiFeature.java
+++ b/rt/rs/description-openapi-v3/src/main/java/org/apache/cxf/jaxrs/openapi/OpenApiFeature.java
@@ -37,9 +37,11 @@ import org.apache.cxf.annotations.Provider.Scope;
 import org.apache.cxf.annotations.Provider.Type;
 import org.apache.cxf.common.util.PropertyUtils;
 import org.apache.cxf.common.util.StringUtils;
+import org.apache.cxf.endpoint.Client;
 import org.apache.cxf.endpoint.Server;
 import org.apache.cxf.feature.AbstractFeature;
 import org.apache.cxf.feature.AbstractPortableFeature;
+import org.apache.cxf.interceptor.InterceptorProvider;
 import org.apache.cxf.jaxrs.JAXRSServiceFactoryBean;
 import org.apache.cxf.jaxrs.common.openapi.DefaultApplicationFactory;
 import org.apache.cxf.jaxrs.common.openapi.SwaggerProperties;
@@ -68,6 +70,21 @@ public class OpenApiFeature extends AbstractFeature implements SwaggerUiSupport,
     @Override
     public void initialize(Server server, Bus bus) {
         delegate.initialize(server, bus);
+    }
+
+    @Override
+    public void initialize(Client client, Bus bus) {
+        delegate.initialize(client, bus);
+    }
+
+    @Override
+    public void initialize(InterceptorProvider interceptorProvider, Bus bus) {
+        delegate.initialize(interceptorProvider, bus);
+    }
+
+    @Override
+    public void initialize(Bus bus) {
+        delegate.initialize(bus);
     }
 
     public boolean isScan() {

--- a/rt/rs/description-openapi-v3/src/main/java/org/apache/cxf/jaxrs/openapi/OpenApiFeature.java
+++ b/rt/rs/description-openapi-v3/src/main/java/org/apache/cxf/jaxrs/openapi/OpenApiFeature.java
@@ -323,7 +323,8 @@ public class OpenApiFeature extends AbstractFeature implements SwaggerUiSupport,
         return delegate.getUserProperties(userDefinedOptions);
     }
 
-    public void registerOpenApiResources(JAXRSServiceFactoryBean sfb, Set<String> packages, OpenAPIConfiguration config) {
+    public void registerOpenApiResources(JAXRSServiceFactoryBean sfb, Set<String> packages,
+                                         OpenAPIConfiguration config) {
         delegate.registerOpenApiResources(sfb, packages, config);
     }
 
@@ -331,7 +332,8 @@ public class OpenApiFeature extends AbstractFeature implements SwaggerUiSupport,
         delegate.registerServletConfigProvider(factory);
     }
 
-    public void registerSwaggerUiResources(JAXRSServiceFactoryBean sfb, Properties properties, ServerProviderFactory factory, Bus bus) {
+    public void registerSwaggerUiResources(JAXRSServiceFactoryBean sfb, Properties properties,
+                                           ServerProviderFactory factory, Bus bus) {
         delegate.registerSwaggerUiResources(sfb, properties, factory, bus);
     }
 

--- a/rt/rs/description-swagger/src/main/java/org/apache/cxf/jaxrs/swagger/AbstractSwaggerFeature.java
+++ b/rt/rs/description-swagger/src/main/java/org/apache/cxf/jaxrs/swagger/AbstractSwaggerFeature.java
@@ -171,7 +171,7 @@ public abstract class AbstractSwaggerFeature extends AbstractFeature {
         getDelegate().setActivateOnlyIfJaxrsSupported(activateOnlyIfJaxrsSupported);
     }
 
-    public static abstract class Portable implements AbstractPortableFeature {
+    public abstract static class Portable implements AbstractPortableFeature {
         private static final boolean SWAGGER_JAXRS_AVAILABLE;
 
         static {

--- a/rt/rs/description-swagger/src/main/java/org/apache/cxf/jaxrs/swagger/AbstractSwaggerFeature.java
+++ b/rt/rs/description-swagger/src/main/java/org/apache/cxf/jaxrs/swagger/AbstractSwaggerFeature.java
@@ -24,39 +24,20 @@ import java.util.List;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.cxf.Bus;
 import org.apache.cxf.common.util.PackageUtils;
-import org.apache.cxf.endpoint.Client;
 import org.apache.cxf.endpoint.Server;
-import org.apache.cxf.feature.AbstractFeature;
 import org.apache.cxf.feature.AbstractPortableFeature;
-import org.apache.cxf.interceptor.InterceptorProvider;
+import org.apache.cxf.feature.DelegatingFeature;
 import org.apache.cxf.jaxrs.JAXRSServiceFactoryBean;
 import org.apache.cxf.jaxrs.model.ClassResourceInfo;
 
-public abstract class AbstractSwaggerFeature extends AbstractFeature {
-    protected abstract Portable getDelegate();
+public abstract class AbstractSwaggerFeature<T extends AbstractSwaggerFeature.Portable>
+        extends DelegatingFeature<T> {
+    protected AbstractSwaggerFeature(final T d) {
+        super(d);
+    }
 
     public static boolean isSwaggerJaxRsAvailable() {
         return Portable.isSwaggerJaxRsAvailable();
-    }
-
-    @Override
-    public void initialize(Client client, Bus bus) {
-        getDelegate().initialize(client, bus);
-    }
-
-    @Override
-    public void initialize(InterceptorProvider interceptorProvider, Bus bus) {
-        getDelegate().initialize(interceptorProvider, bus);
-    }
-
-    @Override
-    public void initialize(Bus bus) {
-        getDelegate().initialize(bus);
-    }
-
-    @Override
-    public void initialize(Server server, Bus bus) {
-        getDelegate().initialize(server, bus);
     }
 
     public void addSwaggerResource(Server server, Bus bus) {
@@ -217,7 +198,7 @@ public abstract class AbstractSwaggerFeature extends AbstractFeature {
 
         protected abstract void setBasePathByAddress(String address);
 
-        private void calculateDefaultResourcePackage(Server server) {
+        void calculateDefaultResourcePackage(Server server) {
             if (!StringUtils.isEmpty(getResourcePackage())) {
                 return;
             }

--- a/rt/rs/description-swagger/src/main/java/org/apache/cxf/jaxrs/swagger/AbstractSwaggerFeature.java
+++ b/rt/rs/description-swagger/src/main/java/org/apache/cxf/jaxrs/swagger/AbstractSwaggerFeature.java
@@ -26,160 +26,285 @@ import org.apache.cxf.Bus;
 import org.apache.cxf.common.util.PackageUtils;
 import org.apache.cxf.endpoint.Server;
 import org.apache.cxf.feature.AbstractFeature;
+import org.apache.cxf.feature.AbstractPortableFeature;
 import org.apache.cxf.jaxrs.JAXRSServiceFactoryBean;
 import org.apache.cxf.jaxrs.model.ClassResourceInfo;
 
 public abstract class AbstractSwaggerFeature extends AbstractFeature {
+    protected abstract Portable getDelegate();
 
-    private static final boolean SWAGGER_JAXRS_AVAILABLE;
-
-    static {
-        SWAGGER_JAXRS_AVAILABLE = isSwaggerJaxRsAvailable();
-    }
-
-    protected boolean licenseWasSet;
-    private boolean runAsFilter;
-    private boolean activateOnlyIfJaxrsSupported;
-    private String resourcePackage;
-    private String version;
-    private String basePath;
-    private String title;
-    private String description;
-    private String contact;
-    private String license;
-    private String licenseUrl;
-    private String termsOfServiceUrl;
-    private String filterClass;
-
-    private static boolean isSwaggerJaxRsAvailable() {
-        try {
-            Class.forName("io.swagger.jaxrs.DefaultParameterExtension");
-            return true;
-        } catch (Throwable ex) {
-            return false;
-        }
+    public static boolean isSwaggerJaxRsAvailable() {
+        return Portable.isSwaggerJaxRsAvailable();
     }
 
     @Override
     public void initialize(Server server, Bus bus) {
-        if (!activateOnlyIfJaxrsSupported || SWAGGER_JAXRS_AVAILABLE) {
-            calculateDefaultResourcePackage(server);
-            calculateDefaultBasePath(server);
-            addSwaggerResource(server, bus);
-
-            initializeProvider(server.getEndpoint(), bus);
-            bus.setProperty("swagger.service.description.available", "true");
-        }
+        getDelegate().initialize(server, bus);
     }
 
-    protected abstract void addSwaggerResource(Server server, Bus bus);
-
-    protected abstract void setBasePathByAddress(String address);
-
-    private void calculateDefaultResourcePackage(Server server) {
-        if (!StringUtils.isEmpty(getResourcePackage())) {
-            return;
-        }
-        JAXRSServiceFactoryBean serviceFactoryBean =
-            (JAXRSServiceFactoryBean)server.getEndpoint().get(JAXRSServiceFactoryBean.class.getName());
-        List<ClassResourceInfo> resourceInfos = serviceFactoryBean.getClassResourceInfo();
-
-        if (resourceInfos.size() == 1) {
-            setResourcePackage(resourceInfos.get(0).getServiceClass().getPackage().getName());
-        } else {
-            List<Class<?>> serviceClasses = new ArrayList<>(resourceInfos.size());
-            for (ClassResourceInfo cri : resourceInfos) {
-                serviceClasses.add(cri.getServiceClass());
-            }
-            String sharedPackage = PackageUtils.getSharedPackageName(serviceClasses);
-            if (!StringUtils.isEmpty(sharedPackage)) {
-                setResourcePackage(sharedPackage);
-            }
-        }
+    public void addSwaggerResource(Server server, Bus bus) {
+        getDelegate().addSwaggerResource(server, bus);
     }
 
-    protected void calculateDefaultBasePath(Server server) {
-        if (getBasePath() == null || getBasePath().length() == 0) {
-            String address = server.getEndpoint().getEndpointInfo().getAddress();
-            setBasePathByAddress(address);
-        }
+    public void setBasePathByAddress(String address) {
+        getDelegate().setBasePathByAddress(address);
+    }
+
+    public void calculateDefaultResourcePackage(Server server) {
+        getDelegate().calculateDefaultResourcePackage(server);
+    }
+
+    public void calculateDefaultBasePath(Server server) {
+        getDelegate().calculateDefaultBasePath(server);
     }
 
     public String getResourcePackage() {
-        return resourcePackage;
+        return getDelegate().getResourcePackage();
     }
+
     public void setResourcePackage(String resourcePackage) {
-        this.resourcePackage = resourcePackage;
+        getDelegate().setResourcePackage(resourcePackage);
     }
+
     public String getVersion() {
-        return version;
+        return getDelegate().getVersion();
     }
+
     public void setVersion(String version) {
-        this.version = version;
+        getDelegate().setVersion(version);
     }
+
     public String getBasePath() {
-        return basePath;
+        return getDelegate().getBasePath();
     }
+
     public void setBasePath(String basePath) {
-        this.basePath = basePath;
+        getDelegate().setBasePath(basePath);
     }
+
     public String getTitle() {
-        return title;
+        return getDelegate().getTitle();
     }
+
     public void setTitle(String title) {
-        this.title = title;
+        getDelegate().setTitle(title);
     }
+
     public String getDescription() {
-        return description;
+        return getDelegate().getDescription();
     }
+
     public void setDescription(String description) {
-        this.description = description;
+        getDelegate().setDescription(description);
     }
+
     public String getContact() {
-        return contact;
+        return getDelegate().getContact();
     }
+
     public void setContact(String contact) {
-        this.contact = contact;
+        getDelegate().setContact(contact);
     }
+
     public String getLicense() {
-        return license;
+        return getDelegate().getLicense();
     }
+
     public void setLicense(String license) {
-        this.licenseWasSet = true;
-        this.license = license;
+        getDelegate().setLicense(license);
     }
+
     public String getLicenseUrl() {
-        return licenseUrl;
+        return getDelegate().getLicenseUrl();
     }
+
     public void setLicenseUrl(String licenseUrl) {
-        this.licenseUrl = licenseUrl;
+        getDelegate().setLicenseUrl(licenseUrl);
     }
+
     public String getTermsOfServiceUrl() {
-        return termsOfServiceUrl;
+        return getDelegate().getTermsOfServiceUrl();
     }
+
     public void setTermsOfServiceUrl(String termsOfServiceUrl) {
-        this.termsOfServiceUrl = termsOfServiceUrl;
+        getDelegate().setTermsOfServiceUrl(termsOfServiceUrl);
     }
+
     public String getFilterClass() {
-        return filterClass;
+        return getDelegate().getFilterClass();
     }
+
     public void setFilterClass(String filterClass) {
-        this.filterClass = filterClass;
+        getDelegate().setFilterClass(filterClass);
     }
 
     public boolean isRunAsFilter() {
-        return runAsFilter;
+        return getDelegate().isRunAsFilter();
     }
+
     public void setRunAsFilter(boolean runAsFilter) {
-        this.runAsFilter = runAsFilter;
+        getDelegate().setRunAsFilter(runAsFilter);
     }
 
     public boolean isActivateOnlyIfJaxrsSupported() {
-        return activateOnlyIfJaxrsSupported;
+        return getDelegate().isActivateOnlyIfJaxrsSupported();
     }
 
     public void setActivateOnlyIfJaxrsSupported(boolean activateOnlyIfJaxrsSupported) {
-        this.activateOnlyIfJaxrsSupported = activateOnlyIfJaxrsSupported;
+        getDelegate().setActivateOnlyIfJaxrsSupported(activateOnlyIfJaxrsSupported);
+    }
+
+    public static abstract class Portable implements AbstractPortableFeature {
+        private static final boolean SWAGGER_JAXRS_AVAILABLE;
+
+        static {
+            SWAGGER_JAXRS_AVAILABLE = isSwaggerJaxRsAvailable();
+        }
+
+        protected boolean licenseWasSet;
+        private boolean runAsFilter;
+        private boolean activateOnlyIfJaxrsSupported;
+        private String resourcePackage;
+        private String version;
+        private String basePath;
+        private String title;
+        private String description;
+        private String contact;
+        private String license;
+        private String licenseUrl;
+        private String termsOfServiceUrl;
+        private String filterClass;
+
+        private static boolean isSwaggerJaxRsAvailable() {
+            try {
+                Class.forName("io.swagger.jaxrs.DefaultParameterExtension");
+                return true;
+            } catch (Throwable ex) {
+                return false;
+            }
+        }
+
+        @Override
+        public void initialize(Server server, Bus bus) {
+            if (!activateOnlyIfJaxrsSupported || SWAGGER_JAXRS_AVAILABLE) {
+                calculateDefaultResourcePackage(server);
+                calculateDefaultBasePath(server);
+                addSwaggerResource(server, bus);
+
+                doInitializeProvider(server.getEndpoint(), bus);
+                bus.setProperty("swagger.service.description.available", "true");
+            }
+        }
+
+        protected abstract void addSwaggerResource(Server server, Bus bus);
+
+        protected abstract void setBasePathByAddress(String address);
+
+        private void calculateDefaultResourcePackage(Server server) {
+            if (!StringUtils.isEmpty(getResourcePackage())) {
+                return;
+            }
+            JAXRSServiceFactoryBean serviceFactoryBean =
+                    (JAXRSServiceFactoryBean)server.getEndpoint().get(JAXRSServiceFactoryBean.class.getName());
+            List<ClassResourceInfo> resourceInfos = serviceFactoryBean.getClassResourceInfo();
+
+            if (resourceInfos.size() == 1) {
+                setResourcePackage(resourceInfos.get(0).getServiceClass().getPackage().getName());
+            } else {
+                List<Class<?>> serviceClasses = new ArrayList<>(resourceInfos.size());
+                for (ClassResourceInfo cri : resourceInfos) {
+                    serviceClasses.add(cri.getServiceClass());
+                }
+                String sharedPackage = PackageUtils.getSharedPackageName(serviceClasses);
+                if (!StringUtils.isEmpty(sharedPackage)) {
+                    setResourcePackage(sharedPackage);
+                }
+            }
+        }
+
+        protected void calculateDefaultBasePath(Server server) {
+            if (getBasePath() == null || getBasePath().length() == 0) {
+                String address = server.getEndpoint().getEndpointInfo().getAddress();
+                setBasePathByAddress(address);
+            }
+        }
+
+        public String getResourcePackage() {
+            return resourcePackage;
+        }
+        public void setResourcePackage(String resourcePackage) {
+            this.resourcePackage = resourcePackage;
+        }
+        public String getVersion() {
+            return version;
+        }
+        public void setVersion(String version) {
+            this.version = version;
+        }
+        public String getBasePath() {
+            return basePath;
+        }
+        public void setBasePath(String basePath) {
+            this.basePath = basePath;
+        }
+        public String getTitle() {
+            return title;
+        }
+        public void setTitle(String title) {
+            this.title = title;
+        }
+        public String getDescription() {
+            return description;
+        }
+        public void setDescription(String description) {
+            this.description = description;
+        }
+        public String getContact() {
+            return contact;
+        }
+        public void setContact(String contact) {
+            this.contact = contact;
+        }
+        public String getLicense() {
+            return license;
+        }
+        public void setLicense(String license) {
+            this.licenseWasSet = true;
+            this.license = license;
+        }
+        public String getLicenseUrl() {
+            return licenseUrl;
+        }
+        public void setLicenseUrl(String licenseUrl) {
+            this.licenseUrl = licenseUrl;
+        }
+        public String getTermsOfServiceUrl() {
+            return termsOfServiceUrl;
+        }
+        public void setTermsOfServiceUrl(String termsOfServiceUrl) {
+            this.termsOfServiceUrl = termsOfServiceUrl;
+        }
+        public String getFilterClass() {
+            return filterClass;
+        }
+        public void setFilterClass(String filterClass) {
+            this.filterClass = filterClass;
+        }
+
+        public boolean isRunAsFilter() {
+            return runAsFilter;
+        }
+        public void setRunAsFilter(boolean runAsFilter) {
+            this.runAsFilter = runAsFilter;
+        }
+
+        public boolean isActivateOnlyIfJaxrsSupported() {
+            return activateOnlyIfJaxrsSupported;
+        }
+
+        public void setActivateOnlyIfJaxrsSupported(boolean activateOnlyIfJaxrsSupported) {
+            this.activateOnlyIfJaxrsSupported = activateOnlyIfJaxrsSupported;
+        }
     }
 
 }

--- a/rt/rs/description-swagger/src/main/java/org/apache/cxf/jaxrs/swagger/AbstractSwaggerFeature.java
+++ b/rt/rs/description-swagger/src/main/java/org/apache/cxf/jaxrs/swagger/AbstractSwaggerFeature.java
@@ -24,9 +24,11 @@ import java.util.List;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.cxf.Bus;
 import org.apache.cxf.common.util.PackageUtils;
+import org.apache.cxf.endpoint.Client;
 import org.apache.cxf.endpoint.Server;
 import org.apache.cxf.feature.AbstractFeature;
 import org.apache.cxf.feature.AbstractPortableFeature;
+import org.apache.cxf.interceptor.InterceptorProvider;
 import org.apache.cxf.jaxrs.JAXRSServiceFactoryBean;
 import org.apache.cxf.jaxrs.model.ClassResourceInfo;
 
@@ -35,6 +37,21 @@ public abstract class AbstractSwaggerFeature extends AbstractFeature {
 
     public static boolean isSwaggerJaxRsAvailable() {
         return Portable.isSwaggerJaxRsAvailable();
+    }
+
+    @Override
+    public void initialize(Client client, Bus bus) {
+        getDelegate().initialize(client, bus);
+    }
+
+    @Override
+    public void initialize(InterceptorProvider interceptorProvider, Bus bus) {
+        getDelegate().initialize(interceptorProvider, bus);
+    }
+
+    @Override
+    public void initialize(Bus bus) {
+        getDelegate().initialize(bus);
     }
 
     @Override

--- a/rt/rs/description-swagger/src/main/java/org/apache/cxf/jaxrs/swagger/Swagger2Feature.java
+++ b/rt/rs/description-swagger/src/main/java/org/apache/cxf/jaxrs/swagger/Swagger2Feature.java
@@ -70,11 +70,14 @@ import io.swagger.models.Swagger;
 import io.swagger.models.auth.SecuritySchemeDefinition;
 
 @Provider(value = Type.Feature, scope = Scope.Server)
-public class Swagger2Feature extends AbstractSwaggerFeature implements SwaggerUiSupport, SwaggerProperties {
-    private Portable delegate = new Portable();
+public class Swagger2Feature extends AbstractSwaggerFeature<Swagger2Feature.Portable>
+        implements SwaggerUiSupport, SwaggerProperties {
+    public Swagger2Feature() {
+        super(new Portable());
+    }
 
     @Override
-    protected AbstractSwaggerFeature.Portable getDelegate() {
+    protected Portable getDelegate() {
         return delegate;
     }
 

--- a/rt/rs/description-swagger/src/main/java/org/apache/cxf/jaxrs/swagger/Swagger2Feature.java
+++ b/rt/rs/description-swagger/src/main/java/org/apache/cxf/jaxrs/swagger/Swagger2Feature.java
@@ -71,376 +71,532 @@ import io.swagger.models.auth.SecuritySchemeDefinition;
 
 @Provider(value = Type.Feature, scope = Scope.Server)
 public class Swagger2Feature extends AbstractSwaggerFeature implements SwaggerUiSupport, SwaggerProperties {
-    private static final String SCHEMES_PROPERTY = "schemes";
-    private static final String HOST_PROPERTY = "host";
-    private static final String USE_PATH_CFG_PROPERTY = "use.path.based.config";
-
-    private boolean scan;
-    private boolean scanAllResources;
-
-    private String ignoreRoutes;
-
-    private Boolean supportSwaggerUi;
-
-    private String swaggerUiVersion;
-
-    private String swaggerUiMavenGroupAndArtifact;
-
-    private Map<String, String> swaggerUiMediaTypes;
-
-    private boolean dynamicBasePath;
-
-    private Map<String, SecuritySchemeDefinition> securityDefinitions;
-
-    private Swagger2Customizer customizer;
-
-    private String host;
-    private String[] schemes;
-    private Boolean prettyPrint;
-    private Boolean usePathBasedConfig;
-
-    private String propertiesLocation = DEFAULT_PROPS_LOCATION;
-    // Swagger UI configuration parameters (to be passed as query string).
-    private SwaggerUiConfig swaggerUiConfig;
+    private Portable delegate = new Portable();
 
     @Override
-    protected void calculateDefaultBasePath(Server server) {
-        dynamicBasePath = true;
-        super.calculateDefaultBasePath(server);
+    protected AbstractSwaggerFeature.Portable getDelegate() {
+        return delegate;
     }
 
     @Override
-    protected void addSwaggerResource(Server server, Bus bus) {
-        JAXRSServiceFactoryBean sfb =
-            (JAXRSServiceFactoryBean) server.getEndpoint().get(JAXRSServiceFactoryBean.class.getName());
-
-        ServerProviderFactory factory =
-            (ServerProviderFactory)server.getEndpoint().get(ServerProviderFactory.class.getName());
-        final ApplicationInfo appInfo = DefaultApplicationFactory.createApplicationInfoOrDefault(server, 
-            factory, sfb, bus, isScan());
-
-        List<Object> swaggerResources = new LinkedList<>();
-
-        if (customizer == null) {
-            customizer = new Swagger2Customizer();
-        }
-        ApiListingResource apiListingResource = new Swagger2ApiListingResource(customizer);
-        swaggerResources.add(apiListingResource);
-
-        List<Object> providers = new ArrayList<>();
-        providers.add(new SwaggerSerializers());
-
-        if (isRunAsFilter()) {
-            providers.add(new SwaggerContainerRequestFilter(appInfo == null ? null : appInfo.getProvider(),
-                                                            customizer));
-        }
-
-        final Properties swaggerProps = getSwaggerProperties(propertiesLocation, bus);
-        final Registration swaggerUiRegistration = getSwaggerUi(bus, swaggerProps, isRunAsFilter());
-
-        if (!isRunAsFilter()) {
-            swaggerResources.addAll(swaggerUiRegistration.getResources());
-        }
-
-        providers.addAll(swaggerUiRegistration.getProviders());
-        sfb.setResourceClassesFromBeans(swaggerResources);
-
-        List<ClassResourceInfo> cris = sfb.getClassResourceInfo();
-        if (!isRunAsFilter()) {
-            for (ClassResourceInfo cri : cris) {
-                if (ApiListingResource.class.isAssignableFrom(cri.getResourceClass())) {
-                    InjectionUtils.injectContextProxies(cri, apiListingResource);
-                }
-            }
-        }
-        customizer.setClassResourceInfos(cris);
-        customizer.setDynamicBasePath(dynamicBasePath);
-
-        BeanConfig beanConfig = appInfo == null
-            ? new BeanConfig()
-            : new ApplicationBeanConfig(appInfo.getProvider());
-        initBeanConfig(beanConfig, swaggerProps);
-
-        Swagger swagger = beanConfig.getSwagger();
-        if (swagger != null && securityDefinitions != null) {
-            swagger.setSecurityDefinitions(securityDefinitions);
-        }
-        customizer.setBeanConfig(beanConfig);
-
-        providers.add(new ReaderConfigFilter());
-
-        if (beanConfig.isUsePathBasedConfig()) {
-            providers.add(new ServletConfigProvider());
-        }
-
-        factory.setUserProviders(providers);
+    public void calculateDefaultBasePath(Server server) {
+        delegate.calculateDefaultBasePath(server);
     }
 
-    protected void initBeanConfig(BeanConfig beanConfig, Properties props) {
+    @Override
+    public void addSwaggerResource(Server server, Bus bus) {
+        delegate.addSwaggerResource(server, bus);
+    }
 
-        // resource package
-        String theResourcePackage = getResourcePackage();
-        if (theResourcePackage == null && props != null) {
-            theResourcePackage = props.getProperty(RESOURCE_PACKAGE_PROPERTY);
-        }
-        beanConfig.setResourcePackage(theResourcePackage);
-
-        // use path based configuration
-        Boolean theUsePathBasedConfig = isUsePathBasedConfig();
-        if (theUsePathBasedConfig == null && props != null) {
-            theUsePathBasedConfig = PropertyUtils.isTrue(props.get(USE_PATH_CFG_PROPERTY));
-        }
-        if (theUsePathBasedConfig == null) {
-            theUsePathBasedConfig = false;
-        }
-        beanConfig.setUsePathBasedConfig(theUsePathBasedConfig);
-
-        // version
-        String theVersion = getVersion();
-        if (theVersion == null && props != null) {
-            theVersion = props.getProperty(VERSION_PROPERTY);
-        }
-        beanConfig.setVersion(theVersion);
-
-        // host
-        String theHost = getHost();
-        if (theHost == null && props != null) {
-            theHost = props.getProperty(HOST_PROPERTY);
-        }
-        beanConfig.setHost(theHost);
-
-        // schemes
-        String[] theSchemes = getSchemes();
-        if (theSchemes == null && props != null && props.containsKey(SCHEMES_PROPERTY)) {
-            theSchemes = props.getProperty(SCHEMES_PROPERTY).split(",");
-        }
-        beanConfig.setSchemes(theSchemes);
-
-        // title
-        String theTitle = getTitle();
-        if (theTitle == null && props != null) {
-            theTitle = props.getProperty(TITLE_PROPERTY);
-        }
-        beanConfig.setTitle(theTitle);
-
-        // description
-        String theDescription = getDescription();
-        if (theDescription == null && props != null) {
-            theDescription = props.getProperty(DESCRIPTION_PROPERTY);
-        }
-        beanConfig.setDescription(theDescription);
-
-        // contact
-        String theContact = getContact();
-        if (theContact == null && props != null) {
-            theContact = props.getProperty(CONTACT_PROPERTY);
-        }
-        beanConfig.setContact(theContact);
-
-        // license
-        String theLicense = getLicense();
-        if (theLicense == null && !licenseWasSet) {
-            if (props != null) {
-                theLicense = props.getProperty(LICENSE_PROPERTY);
-                if (theLicense != null && theLicense.isEmpty()) {
-                    theLicense = null;
-                }
-            } else {
-                theLicense = DEFAULT_LICENSE_VALUE;
-            }
-        }
-        beanConfig.setLicense(theLicense);
-
-        // license url
-        String theLicenseUrl = getLicenseUrl();
-        if (theLicenseUrl == null && props != null) {
-            theLicenseUrl = props.getProperty(LICENSE_URL_PROPERTY);
-        }
-        if (theLicenseUrl == null && DEFAULT_LICENSE_VALUE.equals(theLicense)) {
-            theLicenseUrl = DEFAULT_LICENSE_URL;
-        }
-        beanConfig.setLicenseUrl(theLicenseUrl);
-
-        // terms of service url
-        String theTermsUrl = getTermsOfServiceUrl();
-        if (theTermsUrl == null && props != null) {
-            theTermsUrl = props.getProperty(TERMS_URL_PROPERTY);
-        }
-        beanConfig.setTermsOfServiceUrl(theTermsUrl);
-
-        // pretty print
-        Boolean thePrettyPrint = isPrettyPrint();
-        if (thePrettyPrint == null && props != null) {
-            thePrettyPrint = PropertyUtils.isTrue(props.get(PRETTY_PRINT_PROPERTY));
-        }
-        if (thePrettyPrint == null) {
-            thePrettyPrint = false;
-        }
-        beanConfig.setPrettyPrint(thePrettyPrint);
-
-        // filter class
-        String theFilterClass = getFilterClass();
-        if (theFilterClass == null && props != null) {
-            theFilterClass = props.getProperty(FILTER_CLASS_PROPERTY);
-        }
-        beanConfig.setFilterClass(theFilterClass);
-
-        // scan
-        beanConfig.setScan(isScan());
-
-        // base path is calculated dynamically
-        beanConfig.setBasePath(getBasePath());
-
+    public void initBeanConfig(BeanConfig beanConfig, Properties props) {
+        delegate.initBeanConfig(beanConfig, props);
     }
 
     public Boolean isUsePathBasedConfig() {
-        return usePathBasedConfig;
+        return delegate.isUsePathBasedConfig();
     }
 
     public void setUsePathBasedConfig(Boolean usePathBasedConfig) {
-        this.usePathBasedConfig = usePathBasedConfig;
+        delegate.setUsePathBasedConfig(usePathBasedConfig);
     }
 
     public String getHost() {
-        return host;
+        return delegate.getHost();
     }
 
     public void setHost(String host) {
-        this.host = host;
+        delegate.setHost(host);
     }
 
     public String[] getSchemes() {
-        return schemes;
+        return delegate.getSchemes();
     }
 
     public void setSchemes(String[] schemes) {
-        this.schemes = schemes;
+        delegate.setSchemes(schemes);
     }
 
     public Boolean isPrettyPrint() {
-        return prettyPrint;
+        return delegate.isPrettyPrint();
     }
 
     public void setPrettyPrint(Boolean prettyPrint) {
-        this.prettyPrint = prettyPrint;
+        delegate.setPrettyPrint(prettyPrint);
     }
 
     public Swagger2Customizer getCustomizer() {
-        return customizer;
+        return delegate.getCustomizer();
     }
 
     public void setCustomizer(Swagger2Customizer customizer) {
-        this.customizer = customizer;
+        delegate.setCustomizer(customizer);
     }
 
     public boolean isScanAllResources() {
-        return scanAllResources;
+        return delegate.isScanAllResources();
     }
 
     public void setScanAllResources(boolean scanAllResources) {
-        this.scanAllResources = scanAllResources;
+        delegate.setScanAllResources(scanAllResources);
     }
 
     public String getIgnoreRoutes() {
-        return ignoreRoutes;
+        return delegate.getIgnoreRoutes();
     }
 
     public void setIgnoreRoutes(String ignoreRoutes) {
-        this.ignoreRoutes = ignoreRoutes;
+        delegate.setIgnoreRoutes(ignoreRoutes);
     }
 
     @Override
-    protected void setBasePathByAddress(String address) {
-        if (!address.startsWith("/")) {
-            // get the path part
-            URI u = URI.create(address);
-            setBasePath(u.getPath());
-            if (getHost() == null) {
-                setHost(u.getPort() < 0 ? u.getHost() : u.getHost() + ":" + u.getPort());
-            }
-        } else {
-            setBasePath(address);
-        }
+    public void setBasePathByAddress(String address) {
+        delegate.setBasePathByAddress(address);
     }
 
-    /**
-     * Set SwaggerUI Maven group and artifact using the "groupId/artifactId" format.
-     * @param swaggerUiMavenGroupAndArtifact
-     */
     public void setSwaggerUiMavenGroupAndArtifact(String swaggerUiMavenGroupAndArtifact) {
-        this.swaggerUiMavenGroupAndArtifact = swaggerUiMavenGroupAndArtifact;
+        delegate.setSwaggerUiMavenGroupAndArtifact(swaggerUiMavenGroupAndArtifact);
     }
 
     public void setSwaggerUiVersion(String swaggerUiVersion) {
-        this.swaggerUiVersion = swaggerUiVersion;
+        delegate.setSwaggerUiVersion(swaggerUiVersion);
     }
 
     public void setSupportSwaggerUi(boolean supportSwaggerUi) {
-        this.supportSwaggerUi = supportSwaggerUi;
+        delegate.setSupportSwaggerUi(supportSwaggerUi);
     }
 
     @Override
     public Boolean isSupportSwaggerUi() {
-        return supportSwaggerUi;
+        return delegate.isSupportSwaggerUi();
     }
 
     public void setSwaggerUiMediaTypes(Map<String, String> swaggerUiMediaTypes) {
-        this.swaggerUiMediaTypes = swaggerUiMediaTypes;
+        delegate.setSwaggerUiMediaTypes(swaggerUiMediaTypes);
     }
 
     @Override
     public Map<String, String> getSwaggerUiMediaTypes() {
-        return swaggerUiMediaTypes;
+        return delegate.getSwaggerUiMediaTypes();
     }
 
     public void setSecurityDefinitions(Map<String, SecuritySchemeDefinition> securityDefinitions) {
-        this.securityDefinitions = securityDefinitions;
+        delegate.setSecurityDefinitions(securityDefinitions);
     }
 
     public String getPropertiesLocation() {
-        return propertiesLocation;
+        return delegate.getPropertiesLocation();
     }
 
     public void setPropertiesLocation(String propertiesLocation) {
-        this.propertiesLocation = propertiesLocation;
+        delegate.setPropertiesLocation(propertiesLocation);
     }
 
     public boolean isScan() {
-        return scan;
+        return delegate.isScan();
     }
 
     public void setScan(boolean scan) {
-        this.scan = scan;
+        delegate.setScan(scan);
     }
-    
-    public void setSwaggerUiConfig(final SwaggerUiConfig swaggerUiConfig) {
-        this.swaggerUiConfig = swaggerUiConfig;
+
+    public void setSwaggerUiConfig(SwaggerUiConfig swaggerUiConfig) {
+        delegate.setSwaggerUiConfig(swaggerUiConfig);
     }
-    
+
     @Override
     public SwaggerUiConfig getSwaggerUiConfig() {
-        return swaggerUiConfig;
+        return delegate.getSwaggerUiConfig();
     }
 
     @Override
     public String findSwaggerUiRoot() {
-        return SwaggerUi.findSwaggerUiRoot(swaggerUiMavenGroupAndArtifact, swaggerUiVersion);
+        return delegate.findSwaggerUiRoot();
     }
 
-    private class ServletConfigProvider implements ContextProvider<ServletConfig> {
+    @Provider(value = Type.Feature, scope = Scope.Server)
+    public static class Portable extends AbstractSwaggerFeature.Portable implements SwaggerUiSupport, SwaggerProperties {
+        private static final String SCHEMES_PROPERTY = "schemes";
+        private static final String HOST_PROPERTY = "host";
+        private static final String USE_PATH_CFG_PROPERTY = "use.path.based.config";
+
+        private boolean scan;
+        private boolean scanAllResources;
+
+        private String ignoreRoutes;
+
+        private Boolean supportSwaggerUi;
+
+        private String swaggerUiVersion;
+
+        private String swaggerUiMavenGroupAndArtifact;
+
+        private Map<String, String> swaggerUiMediaTypes;
+
+        private boolean dynamicBasePath;
+
+        private Map<String, SecuritySchemeDefinition> securityDefinitions;
+
+        private Swagger2Customizer customizer;
+
+        private String host;
+        private String[] schemes;
+        private Boolean prettyPrint;
+        private Boolean usePathBasedConfig;
+
+        private String propertiesLocation = DEFAULT_PROPS_LOCATION;
+        // Swagger UI configuration parameters (to be passed as query string).
+        private SwaggerUiConfig swaggerUiConfig;
 
         @Override
-        public ServletConfig createContext(Message message) {
-            final ServletConfig sc = (ServletConfig)message.get("HTTP.CONFIG");
+        protected void calculateDefaultBasePath(Server server) {
+            dynamicBasePath = true;
+            super.calculateDefaultBasePath(server);
+        }
 
-            // When deploying into OSGi container, it is possible to use embedded Jetty
-            // transport. In this case, the ServletConfig is not available and Swagger
-            // does not take into account certain configuration parameters. To overcome
-            // that, the ServletConfig is synthesized from ServletContext instance.
-            if (sc == null) {
-                final ServletContext context = (ServletContext)message.get("HTTP.CONTEXT");
-                if (context != null) {
-                    return new SyntheticServletConfig(context) {
+        @Override
+        protected void addSwaggerResource(Server server, Bus bus) {
+            JAXRSServiceFactoryBean sfb =
+                    (JAXRSServiceFactoryBean) server.getEndpoint().get(JAXRSServiceFactoryBean.class.getName());
+
+            ServerProviderFactory factory =
+                    (ServerProviderFactory)server.getEndpoint().get(ServerProviderFactory.class.getName());
+            final ApplicationInfo appInfo = DefaultApplicationFactory.createApplicationInfoOrDefault(server,
+                    factory, sfb, bus, isScan());
+
+            List<Object> swaggerResources = new LinkedList<>();
+
+            if (customizer == null) {
+                customizer = new Swagger2Customizer();
+            }
+            ApiListingResource apiListingResource = new Swagger2ApiListingResource(customizer);
+            swaggerResources.add(apiListingResource);
+
+            List<Object> providers = new ArrayList<>();
+            providers.add(new SwaggerSerializers());
+
+            if (isRunAsFilter()) {
+                providers.add(new SwaggerContainerRequestFilter(appInfo == null ? null : appInfo.getProvider(),
+                        customizer));
+            }
+
+            final Properties swaggerProps = getSwaggerProperties(propertiesLocation, bus);
+            final Registration swaggerUiRegistration = getSwaggerUi(bus, swaggerProps, isRunAsFilter());
+
+            if (!isRunAsFilter()) {
+                swaggerResources.addAll(swaggerUiRegistration.getResources());
+            }
+
+            providers.addAll(swaggerUiRegistration.getProviders());
+            sfb.setResourceClassesFromBeans(swaggerResources);
+
+            List<ClassResourceInfo> cris = sfb.getClassResourceInfo();
+            if (!isRunAsFilter()) {
+                for (ClassResourceInfo cri : cris) {
+                    if (ApiListingResource.class.isAssignableFrom(cri.getResourceClass())) {
+                        InjectionUtils.injectContextProxies(cri, apiListingResource);
+                    }
+                }
+            }
+            customizer.setClassResourceInfos(cris);
+            customizer.setDynamicBasePath(dynamicBasePath);
+
+            BeanConfig beanConfig = appInfo == null
+                    ? new BeanConfig()
+                    : new ApplicationBeanConfig(appInfo.getProvider());
+            initBeanConfig(beanConfig, swaggerProps);
+
+            Swagger swagger = beanConfig.getSwagger();
+            if (swagger != null && securityDefinitions != null) {
+                swagger.setSecurityDefinitions(securityDefinitions);
+            }
+            customizer.setBeanConfig(beanConfig);
+
+            providers.add(new ReaderConfigFilter());
+
+            if (beanConfig.isUsePathBasedConfig()) {
+                providers.add(new ServletConfigProvider());
+            }
+
+            factory.setUserProviders(providers);
+        }
+
+        protected void initBeanConfig(BeanConfig beanConfig, Properties props) {
+
+            // resource package
+            String theResourcePackage = getResourcePackage();
+            if (theResourcePackage == null && props != null) {
+                theResourcePackage = props.getProperty(RESOURCE_PACKAGE_PROPERTY);
+            }
+            beanConfig.setResourcePackage(theResourcePackage);
+
+            // use path based configuration
+            Boolean theUsePathBasedConfig = isUsePathBasedConfig();
+            if (theUsePathBasedConfig == null && props != null) {
+                theUsePathBasedConfig = PropertyUtils.isTrue(props.get(USE_PATH_CFG_PROPERTY));
+            }
+            if (theUsePathBasedConfig == null) {
+                theUsePathBasedConfig = false;
+            }
+            beanConfig.setUsePathBasedConfig(theUsePathBasedConfig);
+
+            // version
+            String theVersion = getVersion();
+            if (theVersion == null && props != null) {
+                theVersion = props.getProperty(VERSION_PROPERTY);
+            }
+            beanConfig.setVersion(theVersion);
+
+            // host
+            String theHost = getHost();
+            if (theHost == null && props != null) {
+                theHost = props.getProperty(HOST_PROPERTY);
+            }
+            beanConfig.setHost(theHost);
+
+            // schemes
+            String[] theSchemes = getSchemes();
+            if (theSchemes == null && props != null && props.containsKey(SCHEMES_PROPERTY)) {
+                theSchemes = props.getProperty(SCHEMES_PROPERTY).split(",");
+            }
+            beanConfig.setSchemes(theSchemes);
+
+            // title
+            String theTitle = getTitle();
+            if (theTitle == null && props != null) {
+                theTitle = props.getProperty(TITLE_PROPERTY);
+            }
+            beanConfig.setTitle(theTitle);
+
+            // description
+            String theDescription = getDescription();
+            if (theDescription == null && props != null) {
+                theDescription = props.getProperty(DESCRIPTION_PROPERTY);
+            }
+            beanConfig.setDescription(theDescription);
+
+            // contact
+            String theContact = getContact();
+            if (theContact == null && props != null) {
+                theContact = props.getProperty(CONTACT_PROPERTY);
+            }
+            beanConfig.setContact(theContact);
+
+            // license
+            String theLicense = getLicense();
+            if (theLicense == null && !licenseWasSet) {
+                if (props != null) {
+                    theLicense = props.getProperty(LICENSE_PROPERTY);
+                    if (theLicense != null && theLicense.isEmpty()) {
+                        theLicense = null;
+                    }
+                } else {
+                    theLicense = DEFAULT_LICENSE_VALUE;
+                }
+            }
+            beanConfig.setLicense(theLicense);
+
+            // license url
+            String theLicenseUrl = getLicenseUrl();
+            if (theLicenseUrl == null && props != null) {
+                theLicenseUrl = props.getProperty(LICENSE_URL_PROPERTY);
+            }
+            if (theLicenseUrl == null && DEFAULT_LICENSE_VALUE.equals(theLicense)) {
+                theLicenseUrl = DEFAULT_LICENSE_URL;
+            }
+            beanConfig.setLicenseUrl(theLicenseUrl);
+
+            // terms of service url
+            String theTermsUrl = getTermsOfServiceUrl();
+            if (theTermsUrl == null && props != null) {
+                theTermsUrl = props.getProperty(TERMS_URL_PROPERTY);
+            }
+            beanConfig.setTermsOfServiceUrl(theTermsUrl);
+
+            // pretty print
+            Boolean thePrettyPrint = isPrettyPrint();
+            if (thePrettyPrint == null && props != null) {
+                thePrettyPrint = PropertyUtils.isTrue(props.get(PRETTY_PRINT_PROPERTY));
+            }
+            if (thePrettyPrint == null) {
+                thePrettyPrint = false;
+            }
+            beanConfig.setPrettyPrint(thePrettyPrint);
+
+            // filter class
+            String theFilterClass = getFilterClass();
+            if (theFilterClass == null && props != null) {
+                theFilterClass = props.getProperty(FILTER_CLASS_PROPERTY);
+            }
+            beanConfig.setFilterClass(theFilterClass);
+
+            // scan
+            beanConfig.setScan(isScan());
+
+            // base path is calculated dynamically
+            beanConfig.setBasePath(getBasePath());
+
+        }
+
+        public Boolean isUsePathBasedConfig() {
+            return usePathBasedConfig;
+        }
+
+        public void setUsePathBasedConfig(Boolean usePathBasedConfig) {
+            this.usePathBasedConfig = usePathBasedConfig;
+        }
+
+        public String getHost() {
+            return host;
+        }
+
+        public void setHost(String host) {
+            this.host = host;
+        }
+
+        public String[] getSchemes() {
+            return schemes;
+        }
+
+        public void setSchemes(String[] schemes) {
+            this.schemes = schemes;
+        }
+
+        public Boolean isPrettyPrint() {
+            return prettyPrint;
+        }
+
+        public void setPrettyPrint(Boolean prettyPrint) {
+            this.prettyPrint = prettyPrint;
+        }
+
+        public Swagger2Customizer getCustomizer() {
+            return customizer;
+        }
+
+        public void setCustomizer(Swagger2Customizer customizer) {
+            this.customizer = customizer;
+        }
+
+        public boolean isScanAllResources() {
+            return scanAllResources;
+        }
+
+        public void setScanAllResources(boolean scanAllResources) {
+            this.scanAllResources = scanAllResources;
+        }
+
+        public String getIgnoreRoutes() {
+            return ignoreRoutes;
+        }
+
+        public void setIgnoreRoutes(String ignoreRoutes) {
+            this.ignoreRoutes = ignoreRoutes;
+        }
+
+        @Override
+        protected void setBasePathByAddress(String address) {
+            if (!address.startsWith("/")) {
+                // get the path part
+                URI u = URI.create(address);
+                setBasePath(u.getPath());
+                if (getHost() == null) {
+                    setHost(u.getPort() < 0 ? u.getHost() : u.getHost() + ":" + u.getPort());
+                }
+            } else {
+                setBasePath(address);
+            }
+        }
+
+        /**
+         * Set SwaggerUI Maven group and artifact using the "groupId/artifactId" format.
+         * @param swaggerUiMavenGroupAndArtifact
+         */
+        public void setSwaggerUiMavenGroupAndArtifact(String swaggerUiMavenGroupAndArtifact) {
+            this.swaggerUiMavenGroupAndArtifact = swaggerUiMavenGroupAndArtifact;
+        }
+
+        public void setSwaggerUiVersion(String swaggerUiVersion) {
+            this.swaggerUiVersion = swaggerUiVersion;
+        }
+
+        public void setSupportSwaggerUi(boolean supportSwaggerUi) {
+            this.supportSwaggerUi = supportSwaggerUi;
+        }
+
+        @Override
+        public Boolean isSupportSwaggerUi() {
+            return supportSwaggerUi;
+        }
+
+        public void setSwaggerUiMediaTypes(Map<String, String> swaggerUiMediaTypes) {
+            this.swaggerUiMediaTypes = swaggerUiMediaTypes;
+        }
+
+        @Override
+        public Map<String, String> getSwaggerUiMediaTypes() {
+            return swaggerUiMediaTypes;
+        }
+
+        public void setSecurityDefinitions(Map<String, SecuritySchemeDefinition> securityDefinitions) {
+            this.securityDefinitions = securityDefinitions;
+        }
+
+        public String getPropertiesLocation() {
+            return propertiesLocation;
+        }
+
+        public void setPropertiesLocation(String propertiesLocation) {
+            this.propertiesLocation = propertiesLocation;
+        }
+
+        public boolean isScan() {
+            return scan;
+        }
+
+        public void setScan(boolean scan) {
+            this.scan = scan;
+        }
+
+        public void setSwaggerUiConfig(final SwaggerUiConfig swaggerUiConfig) {
+            this.swaggerUiConfig = swaggerUiConfig;
+        }
+
+        @Override
+        public SwaggerUiConfig getSwaggerUiConfig() {
+            return swaggerUiConfig;
+        }
+
+        @Override
+        public String findSwaggerUiRoot() {
+            return SwaggerUi.findSwaggerUiRoot(swaggerUiMavenGroupAndArtifact, swaggerUiVersion);
+        }
+
+        private class ServletConfigProvider implements ContextProvider<ServletConfig> {
+
+            @Override
+            public ServletConfig createContext(Message message) {
+                final ServletConfig sc = (ServletConfig)message.get("HTTP.CONFIG");
+
+                // When deploying into OSGi container, it is possible to use embedded Jetty
+                // transport. In this case, the ServletConfig is not available and Swagger
+                // does not take into account certain configuration parameters. To overcome
+                // that, the ServletConfig is synthesized from ServletContext instance.
+                if (sc == null) {
+                    final ServletContext context = (ServletContext)message.get("HTTP.CONTEXT");
+                    if (context != null) {
+                        return new SyntheticServletConfig(context) {
+                            @Override
+                            public String getInitParameter(String name) {
+                                if (Objects.equals(SwaggerContextService.USE_PATH_BASED_CONFIG, name)) {
+                                    return "true";
+                                } else {
+                                    return super.getInitParameter(name);
+                                }
+                            }
+                        };
+                    }
+                } else if (sc.getInitParameter(SwaggerContextService.USE_PATH_BASED_CONFIG) == null) {
+                    return new DelegatingServletConfig(sc) {
                         @Override
                         public String getInitParameter(String name) {
                             if (Objects.equals(SwaggerContextService.USE_PATH_BASED_CONFIG, name)) {
@@ -451,26 +607,47 @@ public class Swagger2Feature extends AbstractSwaggerFeature implements SwaggerUi
                         }
                     };
                 }
-            } else if (sc.getInitParameter(SwaggerContextService.USE_PATH_BASED_CONFIG) == null) {
-                return new DelegatingServletConfig(sc) {
-                    @Override
-                    public String getInitParameter(String name) {
-                        if (Objects.equals(SwaggerContextService.USE_PATH_BASED_CONFIG, name)) {
-                            return "true";
-                        } else {
-                            return super.getInitParameter(name);
-                        }
+
+                return sc;
+            }
+        }
+
+        protected class ReaderConfigFilter implements ContainerRequestFilter {
+
+            @Context
+            protected MessageContext mc;
+
+            @Override
+            public void filter(ContainerRequestContext requestContext) throws IOException {
+                ServletContext servletContext = mc.getServletContext();
+                if (servletContext != null && servletContext.getAttribute(ReaderConfig.class.getName()) == null) {
+                    if (mc.getServletConfig() != null
+                            && Boolean.valueOf(mc.getServletConfig().getInitParameter("scan.all.resources"))) {
+                        addReaderConfig(mc.getServletConfig().getInitParameter("ignore.routes"));
+                    } else if (isScanAllResources()) {
+                        addReaderConfig(getIgnoreRoutes());
                     }
-                };
+                }
             }
 
-            return sc;
+            protected void addReaderConfig(String ignoreRoutesParam) {
+                DefaultReaderConfig rc = new DefaultReaderConfig();
+                rc.setScanAllResources(true);
+                if (ignoreRoutesParam != null) {
+                    Set<String> routes = new LinkedHashSet<>();
+                    for (String route : ignoreRoutesParam.split(",")) {
+                        routes.add(route.trim());
+                    }
+                    rc.setIgnoredRoutes(routes);
+                }
+                mc.getServletContext().setAttribute(ReaderConfig.class.getName(), rc);
+            }
         }
     }
 
     @PreMatching
     protected static class SwaggerContainerRequestFilter extends Swagger2ApiListingResource
-        implements ContainerRequestFilter {
+            implements ContainerRequestFilter {
 
         protected static final String APIDOCS_LISTING_PATH_JSON = "swagger.json";
         protected static final String APIDOCS_LISTING_PATH_YAML = "swagger.yaml";
@@ -502,38 +679,6 @@ public class Swagger2Feature extends AbstractSwaggerFeature implements SwaggerUi
             if (response != null) {
                 requestContext.abortWith(response);
             }
-        }
-    }
-
-    protected class ReaderConfigFilter implements ContainerRequestFilter {
-
-        @Context
-        protected MessageContext mc;
-
-        @Override
-        public void filter(ContainerRequestContext requestContext) throws IOException {
-            ServletContext servletContext = mc.getServletContext();
-            if (servletContext != null && servletContext.getAttribute(ReaderConfig.class.getName()) == null) {
-                if (mc.getServletConfig() != null
-                        && Boolean.valueOf(mc.getServletConfig().getInitParameter("scan.all.resources"))) {
-                    addReaderConfig(mc.getServletConfig().getInitParameter("ignore.routes"));
-                } else if (isScanAllResources()) {
-                    addReaderConfig(getIgnoreRoutes());
-                }
-            }
-        }
-
-        protected void addReaderConfig(String ignoreRoutesParam) {
-            DefaultReaderConfig rc = new DefaultReaderConfig();
-            rc.setScanAllResources(true);
-            if (ignoreRoutesParam != null) {
-                Set<String> routes = new LinkedHashSet<>();
-                for (String route : ignoreRoutesParam.split(",")) {
-                    routes.add(route.trim());
-                }
-                rc.setIgnoredRoutes(routes);
-            }
-            mc.getServletContext().setAttribute(ReaderConfig.class.getName(), rc);
         }
     }
 }

--- a/rt/rs/description-swagger/src/main/java/org/apache/cxf/jaxrs/swagger/Swagger2Feature.java
+++ b/rt/rs/description-swagger/src/main/java/org/apache/cxf/jaxrs/swagger/Swagger2Feature.java
@@ -214,7 +214,8 @@ public class Swagger2Feature extends AbstractSwaggerFeature implements SwaggerUi
     }
 
     @Provider(value = Type.Feature, scope = Scope.Server)
-    public static class Portable extends AbstractSwaggerFeature.Portable implements SwaggerUiSupport, SwaggerProperties {
+    public static class Portable extends AbstractSwaggerFeature.Portable
+            implements SwaggerUiSupport, SwaggerProperties {
         private static final String SCHEMES_PROPERTY = "schemes";
         private static final String HOST_PROPERTY = "host";
         private static final String USE_PATH_CFG_PROPERTY = "use.path.based.config";

--- a/rt/rs/sse/src/main/java/org/apache/cxf/jaxrs/sse/SseFeature.java
+++ b/rt/rs/sse/src/main/java/org/apache/cxf/jaxrs/sse/SseFeature.java
@@ -25,6 +25,7 @@ import org.apache.cxf.Bus;
 import org.apache.cxf.annotations.Provider;
 import org.apache.cxf.annotations.Provider.Scope;
 import org.apache.cxf.annotations.Provider.Type;
+import org.apache.cxf.endpoint.Client;
 import org.apache.cxf.endpoint.Server;
 import org.apache.cxf.feature.AbstractFeature;
 import org.apache.cxf.feature.AbstractPortableFeature;
@@ -38,6 +39,21 @@ public class SseFeature extends AbstractFeature {
     @Override
     public void initialize(Server server, Bus bus) {
         delegate.initialize(server, bus);
+    }
+
+    @Override
+    public void initialize(Client client, Bus bus) {
+        delegate.initialize(client, bus);
+    }
+
+    @Override
+    public void initialize(InterceptorProvider interceptorProvider, Bus bus) {
+        delegate.initialize(interceptorProvider, bus);
+    }
+
+    @Override
+    public void initialize(Bus bus) {
+        delegate.initialize(bus);
     }
 
     @Provider(value = Type.Feature, scope = Scope.Server)

--- a/rt/rs/sse/src/main/java/org/apache/cxf/jaxrs/sse/SseFeature.java
+++ b/rt/rs/sse/src/main/java/org/apache/cxf/jaxrs/sse/SseFeature.java
@@ -25,35 +25,16 @@ import org.apache.cxf.Bus;
 import org.apache.cxf.annotations.Provider;
 import org.apache.cxf.annotations.Provider.Scope;
 import org.apache.cxf.annotations.Provider.Type;
-import org.apache.cxf.endpoint.Client;
 import org.apache.cxf.endpoint.Server;
-import org.apache.cxf.feature.AbstractFeature;
 import org.apache.cxf.feature.AbstractPortableFeature;
-import org.apache.cxf.interceptor.InterceptorProvider;
+import org.apache.cxf.feature.DelegatingFeature;
 import org.apache.cxf.jaxrs.provider.ServerProviderFactory;
 
 @Provider(value = Type.Feature, scope = Scope.Server)
-public class SseFeature extends AbstractFeature {
-    private final Portable delegate = new Portable();
+public class SseFeature extends DelegatingFeature<SseFeature.Portable> {
 
-    @Override
-    public void initialize(Server server, Bus bus) {
-        delegate.initialize(server, bus);
-    }
-
-    @Override
-    public void initialize(Client client, Bus bus) {
-        delegate.initialize(client, bus);
-    }
-
-    @Override
-    public void initialize(InterceptorProvider interceptorProvider, Bus bus) {
-        delegate.initialize(interceptorProvider, bus);
-    }
-
-    @Override
-    public void initialize(Bus bus) {
-        delegate.initialize(bus);
+    public SseFeature() {
+        super(new Portable());
     }
 
     @Provider(value = Type.Feature, scope = Scope.Server)

--- a/rt/rs/sse/src/main/java/org/apache/cxf/jaxrs/sse/SseFeature.java
+++ b/rt/rs/sse/src/main/java/org/apache/cxf/jaxrs/sse/SseFeature.java
@@ -27,18 +27,31 @@ import org.apache.cxf.annotations.Provider.Scope;
 import org.apache.cxf.annotations.Provider.Type;
 import org.apache.cxf.endpoint.Server;
 import org.apache.cxf.feature.AbstractFeature;
+import org.apache.cxf.feature.AbstractPortableFeature;
+import org.apache.cxf.interceptor.InterceptorProvider;
 import org.apache.cxf.jaxrs.provider.ServerProviderFactory;
 
 @Provider(value = Type.Feature, scope = Scope.Server)
 public class SseFeature extends AbstractFeature {
+    private final Portable delegate = new Portable();
+
     @Override
     public void initialize(Server server, Bus bus) {
-        final List<Object> providers = new ArrayList<>();
+        delegate.initialize(server, bus);
+    }
 
-        providers.add(new SseContextProvider());
-        providers.add(new SseEventSinkContextProvider());
+    @Provider(value = Type.Feature, scope = Scope.Server)
+    public static class Portable implements AbstractPortableFeature {
 
-        ((ServerProviderFactory) server.getEndpoint().get(
-            ServerProviderFactory.class.getName())).setUserProviders(providers);
+        @Override
+        public void initialize(Server server, Bus bus) {
+            final List<Object> providers = new ArrayList<>();
+
+            providers.add(new SseContextProvider());
+            providers.add(new SseEventSinkContextProvider());
+
+            ((ServerProviderFactory) server.getEndpoint().get(
+                    ServerProviderFactory.class.getName())).setUserProviders(providers);
+        }
     }
 }

--- a/rt/transports/http/src/main/java/org/apache/cxf/transport/http/HttpConduitFeature.java
+++ b/rt/transports/http/src/main/java/org/apache/cxf/transport/http/HttpConduitFeature.java
@@ -21,6 +21,7 @@ package org.apache.cxf.transport.http;
 import org.apache.cxf.Bus;
 import org.apache.cxf.endpoint.Client;
 import org.apache.cxf.feature.AbstractFeature;
+import org.apache.cxf.feature.AbstractPortableFeature;
 import org.apache.cxf.transport.Conduit;
 
 /**
@@ -28,18 +29,30 @@ import org.apache.cxf.transport.Conduit;
  * intent.
  */
 public class HttpConduitFeature extends AbstractFeature {
-    private HttpConduitConfig conduitConfig;
+    private Portable delegate = new Portable();
 
     @Override
     public void initialize(Client client, Bus bus) {
-        Conduit conduit = client.getConduit();
-        if (conduitConfig != null && conduit instanceof HTTPConduit) {
-            conduitConfig.apply((HTTPConduit)conduit);
-        }
+        delegate.initialize(client, bus);
     }
 
     public void setConduitConfig(HttpConduitConfig conduitConfig) {
-        this.conduitConfig = conduitConfig;
+        delegate.setConduitConfig(conduitConfig);
     }
 
+    public static class Portable implements AbstractPortableFeature {
+        private HttpConduitConfig conduitConfig;
+
+        @Override
+        public void initialize(Client client, Bus bus) {
+            Conduit conduit = client.getConduit();
+            if (conduitConfig != null && conduit instanceof HTTPConduit) {
+                conduitConfig.apply((HTTPConduit)conduit);
+            }
+        }
+
+        public void setConduitConfig(HttpConduitConfig conduitConfig) {
+            this.conduitConfig = conduitConfig;
+        }
+    }
 }

--- a/rt/transports/http/src/main/java/org/apache/cxf/transport/http/HttpConduitFeature.java
+++ b/rt/transports/http/src/main/java/org/apache/cxf/transport/http/HttpConduitFeature.java
@@ -20,37 +20,17 @@ package org.apache.cxf.transport.http;
 
 import org.apache.cxf.Bus;
 import org.apache.cxf.endpoint.Client;
-import org.apache.cxf.endpoint.Server;
-import org.apache.cxf.feature.AbstractFeature;
 import org.apache.cxf.feature.AbstractPortableFeature;
-import org.apache.cxf.interceptor.InterceptorProvider;
+import org.apache.cxf.feature.DelegatingFeature;
 import org.apache.cxf.transport.Conduit;
 
 /**
  * Programmatically configure a http conduit. This can also be used as a DOSGi
  * intent.
  */
-public class HttpConduitFeature extends AbstractFeature {
-    private Portable delegate = new Portable();
-
-    @Override
-    public void initialize(Client client, Bus bus) {
-        delegate.initialize(client, bus);
-    }
-
-    @Override
-    public void initialize(Server server, Bus bus) {
-        delegate.initialize(server, bus);
-    }
-
-    @Override
-    public void initialize(InterceptorProvider interceptorProvider, Bus bus) {
-        delegate.initialize(interceptorProvider, bus);
-    }
-
-    @Override
-    public void initialize(Bus bus) {
-        delegate.initialize(bus);
+public class HttpConduitFeature extends DelegatingFeature<HttpConduitFeature.Portable> {
+    public HttpConduitFeature() {
+        super(new Portable());
     }
 
     public void setConduitConfig(HttpConduitConfig conduitConfig) {

--- a/rt/transports/http/src/main/java/org/apache/cxf/transport/http/HttpConduitFeature.java
+++ b/rt/transports/http/src/main/java/org/apache/cxf/transport/http/HttpConduitFeature.java
@@ -20,8 +20,10 @@ package org.apache.cxf.transport.http;
 
 import org.apache.cxf.Bus;
 import org.apache.cxf.endpoint.Client;
+import org.apache.cxf.endpoint.Server;
 import org.apache.cxf.feature.AbstractFeature;
 import org.apache.cxf.feature.AbstractPortableFeature;
+import org.apache.cxf.interceptor.InterceptorProvider;
 import org.apache.cxf.transport.Conduit;
 
 /**
@@ -34,6 +36,21 @@ public class HttpConduitFeature extends AbstractFeature {
     @Override
     public void initialize(Client client, Bus bus) {
         delegate.initialize(client, bus);
+    }
+
+    @Override
+    public void initialize(Server server, Bus bus) {
+        delegate.initialize(server, bus);
+    }
+
+    @Override
+    public void initialize(InterceptorProvider interceptorProvider, Bus bus) {
+        delegate.initialize(interceptorProvider, bus);
+    }
+
+    @Override
+    public void initialize(Bus bus) {
+        delegate.initialize(bus);
     }
 
     public void setConduitConfig(HttpConduitConfig conduitConfig) {

--- a/rt/transports/http/src/main/java/org/apache/cxf/transport/http/HttpDestinationFeature.java
+++ b/rt/transports/http/src/main/java/org/apache/cxf/transport/http/HttpDestinationFeature.java
@@ -19,38 +19,18 @@
 package org.apache.cxf.transport.http;
 
 import org.apache.cxf.Bus;
-import org.apache.cxf.endpoint.Client;
 import org.apache.cxf.endpoint.Server;
-import org.apache.cxf.feature.AbstractFeature;
 import org.apache.cxf.feature.AbstractPortableFeature;
-import org.apache.cxf.interceptor.InterceptorProvider;
+import org.apache.cxf.feature.DelegatingFeature;
 import org.apache.cxf.transport.Destination;
 
 /**
  * Programmatically configure a http destination. This can also be used as a DOSGi
  * intent.
  */
-public class HttpDestinationFeature extends AbstractFeature {
-    private Portable delegate = new Portable();
-
-    @Override
-    public void initialize(Server server, Bus bus) {
-        delegate.initialize(server, bus);
-    }
-
-    @Override
-    public void initialize(Client client, Bus bus) {
-        delegate.initialize(client, bus);
-    }
-
-    @Override
-    public void initialize(InterceptorProvider interceptorProvider, Bus bus) {
-        delegate.initialize(interceptorProvider, bus);
-    }
-
-    @Override
-    public void initialize(Bus bus) {
-        delegate.initialize(bus);
+public class HttpDestinationFeature extends DelegatingFeature<HttpDestinationFeature.Portable> {
+    public HttpDestinationFeature() {
+        super(new Portable());
     }
 
     public void setDestinationConfig(HttpDestinationConfig destinationConfig) {

--- a/rt/transports/http/src/main/java/org/apache/cxf/transport/http/HttpDestinationFeature.java
+++ b/rt/transports/http/src/main/java/org/apache/cxf/transport/http/HttpDestinationFeature.java
@@ -19,9 +19,11 @@
 package org.apache.cxf.transport.http;
 
 import org.apache.cxf.Bus;
+import org.apache.cxf.endpoint.Client;
 import org.apache.cxf.endpoint.Server;
 import org.apache.cxf.feature.AbstractFeature;
 import org.apache.cxf.feature.AbstractPortableFeature;
+import org.apache.cxf.interceptor.InterceptorProvider;
 import org.apache.cxf.transport.Destination;
 
 /**
@@ -34,6 +36,21 @@ public class HttpDestinationFeature extends AbstractFeature {
     @Override
     public void initialize(Server server, Bus bus) {
         delegate.initialize(server, bus);
+    }
+
+    @Override
+    public void initialize(Client client, Bus bus) {
+        delegate.initialize(client, bus);
+    }
+
+    @Override
+    public void initialize(InterceptorProvider interceptorProvider, Bus bus) {
+        delegate.initialize(interceptorProvider, bus);
+    }
+
+    @Override
+    public void initialize(Bus bus) {
+        delegate.initialize(bus);
     }
 
     public void setDestinationConfig(HttpDestinationConfig destinationConfig) {

--- a/rt/transports/http/src/main/java/org/apache/cxf/transport/http/HttpDestinationFeature.java
+++ b/rt/transports/http/src/main/java/org/apache/cxf/transport/http/HttpDestinationFeature.java
@@ -21,6 +21,7 @@ package org.apache.cxf.transport.http;
 import org.apache.cxf.Bus;
 import org.apache.cxf.endpoint.Server;
 import org.apache.cxf.feature.AbstractFeature;
+import org.apache.cxf.feature.AbstractPortableFeature;
 import org.apache.cxf.transport.Destination;
 
 /**
@@ -28,17 +29,30 @@ import org.apache.cxf.transport.Destination;
  * intent.
  */
 public class HttpDestinationFeature extends AbstractFeature {
-    private HttpDestinationConfig destinationConfig;
+    private Portable delegate = new Portable();
 
     @Override
     public void initialize(Server server, Bus bus) {
-        Destination destination = server.getDestination();
-        if (destinationConfig != null && destination instanceof AbstractHTTPDestination) {
-            destinationConfig.apply((AbstractHTTPDestination)destination);
-        }
+        delegate.initialize(server, bus);
     }
 
     public void setDestinationConfig(HttpDestinationConfig destinationConfig) {
-        this.destinationConfig = destinationConfig;
+        delegate.setDestinationConfig(destinationConfig);
+    }
+
+    public static class Portable implements AbstractPortableFeature {
+        private HttpDestinationConfig destinationConfig;
+
+        @Override
+        public void initialize(Server server, Bus bus) {
+            Destination destination = server.getDestination();
+            if (destinationConfig != null && destination instanceof AbstractHTTPDestination) {
+                destinationConfig.apply((AbstractHTTPDestination)destination);
+            }
+        }
+
+        public void setDestinationConfig(HttpDestinationConfig destinationConfig) {
+            this.destinationConfig = destinationConfig;
+        }
     }
 }

--- a/rt/transports/http/src/main/java/org/apache/cxf/transport/https/CertConstraintsFeature.java
+++ b/rt/transports/http/src/main/java/org/apache/cxf/transport/https/CertConstraintsFeature.java
@@ -25,6 +25,7 @@ import org.apache.cxf.configuration.security.CertificateConstraintsType;
 import org.apache.cxf.endpoint.Client;
 import org.apache.cxf.endpoint.Server;
 import org.apache.cxf.feature.AbstractFeature;
+import org.apache.cxf.feature.AbstractPortableFeature;
 import org.apache.cxf.interceptor.InterceptorProvider;
 
 /**
@@ -56,56 +57,88 @@ import org.apache.cxf.interceptor.InterceptorProvider;
  */
 @NoJSR250Annotations
 public class CertConstraintsFeature extends AbstractFeature {
-    CertificateConstraintsType contraints;
-
-
-    public CertConstraintsFeature() {
-    }
+    private Portable delegate = new Portable();
 
     @Override
     public void initialize(Server server, Bus bus) {
-        if (contraints == null) {
-            return;
-        }
-        initializeProvider(server.getEndpoint(), bus);
-        CertConstraints c = CertConstraintsJaxBUtils.createCertConstraints(contraints);
-        server.getEndpoint().put(CertConstraints.class.getName(), c);
+        delegate.initialize(server, bus);
     }
 
     @Override
     public void initialize(Client client, Bus bus) {
-        if (contraints == null) {
-            return;
-        }
-        initializeProvider(client, bus);
-        CertConstraints c = CertConstraintsJaxBUtils.createCertConstraints(contraints);
-        client.getEndpoint().put(CertConstraints.class.getName(), c);
+        delegate.initialize(client, bus);
     }
 
     @Override
     public void initialize(Bus bus) {
-        if (contraints == null) {
-            return;
-        }
-        initializeProvider(bus, bus);
-        CertConstraints c = CertConstraintsJaxBUtils.createCertConstraints(contraints);
-        bus.setProperty(CertConstraints.class.getName(), c);
+        delegate.initialize(bus);
     }
 
     @Override
     protected void initializeProvider(InterceptorProvider provider, Bus bus) {
-        if (contraints == null) {
-            return;
-        }
-        provider.getInInterceptors().add(CertConstraintsInterceptor.INSTANCE);
-        provider.getInFaultInterceptors().add(CertConstraintsInterceptor.INSTANCE);
+        delegate.doInitializeProvider(provider, bus);
     }
 
     public void setCertificateConstraints(CertificateConstraintsType c) {
-        contraints = c;
+        delegate.setCertificateConstraints(c);
     }
 
     public CertificateConstraintsType getCertificateConstraints() {
-        return contraints;
+        return delegate.getCertificateConstraints();
+    }
+
+    public static class Portable implements AbstractPortableFeature {
+        CertificateConstraintsType contraints;
+
+
+        public Portable() {
+        }
+
+        @Override
+        public void initialize(Server server, Bus bus) {
+            if (contraints == null) {
+                return;
+            }
+            doInitializeProvider(server.getEndpoint(), bus);
+            CertConstraints c = CertConstraintsJaxBUtils.createCertConstraints(contraints);
+            server.getEndpoint().put(CertConstraints.class.getName(), c);
+        }
+
+        @Override
+        public void initialize(Client client, Bus bus) {
+            if (contraints == null) {
+                return;
+            }
+            doInitializeProvider(client, bus);
+            CertConstraints c = CertConstraintsJaxBUtils.createCertConstraints(contraints);
+            client.getEndpoint().put(CertConstraints.class.getName(), c);
+        }
+
+        @Override
+        public void initialize(Bus bus) {
+            if (contraints == null) {
+                return;
+            }
+            doInitializeProvider(bus, bus);
+            CertConstraints c = CertConstraintsJaxBUtils.createCertConstraints(contraints);
+            bus.setProperty(CertConstraints.class.getName(), c);
+        }
+
+        @Override
+        public void doInitializeProvider(InterceptorProvider provider, Bus bus) {
+            if (contraints == null) {
+                return;
+            }
+            provider.getInInterceptors().add(CertConstraintsInterceptor.INSTANCE);
+            provider.getInFaultInterceptors().add(CertConstraintsInterceptor.INSTANCE);
+        }
+
+        public void setCertificateConstraints(CertificateConstraintsType c) {
+            contraints = c;
+        }
+
+        public CertificateConstraintsType getCertificateConstraints() {
+            return contraints;
+        }
     }
 }

--- a/rt/transports/http/src/main/java/org/apache/cxf/transport/https/CertConstraintsFeature.java
+++ b/rt/transports/http/src/main/java/org/apache/cxf/transport/https/CertConstraintsFeature.java
@@ -24,8 +24,8 @@ import org.apache.cxf.common.injection.NoJSR250Annotations;
 import org.apache.cxf.configuration.security.CertificateConstraintsType;
 import org.apache.cxf.endpoint.Client;
 import org.apache.cxf.endpoint.Server;
-import org.apache.cxf.feature.AbstractFeature;
 import org.apache.cxf.feature.AbstractPortableFeature;
+import org.apache.cxf.feature.DelegatingFeature;
 import org.apache.cxf.interceptor.InterceptorProvider;
 
 /**
@@ -56,27 +56,10 @@ import org.apache.cxf.interceptor.InterceptorProvider;
   </pre>
  */
 @NoJSR250Annotations
-public class CertConstraintsFeature extends AbstractFeature {
-    private Portable delegate = new Portable();
+public class CertConstraintsFeature extends DelegatingFeature<CertConstraintsFeature.Portable> {
 
-    @Override
-    public void initialize(Server server, Bus bus) {
-        delegate.initialize(server, bus);
-    }
-
-    @Override
-    public void initialize(Client client, Bus bus) {
-        delegate.initialize(client, bus);
-    }
-
-    @Override
-    public void initialize(Bus bus) {
-        delegate.initialize(bus);
-    }
-
-    @Override
-    protected void initializeProvider(InterceptorProvider provider, Bus bus) {
-        delegate.doInitializeProvider(provider, bus);
+    public CertConstraintsFeature() {
+        super(new Portable());
     }
 
     public void setCertificateConstraints(CertificateConstraintsType c) {

--- a/rt/transports/jms/src/main/java/org/apache/cxf/transport/jms/ConnectionFactoryFeature.java
+++ b/rt/transports/jms/src/main/java/org/apache/cxf/transport/jms/ConnectionFactoryFeature.java
@@ -62,6 +62,11 @@ public class ConnectionFactoryFeature extends AbstractFeature {
         delegate.initialize(server, bus);
     }
 
+    @Override
+    public void initialize(Bus bus) {
+        delegate.initialize(bus);
+    }
+
     public static class Portable implements AbstractPortableFeature {
         private ConnectionFactory connectionFactory;
 

--- a/rt/transports/jms/src/main/java/org/apache/cxf/transport/jms/ConnectionFactoryFeature.java
+++ b/rt/transports/jms/src/main/java/org/apache/cxf/transport/jms/ConnectionFactoryFeature.java
@@ -24,8 +24,8 @@ import org.apache.cxf.Bus;
 import org.apache.cxf.common.injection.NoJSR250Annotations;
 import org.apache.cxf.endpoint.Client;
 import org.apache.cxf.endpoint.Server;
-import org.apache.cxf.feature.AbstractFeature;
 import org.apache.cxf.feature.AbstractPortableFeature;
+import org.apache.cxf.feature.DelegatingFeature;
 import org.apache.cxf.interceptor.Fault;
 import org.apache.cxf.interceptor.InterceptorProvider;
 import org.apache.cxf.message.Message;
@@ -40,31 +40,9 @@ import org.apache.cxf.transport.Destination;
  * configuration that is generated from the old configuration style.
  */
 @NoJSR250Annotations
-public class ConnectionFactoryFeature extends AbstractFeature {
-    private Portable delegate;
-
+public class ConnectionFactoryFeature extends DelegatingFeature<ConnectionFactoryFeature.Portable> {
     public ConnectionFactoryFeature(ConnectionFactory cf) {
-        delegate = new Portable(cf);
-    }
-
-    @Override
-    public void initialize(Client client, Bus bus) {
-        delegate.initialize(client, bus);
-    }
-
-    @Override
-    public void initialize(InterceptorProvider provider, Bus bus) {
-        delegate.initialize(provider, bus);
-    }
-
-    @Override
-    public void initialize(Server server, Bus bus) {
-        delegate.initialize(server, bus);
-    }
-
-    @Override
-    public void initialize(Bus bus) {
-        delegate.initialize(bus);
+        super(new Portable(cf));
     }
 
     public static class Portable implements AbstractPortableFeature {

--- a/rt/transports/jms/src/main/java/org/apache/cxf/transport/jms/ConnectionFactoryFeature.java
+++ b/rt/transports/jms/src/main/java/org/apache/cxf/transport/jms/ConnectionFactoryFeature.java
@@ -77,12 +77,10 @@ public class ConnectionFactoryFeature extends AbstractFeature {
         @Override
         public void initialize(Client client, Bus bus) {
             client.getEndpoint().getOutInterceptors().add(new JMSConduitConfigOutInterceptor());
-            initialize(client, bus);
         }
         @Override
         public void initialize(InterceptorProvider provider, Bus bus) {
             provider.getOutInterceptors().add(new JMSConduitConfigOutInterceptor());
-            initialize(provider, bus);
         }
 
         @Override
@@ -92,7 +90,6 @@ public class ConnectionFactoryFeature extends AbstractFeature {
                 JMSDestination jmsDestination = (JMSDestination)destination;
                 jmsDestination.getJmsConfig().setConnectionFactory(connectionFactory);
             }
-            initialize(server, bus);
         }
         private class JMSConduitConfigOutInterceptor extends AbstractPhaseInterceptor<Message> {
             JMSConduitConfigOutInterceptor() {

--- a/rt/transports/jms/src/main/java/org/apache/cxf/transport/jms/JMSConfigFeature.java
+++ b/rt/transports/jms/src/main/java/org/apache/cxf/transport/jms/JMSConfigFeature.java
@@ -27,9 +27,8 @@ import org.apache.cxf.common.logging.LogUtils;
 import org.apache.cxf.configuration.ConfigurationException;
 import org.apache.cxf.endpoint.Client;
 import org.apache.cxf.endpoint.Server;
-import org.apache.cxf.feature.AbstractFeature;
 import org.apache.cxf.feature.AbstractPortableFeature;
-import org.apache.cxf.interceptor.InterceptorProvider;
+import org.apache.cxf.feature.DelegatingFeature;
 import org.apache.cxf.transport.Conduit;
 import org.apache.cxf.transport.Destination;
 
@@ -39,27 +38,9 @@ import org.apache.cxf.transport.Destination;
  * configuration that is generated from the old configuration style.
  */
 @NoJSR250Annotations
-public class JMSConfigFeature extends AbstractFeature {
-    private Portable delegate = new Portable();
-
-    @Override
-    public void initialize(Client client, Bus bus) {
-        delegate.initialize(client, bus);
-    }
-
-    @Override
-    public void initialize(Server server, Bus bus) {
-        delegate.initialize(server, bus);
-    }
-
-    @Override
-    public void initialize(InterceptorProvider interceptorProvider, Bus bus) {
-        delegate.initialize(interceptorProvider, bus);
-    }
-
-    @Override
-    public void initialize(Bus bus) {
-        delegate.initialize(bus);
+public class JMSConfigFeature extends DelegatingFeature<JMSConfigFeature.Portable> {
+    public JMSConfigFeature() {
+        super(new Portable());
     }
 
     public JMSConfiguration getJmsConfig() {

--- a/rt/transports/jms/src/main/java/org/apache/cxf/transport/jms/JMSConfigFeature.java
+++ b/rt/transports/jms/src/main/java/org/apache/cxf/transport/jms/JMSConfigFeature.java
@@ -28,6 +28,7 @@ import org.apache.cxf.configuration.ConfigurationException;
 import org.apache.cxf.endpoint.Client;
 import org.apache.cxf.endpoint.Server;
 import org.apache.cxf.feature.AbstractFeature;
+import org.apache.cxf.feature.AbstractPortableFeature;
 import org.apache.cxf.transport.Conduit;
 import org.apache.cxf.transport.Destination;
 
@@ -38,45 +39,65 @@ import org.apache.cxf.transport.Destination;
  */
 @NoJSR250Annotations
 public class JMSConfigFeature extends AbstractFeature {
-    static final Logger LOG = LogUtils.getL7dLogger(JMSConfigFeature.class);
-
-    JMSConfiguration jmsConfig;
+    private Portable portable = new Portable();
 
     @Override
     public void initialize(Client client, Bus bus) {
-        checkJmsConfig();
-        Conduit conduit = client.getConduit();
-        if (!(conduit instanceof JMSConduit)) {
-            throw new ConfigurationException(new Message("JMSCONFIGFEATURE_ONLY_JMS", LOG));
-        }
-        JMSConduit jmsConduit = (JMSConduit)conduit;
-        jmsConduit.setJmsConfig(jmsConfig);
-        super.initialize(client, bus);
+        portable.initialize(client, bus);
     }
 
     @Override
     public void initialize(Server server, Bus bus) {
-        checkJmsConfig();
-        Destination destination = server.getDestination();
-        if (!(destination instanceof JMSDestination)) {
-            throw new ConfigurationException(new Message("JMSCONFIGFEATURE_ONLY_JMS", LOG));
-        }
-        JMSDestination jmsDestination = (JMSDestination)destination;
-        jmsDestination.setJmsConfig(jmsConfig);
-        super.initialize(server, bus);
+        portable.initialize(server, bus);
     }
 
     public JMSConfiguration getJmsConfig() {
-        return jmsConfig;
+        return portable.getJmsConfig();
     }
 
     public void setJmsConfig(JMSConfiguration jmsConfig) {
-        this.jmsConfig = jmsConfig;
+        portable.setJmsConfig(jmsConfig);
     }
 
-    private void checkJmsConfig() {
-        if (jmsConfig == null) {
-            throw new ConfigurationException(new Message("JMSCONFIG_REQUIRED", LOG));
+    public static class Portable implements AbstractPortableFeature {
+        static final Logger LOG = LogUtils.getL7dLogger(JMSConfigFeature.class);
+
+        JMSConfiguration jmsConfig;
+
+        @Override
+        public void initialize(Client client, Bus bus) {
+            checkJmsConfig();
+            Conduit conduit = client.getConduit();
+            if (!(conduit instanceof JMSConduit)) {
+                throw new ConfigurationException(new Message("JMSCONFIGFEATURE_ONLY_JMS", LOG));
+            }
+            JMSConduit jmsConduit = (JMSConduit)conduit;
+            jmsConduit.setJmsConfig(jmsConfig);
+        }
+
+        @Override
+        public void initialize(Server server, Bus bus) {
+            checkJmsConfig();
+            Destination destination = server.getDestination();
+            if (!(destination instanceof JMSDestination)) {
+                throw new ConfigurationException(new Message("JMSCONFIGFEATURE_ONLY_JMS", LOG));
+            }
+            JMSDestination jmsDestination = (JMSDestination)destination;
+            jmsDestination.setJmsConfig(jmsConfig);
+        }
+
+        public JMSConfiguration getJmsConfig() {
+            return jmsConfig;
+        }
+
+        public void setJmsConfig(JMSConfiguration jmsConfig) {
+            this.jmsConfig = jmsConfig;
+        }
+
+        private void checkJmsConfig() {
+            if (jmsConfig == null) {
+                throw new ConfigurationException(new Message("JMSCONFIG_REQUIRED", LOG));
+            }
         }
     }
 }

--- a/rt/transports/jms/src/main/java/org/apache/cxf/transport/jms/JMSConfigFeature.java
+++ b/rt/transports/jms/src/main/java/org/apache/cxf/transport/jms/JMSConfigFeature.java
@@ -29,6 +29,7 @@ import org.apache.cxf.endpoint.Client;
 import org.apache.cxf.endpoint.Server;
 import org.apache.cxf.feature.AbstractFeature;
 import org.apache.cxf.feature.AbstractPortableFeature;
+import org.apache.cxf.interceptor.InterceptorProvider;
 import org.apache.cxf.transport.Conduit;
 import org.apache.cxf.transport.Destination;
 
@@ -39,24 +40,34 @@ import org.apache.cxf.transport.Destination;
  */
 @NoJSR250Annotations
 public class JMSConfigFeature extends AbstractFeature {
-    private Portable portable = new Portable();
+    private Portable delegate = new Portable();
 
     @Override
     public void initialize(Client client, Bus bus) {
-        portable.initialize(client, bus);
+        delegate.initialize(client, bus);
     }
 
     @Override
     public void initialize(Server server, Bus bus) {
-        portable.initialize(server, bus);
+        delegate.initialize(server, bus);
+    }
+
+    @Override
+    public void initialize(InterceptorProvider interceptorProvider, Bus bus) {
+        delegate.initialize(interceptorProvider, bus);
+    }
+
+    @Override
+    public void initialize(Bus bus) {
+        delegate.initialize(bus);
     }
 
     public JMSConfiguration getJmsConfig() {
-        return portable.getJmsConfig();
+        return delegate.getJmsConfig();
     }
 
     public void setJmsConfig(JMSConfiguration jmsConfig) {
-        portable.setJmsConfig(jmsConfig);
+        delegate.setJmsConfig(jmsConfig);
     }
 
     public static class Portable implements AbstractPortableFeature {

--- a/systests/tracing/src/test/java/org/apache/cxf/systest/jaeger/TestSender.java
+++ b/systests/tracing/src/test/java/org/apache/cxf/systest/jaeger/TestSender.java
@@ -30,13 +30,13 @@ public class TestSender implements Sender {
 
     private static final List<JaegerSpan> SPANS = new CopyOnWriteArrayList<>();
 
-    private static CountDownLatch SYNCHRO;
+    private static CountDownLatch synchro;
 
     @Override
     public int append(JaegerSpan span) throws SenderException {
         SPANS.add(span);
-        if (SYNCHRO != null) {
-            SYNCHRO.countDown();
+        if (synchro != null) {
+            synchro.countDown();
         }
         return 0;
     }
@@ -59,7 +59,7 @@ public class TestSender implements Sender {
         SPANS.clear();
     }
 
-    public static void setSynchro(CountDownLatch synchro) {
-        SYNCHRO = synchro;
+    public static void setSynchro(CountDownLatch newSynchro) {
+        synchro = newSynchro;
     }
 }

--- a/systests/tracing/src/test/java/org/apache/cxf/systest/jaeger/TestSender.java
+++ b/systests/tracing/src/test/java/org/apache/cxf/systest/jaeger/TestSender.java
@@ -20,6 +20,7 @@ package org.apache.cxf.systest.jaeger;
 
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
 
 import io.jaegertracing.internal.JaegerSpan;
 import io.jaegertracing.internal.exceptions.SenderException;
@@ -29,9 +30,14 @@ public class TestSender implements Sender {
 
     private static final List<JaegerSpan> SPANS = new CopyOnWriteArrayList<>();
 
+    private static CountDownLatch SYNCHRO;
+
     @Override
     public int append(JaegerSpan span) throws SenderException {
         SPANS.add(span);
+        if (SYNCHRO != null) {
+            SYNCHRO.countDown();
+        }
         return 0;
     }
 
@@ -51,5 +57,9 @@ public class TestSender implements Sender {
 
     public static void clear() {
         SPANS.clear();
+    }
+
+    public static void setSynchro(CountDownLatch synchro) {
+        SYNCHRO = synchro;
     }
 }

--- a/systests/uncategorized/src/test/java/org/apache/cxf/systest/schema_validation/ValidationClientServerTest.java
+++ b/systests/uncategorized/src/test/java/org/apache/cxf/systest/schema_validation/ValidationClientServerTest.java
@@ -23,6 +23,7 @@ import java.io.Serializable;
 import java.io.StringReader;
 import java.net.URL;
 import java.util.List;
+import java.util.Locale;
 
 import javax.xml.namespace.QName;
 import javax.xml.transform.Source;
@@ -45,6 +46,7 @@ import org.apache.schema_validation.types.OccuringStruct;
 import org.apache.schema_validation.types.SomeRequest;
 import org.apache.schema_validation.types.SomeResponse;
 
+import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
@@ -60,10 +62,18 @@ public class ValidationClientServerTest extends AbstractBusClientServerTestBase 
                                                 "SchemaValidationService");
     private final QName portName = new QName("http://apache.org/schema_validation", "SoapPort");
 
+    private static Locale oldLocale;
 
     @BeforeClass
     public static void startservers() throws Exception {
+        oldLocale = Locale.getDefault();
+        Locale.setDefault(Locale.ENGLISH);
         assertTrue("server did not launch correctly", launchServer(ValidationServer.class, true));
+    }
+
+    @AfterClass
+    public static void resetLocale() {
+        Locale.setDefault(oldLocale);
     }
 
     @Test

--- a/systests/uncategorized/src/test/java/org/apache/cxf/systest/schema_validation/ValidationClientServerTest.java
+++ b/systests/uncategorized/src/test/java/org/apache/cxf/systest/schema_validation/ValidationClientServerTest.java
@@ -58,11 +58,11 @@ import static org.junit.Assert.fail;
 public class ValidationClientServerTest extends AbstractBusClientServerTestBase {
     public static final String PORT = ValidationServer.PORT;
 
+    private static Locale oldLocale;
+
     private final QName serviceName = new QName("http://apache.org/schema_validation",
                                                 "SchemaValidationService");
     private final QName portName = new QName("http://apache.org/schema_validation", "SoapPort");
-
-    private static Locale oldLocale;
 
     @BeforeClass
     public static void startservers() throws Exception {


### PR DESCRIPTION
This PR aims at enabling users to rely on CXF features without the need of jaxws API in the classpath (targets JAXRS users and java >= 9).