### PR TITLE
CXF-8163: javax.ws.rs.core.Response#getCookies() fails when cookie has no value

### DIFF
--- a/rt/frontend/jaxrs/src/main/java/org/apache/cxf/jaxrs/impl/NewCookieHeaderProvider.java
+++ b/rt/frontend/jaxrs/src/main/java/org/apache/cxf/jaxrs/impl/NewCookieHeaderProvider.java
@@ -67,8 +67,14 @@ public class NewCookieHeaderProvider implements HeaderDelegate<NewCookie> {
 
             int sepIndex = theToken.indexOf('=');
             String paramName = sepIndex != -1 ? theToken.substring(0, sepIndex) : theToken;
-            String paramValue = sepIndex == -1 || sepIndex == theToken.length() - 1
-                ? null : theToken.substring(sepIndex + 1);
+            String paramValue = null; 
+
+            if (sepIndex == theToken.length() - 1) {
+                paramValue = "";
+            } else if (sepIndex != -1) {
+                paramValue = theToken.substring(sepIndex + 1);
+            }
+
             if (paramValue != null) {
                 paramValue = stripQuotes(paramValue);
             }
@@ -164,7 +170,7 @@ public class NewCookieHeaderProvider implements HeaderDelegate<NewCookie> {
     }
 
     /**
-     * Return true iff the string contains special characters that need to be
+     * Return true if the string contains special characters that need to be
      * quoted.
      *
      * @param value

--- a/rt/frontend/jaxrs/src/test/java/org/apache/cxf/jaxrs/impl/NewCookieHeaderProviderTest.java
+++ b/rt/frontend/jaxrs/src/test/java/org/apache/cxf/jaxrs/impl/NewCookieHeaderProviderTest.java
@@ -52,6 +52,12 @@ public class NewCookieHeaderProviderTest {
                    && "foo".equals(c.getName()));
     }
 
+    @Test
+    public void testNoValue() {
+        NewCookie c = NewCookie.valueOf("foo=");
+        assertTrue("".equals(c.getValue())
+                   && "foo".equals(c.getName()));
+    }
 
     @Test
     public void testFromComplexString() {

--- a/rt/frontend/jaxrs/src/test/java/org/apache/cxf/jaxrs/impl/ResponseImplTest.java
+++ b/rt/frontend/jaxrs/src/test/java/org/apache/cxf/jaxrs/impl/ResponseImplTest.java
@@ -279,6 +279,21 @@ public class ResponseImplTest {
     }
 
     @Test
+    public void testGetCookiesWithEmptyValues() {
+        ResponseImpl ri = new ResponseImpl(200);
+        MetadataMap<String, Object> meta = new MetadataMap<>();
+        meta.add("Set-Cookie", NewCookie.valueOf("a="));
+        meta.add("Set-Cookie", NewCookie.valueOf("c=\"\""));
+        ri.addMetadata(meta);
+        Map<String, NewCookie> cookies = ri.getCookies();
+        assertEquals(2, cookies.size());
+        assertEquals("a=\"\";Version=1", cookies.get("a").toString());
+        assertEquals("c=\"\";Version=1", cookies.get("c").toString());
+        assertEquals("", cookies.get("a").getValue());
+        assertEquals("", cookies.get("c").getValue());
+    }
+    
+    @Test
     public void testGetCookies() {
         ResponseImpl ri = new ResponseImpl(200);
         MetadataMap<String, Object> meta = new MetadataMap<>();


### PR DESCRIPTION
The RFC-6265 has the clarifications regarding empty cookie values, both in grammar  [1] and interpretation [2]. The approach adopted by other Java libraries (RESTEasy, Jersey, JDK11's HttpClient, ...) is to return an empty string as the value of the cookie.

[1] https://tools.ietf.org/html/rfc6265#section-4.1.1
[2] https://tools.ietf.org/html/rfc6265#section-5.2

@rmannibucau 