### PR TITLE
[CXF-8170] Parse HTTP link headers

### DIFF
--- a/rt/frontend/jaxrs/src/main/java/org/apache/cxf/jaxrs/impl/ResponseImpl.java
+++ b/rt/frontend/jaxrs/src/main/java/org/apache/cxf/jaxrs/impl/ResponseImpl.java
@@ -37,6 +37,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
+import java.util.regex.Pattern;
 
 import javax.ws.rs.ProcessingException;
 import javax.ws.rs.client.ResponseProcessingException;
@@ -63,6 +64,8 @@ import org.apache.cxf.message.Message;
 import org.apache.cxf.message.MessageUtils;
 
 public final class ResponseImpl extends Response {
+
+    private static final Pattern LINK_DELIMITER = Pattern.compile(",(?=\\<|$)");
 
     private StatusType status;
     private Object entity;
@@ -255,9 +258,16 @@ public final class ResponseImpl extends Response {
         List<Object> linkValues = metadata.get(HttpHeaders.LINK);
         if (linkValues != null) {
             for (Object o : linkValues) {
-                Link link = o instanceof Link ? (Link)o : Link.valueOf(o.toString());
-                if (relation.equals(link.getRel())) {
+                if (o instanceof Link && relation.equals(((Link)o).getRel())) {
                     return true;
+                }
+
+                String[] links = LINK_DELIMITER.split(o.toString());
+                for (String splitLink : links) {
+                    Link link = Link.valueOf(splitLink);
+                    if (relation.equals(link.getRel())) {
+                        return true;
+                    }
                 }
             }
         }
@@ -290,14 +300,36 @@ public final class ResponseImpl extends Response {
         }
         Set<Link> links = new LinkedHashSet<>();
         for (Object o : linkValues) {
-            Link link = o instanceof Link ? (Link)o : Link.valueOf(o.toString());
-            if (!link.getUri().isAbsolute()) {
-                URI requestURI = URI.create((String)outMessage.get(Message.REQUEST_URI));
-                link = Link.fromLink(link).baseUri(requestURI).build();
-            }
-            links.add(link);
+            List<Link> parsedLinks = parseLink(o);
+
+            links.addAll(parsedLinks);
         }
         return links;
+    }
+
+    private Link makeAbsoluteLink(Link link) {
+        if (!link.getUri().isAbsolute()) {
+            URI requestURI = URI.create((String)outMessage.get(Message.REQUEST_URI));
+            link = Link.fromLink(link).baseUri(requestURI).build();
+        }
+
+        return link;
+    }
+
+    private List<Link> parseLink(Object o) {
+        if (o instanceof Link) {
+            return Collections.singletonList(makeAbsoluteLink((Link) o));
+        }
+
+        List<Link> links = new ArrayList<>();
+        String[] linkArray = LINK_DELIMITER.split(o.toString());
+
+        for (String textLink : linkArray) {
+            Link link = Link.valueOf(textLink);
+            links.add(makeAbsoluteLink(link));
+        }
+
+        return Collections.unmodifiableList(links);
     }
 
     public <T> T readEntity(Class<T> cls) throws ProcessingException, IllegalStateException {

--- a/rt/frontend/jaxrs/src/test/java/org/apache/cxf/jaxrs/impl/ResponseImplTest.java
+++ b/rt/frontend/jaxrs/src/test/java/org/apache/cxf/jaxrs/impl/ResponseImplTest.java
@@ -444,6 +444,30 @@ public class ResponseImplTest {
         }
     }
 
+    @Test
+    public void testGetLinksMultiple() {
+        try (ResponseImpl ri = new ResponseImpl(200)) {
+            MetadataMap<String, Object> meta = new MetadataMap<>();
+            ri.addMetadata(meta);
+
+            Set<Link> links = ri.getLinks();
+            assertTrue(links.isEmpty());
+
+            meta.add(HttpHeaders.LINK, "<http://next>;rel=\"next\",<http://prev>;rel=\"prev\"");
+
+            assertTrue(ri.hasLink("next"));
+            Link next = ri.getLink("next");
+            assertNotNull(next);
+            assertTrue(ri.hasLink("prev"));
+            Link prev = ri.getLink("prev");
+            assertNotNull(prev);
+
+            links = ri.getLinks();
+            assertTrue(links.contains(Link.fromUri("http://next").rel("next").build()));
+            assertTrue(links.contains(Link.fromUri("http://prev").rel("prev").build()));
+        }
+    }
+
     public static class StringBean {
         private String header;
 


### PR DESCRIPTION
  - if multiple, comma separated links are present in a single header, split up by comma and parse each.
  - static final Pattern from open-liberty, see https://github.com/OpenLiberty/open-liberty/pull/8956/commits/e159898d1c9a230f5d71b82414874204a1a66715

Co-authored-by: Adam Anderson <atanderson9383@gmail.com>
Signed-off-by: Benjamin Marwell <bmarwell@gmail.com>