### PR TITLE
subclasses of declared exception should be thrown

### DIFF
--- a/rt/rs/microprofile-client/src/main/java/org/apache/cxf/microprofile/client/proxy/MicroProfileClientProxyImpl.java
+++ b/rt/rs/microprofile-client/src/main/java/org/apache/cxf/microprofile/client/proxy/MicroProfileClientProxyImpl.java
@@ -186,7 +186,7 @@ public class MicroProfileClientProxyImpl extends ClientProxyImpl {
                 } else if (t != null && m.getExceptionTypes() != null) {
                     // its a checked exception, make sure its declared
                     for (Class<?> c : m.getExceptionTypes()) {
-                        if (t.getClass().isAssignableFrom(c)) {
+                        if (c.isAssignableFrom(t.getClass())) {
                             throw t;
                         }
                     }


### PR DESCRIPTION
if a service throws "ServerExecption" but ends up throwing a sub-class
of ServerException e.g. ValidationException, the ResponseExceptionMapper
resulting Exception is lost.

Additional information, Resteasy also does it this way:
https://github.com/resteasy/Resteasy/blob/cc424c27f0e9b5ccbc712fd114b7c9abb43e6ba5/resteasy-client-microprofile/src/main/java/org/jboss/resteasy/microprofile/client/ExceptionMapping.java