### PR TITLE
[CXF-8161] fix memory leak and thread leak in JMSDestination

### DIFF
--- a/rt/transports/jms/src/main/java/org/apache/cxf/transport/jms/util/PollingMessageListenerContainer.java
+++ b/rt/transports/jms/src/main/java/org/apache/cxf/transport/jms/util/PollingMessageListenerContainer.java
@@ -152,6 +152,7 @@ public class PollingMessageListenerContainer extends AbstractMessageListenerCont
                         safeRollBack();
                     }
                 } catch (Throwable e) {
+                    safeRollBack();
                     handleException(e);
                 }
             }
@@ -201,7 +202,6 @@ public class PollingMessageListenerContainer extends AbstractMessageListenerCont
     }
     
     protected void handleException(Throwable e) {
-        running = false;
         JMSException wrapped;
         if (e  instanceof JMSException) {
             wrapped = (JMSException) e;
@@ -239,10 +239,7 @@ public class PollingMessageListenerContainer extends AbstractMessageListenerCont
 
     @Override
     public void stop() {
-        LOG.fine("Shuttting down " + this.getClass().getSimpleName());
-        if (!running) {
-            return;
-        }
+        LOG.fine("Shutting down " + this.getClass().getSimpleName());
         running = false;
         super.stop();
     }

--- a/rt/transports/jms/src/test/java/org/apache/cxf/transport/jms/util/MessageListenerTest.java
+++ b/rt/transports/jms/src/test/java/org/apache/cxf/transport/jms/util/MessageListenerTest.java
@@ -61,7 +61,7 @@ public class MessageListenerTest {
             new PollingMessageListenerContainer(connection, dest, listenerHandler, exListener);
         connection.close(); // Simulate connection problem
         container.start();
-        Awaitility.await().until(() -> !container.isRunning());
+        Awaitility.await().until(() -> exListener.exception != null);
         JMSException ex = exListener.exception;
         assertNotNull(ex);
         assertEquals("The connection is already closed", ex.getMessage());
@@ -84,7 +84,7 @@ public class MessageListenerTest {
 
         connection.close(); // Simulate connection problem
         container.start();
-        Awaitility.await().until(() -> !container.isRunning());
+        Awaitility.await().until(() -> exListener.exception != null);
         JMSException ex = exListener.exception;
         assertNotNull(ex);
         // Closing the pooled connection will result in a NPE when using it


### PR DESCRIPTION
Solves problems of https://issues.apache.org/jira/browse/CXF-8161:

- JMSDestination#restartConnection() is synchronized: when multiple poller-threads run into exception handling, the restart will only run sequential. (otherwise there will be race conditions in restartConnection)
- JMSDestination#restartConnection() now checks if the PollingMessageListenerContainer is running before restart. When multiple poller-threads trigger the restart, it will only starts one new PollingMessageListenerContainer.
- PollingMessageListenerContainer stops the Executor after exception handling, resources will be released