### PR TITLE
CXF-8128: Fill address field in case of responses

### DIFF
--- a/rt/features/logging/src/main/java/org/apache/cxf/ext/logging/event/DefaultLogEventMapper.java
+++ b/rt/features/logging/src/main/java/org/apache/cxf/ext/logging/event/DefaultLogEventMapper.java
@@ -86,10 +86,7 @@ public class DefaultLogEventMapper {
         Map<String, String> headerMap = getHeaders(message);
         event.setHeaders(headerMap);
 
-        String uri = getUri(message);
-        if (uri != null) {
-            event.setAddress(uri);
-        }
+        event.setAddress(getAddress(message, event));
 
         event.setPrincipal(getPrincipal(message));
         event.setBinaryContent(isBinaryContent(message));
@@ -153,6 +150,19 @@ public class DefaultLogEventMapper {
             }
         }
         return result;
+    }
+
+    private String getAddress(Message message, LogEvent event) {
+        final Message observedMessage;
+        if (event.getType() == EventType.RESP_IN) {
+            observedMessage = message.getExchange().getOutMessage();
+        } else if (event.getType() == EventType.RESP_OUT) {
+            observedMessage = message.getExchange().getInMessage();
+        } else {
+            observedMessage = message;
+        }
+
+        return getUri(observedMessage);
     }
 
     private String getUri(Message message) {

--- a/rt/frontend/jaxws/src/test/java/org/apache/cxf/jaxws/logging/SOAPLoggingTest.java
+++ b/rt/frontend/jaxws/src/test/java/org/apache/cxf/jaxws/logging/SOAPLoggingTest.java
@@ -137,7 +137,7 @@ public class SOAPLoggingTest extends AbstractJaxWsTest {
 
     private void checkResponseOut(LogEvent responseOut) {
         // Not yet available
-        Assert.assertNull(responseOut.getAddress());
+        Assert.assertEquals(SERVICE_URI, responseOut.getAddress());
         Assert.assertEquals("text/xml", responseOut.getContentType());
         Assert.assertEquals(EventType.RESP_OUT, responseOut.getType());
         Assert.assertEquals(StandardCharsets.UTF_8.name(), responseOut.getEncoding());
@@ -153,7 +153,7 @@ public class SOAPLoggingTest extends AbstractJaxWsTest {
     }
 
     private void checkResponseIn(LogEvent responseIn) {
-        Assert.assertNull(responseIn.getAddress());
+        Assert.assertEquals(SERVICE_URI, responseIn.getAddress());
         Assert.assertTrue(responseIn.getContentType(), responseIn.getContentType().contains("text/xml"));
         Assert.assertEquals(EventType.RESP_IN, responseIn.getType());
         Assert.assertEquals(StandardCharsets.UTF_8.name(), responseIn.getEncoding());


### PR DESCRIPTION
Fill address in case of responses to be able to find out which URI does belong to the logged response.