### PR TITLE
CXF-8188: Inject into ClientHeadersFactory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,5 @@ node_modules/
 derby.log
 .pmdruleset.xml
 .sts4-cache/
+**/.factorypath
+.vscode/

--- a/rt/rs/microprofile-client/src/main/java/org/apache/cxf/microprofile/client/cdi/CDIFacade.java
+++ b/rt/rs/microprofile-client/src/main/java/org/apache/cxf/microprofile/client/cdi/CDIFacade.java
@@ -1,0 +1,39 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.cxf.microprofile.client.cdi;
+
+import java.util.Optional;
+
+public final class CDIFacade {
+
+    private CDIFacade() {
+    }
+
+    public static <T> Optional<T> getInstanceFromCDI(Class<T> clazz) {
+        T t;
+        try {
+            t = CDIUtils.getInstanceFromCDI(clazz);
+        } catch (ExceptionInInitializerError | NoClassDefFoundError | IllegalStateException ex) {
+            // expected if no MP Config implementation is available
+            t = null;
+        }
+        return Optional.ofNullable(t);
+    }
+}

--- a/rt/rs/microprofile-client/src/main/java/org/apache/cxf/microprofile/client/cdi/CDIFacade.java
+++ b/rt/rs/microprofile-client/src/main/java/org/apache/cxf/microprofile/client/cdi/CDIFacade.java
@@ -56,17 +56,17 @@ public final class CDIFacade {
         }
     }
 
