### PR TITLE
CXF-8066: Support Doclet API (JDK13+)

### DIFF
--- a/maven-plugins/java2wadl-plugin/pom.xml
+++ b/maven-plugins/java2wadl-plugin/pom.xml
@@ -208,5 +208,56 @@
                 </plugins>
             </build>
         </profile>
+        
+        <profile>
+            <id>jdk13</id>
+              <activation>
+                  <jdk>[13,)</jdk>
+              </activation>
+              <build>
+                  <pluginManagement>
+                      <plugins>
+                          <plugin>
+                              <groupId>org.apache.maven.plugins</groupId>
+                              <artifactId>maven-compiler-plugin</artifactId>
+                              <executions>
+                                  <execution>
+                                    <id>default-jdk13-compile</id>
+                                    <goals>
+                                        <goal>compile</goal>
+                                    </goals>
+                                    <configuration>
+                                        <forceJavacCompilerUse>true</forceJavacCompilerUse>
+                                        <compileSourceRoots>
+                                            <compileSourceRoot>${project.basedir}/src/main/java13</compileSourceRoot>
+                                        </compileSourceRoots>
+                                        <outputDirectory>${project.build.outputDirectory}/META-INF/versions/13</outputDirectory>
+                                    </configuration>
+                              </execution>
+                          </executions>
+                          <configuration>
+                              <release>9</release>
+                          </configuration>
+                      </plugin>
+                      <plugin>
+                          <groupId>org.apache.maven.plugins</groupId>
+                          <artifactId>maven-jar-plugin</artifactId>
+                          <executions>
+                              <execution>
+                                  <id>default-jar</id>
+                                  <configuration>
+                                      <archive>
+                                          <manifestEntries>
+                                              <Multi-Release>true</Multi-Release>
+                                          </manifestEntries>
+                                      </archive>
+                                  </configuration>
+                              </execution>
+                          </executions>
+                      </plugin>
+                  </plugins>
+              </pluginManagement>
+          </build>
+        </profile>
     </profiles>
 </project>

--- a/maven-plugins/java2wadl-plugin/src/main/java/org/apache/cxf/maven_plugin/javatowadl/DumpJavaDoc.java
+++ b/maven-plugins/java2wadl-plugin/src/main/java/org/apache/cxf/maven_plugin/javatowadl/DumpJavaDoc.java
@@ -101,7 +101,7 @@ public final class DumpJavaDoc {
             }
         }
         if (!foundTagOption) {
-            reporter.printError("Usage: -dumpJavaDocFile theFileToDumpJavaDocForLatarUse...");
+            reporter.printError("Usage: -dumpJavaDocFile theFileToDumpJavaDocForLaterUse...");
         }
         return foundTagOption;
     }

--- a/maven-plugins/java2wadl-plugin/src/main/java/org/apache/cxf/maven_plugin/javatowadl/Java2WADLMojo.java
+++ b/maven-plugins/java2wadl-plugin/src/main/java/org/apache/cxf/maven_plugin/javatowadl/Java2WADLMojo.java
@@ -307,27 +307,15 @@ public class Java2WADLMojo extends AbstractMojo {
                 + outputFileExtension).replace("/", File.separator);
         }
 
