### PR TITLE
CXF-8235 Handle null continuation in AsyncResponseImpl

### DIFF
--- a/rt/frontend/jaxrs/src/main/java/org/apache/cxf/jaxrs/impl/AsyncResponseImpl.java
+++ b/rt/frontend/jaxrs/src/main/java/org/apache/cxf/jaxrs/impl/AsyncResponseImpl.java
@@ -302,6 +302,11 @@ public class AsyncResponseImpl implements AsyncResponse, ContinuationCallback {
     private void initContinuation() {
         ContinuationProvider provider =
             (ContinuationProvider)inMessage.get(ContinuationProvider.class.getName());
+        if (provider == null) {
+            throw new IllegalArgumentException(
+                "Continuation not supported. " 
+                + "Please ensure that all servlets and servlet filters support async operations");
+        }
         cont = provider.getContinuation();
         initialSuspend = true;
     }

--- a/rt/frontend/jaxrs/src/test/java/org/apache/cxf/jaxrs/impl/AsyncResponseImplTest.java
+++ b/rt/frontend/jaxrs/src/test/java/org/apache/cxf/jaxrs/impl/AsyncResponseImplTest.java
@@ -33,6 +33,7 @@ import org.apache.cxf.transport.http.Servlet3ContinuationProvider;
 
 import org.easymock.EasyMock;
 import org.easymock.IMocksControl;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -160,5 +161,32 @@ public class AsyncResponseImplTest {
                      isDone, impl.isDone());
         assertEquals("AsynchResponse.isSuspended() returned a different response after canceling a second time",
                      isSuspended, impl.isSuspended());
+    }
+    
+    /**
+     * Test that creatinging an AsyncResponse with a null continuation throws
+     * an IllegalArgumentException instead of a NullPointer Exception.
+     */
+    @Test
+    public void testNullContinutaion() {
+        HttpServletRequest req = control.createMock(HttpServletRequest.class);
+        AsyncContext asyncCtx = control.createMock(AsyncContext.class);
+        Message msg = new MessageImpl();
+        msg.setExchange(new ExchangeImpl());
+
+        req.startAsync();
+        EasyMock.expectLastCall().andReturn(asyncCtx);
+        control.replay();
+
+        AsyncResponse impl;
+        try {
+            impl = new AsyncResponseImpl(msg);
+        } catch (IllegalArgumentException e) {
+            assertEquals("Continuation not supported. " 
+                             + "Please ensure that all servlets and servlet filters support async operations",
+                         e.getMessage());
+            return;
+        }
+        Assert.fail("Expected IllegalArgumentException, but instead got valid AsyncResponse, " + impl);
     }
 }


### PR DESCRIPTION
instead of throwing a NullPointerException