### PR TITLE
The current statement does nothing at all ...

### DIFF
--- a/core/src/main/java/org/apache/cxf/interceptor/LoggingInInterceptor.java
+++ b/core/src/main/java/org/apache/cxf/interceptor/LoggingInInterceptor.java
@@ -129,7 +129,7 @@ public class LoggingInInterceptor extends AbstractLoggingInterceptor {
             if (uri != null && uri.startsWith("/")) {
                 if (address != null && !address.startsWith(uri)) {
                     if (address.endsWith("/") && address.length() > 1) {
-                        address = address.substring(0, address.length());
+                        address = address.substring(0, address.length() - 1);
                     }
                     uri = address + uri;
                 }


### PR DESCRIPTION
... and it seems to be intended that the ending slash should be removed.

The following code always dows nothing at all:
address = address.substring(0, address.length());

It seems that the ending slash should be removed in some cases:
address = address.substring(0, address.length() - 1);