### PR TITLE
CXF-8089: Build Comma Separated Values in url from Array/List Query Param

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ bin/
 node_modules/
 derby.log
 .pmdruleset.xml
+.sts4-cache/

--- a/rt/frontend/jaxrs/src/test/java/org/apache/cxf/jaxrs/impl/UriBuilderImplTest.java
+++ b/rt/frontend/jaxrs/src/test/java/org/apache/cxf/jaxrs/impl/UriBuilderImplTest.java
@@ -343,7 +343,7 @@ public class UriBuilderImplTest {
 
     @Test(expected = IllegalArgumentException.class)
     public void testCtorNull() throws Exception {
-        new UriBuilderImpl(null);
+        new UriBuilderImpl((URI)null);
     }
 
     @Test(expected = IllegalArgumentException.class)

--- a/rt/rs/client/src/main/java/org/apache/cxf/jaxrs/client/ClientProxyImpl.java
+++ b/rt/rs/client/src/main/java/org/apache/cxf/jaxrs/client/ClientProxyImpl.java
@@ -119,7 +119,17 @@ public class ClientProxyImpl extends AbstractClient implements
                            boolean isRoot,
                            boolean inheritHeaders,
                            Object... varValues) {
-        this(new LocalClientState(baseURI), loader, cri, isRoot, inheritHeaders, varValues);
+        this(baseURI, loader, cri, isRoot, inheritHeaders, Collections.emptyMap(), varValues);
+    }
+
+    public ClientProxyImpl(URI baseURI,
+            ClassLoader loader,
+            ClassResourceInfo cri,
+            boolean isRoot,
+            boolean inheritHeaders,
+            Map<String, Object> properties,
+            Object... varValues) {
+        this(new LocalClientState(baseURI, properties), loader, cri, isRoot, inheritHeaders, varValues);
     }
 
     public ClientProxyImpl(ClientState initialState,

--- a/rt/rs/client/src/main/java/org/apache/cxf/jaxrs/client/ClientState.java
+++ b/rt/rs/client/src/main/java/org/apache/cxf/jaxrs/client/ClientState.java
@@ -19,6 +19,7 @@
 package org.apache.cxf.jaxrs.client;
 
 import java.net.URI;
+import java.util.Map;
 
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.Response;
@@ -115,4 +116,22 @@ public interface ClientState {
     ClientState newState(URI baseURI,
                          MultivaluedMap<String, String> headers,
                          MultivaluedMap<String, String> templates);
+    
+    /**
+     * The factory method for creating a new state.
+     * Example, proxy and WebClient.fromClient will use this method when creating
+     * subresource proxies and new web clients respectively to ensure thet stay
+     * thread-local if needed
+     * @param baseURI baseURI
+     * @param headers request headers, can be null
+     * @param templates initial templates map, can be null
+     * @param additional properties, could be null
+     * @return client state
+     */
+    default ClientState newState(URI baseURI,
+                         MultivaluedMap<String, String> headers,
+                         MultivaluedMap<String, String> templates,
+                         Map<String, Object> properties) {
+        return newState(baseURI, headers, templates);
+    }
 }

--- a/rt/rs/client/src/main/java/org/apache/cxf/jaxrs/client/JAXRSClientFactory.java
+++ b/rt/rs/client/src/main/java/org/apache/cxf/jaxrs/client/JAXRSClientFactory.java
@@ -22,6 +22,7 @@ import java.lang.reflect.InvocationHandler;
 import java.net.URI;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 
 import javax.ws.rs.core.MultivaluedMap;
 
@@ -88,6 +89,19 @@ public final class JAXRSClientFactory {
 
     /**
      * Creates a proxy
+     * @param baseAddress baseAddres
+     * @param cls resource class, if not interface then a CGLIB proxy will be created
+     * @param properties additional properties
+     * @return typed proxy
+     */
+    public static <T> T create(String baseAddress, Class<T> cls, Map<String, Object> properties) {
+        JAXRSClientFactoryBean bean = getBean(baseAddress, cls, null);
+        bean.setProperties(properties);
+        return bean.create(cls);
+    }
+
+    /**
+     * Creates a proxy
      * @param baseAddress baseAddress
      * @param cls resource class, if not interface then a CGLIB proxy will be created
      * @param configLocation classpath location of the configuration resource
@@ -135,10 +149,24 @@ public final class JAXRSClientFactory {
      * @return typed proxy
      */
     public static <T> T create(String baseAddress, Class<T> cls, List<?> providers, boolean threadSafe) {
+        return create(baseAddress, cls, providers, Collections.emptyMap(), threadSafe);
+    }
+    /**
+     * Creates a thread safe proxy
+     * @param baseAddress baseAddress
+     * @param cls proxy class, if not interface then a CGLIB proxy will be created
+     * @param providers list of providers
+     * @param threadSafe if true then a thread-safe proxy will be created
+     * @param properties additional properties
+     * @return typed proxy
+     */
+    public static <T> T create(String baseAddress, Class<T> cls, List<?> providers, 
+            Map<String, Object> properties, boolean threadSafe) {
         JAXRSClientFactoryBean bean = getBean(baseAddress, cls, null);
         bean.setProviders(providers);
+        bean.setProperties(properties);
         if (threadSafe) {
-            bean.setInitialState(new ThreadLocalClientState(baseAddress));
+            bean.setInitialState(new ThreadLocalClientState(baseAddress, properties));
         }
         return bean.create(cls);
     }
@@ -362,7 +390,7 @@ public final class JAXRSClientFactory {
             }
         } else {
             MultivaluedMap<String, String> headers = inheritHeaders ? client.getHeaders() : null;
-            bean.setInitialState(clientState.newState(client.getCurrentURI(), headers, null));
+            bean.setInitialState(clientState.newState(client.getCurrentURI(), headers, null, bean.getProperties()));
             proxy = bean.create(cls);
         }
         WebClient.copyProperties(WebClient.client(proxy), client);

--- a/rt/rs/client/src/main/java/org/apache/cxf/jaxrs/client/JAXRSClientFactoryBean.java
+++ b/rt/rs/client/src/main/java/org/apache/cxf/jaxrs/client/JAXRSClientFactoryBean.java
@@ -221,7 +221,7 @@ public class JAXRSClientFactoryBean extends AbstractJAXRSFactoryBean {
             Endpoint ep = createEndpoint();
             this.getServiceFactory().sendEvent(FactoryBeanListener.Event.PRE_CLIENT_CREATE, ep);
             ClientState actualState = getActualState();
-            WebClient client = actualState == null ? new WebClient(getAddress())
+            WebClient client = actualState == null ? new WebClient(getAddress(), getProperties())
                 : new WebClient(actualState);
             initClient(client, ep, actualState == null);
 
@@ -244,11 +244,11 @@ public class JAXRSClientFactoryBean extends AbstractJAXRSFactoryBean {
 
     protected ClientState getActualState() {
         if (threadSafe) {
-            initialState = new ThreadLocalClientState(getAddress(), timeToKeepState);
+            initialState = new ThreadLocalClientState(getAddress(), timeToKeepState, getProperties());
         }
         if (initialState != null) {
             return headers != null
-                ? initialState.newState(URI.create(getAddress()), headers, null) : initialState;
+                ? initialState.newState(URI.create(getAddress()), headers, null, getProperties()) : initialState;
         }
         return null;
     }
@@ -341,10 +341,10 @@ public class JAXRSClientFactoryBean extends AbstractJAXRSFactoryBean {
                                                 ClientState actualState, Object[] varValues) {
         if (actualState == null) {
             return new ClientProxyImpl(URI.create(getAddress()), proxyLoader, cri, isRoot,
-                                    inheritHeaders, varValues);
+                                    inheritHeaders, getProperties(), varValues);
         } else {
             return new ClientProxyImpl(actualState, proxyLoader, cri, isRoot,
-                                    inheritHeaders, varValues);
+                                    inheritHeaders, getProperties(), varValues);
         }
     }
 

--- a/rt/rs/client/src/main/java/org/apache/cxf/jaxrs/client/LocalClientState.java
+++ b/rt/rs/client/src/main/java/org/apache/cxf/jaxrs/client/LocalClientState.java
@@ -19,6 +19,9 @@
 package org.apache.cxf.jaxrs.client;
 
 import java.net.URI;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.Response;
@@ -41,19 +44,38 @@ public class LocalClientState implements ClientState {
     private Response response;
     private URI baseURI;
     private UriBuilder currentBuilder;
+    private Map<String, Object> properties;
 
     public LocalClientState() {
 
     }
 
     public LocalClientState(URI baseURI) {
+        this(baseURI, Collections.emptyMap());
+    }
+    
+    public LocalClientState(URI baseURI, Map<String, Object> properties) {
         this.baseURI = baseURI;
-        resetCurrentUri();
+        
+        if (properties != null) {
+            this.properties = new HashMap<>(properties);
+        }
+        
+        resetCurrentUri(properties);
     }
 
     public LocalClientState(URI baseURI, URI currentURI) {
+        this(baseURI, currentURI, Collections.emptyMap()); 
+    }
+
+    public LocalClientState(URI baseURI, URI currentURI, Map<String, Object> properties) {
         this.baseURI = baseURI;
-        this.currentBuilder = new UriBuilderImpl().uri(currentURI);
+        
+        if (properties != null) {
+            this.properties = new HashMap<>(properties);
+        }
+        
+        this.currentBuilder = new UriBuilderImpl(properties).uri(currentURI);
     }
 
     public LocalClientState(LocalClientState cs) {
@@ -63,13 +85,14 @@ public class LocalClientState implements ClientState {
 
         this.baseURI = cs.baseURI;
         this.currentBuilder = cs.currentBuilder != null ? cs.currentBuilder.clone() : null;
+        this.properties = cs.properties;
     }
 
-    private void resetCurrentUri() {
+    private void resetCurrentUri(Map<String, Object> props) {
         if (isSupportedScheme(baseURI)) {
-            this.currentBuilder = new UriBuilderImpl().uri(baseURI);
+            this.currentBuilder = new UriBuilderImpl(props).uri(baseURI);
         } else {
-            this.currentBuilder = new UriBuilderImpl().uri("/");
+            this.currentBuilder = new UriBuilderImpl(props).uri("/");
         }
     }
 
@@ -83,7 +106,7 @@ public class LocalClientState implements ClientState {
 
     public void setBaseURI(URI baseURI) {
         this.baseURI = baseURI;
-        resetCurrentUri();
+        resetCurrentUri(Collections.emptyMap());
     }
 
     public URI getBaseURI() {
@@ -123,18 +146,17 @@ public class LocalClientState implements ClientState {
     public void reset() {
         requestHeaders.clear();
         response = null;
-        currentBuilder = new UriBuilderImpl().uri(baseURI);
+        currentBuilder = new UriBuilderImpl(properties).uri(baseURI);
         templates = null;
     }
-
-    public ClientState newState(URI currentURI,
-                                MultivaluedMap<String, String> headers,
-                                MultivaluedMap<String, String> templatesMap) {
+    
+    public ClientState newState(URI currentURI, MultivaluedMap<String, String> headers,
+            MultivaluedMap<String, String> templatesMap, Map<String, Object> props) {
         ClientState state = null;
         if (isSupportedScheme(currentURI)) {
-            state = new LocalClientState(currentURI);
+            state = new LocalClientState(currentURI, props);
         } else {
-            state = new LocalClientState(baseURI, currentURI);
+            state = new LocalClientState(baseURI, currentURI, props);
         }
         if (headers != null) {
             state.setRequestHeaders(headers);
@@ -148,6 +170,12 @@ public class LocalClientState implements ClientState {
         }
         state.setTemplates(newTemplateParams);
         return state;
+    }
+
+    public ClientState newState(URI currentURI,
+                                MultivaluedMap<String, String> headers,
+                                MultivaluedMap<String, String> templatesMap) {
+        return newState(currentURI, headers, templatesMap, properties);
     }
 
     private static boolean isSupportedScheme(URI uri) {

--- a/rt/rs/client/src/main/java/org/apache/cxf/jaxrs/client/ThreadLocalClientState.java
+++ b/rt/rs/client/src/main/java/org/apache/cxf/jaxrs/client/ThreadLocalClientState.java
@@ -43,11 +43,19 @@ public class ThreadLocalClientState implements ClientState {
     private long timeToKeepState;
 
     public ThreadLocalClientState(String baseURI) {
-        this.initialState = new LocalClientState(URI.create(baseURI));
+        this(baseURI, Collections.emptyMap());
+    }
+    
+    public ThreadLocalClientState(String baseURI, Map<String, Object> properties) {
+        this.initialState = new LocalClientState(URI.create(baseURI), properties);
     }
 
     public ThreadLocalClientState(String baseURI, long timeToKeepState) {
-        this.initialState = new LocalClientState(URI.create(baseURI));
+        this(baseURI, timeToKeepState, Collections.emptyMap());
+    }
+
+    public ThreadLocalClientState(String baseURI, long timeToKeepState, Map<String, Object> properties) {
+        this.initialState = new LocalClientState(URI.create(baseURI), properties);
         this.timeToKeepState = timeToKeepState;
     }
 
@@ -104,6 +112,15 @@ public class ThreadLocalClientState implements ClientState {
                                 MultivaluedMap<String, String> headers,
                                 MultivaluedMap<String, String> templates) {
         LocalClientState ls = (LocalClientState)getState().newState(currentURI, headers, templates);
+        return new ThreadLocalClientState(ls, timeToKeepState);
+    }
+    
+    @Override
+    public ClientState newState(URI currentURI,
+            MultivaluedMap<String, String> headers,
+            MultivaluedMap<String, String> templates,
+            Map<String, Object> properties) {
+        LocalClientState ls = (LocalClientState)getState().newState(currentURI, headers, templates, properties);
         return new ThreadLocalClientState(ls, timeToKeepState);
     }
 

--- a/rt/rs/client/src/main/java/org/apache/cxf/jaxrs/client/WebClient.java
+++ b/rt/rs/client/src/main/java/org/apache/cxf/jaxrs/client/WebClient.java
@@ -90,11 +90,19 @@ public class WebClient extends AbstractClient {
     private static final String WEB_CLIENT_OPERATION_REPORTING = "enable.webclient.operation.reporting";
     private BodyWriter bodyWriter = new BodyWriter();
     protected WebClient(String baseAddress) {
-        this(convertStringToURI(baseAddress));
+        this(convertStringToURI(baseAddress), Collections.emptyMap());
+    }
+    
+    protected WebClient(String baseAddress, Map<String, Object> properties) {
+        this(convertStringToURI(baseAddress), properties);
     }
 
     protected WebClient(URI baseURI) {
-        this(new LocalClientState(baseURI));
+        this(baseURI, Collections.emptyMap());
+    }
+
+    protected WebClient(URI baseURI, Map<String, Object> properties) {
+        this(new LocalClientState(baseURI, properties));
     }
 
     protected WebClient(ClientState state) {
@@ -110,8 +118,17 @@ public class WebClient extends AbstractClient {
      * @param baseAddress baseAddress
      */
     public static WebClient create(String baseAddress) {
+        return create(baseAddress, Collections.emptyMap());
+    }
+
+    /**
+     * Creates WebClient
+     * @param baseAddress baseAddress
+     */
+    public static WebClient create(String baseAddress, Map<String, Object> properties) {
         JAXRSClientFactoryBean bean = new JAXRSClientFactoryBean();
         bean.setAddress(baseAddress);
+        bean.setProperties(properties);
         return bean.createWebClient();
     }
 
@@ -147,10 +164,23 @@ public class WebClient extends AbstractClient {
      * @param threadSafe if true ThreadLocalClientState is used
      */
     public static WebClient create(String baseAddress, List<?> providers, boolean threadSafe) {
+        return create(baseAddress, providers, Collections.emptyMap(), threadSafe);
+    }
+    
+    /**
+     * Creates WebClient
+     * @param baseAddress baseURI
+     * @param providers list of providers
+     * @param threadSafe if true ThreadLocalClientState is used
+     * @param properties additional properties
+     */
+    public static WebClient create(String baseAddress, List<?> providers, 
+            Map<String, Object> properties, boolean threadSafe) {
         JAXRSClientFactoryBean bean = getBean(baseAddress, null);
         bean.setProviders(providers);
+        bean.setProperties(properties);
         if (threadSafe) {
-            bean.setInitialState(new ThreadLocalClientState(baseAddress));
+            bean.setInitialState(new ThreadLocalClientState(baseAddress, properties));
         }
         return bean.createWebClient();
     }

--- a/rt/rs/client/src/main/java/org/apache/cxf/jaxrs/client/spec/ClientImpl.java
+++ b/rt/rs/client/src/main/java/org/apache/cxf/jaxrs/client/spec/ClientImpl.java
@@ -345,6 +345,7 @@ public class ClientImpl implements Client {
             if (targetClient == null) {
                 JAXRSClientFactoryBean bean = new JAXRSClientFactoryBean();
                 bean.setAddress(uri.toString());
+                bean.setProperties(configProps);
                 Boolean threadSafe = getBooleanValue(configProps.get(THREAD_SAFE_CLIENT_PROP));
                 if (threadSafe == null) {
                     threadSafe = DEFAULT_THREAD_SAFETY_CLIENT_STATUS;

--- a/rt/rs/client/src/test/java/org/apache/cxf/jaxrs/client/spring/JAXRSClientFactoryBeanTest.java
+++ b/rt/rs/client/src/test/java/org/apache/cxf/jaxrs/client/spring/JAXRSClientFactoryBeanTest.java
@@ -21,14 +21,17 @@ package org.apache.cxf.jaxrs.client.spring;
 import javax.xml.namespace.QName;
 
 import org.apache.cxf.BusFactory;
+import org.apache.cxf.jaxrs.client.Client;
 import org.apache.cxf.jaxrs.client.JAXRSClientFactoryBean;
 import org.springframework.context.support.ClassPathXmlApplicationContext;
 
 import org.junit.After;
 import org.junit.Test;
 
+import static org.hamcrest.CoreMatchers.endsWith;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
 
 
 public class JAXRSClientFactoryBeanTest {
@@ -66,8 +69,29 @@ public class JAXRSClientFactoryBeanTest {
         assertEquals("Get a wrong map size", cfb.getHeaders().size(), 1);
         assertEquals("Get a wrong username", cfb.getUsername(), "username");
         assertEquals("Get a wrong password", cfb.getPassword(), "password");
+        
+        bean = ctx.getBean("client2.proxyFactory");
+        assertNotNull(bean);
+        cfb = (JAXRSClientFactoryBean) bean;
+        assertNotNull(cfb.getProperties());
+        assertEquals("Get a wrong map size", cfb.getProperties().size(), 1);
+
         ctx.close();
-
     }
-
+    
+    @Test
+    public void testClientProperties() throws Exception {
+        try (ClassPathXmlApplicationContext ctx =
+                new ClassPathXmlApplicationContext(new String[] {"/org/apache/cxf/jaxrs/client/spring/clients.xml"})) {
+            Client bean = (Client) ctx.getBean("client2");
+            assertNotNull(bean);
+            assertThat(bean.query("list", "1").query("list", "2").getCurrentURI().toString(),
+                endsWith("?list=1,2"));
+            
+            bean = (Client) ctx.getBean("client1");
+            assertNotNull(bean);
+            assertThat(bean.query("list", "1").query("list", "2").getCurrentURI().toString(),
+                endsWith("?list=1&list=2"));
+        }
+    }
 }

--- a/rt/rs/client/src/test/java/org/apache/cxf/jaxrs/client/spring/clients.xml
+++ b/rt/rs/client/src/test/java/org/apache/cxf/jaxrs/client/spring/clients.xml
@@ -49,4 +49,9 @@
             <entry key="Accept" value="text/xml"/>
         </jaxrs:headers>
     </jaxrs:client>
+    <jaxrs:client id="client2" serviceClass="org.apache.cxf.jaxrs.resources.BookStore" address="http://localhost:9000/foo">
+        <jaxrs:properties>
+            <entry key="expand.query.value.as.collection" value="true" />
+        </jaxrs:properties>
+    </jaxrs:client>
 </beans>

--- a/rt/rs/microprofile-client/src/main/java/org/apache/cxf/microprofile/client/proxy/MicroProfileClientProxyImpl.java
+++ b/rt/rs/microprofile-client/src/main/java/org/apache/cxf/microprofile/client/proxy/MicroProfileClientProxyImpl.java
@@ -102,7 +102,7 @@ public class MicroProfileClientProxyImpl extends ClientProxyImpl {
                                        boolean isRoot, boolean inheritHeaders, ExecutorService executorService,
                                        Configuration configuration, CDIInterceptorWrapper interceptorWrapper, 
                                        Object... varValues) {
-        super(new LocalClientState(baseURI), loader, cri, isRoot, inheritHeaders, varValues);
+        super(new LocalClientState(baseURI, configuration.getProperties()), loader, cri, isRoot, inheritHeaders, varValues);
         this.interceptorWrapper = interceptorWrapper;
         init(executorService, configuration);
     }

--- a/systests/jaxrs/src/test/java/org/apache/cxf/systest/jaxrs/BookStore.java
+++ b/systests/jaxrs/src/test/java/org/apache/cxf/systest/jaxrs/BookStore.java
@@ -185,9 +185,13 @@ public class BookStore {
         String dStr = dBuilder.toString();
         if (!lStr.equals(dStr)) {
             throw new InternalServerErrorException();
+        } else if ("".equalsIgnoreCase(lStr)) {
+            lStr = "0";
         }
+        
         return new Book("cxf", Long.parseLong(lStr));
     }
+    
     @GET
     @Path("/")
     public Book getBookRoot() {
@@ -390,6 +394,11 @@ public class BookStore {
     @Path("/beanparamsub")
     public BookStoreSub getBeanParamBookSub() {
         return new BookStoreSub(this);
+    }
+    
+    @Path("/querysub")
+    public BookStoreQuerySub getQuerySub() {
+        return new BookStoreQuerySub();
     }
 
     @GET
@@ -2225,6 +2234,26 @@ public class BookStore {
             return bookStore.getBeanParamBook(bean);
         }
     }
+    
+    public static class BookStoreQuerySub {
+        @GET
+        @Path("/listofstrings")
+        @Produces("text/xml")
+        public Book getBookFromListStrings(@QueryParam("value") List<String> value) {
+            final StringBuilder builder = new StringBuilder();
+            
+            for (String v : value) {
+                if (builder.length() > 0) {
+                    builder.append(' ');
+                }
+                
+                builder.append(v);
+            }
+            
+            return new Book(builder.toString(), 0L);
+        }
+    }
+
 }
 
 

--- a/systests/jaxrs/src/test/java/org/apache/cxf/systest/jaxrs/JAXRSClientServerQueryParamBookTest.java
+++ b/systests/jaxrs/src/test/java/org/apache/cxf/systest/jaxrs/JAXRSClientServerQueryParamBookTest.java
@@ -1,0 +1,234 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.cxf.systest.jaxrs;
+
+import java.io.InputStream;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+
+import javax.ws.rs.client.ClientBuilder;
+import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.core.Response;
+
+import org.apache.cxf.jaxrs.client.JAXRSClientFactory;
+import org.apache.cxf.jaxrs.client.WebClient;
+import org.apache.cxf.jaxrs.ext.xml.XMLSource;
+import org.apache.cxf.jaxrs.model.AbstractResourceInfo;
+import org.apache.cxf.testutil.common.AbstractBusClientServerTestBase;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.utils.URIBuilder;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClientBuilder;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+
+import static org.hamcrest.CoreMatchers.endsWith;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(Parameterized.class)
+public class JAXRSClientServerQueryParamBookTest extends AbstractBusClientServerTestBase {
+    public static final String PORT = BookServer.PORT;
+    private final Boolean threadSafe;
+    
+    public JAXRSClientServerQueryParamBookTest(Boolean threadSafe) {
+        this.threadSafe = threadSafe;
+    }
+    
+    @Parameters(name = "Client is thread safe = {0}")
+    public static Collection<Boolean> data() {
+        return Arrays.asList(new Boolean[] {null, true, false});
+    }
+
+    @BeforeClass
+    public static void startServers() throws Exception {
+        AbstractResourceInfo.clearAllMaps();
+        assertTrue("server did not launch correctly",
+                launchServer(BookServer.class, true));
+        createStaticBus();
+    }
+
+    @Test
+    public void testListOfLongAndDoubleQuery() throws Exception {
+        BookStore client = createClient();
+        Book book = client.getBookFromListOfLongAndDouble(Arrays.asList(1L, 2L, 3L), Arrays.asList());
+        assertEquals(123L, book.getId());
+    }
+    
+    @Test
+    public void testListOfLongAndDoubleQueryWebClient() throws Exception {
+        WebClient wc = createWebClient();
+        
+        Response r = wc
+                .path("/bookstore/listoflonganddouble")
+                .query("value", Arrays.asList(1L, 2L, 3L))
+                .accept("text/xml")
+                .get();
+
+        assertThat(wc.getCurrentURI().toString(), endsWith("value=1&value=2&value=3"));
+        try (InputStream is = (InputStream)r.getEntity()) {
+            XMLSource source = new XMLSource(is);
+            assertEquals(123L, Long.parseLong(source.getValue("Book/id")));
+        }
+    }
+
+    @Test
+    public void testListOfLongAndDoubleQueryAsManyWebClient() throws Exception {
+        WebClient wc = createWebClient();
+        
+        Response r = wc
+                .path("/bookstore/listoflonganddouble")
+                .query("value", "1")
+                .query("value", "2")
+                .query("value", "3")
+                .accept("text/xml")
+                .get();
+
+        assertThat(wc.getCurrentURI().toString(), endsWith("value=1&value=2&value=3"));
+        try (InputStream is = (InputStream)r.getEntity()) {
+            XMLSource source = new XMLSource(is);
+            assertEquals(123L, Long.parseLong(source.getValue("Book/id")));
+        }
+    }
+    
+    @Test
+    public void testListOfLongAndDoubleQueryAsString() throws Exception {
+        final URIBuilder builder = new URIBuilder("http://localhost:" + PORT + "/bookstore/listoflonganddouble");
+        builder.setCustomQuery("value=1,2,3");
+
+        final CloseableHttpClient client = HttpClientBuilder.create().build();
+        HttpGet get = new HttpGet(builder.build());
+        get.addHeader("Accept", "text/xml");
+
+        try (CloseableHttpResponse response = client.execute(get)) {
+            // should not succeed since "parse.query.value.as.collection" contextual property is not set
+            assertEquals(404, response.getStatusLine().getStatusCode());
+        }
+    }
+    
+    @Test
+    public void testListOfLongAndDoubleQueryEmptyWebClient() throws Exception {
+        WebClient wc = createWebClient();
+        
+        Response r = wc
+                .path("/bookstore/listoflonganddouble")
+                .query("value", "")
+                .accept("text/xml")
+                .get();
+
+        assertThat(wc.getCurrentURI().toString(), endsWith("value="));
+        try (InputStream is = (InputStream)r.getEntity()) {
+            XMLSource source = new XMLSource(is);
+            assertEquals(0L, Long.parseLong(source.getValue("Book/id")));
+        }
+    }
+    
+    @Test
+    public void testListOfLongAndDoubleQueryEmpty() throws Exception {
+        BookStore client = createClient();
+        Book book = client.getBookFromListOfLongAndDouble(Arrays.asList(), Arrays.asList());
+        assertEquals(0L, book.getId());
+    }
+
+    @Test
+    public void testListOfStringsWebClient() throws Exception {
+        WebClient wc = createWebClient();
+        
+        Response r = wc
+                .path("/bookstore/querysub/listofstrings")
+                .query("value", "this is")
+                .query("value", "the book")
+                .query("value", "title")
+                .accept("text/xml")
+                .get();
+
+        assertThat(wc.getCurrentURI().toString(), endsWith("value=this+is&value=the+book&value=title"));
+        try (InputStream is = (InputStream)r.getEntity()) {
+            XMLSource source = new XMLSource(is);
+            assertEquals("this is the book title", source.getValue("Book/name"));
+        }
+    }
+    
+    @Test
+    public void testListOfStringsJaxrsClient() throws Exception {
+        WebTarget client = createJaxrsClient();
+        
+        Response r = client
+                .path("/bookstore/querysub/listofstrings")
+                .queryParam("value", "this is")
+                .queryParam("value", "the book")
+                .queryParam("value", "title")
+                .request()
+                .accept("text/xml")
+                .get();
+
+        try (InputStream is = (InputStream)r.getEntity()) {
+            XMLSource source = new XMLSource(is);
+            assertEquals("this is the book title", source.getValue("Book/name"));
+        }
+    }
+
+    @Test
+    public void testListOfStrings() throws Exception {
+        BookStore client = createClient();
+        
+        Book book = client.getQuerySub().getBookFromListStrings(
+            Arrays.asList("this is", "the book", "title"));
+
+        assertEquals("this is the book title", book.getName());
+    }
+    
+    private WebClient createWebClient() {
+        if (threadSafe == null) {
+            return WebClient.create("http://localhost:" + PORT);
+        } else {
+            return WebClient.create("http://localhost:" + PORT, Collections.emptyList(), threadSafe);
+        }
+    }
+    
+    private BookStore createClient() {
+        if (threadSafe == null) {
+            return JAXRSClientFactory.create("http://localhost:" + PORT, BookStore.class);
+        } else {
+            return JAXRSClientFactory.create("http://localhost:" + PORT, BookStore.class, 
+                Collections.emptyList(), threadSafe);
+        }
+    }
+    
+    private WebTarget createJaxrsClient() {
+        if (threadSafe == null) {
+            return ClientBuilder
+                .newClient()
+                .target("http://localhost:" + PORT);
+        } else {
+            return ClientBuilder
+                .newClient()
+                .property("thread.safe.client", threadSafe)
+                .target("http://localhost:" + PORT);
+        }
+    }
+}

--- a/systests/jaxrs/src/test/java/org/apache/cxf/systest/jaxrs/JAXRSClientServerQueryParamCollectionBookTest.java
+++ b/systests/jaxrs/src/test/java/org/apache/cxf/systest/jaxrs/JAXRSClientServerQueryParamCollectionBookTest.java
@@ -1,0 +1,244 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.cxf.systest.jaxrs;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+
+import javax.ws.rs.client.ClientBuilder;
+import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.core.Response;
+
+import org.apache.cxf.jaxrs.client.JAXRSClientFactory;
+import org.apache.cxf.jaxrs.client.WebClient;
+import org.apache.cxf.jaxrs.ext.xml.XMLSource;
+import org.apache.cxf.jaxrs.model.AbstractResourceInfo;
+import org.apache.cxf.testutil.common.AbstractBusClientServerTestBase;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.utils.URIBuilder;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.util.EntityUtils;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+
+import static org.hamcrest.CoreMatchers.endsWith;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(Parameterized.class)
+public class JAXRSClientServerQueryParamCollectionBookTest extends AbstractBusClientServerTestBase {
+    public static final String PORT = BookServer.PORT;
+    private final Boolean threadSafe;
+    
+    public JAXRSClientServerQueryParamCollectionBookTest(Boolean threadSafe) {
+        this.threadSafe = threadSafe;
+    }
+
+    @Parameters(name = "Client is thread safe = {0}")
+    public static Collection<Boolean> data() {
+        return Arrays.asList(new Boolean[] {null, true, false});
+    }
+    
+    @BeforeClass
+    public static void startServers() throws Exception {
+        AbstractResourceInfo.clearAllMaps();
+        assertTrue("server did not launch correctly", 
+            launchServer(new BookServer(Collections.singletonMap("parse.query.value.as.collection", "true"))));
+        createStaticBus();
+    }
+
+    @Test
+    public void testListOfLongAndDoubleQuery() throws Exception {
+        BookStore client = createClient();
+        Book book = client.getBookFromListOfLongAndDouble(Arrays.asList(1L, 2L, 3L), Arrays.asList());
+        assertEquals(123L, book.getId());
+    }
+
+    @Test
+    public void testListOfLongAndDoubleQueryEmpty() throws Exception {
+        BookStore client = createClient();
+        Book book = client.getBookFromListOfLongAndDouble(Arrays.asList(), Arrays.asList());
+        assertEquals(0L, book.getId());
+    }
+
+    @Test
+    public void testListOfLongAndDoubleQueryWebClient() throws Exception {
+        WebClient wc = createWebClient();
+        
+        Response r = wc
+            .path("/bookstore/listoflonganddouble")
+            .query("value", Arrays.asList(1L, 2L, 3L))
+            .accept("text/xml")
+            .get();
+
+        assertThat(wc.getCurrentURI().toString(), endsWith("value=1,2,3"));
+        try (InputStream is = (InputStream)r.getEntity()) {
+            XMLSource source = new XMLSource(is);
+            assertEquals(123L, Long.parseLong(source.getValue("Book/id")));
+        }
+    }
+
+    @Test
+    public void testListOfLongAndDoubleQueryAsManyWebClient() throws Exception {
+        WebClient wc = createWebClient();
+        
+        Response r = wc
+                .path("/bookstore/listoflonganddouble")
+                .query("value", "1")
+                .query("value", "2")
+                .query("value", "3")
+                .accept("text/xml")
+                .get();
+
+        assertThat(wc.getCurrentURI().toString(), endsWith("value=1,2,3"));
+        try (InputStream is = (InputStream)r.getEntity()) {
+            XMLSource source = new XMLSource(is);
+            assertEquals(123L, Long.parseLong(source.getValue("Book/id")));
+        }
+    }
+    
+    @Test
+    public void testListOfStringsWebClient() throws Exception {
+        WebClient wc = createWebClient();
+        
+        Response r = wc
+                .path("/bookstore/querysub/listofstrings")
+                .query("value", "this is")
+                .query("value", "the book")
+                .query("value", "title")
+                .accept("text/xml")
+                .get();
+
+        assertThat(wc.getCurrentURI().toString(), endsWith("value=this+is,the+book,title"));
+        try (InputStream is = (InputStream)r.getEntity()) {
+            XMLSource source = new XMLSource(is);
+            assertEquals("this is the book title", source.getValue("Book/name"));
+        }
+    }
+
+    @Test
+    public void testListOfStringsJaxrsClient() throws Exception {
+        WebTarget client = createJaxrsClient();
+        
+        Response r = client
+                .path("/bookstore/querysub/listofstrings")
+                .queryParam("value", "this is")
+                .queryParam("value", "the book")
+                .queryParam("value", "title")
+                .request()
+                .accept("text/xml")
+                .get();
+
+        try (InputStream is = (InputStream)r.getEntity()) {
+            XMLSource source = new XMLSource(is);
+            assertEquals("this is the book title", source.getValue("Book/name"));
+        }
+    }
+
+    @Test
+    public void testListOfStrings() throws Exception {
+        BookStore bookStore = createClient();
+        
+        Book book = bookStore.getQuerySub().getBookFromListStrings(
+            Arrays.asList("this is", "the book", "title"));
+
+        assertEquals("this is the book title", book.getName());
+    }
+
+    @Test
+    public void testListOfLongAndDoubleQueryEmptyWebClient() throws Exception {
+        WebClient wc = createWebClient();
+        
+        Response r = wc
+                .path("/bookstore/listoflonganddouble")
+                .query("value", "")
+                .accept("text/xml")
+                .get();
+
+        assertThat(wc.getCurrentURI().toString(), endsWith("value="));
+        try (InputStream is = (InputStream)r.getEntity()) {
+            XMLSource source = new XMLSource(is);
+            assertEquals(0L, Long.parseLong(source.getValue("Book/id")));
+        }
+    }
+    
+    @Test
+    public void testListOfLongAndDoubleQueryAsString() throws Exception {
+        final URIBuilder builder = new URIBuilder("http://localhost:" + PORT + "/bookstore/listoflonganddouble");
+        builder.setCustomQuery("value=1,2,3");
+
+        final CloseableHttpClient client = HttpClientBuilder.create().build();
+        HttpGet get = new HttpGet(builder.build());
+        get.addHeader("Accept", "text/xml");
+
+        try (CloseableHttpResponse response = client.execute(get)) {
+            final byte[] content = EntityUtils.toByteArray(response.getEntity());
+            try (InputStream is = new ByteArrayInputStream(content)) {
+                XMLSource source = new XMLSource(is);
+                assertEquals(123L, Long.parseLong(source.getValue("Book/id")));
+            }
+        }
+    }
+    
+    private WebClient createWebClient() {
+        if (threadSafe == null) {
+            return WebClient.create("http://localhost:" + PORT, 
+                Collections.singletonMap("expand.query.value.as.collection", "true"));
+        } else {
+            return WebClient.create("http://localhost:" + PORT, Collections.emptyList(),
+                Collections.singletonMap("expand.query.value.as.collection", "true"), true);
+        }
+    }
+    
+    private BookStore createClient() {
+        if (threadSafe == null) {
+            return JAXRSClientFactory.create("http://localhost:" + PORT, BookStore.class,
+                Collections.singletonMap("expand.query.value.as.collection", "true"));
+        } else {
+            return JAXRSClientFactory.create("http://localhost:" + PORT, BookStore.class, Collections.emptyList(),
+                Collections.singletonMap("expand.query.value.as.collection", "true"), threadSafe);
+        }
+    }
+    
+    private WebTarget createJaxrsClient() {
+        if (threadSafe == null) {
+            return ClientBuilder
+                .newClient()
+                .property("expand.query.value.as.collection", "true")
+                .target("http://localhost:" + PORT);
+        } else {
+            return ClientBuilder
+                .newClient()
+                .property("expand.query.value.as.collection", "true")
+                .property("thread.safe.client", threadSafe)
+                .target("http://localhost:" + PORT);
+        }
+    }
+}


### PR DESCRIPTION
### Description
The typical style the collection-like query parameters are encoded assumes the repetition of the parameter in question multiple times, for example:

    http://localhost/books?ids=1&ids=2&ids=3&ids=4

However, as part of https://issues.apache.org/jira/browse/CXF-6941, the CXF server-side includes support for collection query parameters encoded as comma-separated strings, for example:

    http://localhost/books?ids=1,2,3,4

This is quite useful in many cases however the CXF's client side does not anyhow support this encoding and always uses the repetition (`ids=1&ids=2&ids=3&ids=4`). This PRs complements the client-side feature set.

@coheigea @deki @andymc12 if you guys could take a look please, would appreciate the opinion, there are a few corner cases to cover but the idea in general seems to be working fine, thanks guys.