### PR TITLE
CXF-8201 add additional check for file scheme in setUriParts

### DIFF
--- a/core/src/main/java/org/apache/cxf/common/util/CollectionUtils.java
+++ b/core/src/main/java/org/apache/cxf/common/util/CollectionUtils.java
@@ -56,6 +56,10 @@ public final class CollectionUtils {
         return true;
     }
 
+    public static <K, V> boolean isEmpty(Map<K, V> m) {
+        return m == null || m.isEmpty();
+    }
+
     public static <S, T> Dictionary<S, T> singletonDictionary(S s, T t) {
         return toDictionary(Collections.singletonMap(s, t));
     }

--- a/core/src/test/java/org/apache/cxf/common/util/CollectionUtilsTest.java
+++ b/core/src/test/java/org/apache/cxf/common/util/CollectionUtilsTest.java
@@ -22,6 +22,7 @@ package org.apache.cxf.common.util;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Dictionary;
+import java.util.Map;
 
 import org.junit.Test;
 
@@ -52,7 +53,8 @@ public class CollectionUtilsTest {
 
     @Test
     public void testIsEmpty() throws Exception {
-        assertTrue(CollectionUtils.isEmpty(null));
+        assertTrue(CollectionUtils.isEmpty((Collection) null));
+        assertTrue(CollectionUtils.isEmpty((Map) null));
 
         Collection<String> l = Arrays.asList(null, null);
         assertTrue(CollectionUtils.isEmpty(l));

--- a/rt/frontend/jaxrs/src/main/java/org/apache/cxf/jaxrs/impl/UriBuilderImpl.java
+++ b/rt/frontend/jaxrs/src/main/java/org/apache/cxf/jaxrs/impl/UriBuilderImpl.java
@@ -39,6 +39,7 @@ import javax.ws.rs.core.PathSegment;
 import javax.ws.rs.core.UriBuilder;
 import javax.ws.rs.core.UriBuilderException;
 
+import org.apache.cxf.common.util.CollectionUtils;
 import org.apache.cxf.common.util.PropertyUtils;
 import org.apache.cxf.common.util.StringUtils;
 import org.apache.cxf.jaxrs.model.URITemplate;
@@ -651,9 +652,10 @@ public class UriBuilderImpl extends UriBuilder implements Cloneable {
         } else {
             schemeSpecificPart = uri.getSchemeSpecificPart();
         }
-        if (scheme != null && host == null && port == -1
-                && queryIsEmpty() && !sspMatchessPath(uri) && userInfo == null
-                && uri.getSchemeSpecificPart() != null) {
+        if (scheme != null && host == null && port == -1 && userInfo == null
+                && CollectionUtils.isEmpty(query)
+                && uri.getSchemeSpecificPart() != null
+                && !schemeSpecificPartMatchesUriPath(uri)) {
             schemeSpecificPart = uri.getSchemeSpecificPart();
         }
         String theFragment = uri.getFragment();
@@ -662,12 +664,10 @@ public class UriBuilderImpl extends UriBuilder implements Cloneable {
         }
     }
 
-    private boolean queryIsEmpty() {
-        return query == null || query.isEmpty();
-    }
-
-    private boolean sspMatchessPath(final URI uri) {
-        return uri.getRawSchemeSpecificPart() != null && uri.getRawSchemeSpecificPart().equals("//" + uri.getPath());
+    private boolean schemeSpecificPartMatchesUriPath(final URI uri) {
+        return uri.getRawSchemeSpecificPart() != null
+                && uri.getPath() != null
+                && uri.getRawSchemeSpecificPart().equals("//" + uri.getPath());
     }
 
     private void setPathAndMatrix(String path) {

--- a/rt/frontend/jaxrs/src/main/java/org/apache/cxf/jaxrs/impl/UriBuilderImpl.java
+++ b/rt/frontend/jaxrs/src/main/java/org/apache/cxf/jaxrs/impl/UriBuilderImpl.java
@@ -636,7 +636,7 @@ public class UriBuilderImpl extends UriBuilder implements Cloneable {
         }
         String rawPath = uri.getRawPath();
         if (!uri.isOpaque() && schemeSpecificPart == null
-            && (theScheme != null || rawPath != null)) {
+                && (theScheme != null || rawPath != null)) {
             port = uri.getPort();
             host = uri.getHost();
             if (rawPath != null) {
@@ -651,14 +651,23 @@ public class UriBuilderImpl extends UriBuilder implements Cloneable {
         } else {
             schemeSpecificPart = uri.getSchemeSpecificPart();
         }
-        if (scheme != null && !"file".equalsIgnoreCase(scheme) && host == null && (query == null || query.isEmpty())
-            && userInfo == null  && uri.getSchemeSpecificPart() != null) {
+        if (scheme != null && host == null && port == -1
+                && queryIsEmpty() && !sspMatchessPath(uri) && userInfo == null
+                && uri.getSchemeSpecificPart() != null) {
             schemeSpecificPart = uri.getSchemeSpecificPart();
         }
         String theFragment = uri.getFragment();
         if (theFragment != null) {
             fragment = theFragment;
         }
+    }
+
+    private boolean queryIsEmpty() {
+        return query == null || query.isEmpty();
+    }
+
+    private boolean sspMatchessPath(final URI uri) {
+        return uri.getRawSchemeSpecificPart() != null && uri.getRawSchemeSpecificPart().equals("//" + uri.getPath());
     }
 
     private void setPathAndMatrix(String path) {

--- a/rt/frontend/jaxrs/src/main/java/org/apache/cxf/jaxrs/impl/UriBuilderImpl.java
+++ b/rt/frontend/jaxrs/src/main/java/org/apache/cxf/jaxrs/impl/UriBuilderImpl.java
@@ -651,8 +651,8 @@ public class UriBuilderImpl extends UriBuilder implements Cloneable {
         } else {
             schemeSpecificPart = uri.getSchemeSpecificPart();
         }
-        if (scheme != null && host == null && (query == null || query.isEmpty()) && userInfo == null
-            && uri.getSchemeSpecificPart() != null) {
+        if (scheme != null && !"file".equalsIgnoreCase(scheme) && host == null && (query == null || query.isEmpty())
+            && userInfo == null  && uri.getSchemeSpecificPart() != null) {
             schemeSpecificPart = uri.getSchemeSpecificPart();
         }
         String theFragment = uri.getFragment();

--- a/rt/frontend/jaxrs/src/test/java/org/apache/cxf/jaxrs/impl/UriBuilderImplTest.java
+++ b/rt/frontend/jaxrs/src/test/java/org/apache/cxf/jaxrs/impl/UriBuilderImplTest.java
@@ -1633,6 +1633,45 @@ public class UriBuilderImplTest {
     }
 
     @Test
+    public void testURIWithExtraPathMatchesOriginalURIPlusPath() {
+        assertEquals("mailto:bob@apache.org",
+                UriBuilder.fromUri("mailto:bob@apache.org").path("extra").build().toString());
+
+        assertEquals("news:comp.lang.java",
+                UriBuilder.fromUri("news:comp.lang.java").path("extra").build().toString());
+
+        assertEquals("urn:isbn:096139210x",
+                UriBuilder.fromUri("urn:isbn:096139210x").path("extra").build().toString());
+
+        assertEquals("docs/guide/collections/designfaq.html/extra#28",
+                UriBuilder.fromUri("docs/guide/collections/designfaq.html#28").path("extra").build().toString());
+
+        assertEquals("../../../demo/jfc/SwingSet2/src/SwingSet2.java/extra",
+                UriBuilder.fromUri("../../../demo/jfc/SwingSet2/src/SwingSet2.java").path("extra").build().toString());
+
+        assertEquals("file:///~/calendar/extra",
+                UriBuilder.fromUri("file:///~/calendar").path("extra").build().toString());
+
+        assertEquals("bob@somehost.com/extra",
+                UriBuilder.fromUri("bob@somehost.com").path("extra").build().toString());
+
+        assertEquals("http://localhost/somePath/extra",
+                UriBuilder.fromUri("http://localhost/somePath").path("extra").build().toString());
+
+        assertEquals("http://localhost:1234/someOtherPath/extra",
+                UriBuilder.fromUri("http://localhost:1234/someOtherPath").path("extra").build().toString());
+
+        assertEquals("http://127.0.0.1/extra",
+                UriBuilder.fromUri("http://127.0.0.1").path("extra").build().toString());
+
+        assertEquals("http://127.0.0.1/extra",
+                UriBuilder.fromUri("http://127.0.0.1/").path("extra").build().toString());
+
+        assertEquals("http://127.0.0.1/index.html/extra",
+                UriBuilder.fromUri("http://127.0.0.1/index.html").path("extra").build().toString());
+    }
+
+    @Test
     public void testURIWithNonIntegerPort() {
         String url = "myscheme://not.really.a.host:port/";
         UriBuilder builder = UriBuilder.fromUri(url);

--- a/rt/frontend/jaxrs/src/test/java/org/apache/cxf/jaxrs/impl/UriBuilderImplTest.java
+++ b/rt/frontend/jaxrs/src/test/java/org/apache/cxf/jaxrs/impl/UriBuilderImplTest.java
@@ -1669,6 +1669,15 @@ public class UriBuilderImplTest {
 
         assertEquals("http://127.0.0.1/index.html/extra",
                 UriBuilder.fromUri("http://127.0.0.1/index.html").path("extra").build().toString());
+
+        assertEquals("myscheme://a.host:7575/extra",
+                UriBuilder.fromUri("myscheme://a.host:7575/").path("extra").build().toString());
+
+        // note that this will use the scheme specific part of the URI, as opposed to host, port and path,
+        // and therefore the extra path will not be appended. URI uses an int for the port, and therefore
+        // will not parse the "fakePort" part of this URI as a port.
+        assertEquals("myscheme://not.really.a.host:fakePort/",
+                UriBuilder.fromUri("myscheme://not.really.a.host:fakePort/").path("extra").build().toString());
     }
 
     @Test


### PR DESCRIPTION
This additional check enables path appends for file URIs to work as it has done in previous versions of CXF, for example, with this patch:

UriBuilder.fromUri("file:///~/calendar").path("extra").build() will return file:///~calendar/extra as opposed to file:///~/calendar.

This has been discussed on the mailing list here: https://mail-archives.apache.org/mod_mbox/cxf-dev/202001.mbox/%3cCAGRgoZhuKXoYW_JtxyDH=u7Qqqcbeo6-9BXa0dxB8L+iGB4J4g@mail.gmail.com%3e
