### PR TITLE
CXF-8155: Update to Jackson 2.10.1

### DIFF
--- a/osgi/itests/pom.xml
+++ b/osgi/itests/pom.xml
@@ -141,22 +141,6 @@
             <artifactId>pax-exam-junit4</artifactId>
             <version>${cxf.pax.exam.version}</version>
             <scope>test</scope>
-            <!-- 
-                Excluding bndlib in favor of biz.aQute.bndlib since
-                it is old and fails to process the recent JAR files (fe Jackson 
-                Databind 2.9.10.1, ...)
-            -->
-            <exclusions>
-                <exclusion>
-                    <groupId>biz.aQute.bnd</groupId>
-                    <artifactId>bndlib</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>biz.aQute.bnd</groupId>
-            <artifactId>biz.aQute.bndlib</artifactId>
-            <version>3.5.0</version>
         </dependency>
         <dependency>
             <groupId>org.ops4j.pax.exam</groupId>

--- a/osgi/karaf/features/src/main/resources/features.xml
+++ b/osgi/karaf/features/src/main/resources/features.xml
@@ -284,12 +284,8 @@
         <bundle start-level="35">mvn:com.fasterxml.jackson.core/jackson-annotations/${cxf.jackson.version}</bundle>
         <bundle start-level="35">mvn:com.fasterxml.jackson.core/jackson-databind/${cxf.jackson.databind.version}</bundle>
         <bundle start-level="35">mvn:com.fasterxml.jackson.dataformat/jackson-dataformat-yaml/${cxf.jackson.version}</bundle>
-        <bundle start-level="35">mvn:com.fasterxml.jackson.module/jackson-module-jaxb-annotations/${cxf.jackson.version}</bundle>
-        <!-- <bundle start-level="35">mvn:com.fasterxml.jackson.jaxrs/jackson-jaxrs-base/${cxf.jackson.version}</bundle> -->
-        <!-- <bundle start-level="35">mvn:com.fasterxml.jackson.jaxrs/jackson-jaxrs-json-provider/${cxf.jackson.version}</bundle> -->
-        <feature prerequisite="true">wrap</feature>
-        <bundle>wrap:mvn:com.fasterxml.jackson.jaxrs/jackson-jaxrs-base/${cxf.jackson.version}$overwrite=merge&amp;Import-Package=javax.ws.rs*;version="[2.0,3)",com.fasterxml.jackson*;version="[2.8,3)"</bundle>
-        <bundle>wrap:mvn:com.fasterxml.jackson.jaxrs/jackson-jaxrs-json-provider/${cxf.jackson.version}$overwrite=merge&amp;Import-Package=javax.ws.rs*;version="[2.0,3)",com.fasterxml.jackson.module.jaxb;resolution:=optional;version="[2.8,3)",com.fasterxml.jackson*;version="[2.8,3)"</bundle>
+        <bundle start-level="35">mvn:com.fasterxml.jackson.jaxrs/jackson-jaxrs-base/${cxf.jackson.version}</bundle>
+        <bundle start-level="35">mvn:com.fasterxml.jackson.jaxrs/jackson-jaxrs-json-provider/${cxf.jackson.version}</bundle>
     </feature>
     <feature name="cxf-jsr-json" version="${project.version}">
         <bundle dependency="true" start-level="30">mvn:org.apache.aries.spifly/org.apache.aries.spifly.dynamic.bundle/${cxf.aries.fly.version}</bundle>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -130,8 +130,8 @@
         <cxf.httpcomponents.client.version>4.5.10</cxf.httpcomponents.client.version>
         <cxf.httpcomponents.core.version.range>[4.3,4.5.0)</cxf.httpcomponents.core.version.range>
         <cxf.httpcomponents.core.version>4.4.12</cxf.httpcomponents.core.version>
-        <cxf.jackson.version>2.9.10</cxf.jackson.version>
-        <cxf.jackson.databind.version>2.9.10.1</cxf.jackson.databind.version>
+        <cxf.jackson.version>2.10.1</cxf.jackson.version>
+        <cxf.jackson.databind.version>2.10.1</cxf.jackson.databind.version>
         <cxf.jaeger.version>1.0.0</cxf.jaeger.version>
         <cxf.james.mim4j.version>0.7.2</cxf.james.mim4j.version>
         <cxf.javassist.version>3.25.0-GA</cxf.javassist.version>


### PR DESCRIPTION
The following changes seems to fix the issues with Jackson 2.10.x update:

 1. Removing `wrap` for Jackson JAX-RS modules. The `wrap` caused the issue with `bndlib` since Jackson 2.10.x introduces `module-info.class` / built with JDK9+. The exception in the logs:
```
java.lang.ArrayIndexOutOfBoundsException: 19
	at aQute.bnd.osgi.Clazz.parseClassFile(Clazz.java:576)
	at aQute.bnd.osgi.Clazz.parseClassFile(Clazz.java:494)
	at aQute.bnd.osgi.Clazz.parseClassFileWithCollector(Clazz.java:483)
	at aQute.bnd.osgi.Clazz.parseClassFile(Clazz.java:473)
	at aQute.bnd.osgi.Analyzer.analyzeJar(Analyzer.java:2177)
	at aQute.bnd.osgi.Analyzer.analyzeBundleClasspath(Analyzer.java:2083)
	at aQute.bnd.osgi.Analyzer.analyze(Analyzer.java:138)
	at aQute.bnd.osgi.Analyzer.calcManifest(Analyzer.java:616)
	at org.ops4j.pax.swissbox.bnd.BndUtils.createBundle(BndUtils.java:161)
```
2. The conflicts with `javax.xml.bind.annotation` exports, forced to remove `jackson-module-jaxb-annotations` module (and it is not need anymore):

```
karaf@root()> find-class javax.xml.bind.annotation.XmlRootElement
Jackson module: JAXB Annotations (22)
javax/xml/bind/annotation/XmlRootElement.class

jakarta.xml.bind-api (25)
javax/xml/bind/annotation/XmlRootElement.class
```
It basically caused weird issues with our `AbstractJAXBProvider` / `JAXBElementProvider` which was not picked up because of `isXmlType` apparently dealt with two instances of `XmlRootElement` coming from different bundles.