### PR TITLE
Cxf 8208 - Handle exceptions when looking up swagger ui resources

### DIFF
--- a/rt/rs/description-swagger-ui/pom.xml
+++ b/rt/rs/description-swagger-ui/pom.xml
@@ -55,5 +55,10 @@
             <scope>provided</scope>
             <optional>true</optional>
         </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/rt/rs/description-swagger-ui/src/main/java/org/apache/cxf/jaxrs/swagger/ui/SwaggerUiResourceLocator.java
+++ b/rt/rs/description-swagger-ui/src/main/java/org/apache/cxf/jaxrs/swagger/ui/SwaggerUiResourceLocator.java
@@ -50,8 +50,14 @@ public class SwaggerUiResourceLocator {
         if (resourcePath.startsWith("/")) {
             resourcePath = resourcePath.substring(1);
         }
+        URL ret;
 
-        return URI.create(swaggerUiRoot + resourcePath).toURL();
+        try {
+            ret = URI.create(swaggerUiRoot + resourcePath).toURL();
+        } catch (Exception ex) {
+            throw new MalformedURLException(ex.getMessage());
+        }
+        return ret;
     }
 
     /**

--- a/rt/rs/description-swagger-ui/src/main/java/org/apache/cxf/jaxrs/swagger/ui/SwaggerUiResourceLocator.java
+++ b/rt/rs/description-swagger-ui/src/main/java/org/apache/cxf/jaxrs/swagger/ui/SwaggerUiResourceLocator.java
@@ -20,6 +20,7 @@
 package org.apache.cxf.jaxrs.swagger.ui;
 
 import java.io.IOException;
+import java.lang.IllegalArgumentException;
 import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URL;
@@ -54,7 +55,7 @@ public class SwaggerUiResourceLocator {
 
         try {
             ret = URI.create(swaggerUiRoot + resourcePath).toURL();
-        } catch (Exception ex) {
+        } catch (IllegalArgumentException ex) {
             throw new MalformedURLException(ex.getMessage());
         }
         return ret;

--- a/rt/rs/description-swagger-ui/src/main/java/org/apache/cxf/jaxrs/swagger/ui/SwaggerUiResourceLocator.java
+++ b/rt/rs/description-swagger-ui/src/main/java/org/apache/cxf/jaxrs/swagger/ui/SwaggerUiResourceLocator.java
@@ -20,7 +20,6 @@
 package org.apache.cxf.jaxrs.swagger.ui;
 
 import java.io.IOException;
-import java.lang.IllegalArgumentException;
 import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URL;

--- a/rt/rs/description-swagger-ui/src/test/java/org/apache/cxf/jaxrs/swagger/ui/SwaggerUIResourceLocatorTest.java
+++ b/rt/rs/description-swagger-ui/src/test/java/org/apache/cxf/jaxrs/swagger/ui/SwaggerUIResourceLocatorTest.java
@@ -1,0 +1,46 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.cxf.jaxrs.swagger.ui;
+
+import java.net.MalformedURLException;
+
+import org.junit.Test;
+
+
+
+public class SwaggerUIResourceLocatorTest {
+
+    @Test
+    public void testLocateWithBadCharactersInUrl() {
+        String url =
+                "jar:file:/Volumes/bigdrive/test157/jetty/base/webapps/"
+                + "Rhythmyx/WEB-INF/lib/swagger-ui-2.2.10-1.jar!/META-INF/resources/"
+                + "webjars/swagger-ui/2.2.10-1/assets/by-path//Assets/uploads/"
+                + "Screen Shot 2020-02-05 at 10.50.53 AM.png";
+
+        SwaggerUiResourceLocator locator = new SwaggerUiResourceLocator("/");
+
+        try {
+            locator.locate(url);
+        } catch (MalformedURLException e) {
+            // expected.
+        }
+    }
+}

--- a/rt/rs/description-swagger-ui/src/test/java/org/apache/cxf/jaxrs/swagger/ui/SwaggerUIResourceLocatorTest.java
+++ b/rt/rs/description-swagger-ui/src/test/java/org/apache/cxf/jaxrs/swagger/ui/SwaggerUIResourceLocatorTest.java
@@ -27,7 +27,7 @@ import org.junit.Test;
 
 public class SwaggerUIResourceLocatorTest {
 
-    @Test
+    @Test(expected = MalformedURLException.class)
     public void testLocateWithBadCharactersInUrl() {
         String url =
                 "jar:file:/Volumes/bigdrive/test157/jetty/base/webapps/"
@@ -37,10 +37,7 @@ public class SwaggerUIResourceLocatorTest {
 
         SwaggerUiResourceLocator locator = new SwaggerUiResourceLocator("/");
 
-        try {
-            locator.locate(url);
-        } catch (MalformedURLException e) {
-            // expected.
-        }
+        locator.locate(url);
+        
     }
 }

--- a/rt/rs/description-swagger-ui/src/test/java/org/apache/cxf/jaxrs/swagger/ui/SwaggerUIResourceLocatorTest.java
+++ b/rt/rs/description-swagger-ui/src/test/java/org/apache/cxf/jaxrs/swagger/ui/SwaggerUIResourceLocatorTest.java
@@ -28,7 +28,7 @@ import org.junit.Test;
 public class SwaggerUIResourceLocatorTest {
 
     @Test(expected = MalformedURLException.class)
-    public void testLocateWithBadCharactersInUrl() {
+    public void testLocateWithBadCharactersInUrl() throws MalformedURLException {
         String url =
                 "jar:file:/Volumes/bigdrive/test157/jetty/base/webapps/"
                 + "Rhythmyx/WEB-INF/lib/swagger-ui-2.2.10-1.jar!/META-INF/resources/"


### PR DESCRIPTION
CXF-8208 add exception handler so that failed swagger ui resource lookups don't fail the request completely with invalid uri errors.