-        BufferedWriter writer = null;
         try {
             FileUtils.mkDir(new File(outputFile).getParentFile());
-            /*File wadlFile = new File(outputFile);
-            if (!wadlFile.exists()) {
-                wadlFile.createNewFile();
-            }*/
-            writer = new BufferedWriter(new FileWriter(outputFile));
-            writer.write(wadl);
-
+            try (BufferedWriter writer = new BufferedWriter(new FileWriter(outputFile))) {
+                writer.write(wadl);
+            }
         } catch (IOException e) {
             throw new MojoExecutionException(e.getMessage(), e);
-        } finally {
-            try {
-                if (writer != null) {
-                    writer.close();
-                }
-            } catch (IOException e) {
-                throw new MojoExecutionException(e.getMessage(), e);
-            }
-        }
+        } 
+        
         // Attach the generated wadl file to the artifacts that get deployed
         // with the enclosing project
         if (attachWadl && outputFile != null) {

--- a/maven-plugins/java2wadl-plugin/src/main/java13/org/apache/cxf/maven_plugin/javatowadl/DumpJavaDoc.java
+++ b/maven-plugins/java2wadl-plugin/src/main/java13/org/apache/cxf/maven_plugin/javatowadl/DumpJavaDoc.java
@@ -1,0 +1,194 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.cxf.maven_plugin.javatowadl;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+import java.util.Properties;
+
+import javax.lang.model.element.Element;
+import javax.lang.model.element.ElementKind;
+import javax.lang.model.element.ExecutableElement;
+import javax.lang.model.element.Modifier;
+import javax.lang.model.element.TypeElement;
+import javax.lang.model.element.VariableElement;
+import javax.lang.model.util.Elements;
+import javax.tools.Diagnostic;
+
+import com.sun.source.doctree.DocCommentTree;
+import com.sun.source.doctree.DocTree;
+import com.sun.source.doctree.ParamTree;
+import com.sun.source.doctree.ReturnTree;
+import com.sun.source.util.DocTrees;
+
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import javax.lang.model.SourceVersion;
+
+import jdk.javadoc.doclet.Doclet;
+import jdk.javadoc.doclet.DocletEnvironment;
+import jdk.javadoc.doclet.Reporter;
+
+public final class DumpJavaDoc implements Doclet {
+    private String dumpFileName;
+    private Reporter reporter;
+    
+    private final class DumpJavaDocFileOption implements Option {
+        @Override
+        public int getArgumentCount() {
+            return 1;
+        }
+
+        @Override
+        public String getDescription() {
+            return "Specify the file to dump Javadoc for later use";
+        }
+
+        @Override
+        public Kind getKind() {
+            return Kind.STANDARD;
+        }
+
+        @Override
+        public List<String> getNames() {
+            return Collections.singletonList("-dumpJavaDocFile");
+        }
+
+        @Override
+        public String getParameters() {
+            return "theFileToDumpJavaDocForLaterUse";
+        }
+
+        @Override
+        public boolean process(String option, List<String> arguments) {
+            dumpFileName = arguments.get(0);
+            return true;
+        }
+    }
+
+    public DumpJavaDoc() {
+
+    }
+
+    @Override
+    public void init(Locale locale, Reporter reporter) {
+        this.reporter = reporter;
+    }
+
+    @Override
+    public String getName() {
+        return "DumpJavaDoc";
+    }
+
+    @Override
+    public SourceVersion getSupportedSourceVersion() {
+        return SourceVersion.RELEASE_8;
+    }
+
+    @Override
+    public boolean run(DocletEnvironment docEnv) {
+        final Elements utils = docEnv.getElementUtils();
+        final DocTrees docTrees = docEnv.getDocTrees();
+        
+        try (OutputStream os = Files.newOutputStream(Paths.get(dumpFileName))) {
+            final Properties javaDocMap = new Properties();
+            for (Element element : docEnv.getIncludedElements()) {
+                if (element.getKind() == ElementKind.CLASS) {
+                    final TypeElement classDoc = (TypeElement) element;
+                    final DocCommentTree classCommentTree = docTrees.getDocCommentTree(classDoc);
+                    
+                    if (classCommentTree != null) {
+                        javaDocMap.put(classDoc.toString(), getAllComments(classCommentTree.getFullBody()));
+                    }
+                    
+                    for (Element member: classDoc.getEnclosedElements()) {
+                        // Skip all non-public methods
+                        if (!member.getModifiers().contains(Modifier.PUBLIC)) {
+                            continue;
+                        }
+                        
+                        if (member.getKind() == ElementKind.METHOD) {
+                            final ExecutableElement method = (ExecutableElement) member;
+                            final DocCommentTree methodCommentTree = docTrees.getDocCommentTree(method);
+                            final String qualifiedName = utils.getBinaryName(classDoc) + "." + method.getSimpleName();
+                            
+                            if (methodCommentTree == null) {
+                                javaDocMap.put(qualifiedName, "");
+                            } else  {
+                                javaDocMap.put(qualifiedName, getAllComments(methodCommentTree.getFullBody()));
+                                for (DocTree tree: methodCommentTree.getBlockTags()) {
+                                    if (tree.getKind() == DocTree.Kind.RETURN) {
+                                        final ReturnTree returnTree = (ReturnTree) tree;
+                                        javaDocMap.put(qualifiedName + ".returnCommentTag", 
+                                            getAllComments(returnTree.getDescription()));
+                                    } else if (tree.getKind() == DocTree.Kind.PARAM) {
+                                        final ParamTree paramTree = (ParamTree) tree;
+                                        final int index = getParamIndex(method, paramTree);
+                                        if (index >= 0) {
+                                            javaDocMap.put(qualifiedName + ".paramCommentTag." + index, 
+                                                getAllComments(paramTree.getDescription()));
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            
+            javaDocMap.store(os, "");
+            os.flush();
+        } catch (final IOException ex) {
+            reporter.print(Diagnostic.Kind.ERROR, ex.getMessage());
+        }
+        
+        return true;
+    }
+    
+    private int getParamIndex(final ExecutableElement method, final ParamTree paramTree) {
+        final List<? extends VariableElement> parameters = method.getParameters();
+        
+        for (int i = 0; i < parameters.size(); ++i) {
+            if (paramTree.getName().getName().contentEquals(parameters.get(i).getSimpleName())) {
+                return i;
+            }
+        } 
+        
+        return -1;
+    }
+
+    private String getAllComments(final Collection<? extends DocTree> comments) {
+        return comments
+            .stream()
+            .map(DocTree::toString)
+            .collect(Collectors.joining());
+    }
+    
+    @Override
+    public Set<Option> getSupportedOptions() {
+        return Collections.singleton(new DumpJavaDocFileOption());
+    }
+}


### PR DESCRIPTION
The problem
===
Our `java2wadl` plugin uses some part of Javadoc API to extract the documentation pieces from the
Java classes / methods / parameters. Since OpenJDK13, this API has been removed completely [2], [3]. To support JDK13 and above, we essentially have to rewrite the implementation completely. However, we would face another blocker here: how to support JDK8-11 and JDK13+ at the same time?

The solution
===
Use multi-release JAR. This is exactly the use case this feature has been designed for. So what it means 
is that `java2wadl` has additional source folder `src/main/java13` with JDK13 implementation. It would be it however there is another subtle complication. 

The complication 
===
For multi-release JAR, the java2wadl has to be build with 2 JDKs (ideally), pre-JDK13 and JDK13, or 
alternatively by latest JDK13 twice, once for `src/main/java` (using `--release 8`) and once for `src/main/java13` (equivalent to `--release 13`). The issue is that Javadoc-related API comes from `tools.jar`, which is not in scope of javac's `--release` flag [4], it really needs to be built by JDK8. As the workaround, we could used `--release 9` to mitigate this issue (since `tools.jar` was merged into JDK9+). This is not ideal (see please the next paragraph) but we get JDK13 builds back on track.

The impact
===
As of now, since our release jobs are using JDK8, there is no impact on release artifacts BUT `java2wadl` 
will fail when used with JDK13+ea builds. When JDK13 is out, we could rely on toolchain plugin to build `java2wadl` with 2 JDKs (`JDK8` and `JDK13`).

I think this is the first real precedent when we have to deal with large features / API removal from JDK, whereas reflection served as very well before. But this is certainly not the last one. 

[2] https://bugs.openjdk.java.net/browse/JDK-8215608
[3] https://jdk.java.net/13/release-notes 
[4] https://bugs.openjdk.java.net/browse/JDK-8199325