### PR TITLE
CXF-8242: Stop blocking executor thread on microprofile rest asynchronous call

### DIFF
--- a/core/src/test/java/org/apache/cxf/endpoint/ClientCallbackTest.java
+++ b/core/src/test/java/org/apache/cxf/endpoint/ClientCallbackTest.java
@@ -1,0 +1,164 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.cxf.endpoint;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import org.apache.cxf.message.MessageImpl;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertThrows;
+
+public class ClientCallbackTest {
+    private Map<String, Object> ctx;
+    private ClientCallback callback;
+    private ScheduledExecutorService executor;
+    
+    @Before
+    public void setUp() {
+        executor = Executors.newSingleThreadScheduledExecutor();
+        callback = new ClientCallback();
+        ctx = new HashMap<String, Object>();
+    }
+    
+    @After
+    public void tearDown() throws Exception {
+        executor.shutdown();
+        executor.awaitTermination(5, TimeUnit.SECONDS);
+    }
+    
+    @Test
+    public void testHandleResponseCallback() throws Exception {
+        final CyclicBarrier barrier = new CyclicBarrier(2);
+
+        Object[] result = new Object[0];
+        schedule(barrier, () -> callback.handleResponse(ctx, result));
+
+        synchronized (callback) {
+            barrier.await(5, TimeUnit.SECONDS);
+            callback.wait();
+        }
+
+        assertThat(callback.get(), equalTo(result));
+        assertThat(callback.get(10, TimeUnit.MILLISECONDS), equalTo(result));
+        assertThat(callback.isCancelled(), equalTo(false));
+        assertThat(callback.isDone(), equalTo(true));
+    }
+    
+    @Test
+    public void testGetResponseContextOnSuccessCallback() throws Exception {
+        final CyclicBarrier barrier = new CyclicBarrier(1);
+
+        Object[] result = new Object[0];
+        schedule(barrier, () -> callback.handleResponse(ctx, result));
+
+        assertThat(callback.getResponseContext(), equalTo(ctx));
+        assertThat(callback.get(), equalTo(result));
+        assertThat(callback.get(10, TimeUnit.MILLISECONDS), equalTo(result));
+        assertThat(callback.isCancelled(), equalTo(false));
+        assertThat(callback.isDone(), equalTo(true));
+    }
+    
+    @Test
+    public void testHandleExceptionCallback() throws Exception {
+        final CyclicBarrier barrier = new CyclicBarrier(2);
+        schedule(barrier, () -> callback.handleException(ctx, new RuntimeException()));
+
+        synchronized (callback) {
+            barrier.await(5, TimeUnit.SECONDS);
+            callback.wait();
+        }
+
+        assertThrows(ExecutionException.class, () -> callback.get());
+        assertThrows(ExecutionException.class, () -> callback.get(10, TimeUnit.MILLISECONDS));
+        assertThat(callback.isCancelled(), equalTo(false));
+        assertThat(callback.isDone(), equalTo(true));
+    }
+
+    @Test
+    public void testGetResponseContextOnExceptionCallback() throws Exception {
+        final CyclicBarrier barrier = new CyclicBarrier(1);
+        schedule(barrier, () -> callback.handleException(ctx, new RuntimeException()));
+
+        assertThrows(ExecutionException.class, () -> callback.getResponseContext());
+        assertThat(callback.isCancelled(), equalTo(false));
+        assertThat(callback.isDone(), equalTo(true));
+    }
+
+    @Test
+    public void testHandleCancellationCallback() throws Exception {
+        final CyclicBarrier barrier = new CyclicBarrier(2);
+        schedule(barrier, () -> callback.cancel(true));
+
+        synchronized (callback) {
+            barrier.await(5, TimeUnit.SECONDS);
+            callback.wait();
+        }
+
+        assertThrows(InterruptedException.class, () -> callback.get());
+        assertThrows(InterruptedException.class, () -> callback.get(10, TimeUnit.MILLISECONDS));
+        assertThat(callback.isCancelled(), equalTo(true));
+        assertThat(callback.isDone(), equalTo(true));
+    }
+    
+
+    @Test
+    public void testHandleCancellationCallbackWhenStarted() throws Exception {
+        callback.start(new MessageImpl());
+        assertThat(callback.cancel(true), equalTo(false));
+        assertThat(callback.isCancelled(), equalTo(false));
+        assertThat(callback.isDone(), equalTo(false));
+    }
+
+    @Test
+    public void testGetResponseContextOnCancellationCallback() throws Exception {
+        final CyclicBarrier barrier = new CyclicBarrier(1);
+        schedule(barrier, () -> callback.cancel(true));
+
+        assertThrows(InterruptedException.class, () -> callback.getResponseContext());
+        assertThat(callback.isCancelled(), equalTo(true));
+        assertThat(callback.isDone(), equalTo(true));
+    }
+
+    @Test(expected = TimeoutException.class)
+    public void testTimeout() throws Exception {
+        callback.get(10, TimeUnit.MILLISECONDS);
+    }
+
+    private void schedule(CyclicBarrier barrier, Runnable runnable) {
+        executor.schedule(() -> {
+            barrier.await(5, TimeUnit.SECONDS);
+            runnable.run();
+            return null;
+        }, 100, TimeUnit.MILLISECONDS);
+    }
+}

