### PR TITLE
Incompatibility with recent Brave versions causes NullPointerException and hides root cause

### DIFF
--- a/distribution/src/main/release/samples/jax_rs/tracing_brave/pom.xml
+++ b/distribution/src/main/release/samples/jax_rs/tracing_brave/pom.xml
@@ -30,7 +30,7 @@
     </parent>
     <properties>
         <cxf.version>${project.version}</cxf.version>
-        <cxf.brave.version>5.4.2</cxf.brave.version>
+        <cxf.brave.version>5.9.4</cxf.brave.version>
     </properties>
     <profiles>
         <profile>

--- a/integration/tracing/tracing-brave/src/main/java/org/apache/cxf/tracing/brave/AbstractBraveClientProvider.java
+++ b/integration/tracing/tracing-brave/src/main/java/org/apache/cxf/tracing/brave/AbstractBraveClientProvider.java
@@ -28,6 +28,8 @@ import brave.Span;
 import brave.Tracer.SpanInScope;
 import brave.http.HttpClientAdapter;
 import brave.http.HttpClientHandler;
+import brave.http.HttpClientRequest;
+import brave.http.HttpClientResponse;
 import brave.http.HttpTracing;
 import brave.propagation.Propagation.Setter;
 import org.apache.cxf.common.logging.LogUtils;
@@ -123,7 +125,8 @@ public abstract class AbstractBraveClientProvider extends AbstractTracingProvide
                     brave.tracing().tracer().joinSpan(scope.getSpan().context());
                 }
     
-                final HttpClientHandler<?, Response> handler = HttpClientHandler.create(brave, null);
+                final HttpClientHandler<HttpClientRequest, HttpClientResponse> handler = 
+                        HttpClientHandler.create(brave);
                 handler.handleReceive(null, ex, scope.getSpan());
             } finally {
                 scope.close();

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -88,9 +88,9 @@
         <cxf.atmosphere.version.range>[2.4,3.0)</cxf.atmosphere.version.range>
         <cxf.atmosphere.version>2.5.2</cxf.atmosphere.version>
         <cxf.bcprov.version>1.64</cxf.bcprov.version>
-        <cxf.brave.reporter.version>2.10.0</cxf.brave.reporter.version>
-        <cxf.brave.version>5.6.9</cxf.brave.version>
-        <cxf.brave.zipkin.version>2.14.2</cxf.brave.zipkin.version>
+        <cxf.brave.reporter.version>2.12.1</cxf.brave.reporter.version>
+        <cxf.brave.version>5.9.4</cxf.brave.version>
+        <cxf.brave.zipkin.version>2.19.3</cxf.brave.zipkin.version>
         <cxf.cda.api.osgi.range>[1.1,2)</cxf.cda.api.osgi.range>
         <cxf.cdi.api.version>2.0</cxf.cdi.api.version>
         <cxf.classgraph.version>4.6.32</cxf.classgraph.version>


### PR DESCRIPTION
I believe there is an incompatibility between `cxf-integration-tracing-brave` and recent versions of `brave-instrumentation-http`.
CXF master currently depends on Brave version 5.6.9 while the newest version is 5.9.4.

As of version 5.7, `brave-instrumentation-http` throws a `NullPointerException` when invoking `brave.http.HttpClientHandler.create(HttpTracing, HttpClientAdapter)` with a `null` value for the `HttpClientAdapter` parameter.
Which is exactly what `cxf-integration-tracing-brave` does in case of an exception/SOAP fault.

This results in the following stack trace and hides the original SOAP fault from the user:

```
java.lang.NullPointerException: adapter == null
	at brave.http.HttpClientHandler.create(HttpClientHandler.java:64)
	at org.apache.cxf.tracing.brave.AbstractBraveClientProvider.stopTraceSpan(AbstractBraveClientProvider.java:126)
	at org.apache.cxf.tracing.brave.BraveClientStartInterceptor.handleFault(BraveClientStartInterceptor.java:55)
	at org.apache.cxf.phase.PhaseInterceptorChain.unwind(PhaseInterceptorChain.java:499)
```

Users of Spring Cloud Greenwich SR3 or higher are impacted.
Dependency graph from left to right with indication of the impacted versions:

| Spring Boot | Spring Cloud      | Sleuth        | Brave | Status     |
| ----------- | ----------------- | ------------- | ----- | ---------- |
| 2.1         | Greenwich.RELEASE | 2.1.0.RELEASE | 5.6.1 | Works      |
| 2.1         | Greenwich.SR1     | 2.1.1.RELEASE | 5.6.1 | Works      |
| 2.1         | Greenwich.SR2     | 2.1.2.RELEASE | 5.6.5 | Works      |
| 2.1         | Greenwich.SR3     | 2.1.3.RELEASE | 5.7.0 | **Broken** |
| 2.1         | Greenwich.SR4     | 2.1.6.RELEASE | 5.8.0 | **Broken** |
| 2.1         | Greenwich.SR5     | 2.1.7.RELEASE | 5.9.2 | **Broken** |
| 2.2         | Hoxton.RELEASE    | 2.2.0.RELEASE | 5.9.0 | **Broken** |
| 2.2         | Hoxton.SR1        | 2.2.1.RELEASE | 5.9.0 | **Broken** |

This pull requests:
- Bumps the Brave dependencies to the most recent version
  - Bump cxf.reporter.version from 2.10.0 to 2.12.1
  - Bump cxf.brave.version from 5.6.9 to 5.9.4
  - Bump cxf.brave.zipkin.version to 2.14.2 to 2.19.3
- Calls `brave.http.HttpClientHandler.create(HttpTracing)`, introduced in Brave 5.7 instead of `brave.http.HttpClientHandler.create(HttpTracing, HttpClientAdapter)` in case of SOAP faults.

The following repository reproduces the issue using the latest stable versions of Spring Boot, Spring Cloud and Apache CXF.
https://github.com/timpeeters/cxf-brave-np-issue

Depending on a local build of Apache CXF after applying this change resolve the issue.