### PR TITLE
[CXF-8080] Ensure stages from async methods are completed

### DIFF
--- a/rt/rs/client/src/main/java/org/apache/cxf/jaxrs/client/ClientProxyImpl.java
+++ b/rt/rs/client/src/main/java/org/apache/cxf/jaxrs/client/ClientProxyImpl.java
@@ -949,7 +949,7 @@ public class ClientProxyImpl extends AbstractClient implements
                                    InvocationCallback<Object> asyncCallback) {
         outMessage.getExchange().setSynchronous(false);
         setAsyncMessageObserverIfNeeded(outMessage.getExchange());
-        JaxrsClientCallback<?> cb = newJaxrsClientCallback(asyncCallback,
+        JaxrsClientCallback<?> cb = newJaxrsClientCallback(asyncCallback, outMessage,
             ori.getMethodToInvoke().getReturnType(), ori.getMethodToInvoke().getGenericReturnType());
         outMessage.getExchange().put(JaxrsClientCallback.class, cb);
         doRunInterceptorChain(outMessage);
@@ -958,6 +958,7 @@ public class ClientProxyImpl extends AbstractClient implements
     }
 
     protected JaxrsClientCallback<?> newJaxrsClientCallback(InvocationCallback<Object> asyncCallback,
+                                                            Message outMessage,
                                                             Class<?> responseClass,
                                                             Type outGenericType) {
         return new JaxrsClientCallback<>(asyncCallback, responseClass, outGenericType);

--- a/rt/rs/microprofile-client/pom.xml
+++ b/rt/rs/microprofile-client/pom.xml
@@ -173,6 +173,12 @@
           <version>${cxf.commons-jcs-jcache.version}</version>
           <scope>test</scope>
         </dependency>
+        <dependency>
+          <groupId>com.squareup.okhttp3</groupId>
+          <artifactId>mockwebserver</artifactId>
+          <version>4.0.1</version>
+          <scope>test</scope>
+        </dependency>
     </dependencies>
     <profiles>
         <profile>

--- a/rt/rs/microprofile-client/src/main/java/org/apache/cxf/microprofile/client/proxy/MicroProfileClientProxyImpl.java
+++ b/rt/rs/microprofile-client/src/main/java/org/apache/cxf/microprofile/client/proxy/MicroProfileClientProxyImpl.java
@@ -165,9 +165,10 @@ public class MicroProfileClientProxyImpl extends ClientProxyImpl {
 
     @Override
     protected JaxrsClientCallback<?> newJaxrsClientCallback(InvocationCallback<Object> asyncCallback,
+                                                            Message outMessage,
                                                             Class<?> responseClass,
                                                             Type outGenericType) {
-        return new MPRestClientCallback<Object>(asyncCallback, responseClass, outGenericType);
+        return new MPRestClientCallback<Object>(asyncCallback, outMessage, responseClass, outGenericType);
     }
 
     @Override

--- a/rt/rs/microprofile-client/src/test/java/org/apache/cxf/microprofile/client/AsyncTest.java
+++ b/rt/rs/microprofile-client/src/test/java/org/apache/cxf/microprofile/client/AsyncTest.java
@@ -1,0 +1,56 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.cxf.microprofile.client;
+
+import java.net.URI;
+import java.util.concurrent.TimeUnit;
+
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import org.apache.cxf.microprofile.client.mock.AsyncClient;
+import org.eclipse.microprofile.rest.client.RestClientBuilder;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+public class AsyncTest {
+
+    @Test
+    public void testAsyncClient() throws Exception {
+        MockWebServer mockWebServer = new MockWebServer();
+        URI uri = mockWebServer.url("/").uri();
+        AsyncClient client = RestClientBuilder.newBuilder()
+                                              .baseUri(uri)
+                                              .connectTimeout(5, TimeUnit.SECONDS)
+                                              .readTimeout(5, TimeUnit.SECONDS)
+                                              .build(AsyncClient.class);
+        assertNotNull(client);
+
+        mockWebServer.enqueue(new MockResponse().setBody("Hello"));
+        mockWebServer.enqueue(new MockResponse().setBody("World"));
+
+        String combined = client.get().thenCombine(client.get(), (a, b) -> {
+            return a + " " + b;
+        }).toCompletableFuture().get(10, TimeUnit.SECONDS);
+
+        assertTrue("Hello World".equals(combined) || "World Hello".equals(combined));
+    }
+}

--- a/rt/rs/microprofile-client/src/test/java/org/apache/cxf/microprofile/client/mock/AsyncClient.java
+++ b/rt/rs/microprofile-client/src/test/java/org/apache/cxf/microprofile/client/mock/AsyncClient.java
@@ -1,0 +1,35 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.cxf.microprofile.client.mock;
+
+import java.util.concurrent.CompletionStage;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+
+@Path("/")
+@Produces("text/plain")
+@Consumes("text/plain")
+public interface AsyncClient {
+
+    @GET
+    CompletionStage<String> get();
+}


### PR DESCRIPTION
This fix ensures that we use the specified executor service to complete the CompletionStage from the MP Rest Client async methods. It also adds a test case based off of Manish Kumar's [reproducer example](https://gist.github.com/manish2aug/b4133b9fbedc2175e15b303a0682b552).

We may a similar change in OpenLiberty to handle this case, but I neglected to contribute that change back to CXF until now (apologies).  