--- a/rt/frontend/jaxws/src/main/java/org/apache/cxf/jaxws/JaxwsClientCallback.java
+++ b/rt/frontend/jaxws/src/main/java/org/apache/cxf/jaxws/JaxwsClientCallback.java
@@ -39,10 +39,12 @@ class JaxwsClientCallback<T> extends ClientCallback {
     }
     public void handleResponse(Map<String, Object> ctx, Object[] res) {
         context = ctx;
-        result = res;
+        delegate.complete(res);
+        
         if (handler != null) {
             handler.handleResponse(new Response<T>() {
-
+                protected boolean cancelled;
+                
                 public Map<String, Object> getContext() {
                     return context;
                 }
@@ -54,13 +56,13 @@ class JaxwsClientCallback<T> extends ClientCallback {
 
                 @SuppressWarnings("unchecked")
                 public T get() throws InterruptedException, ExecutionException {
-                    return (T)result[0];
+                    return (T)res[0];
                 }
 
                 @SuppressWarnings("unchecked")
                 public T get(long timeout, TimeUnit unit) throws InterruptedException,
                     ExecutionException, TimeoutException {
-                    return (T)result[0];
+                    return (T)res[0];
                 }
 
                 public boolean isCancelled() {
@@ -73,7 +75,7 @@ class JaxwsClientCallback<T> extends ClientCallback {
 
             });
         }
-        done = true;
+        
         synchronized (this) {
             notifyAll();
         }
@@ -82,9 +84,10 @@ class JaxwsClientCallback<T> extends ClientCallback {
     @Override
     public void handleException(Map<String, Object> ctx, final Throwable ex) {
         context = ctx;
-        exception = mapThrowable(ex);
+        delegate.completeExceptionally(mapThrowable(ex));
         if (handler != null) {
             handler.handleResponse(new Response<T>() {
+                protected boolean cancelled;
 
                 public Map<String, Object> getContext() {
                     return context;
@@ -115,7 +118,7 @@ class JaxwsClientCallback<T> extends ClientCallback {
 
             });
         }
-        done = true;
+
         synchronized (this) {
             notifyAll();
         }

--- a/rt/frontend/jaxws/src/test/java/org/apache/cxf/jaxws/JaxwsClientCallbackTest.java
+++ b/rt/frontend/jaxws/src/test/java/org/apache/cxf/jaxws/JaxwsClientCallbackTest.java
@@ -1,0 +1,162 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.cxf.jaxws;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import javax.xml.ws.AsyncHandler;
+import javax.xml.ws.Response;
+
+import org.apache.cxf.message.MessageImpl;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertThrows;
+
+public class JaxwsClientCallbackTest {
+    private Map<String, Object> ctx;
+    private JaxwsClientCallback<String> callback;
+    private AsyncHandler<String> handler;
+    private ScheduledExecutorService executor;
+    
+    @Before
+    public void setUp() {
+        executor = Executors.newSingleThreadScheduledExecutor();
+        handler = new AsyncHandler<String>() {
+            @Override
+            public void handleResponse(Response<String> res) {
+            }
+        };
+        
+        callback = new JaxwsClientCallback<String>(handler, null);
+        ctx = new HashMap<String, Object>();
+    }
+    
+    @After
+    public void tearDown() throws Exception {
+        executor.shutdown();
+        executor.awaitTermination(5, TimeUnit.SECONDS);
+    }
+    
+    @Test
+    public void testHandleResponseCallback() throws Exception {
+        final CyclicBarrier barrier = new CyclicBarrier(2);
+
+        Object[] result = new Object[0];
+        schedule(barrier, () -> callback.handleResponse(ctx, result));
+        barrier.await(5, TimeUnit.SECONDS);
+        
+        assertThat(callback.get(), equalTo(result));
+        assertThat(callback.get(10, TimeUnit.MILLISECONDS), equalTo(result));
+        assertThat(callback.isCancelled(), equalTo(false));
+        assertThat(callback.isDone(), equalTo(true));
+    }
+    
+    @Test
+    public void testGetResponseContextOnSuccessCallback() throws Exception {
+        final CyclicBarrier barrier = new CyclicBarrier(2);
+
+        Object[] result = new Object[0];
+        schedule(barrier, () -> callback.handleResponse(ctx, result));
+        barrier.await(5, TimeUnit.SECONDS);
+        
+        assertThat(callback.getResponseContext(), equalTo(ctx));
+        assertThat(callback.get(), equalTo(result));
+        assertThat(callback.get(10, TimeUnit.MILLISECONDS), equalTo(result));
+        assertThat(callback.isCancelled(), equalTo(false));
+        assertThat(callback.isDone(), equalTo(true));
+    }
+    
+    @Test
+    public void testHandleExceptionCallback() throws Exception {
+        final CyclicBarrier barrier = new CyclicBarrier(1);
+        schedule(barrier, () -> callback.handleException(ctx, new RuntimeException()));
+
+        assertThrows(ExecutionException.class, () -> callback.get());
+        assertThrows(ExecutionException.class, () -> callback.get(10, TimeUnit.MILLISECONDS));
+        assertThat(callback.isCancelled(), equalTo(false));
+        assertThat(callback.isDone(), equalTo(true));
+    }
+
+    @Test
+    public void testGetResponseContextOnExceptionCallback() throws Exception {
+        final CyclicBarrier barrier = new CyclicBarrier(1);
+        schedule(barrier, () -> callback.handleException(ctx, new RuntimeException()));
+
+        assertThrows(ExecutionException.class, () -> callback.getResponseContext());
+        assertThat(callback.isCancelled(), equalTo(false));
+        assertThat(callback.isDone(), equalTo(true));
+    }
+
+    @Test
+    public void testHandleCancellationCallback() throws Exception {
+        final CyclicBarrier barrier = new CyclicBarrier(2);
+        schedule(barrier, () -> callback.cancel(true));
+        barrier.await(5, TimeUnit.SECONDS);
+
+        assertThrows(InterruptedException.class, () -> callback.get());
+        assertThrows(InterruptedException.class, () -> callback.get(10, TimeUnit.MILLISECONDS));
+        assertThat(callback.isCancelled(), equalTo(true));
+        assertThat(callback.isDone(), equalTo(true));
+    }
+    
+
+    @Test
+    public void testHandleCancellationCallbackWhenStarted() throws Exception {
+        callback.start(new MessageImpl());
+        assertThat(callback.cancel(true), equalTo(false));
+        assertThat(callback.isCancelled(), equalTo(false));
+        assertThat(callback.isDone(), equalTo(false));
+    }
+
+    @Test
+    public void testGetResponseContextOnCancellationCallback() throws Exception {
+        final CyclicBarrier barrier = new CyclicBarrier(1);
+        schedule(barrier, () -> callback.cancel(true));
+
+        assertThrows(InterruptedException.class, () -> callback.getResponseContext());
+        assertThat(callback.isCancelled(), equalTo(true));
+        assertThat(callback.isDone(), equalTo(true));
+    }
+    
+    @Test(expected = TimeoutException.class)
+    public void testTimeout() throws Exception {
+        callback.get(10, TimeUnit.MILLISECONDS);
+    }
+
+    private void schedule(CyclicBarrier barrier, Runnable runnable) {
+        executor.schedule(() -> {
+            barrier.await(5, TimeUnit.SECONDS);
+            runnable.run();
+            return null;
+        }, 100, TimeUnit.MILLISECONDS);
+    }
+}

--- a/rt/rs/client/src/main/java/org/apache/cxf/jaxrs/client/JaxrsClientCallback.java
+++ b/rt/rs/client/src/main/java/org/apache/cxf/jaxrs/client/JaxrsClientCallback.java
@@ -71,11 +71,11 @@ public class JaxrsClientCallback<T> extends ClientCallback {
     @SuppressWarnings("unchecked")
     public void handleResponse(Map<String, Object> ctx, Object[] res) {
         context = ctx;
-        result = res;
+        delegate.complete(res);
         if (handler != null) {
             handler.completed((T)res[0]);
         }
-        done = true;
+        
         synchronized (this) {
             notifyAll();
         }
@@ -84,11 +84,11 @@ public class JaxrsClientCallback<T> extends ClientCallback {
     @Override
     public void handleException(Map<String, Object> ctx, final Throwable ex) {
         context = ctx;
-        exception = ex;
+        delegate.completeExceptionally(ex);
         if (handler != null) {
-            handler.failed(exception);
+            handler.failed(ex);
         }
-        done = true;
+        
         synchronized (this) {
             notifyAll();
         }

--- a/rt/rs/client/src/test/java/org/apache/cxf/jaxrs/client/JaxrsClientCallbackTest.java
+++ b/rt/rs/client/src/test/java/org/apache/cxf/jaxrs/client/JaxrsClientCallbackTest.java
@@ -1,0 +1,169 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.cxf.jaxrs.client;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import javax.ws.rs.client.InvocationCallback;
+
+import org.apache.cxf.jaxrs.client.JaxrsClientCallback.JaxrsResponseFuture;
+import org.apache.cxf.message.MessageImpl;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertThrows;
+
+public class JaxrsClientCallbackTest {
+    private Map<String, Object> ctx;
+    private JaxrsClientCallback<String> callback;
+    private InvocationCallback<String> handler;
+    private ScheduledExecutorService executor;
+    private JaxrsResponseFuture<String> future;
+    
+    @Before
+    public void setUp() {
+        executor = Executors.newSingleThreadScheduledExecutor();
+        handler = new InvocationCallback<String>() {
+            @Override
+            public void failed(Throwable throwable) {
+            }
+            
+            @Override
+            public void completed(String response) {
+            }
+        };
+        
+        callback = new JaxrsClientCallback<String>(handler, String.class, null);
+        future = (JaxrsResponseFuture<String>)callback.createFuture();
+        ctx = new HashMap<String, Object>();
+    }
+    
+    @After
+    public void tearDown() throws Exception {
+        executor.shutdown();
+        executor.awaitTermination(5, TimeUnit.SECONDS);
+    }
+    
+    @Test
+    public void testHandleResponseCallback() throws Exception {
+        final CyclicBarrier barrier = new CyclicBarrier(2);
+
+        Object[] result = new String[] {"results"};
+        schedule(barrier, () -> callback.handleResponse(ctx, result));
+        barrier.await(5, TimeUnit.SECONDS);
+        
+        assertThat(future.get(), equalTo("results"));
+        assertThat(future.get(10, TimeUnit.MILLISECONDS), equalTo("results"));
+        assertThat(future.isCancelled(), equalTo(false));
+        assertThat(future.isDone(), equalTo(true));
+    }
+    
+    @Test
+    public void testGetResponseContextOnSuccessCallback() throws Exception {
+        final CyclicBarrier barrier = new CyclicBarrier(2);
+
+        Object[] result = new String[] {"results"};
+        schedule(barrier, () -> callback.handleResponse(ctx, result));
+        barrier.await(5, TimeUnit.SECONDS);
+        
+        assertThat(future.getContext(), equalTo(ctx));
+        assertThat(future.get(), equalTo("results"));
+        assertThat(future.get(10, TimeUnit.MILLISECONDS), equalTo("results"));
+        assertThat(future.isCancelled(), equalTo(false));
+        assertThat(future.isDone(), equalTo(true));
+    }
+    
+    @Test
+    public void testHandleExceptionCallback() throws Exception {
+        final CyclicBarrier barrier = new CyclicBarrier(1);
+        schedule(barrier, () -> callback.handleException(ctx, new RuntimeException()));
+
+        assertThrows(ExecutionException.class, () -> future.get());
+        assertThrows(ExecutionException.class, () -> future.get(10, TimeUnit.MILLISECONDS));
+        assertThat(future.isCancelled(), equalTo(false));
+        assertThat(future.isDone(), equalTo(true));
+    }
+
+    @Test
+    public void testGetResponseContextOnExceptionCallback() throws Exception {
+        final CyclicBarrier barrier = new CyclicBarrier(1);
+        schedule(barrier, () -> callback.handleException(ctx, new RuntimeException()));
+
+        assertThat(future.getContext(), nullValue());
+        assertThat(future.isCancelled(), equalTo(false));
+        assertThat(future.isDone(), equalTo(true));
+    }
+
+    @Test
+    public void testHandleCancellationCallback() throws Exception {
+        final CyclicBarrier barrier = new CyclicBarrier(2);
+        schedule(barrier, () -> future.cancel(true));
+        barrier.await(5, TimeUnit.SECONDS);
+
+        assertThrows(InterruptedException.class, () -> future.get());
+        assertThrows(InterruptedException.class, () -> future.get(10, TimeUnit.MILLISECONDS));
+        assertThat(future.isCancelled(), equalTo(true));
+        assertThat(future.isDone(), equalTo(true));
+    }
+    
+
+    @Test
+    public void testHandleCancellationCallbackWhenStarted() throws Exception {
+        callback.start(new MessageImpl());
+        assertThat(future.cancel(true), equalTo(false));
+        assertThat(future.isCancelled(), equalTo(false));
+        assertThat(future.isDone(), equalTo(false));
+    }
+
+    @Test
+    public void testGetResponseContextOnCancellationCallback() throws Exception {
+        final CyclicBarrier barrier = new CyclicBarrier(1);
+        schedule(barrier, () -> future.cancel(true));
+
+        assertThat(future.getContext(), nullValue());
+        assertThat(future.isCancelled(), equalTo(true));
+        assertThat(future.isDone(), equalTo(true));
+    }
+    
+    @Test(expected = TimeoutException.class)
+    public void testTimeout() throws Exception {
+        future.get(10, TimeUnit.MILLISECONDS);
+    }
+
+    private void schedule(CyclicBarrier barrier, Runnable runnable) {
+        executor.schedule(() -> {
+            barrier.await(5, TimeUnit.SECONDS);
+            runnable.run();
+            return null;
+        }, 100, TimeUnit.MILLISECONDS);
+    }
+}

--- a/rt/rs/microprofile-client/src/test/java/org/apache/cxf/microprofile/client/MPRestClientCallbackTest.java
+++ b/rt/rs/microprofile-client/src/test/java/org/apache/cxf/microprofile/client/MPRestClientCallbackTest.java
@@ -1,0 +1,161 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.cxf.microprofile.client;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import javax.ws.rs.client.InvocationCallback;
+
+import org.apache.cxf.message.Message;
+import org.apache.cxf.message.MessageImpl;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertThrows;
+
+public class MPRestClientCallbackTest {
+    private Map<String, Object> ctx;
+    private MPRestClientCallback<String> callback;
+    private InvocationCallback<String> handler;
+    private ScheduledExecutorService executor;
+    private CompletableFuture<String> future;
+    private Message message;
+    
+    @Before
+    public void setUp() {
+        executor = Executors.newSingleThreadScheduledExecutor();
+        handler = new InvocationCallback<String>() {
+            @Override
+            public void failed(Throwable throwable) {
+            }
+            
+            @Override
+            public void completed(String response) {
+            }
+        };
+        
+        message = new MessageImpl();
+        callback = new MPRestClientCallback<String>(handler, message, String.class, null);
+        future = (CompletableFuture<String>)callback.createFuture();
+        ctx = new HashMap<String, Object>();
+    }
+    
+    @After
+    public void tearDown() throws Exception {
+        executor.shutdown();
+        executor.awaitTermination(5, TimeUnit.SECONDS);
+    }
+    
+    @Test
+    public void testHandleResponseCallback() throws Exception {
+        final CyclicBarrier barrier = new CyclicBarrier(2);
+
+        Object[] result = new String[] {"results"};
+        schedule(barrier, () -> callback.handleResponse(ctx, result));
+        barrier.await(5, TimeUnit.SECONDS);
+        
+        assertThat(future.get(), equalTo("results"));
+        assertThat(future.get(10, TimeUnit.MILLISECONDS), equalTo("results"));
+        assertThat(future.isCancelled(), equalTo(false));
+        assertThat(future.isDone(), equalTo(true));
+    }
+    
+    @Test
+    public void testGetResponseContextOnSuccessCallback() throws Exception {
+        final CyclicBarrier barrier = new CyclicBarrier(2);
+
+        Object[] result = new String[] {"results"};
+        schedule(barrier, () -> callback.handleResponse(ctx, result));
+        barrier.await(5, TimeUnit.SECONDS);
+        
+        assertThat(callback.getResponseContext(), equalTo(ctx));
+        assertThat(future.get(), equalTo("results"));
+        assertThat(future.get(10, TimeUnit.MILLISECONDS), equalTo("results"));
+        assertThat(future.isCancelled(), equalTo(false));
+        assertThat(future.isDone(), equalTo(true));
+    }
+    
+    @Test
+    public void testHandleExceptionCallback() throws Exception {
+        final CyclicBarrier barrier = new CyclicBarrier(1);
+        schedule(barrier, () -> callback.handleException(ctx, new RuntimeException()));
+
+        assertThrows(ExecutionException.class, () -> future.get());
+        assertThrows(ExecutionException.class, () -> future.get(10, TimeUnit.MILLISECONDS));
+        assertThat(future.isCancelled(), equalTo(false));
+        assertThat(future.isDone(), equalTo(true));
+    }
+
+    @Test
+    public void testGetResponseContextOnExceptionCallback() throws Exception {
+        final CyclicBarrier barrier = new CyclicBarrier(1);
+        schedule(barrier, () -> callback.handleException(ctx, new RuntimeException()));
+
+        assertThrows(ExecutionException.class, () -> callback.getResponseContext());
+        assertThat(future.isCancelled(), equalTo(false));
+        assertThat(future.isDone(), equalTo(true));
+    }
+
+    @Test
+    public void testHandleCancellationCallback() throws Exception {
+        final CyclicBarrier barrier = new CyclicBarrier(2);
+        schedule(barrier, () -> future.cancel(true));
+        barrier.await(5, TimeUnit.SECONDS);
+
+        assertThrows(CancellationException.class, () -> future.get());
+        assertThrows(CancellationException.class, () -> future.get(10, TimeUnit.MILLISECONDS));
+        assertThat(future.isCancelled(), equalTo(true));
+        assertThat(future.isDone(), equalTo(true));
+    }
+
+    @Test
+    public void testHandleCancellationCallbackWhenStarted() throws Exception {
+        callback.start(message);
+        assertThat(future.cancel(true), equalTo(true));
+        assertThat(future.isCancelled(), equalTo(true));
+        assertThat(future.isDone(), equalTo(true));
+    }
+
+    @Test(expected = TimeoutException.class)
+    public void testTimeout() throws Exception {
+        future.get(10, TimeUnit.MILLISECONDS);
+    }
+
+    private void schedule(CyclicBarrier barrier, Runnable runnable) {
+        executor.schedule(() -> {
+            barrier.await(5, TimeUnit.SECONDS);
+            runnable.run();
+            return null;
+        }, 100, TimeUnit.MILLISECONDS);
+    }
+}


### PR DESCRIPTION
Replacing CXF's future implementation with Java 8 `CompletableFuture` delegate. 