-    public static <T> Optional<T> getInstanceFromCDI(Class<T> clazz, Bus b) {
+    public static <T> Optional<Instance<T>> getInstanceFromCDI(Class<T> clazz, Bus b) {
         return nullableOptional(() -> CDIUtils.getInstanceFromCDI(clazz, b));
     }
 
-    public static <T> Optional<T> getInstanceFromCDI(Class<T> clazz) {
+    public static <T> Optional<Instance<T>> getInstanceFromCDI(Class<T> clazz) {
         return nullableOptional(() -> CDIUtils.getInstanceFromCDI(clazz));
     }
 
     private static <T> Optional<T> nullableOptional(Callable<T> callable) {
         if (!CDI_AVAILABLE) {
-            return Optional.ofNullable(null);
+            return Optional.empty();
         }
 
         T t;

--- a/rt/rs/microprofile-client/src/main/java/org/apache/cxf/microprofile/client/cdi/CDIInterceptorWrapper.java
+++ b/rt/rs/microprofile-client/src/main/java/org/apache/cxf/microprofile/client/cdi/CDIInterceptorWrapper.java
@@ -47,14 +47,8 @@ public interface CDIInterceptorWrapper {
     static CDIInterceptorWrapper createWrapper(Class<?> restClient) {
         try {
             return AccessController.doPrivileged((PrivilegedExceptionAction<CDIInterceptorWrapper>) () -> {
-                Class<?> cdiClass = Class.forName("javax.enterprise.inject.spi.CDI", false,
-                                                  restClient.getClassLoader());
-                Method currentMethod = cdiClass.getMethod("current");
-                Object cdiCurrent = currentMethod.invoke(null);
-
-                Method getBeanMgrMethod = cdiClass.getMethod("getBeanManager");
-
-                return new CDIInterceptorWrapperImpl(restClient, getBeanMgrMethod.invoke(cdiCurrent));
+                Object beanManager = CDIFacade.getBeanManager().orElseThrow(() -> new Exception("CDI not available"));
+                return new CDIInterceptorWrapperImpl(restClient, beanManager);
             });
         } catch (PrivilegedActionException pae) {
             // expected for environments where CDI is not supported

--- a/rt/rs/microprofile-client/src/main/java/org/apache/cxf/microprofile/client/cdi/CDIUtils.java
+++ b/rt/rs/microprofile-client/src/main/java/org/apache/cxf/microprofile/client/cdi/CDIUtils.java
@@ -1,0 +1,56 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.cxf.microprofile.client.cdi;
+
+import java.util.NoSuchElementException;
+
+import javax.enterprise.context.spi.CreationalContext;
+import javax.enterprise.inject.spi.Bean;
+import javax.enterprise.inject.spi.BeanManager;
+import javax.enterprise.inject.spi.CDI;
+
+public final class CDIUtils {
+
+    private CDIUtils() {
+    }
+
+    public static <T> T getInstanceFromCDI(Class<T> clazz) {
+        T t;
+        try {
+            t = findBean(clazz);
+        } catch (ExceptionInInitializerError | NoClassDefFoundError | IllegalStateException ex) {
+            // expected if no CDI implementation is available
+            t = null;
+        } catch (NoSuchElementException ex) {
+            // expected if ClientHeadersFactory is not managed by CDI
+            t = null;
+        }
+        return t;
+    }
+
+    @SuppressWarnings("unchecked")
+    private static <T> T findBean(Class<T> clazz) {
+        BeanManager beanManager = CDI.current().getBeanManager();
+        Bean<?> bean = beanManager.getBeans(clazz).iterator().next();
+        CreationalContext<?> ctx = beanManager.createCreationalContext(bean);
+        T instance = (T) beanManager.getReference(bean, clazz, ctx);
+        return instance;
+    }
+}

--- a/rt/rs/microprofile-client/src/main/java/org/apache/cxf/microprofile/client/cdi/Instance.java
+++ b/rt/rs/microprofile-client/src/main/java/org/apache/cxf/microprofile/client/cdi/Instance.java
@@ -1,0 +1,39 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.cxf.microprofile.client.cdi;
+
+public class Instance<T> {
+
+    private final T value;
+    private final Runnable releaseMethod;
+
+    Instance(T value, Runnable releaseMethod) {
+        this.value = value;
+        this.releaseMethod = releaseMethod;
+    }
+
+    public T getValue() {
+        return value;
+    }
+
+    public void release() {
+        releaseMethod.run();
+    }
+}

--- a/systests/microprofile/client/jaxrs/src/test/java/org/apache/cxf/systest/microprofile/rest/client/InjectClientHeadersFactory.java
+++ b/systests/microprofile/client/jaxrs/src/test/java/org/apache/cxf/systest/microprofile/rest/client/InjectClientHeadersFactory.java
@@ -1,0 +1,41 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.cxf.systest.microprofile.rest.client;
+
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.MultivaluedHashMap;
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.core.Request;
+
+import org.eclipse.microprofile.rest.client.ext.ClientHeadersFactory;
+
+public class InjectClientHeadersFactory implements ClientHeadersFactory {
+
+    @Context
+    Request jaxrsRequest;
+
+    @Override
+    public MultivaluedMap<String, String> update(MultivaluedMap<String, String> incomingHeaders,
+                                                 MultivaluedMap<String, String> clientOutgoingHeaders) {
+
+        MultivaluedMap<String, String> updatedHeaders = new MultivaluedHashMap<>();
+        updatedHeaders.putSingle("REQUEST_METHOD", jaxrsRequest == null ? "NOT_INJECTED" : jaxrsRequest.getMethod());
+        return updatedHeaders;
+    }
+}

--- a/systests/microprofile/client/jaxrs/src/test/java/org/apache/cxf/systest/microprofile/rest/client/InjectRestClient.java
+++ b/systests/microprofile/client/jaxrs/src/test/java/org/apache/cxf/systest/microprofile/rest/client/InjectRestClient.java
@@ -1,0 +1,32 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.cxf.systest.microprofile.rest.client;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+
+import org.eclipse.microprofile.rest.client.annotation.RegisterClientHeaders;
+
+@Path("/remote")
+@RegisterClientHeaders(InjectClientHeadersFactory.class)
+public interface InjectRestClient {
+
+    @GET
+    String getAllHeadersToBeSent();
+}

--- a/systests/microprofile/client/jaxrs/src/test/java/org/apache/cxf/systest/microprofile/rest/client/JaxrsResource.java
+++ b/systests/microprofile/client/jaxrs/src/test/java/org/apache/cxf/systest/microprofile/rest/client/JaxrsResource.java
@@ -20,6 +20,7 @@ package org.apache.cxf.systest.microprofile.rest.client;
 
 import java.net.URI;
 
+import javax.ws.rs.DELETE;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
@@ -44,6 +45,16 @@ public class JaxrsResource {
                                              .baseUri(URI.create("http://localhost:8080/ignored"))
                                              .register(ReturnAllOutboundHeadersFilter.class)
                                              .build(RestClient.class);
+        return client.getAllHeadersToBeSent();
+    }
+
+    @Path("/inject")
+    @DELETE
+    public String injectContextsIntoClientHeadersFactory() {
+        InjectRestClient client = RestClientBuilder.newBuilder()
+                                                   .baseUri(URI.create("http://localhost:8080/ignored"))
+                                                   .register(ReturnAllOutboundHeadersFilter.class)
+                                                   .build(InjectRestClient.class);
         return client.getAllHeadersToBeSent();
     }
 }

--- a/systests/microprofile/client/jaxrs/src/test/java/org/apache/cxf/systest/microprofile/rest/client/MockConfigProviderResolver.java
+++ b/systests/microprofile/client/jaxrs/src/test/java/org/apache/cxf/systest/microprofile/rest/client/MockConfigProviderResolver.java
@@ -36,6 +36,7 @@ public class MockConfigProviderResolver extends ConfigProviderResolver {
         @Override
         public <T> T getValue(String propertyName, Class<T> propertyType) {
             String value = configValues.get(propertyName);
+            System.out.println("getValue(" + propertyName + ") = " + value);
             if (value != null) {
                 if (propertyType == String.class) {
                     return propertyType.cast(value);


### PR DESCRIPTION
Implements [CXF-8188](https://issues.apache.org/jira/browse/CXF-8188) - injecting `@Context` and `@Inject` into custom `ClientHeadersFactory` implementations.  

This tests JAX-RS injection.  The MP Rest Client 2.0 TCK will test CDI injection.