### PR TITLE
[CXF-8225] Structure send method of Slf4jEventSender

### DIFF
--- a/rt/features/logging/src/main/java/org/apache/cxf/ext/logging/slf4j/Slf4jEventSender.java
+++ b/rt/features/logging/src/main/java/org/apache/cxf/ext/logging/slf4j/Slf4jEventSender.java
@@ -38,26 +38,10 @@ public class Slf4jEventSender implements LogEventSender {
 
     @Override
     public void send(LogEvent event) {
-        String cat = "org.apache.cxf.services." + event.getPortTypeName().getLocalPart() + "." + event.getType();
-        Logger log = LoggerFactory.getLogger(cat);
+        Logger log = getLogger(event);
         Set<String> keys = new HashSet<>();
         try {
-            put(keys, "Type", event.getType().toString());
-            put(keys, "Address", event.getAddress());
-            put(keys, "HttpMethod", event.getHttpMethod());
-            put(keys, "Content-Type", event.getContentType());
-            put(keys, "ResponseCode", event.getResponseCode());
-            put(keys, "ExchangeId", event.getExchangeId());
-            put(keys, "MessageId", event.getMessageId());
-            if (event.getServiceName() != null) {
-                put(keys, "ServiceName", localPart(event.getServiceName()));
-                put(keys, "PortName", localPart(event.getPortName()));
-                put(keys, "PortTypeName", localPart(event.getPortTypeName()));
-            }
-            if (event.getFullContentFile() != null) {
-                put(keys, "FullContentFile", event.getFullContentFile().getAbsolutePath());
-            }
-            put(keys, "Headers", event.getHeaders().toString());
+            fillMDC(event, keys);
             performLogging(log, MarkerFactory.getMarker(event.getServiceName() != null ? "SOAP" : "REST"),
                      getLogMessage(event));
         } finally {
@@ -66,6 +50,30 @@ public class Slf4jEventSender implements LogEventSender {
             }
         }
 
+    }
+
+    protected Logger getLogger(final LogEvent event) {
+        final String cat = "org.apache.cxf.services." + event.getPortTypeName().getLocalPart() + "." + event.getType();
+        return LoggerFactory.getLogger(cat);
+    }
+
+    protected void fillMDC(final LogEvent event, final Set<String> keys) {
+        put(keys, "Type", event.getType().toString());
+        put(keys, "Address", event.getAddress());
+        put(keys, "HttpMethod", event.getHttpMethod());
+        put(keys, "Content-Type", event.getContentType());
+        put(keys, "ResponseCode", event.getResponseCode());
+        put(keys, "ExchangeId", event.getExchangeId());
+        put(keys, "MessageId", event.getMessageId());
+        if (event.getServiceName() != null) {
+            put(keys, "ServiceName", localPart(event.getServiceName()));
+            put(keys, "PortName", localPart(event.getPortName()));
+            put(keys, "PortTypeName", localPart(event.getPortTypeName()));
+        }
+        if (event.getFullContentFile() != null) {
+            put(keys, "FullContentFile", event.getFullContentFile().getAbsolutePath());
+        }
+        put(keys, "Headers", event.getHeaders().toString());
     }
 
     /**


### PR DESCRIPTION
By extracting code into subroutines it is easier to override parts e.g. to make used Logger dependent of called method