### PR TITLE
upgrade guava, CVE-2018-10237

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -119,7 +119,7 @@
         <cxf.geronimo.transaction.version>3.1.4</cxf.geronimo.transaction.version>
         <cxf.geronimo.openapi.version>1.0.12</cxf.geronimo.openapi.version>
         <cxf.glassfish.json.version>1.0.4</cxf.glassfish.json.version>
-        <cxf.guava.version>20.0</cxf.guava.version>
+        <cxf.guava.version>28.2-jre</cxf.guava.version>
         <cxf.hamcrest.version>1.3</cxf.hamcrest.version>
         <cxf.hazelcast.version>3.12.3</cxf.hazelcast.version>
         <cxf.hibernate.em.version>5.4.8.Final</cxf.hibernate.em.version>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -119,7 +119,7 @@
         <cxf.geronimo.transaction.version>3.1.4</cxf.geronimo.transaction.version>
         <cxf.geronimo.openapi.version>1.0.12</cxf.geronimo.openapi.version>
         <cxf.glassfish.json.version>1.0.4</cxf.glassfish.json.version>
-        <cxf.guava.version>28.2-jre</cxf.guava.version>
+        <cxf.guava.version>29.0-jre</cxf.guava.version>
         <cxf.hamcrest.version>1.3</cxf.hamcrest.version>
         <cxf.hazelcast.version>3.12.3</cxf.hazelcast.version>
         <cxf.hibernate.em.version>5.4.8.Final</cxf.hibernate.em.version>


### PR DESCRIPTION
Upgrade guava to avoid being marked for CVE-2018-10237 - although CXF might not directly be affected by the issue.
Signed-off-by: David Karlsen <david@davidkarlsen.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/apache/cxf/638)
<!-- Reviewable:end -->
