### PR TITLE
Consolidate getTargetMethod calls

### DIFF
--- a/core/src/main/java/org/apache/cxf/interceptor/security/AbstractAuthorizingInInterceptor.java
+++ b/core/src/main/java/org/apache/cxf/interceptor/security/AbstractAuthorizingInInterceptor.java
@@ -26,11 +26,10 @@ import java.util.logging.Logger;
 
 import org.apache.cxf.common.logging.LogUtils;
 import org.apache.cxf.message.Message;
+import org.apache.cxf.message.MessageUtils;
 import org.apache.cxf.phase.AbstractPhaseInterceptor;
 import org.apache.cxf.phase.Phase;
 import org.apache.cxf.security.SecurityContext;
-import org.apache.cxf.service.invoker.MethodDispatcher;
-import org.apache.cxf.service.model.BindingOperationInfo;
 
 public abstract class AbstractAuthorizingInInterceptor extends AbstractPhaseInterceptor<Message> {
 
@@ -45,7 +44,8 @@ public abstract class AbstractAuthorizingInInterceptor extends AbstractPhaseInte
         super(null, Phase.PRE_INVOKE, uniqueId);
     }
     public void handleMessage(Message message) {
-        Method method = getTargetMethod(message);
+        Method method = MessageUtils.getTargetMethod(message, () -> 
+            new AccessDeniedException("Method is not available : Unauthorized"));
         SecurityContext sc = message.get(SecurityContext.class);
         if (sc != null && sc.getUserPrincipal() != null) {
             if (authorize(sc, method)) {
@@ -57,20 +57,6 @@ public abstract class AbstractAuthorizingInInterceptor extends AbstractPhaseInte
 
 
         throw new AccessDeniedException("Unauthorized");
-    }
-
-    protected Method getTargetMethod(Message m) {
-        BindingOperationInfo bop = m.getExchange().getBindingOperationInfo();
-        if (bop != null) {
-            MethodDispatcher md = (MethodDispatcher)
-                m.getExchange().getService().get(MethodDispatcher.class.getName());
-            return md.getMethod(bop);
-        }
-        Method method = (Method)m.get("org.apache.cxf.resource.method");
-        if (method != null) {
-            return method;
-        }
-        throw new AccessDeniedException("Method is not available : Unauthorized");
     }
 
     protected boolean authorize(SecurityContext sc, Method method) {

--- a/core/src/main/java/org/apache/cxf/interceptor/security/AbstractAuthorizingInInterceptor.java
+++ b/core/src/main/java/org/apache/cxf/interceptor/security/AbstractAuthorizingInInterceptor.java
@@ -44,7 +44,7 @@ public abstract class AbstractAuthorizingInInterceptor extends AbstractPhaseInte
         super(null, Phase.PRE_INVOKE, uniqueId);
     }
     public void handleMessage(Message message) {
-        Method method = MessageUtils.getTargetMethod(message, () -> 
+        Method method = MessageUtils.getTargetMethod(message).orElseThrow(() -> 
             new AccessDeniedException("Method is not available : Unauthorized"));
         SecurityContext sc = message.get(SecurityContext.class);
         if (sc != null && sc.getUserPrincipal() != null) {

--- a/core/src/main/java/org/apache/cxf/message/MessageUtils.java
+++ b/core/src/main/java/org/apache/cxf/message/MessageUtils.java
@@ -19,12 +19,16 @@
 
 package org.apache.cxf.message;
 
+import java.lang.reflect.Method;
+import java.util.function.Supplier;
 import java.util.logging.Logger;
 
 import org.w3c.dom.Node;
 
 import org.apache.cxf.common.logging.LogUtils;
 import org.apache.cxf.common.util.PropertyUtils;
+import org.apache.cxf.service.invoker.MethodDispatcher;
+import org.apache.cxf.service.model.BindingOperationInfo;
 
 
 /**
@@ -190,4 +194,16 @@ public final class MessageUtils {
         */
     }
 
+    public static Method getTargetMethod(Message m, Supplier<RuntimeException> exceptionSupplier) {
+        BindingOperationInfo bop = m.getExchange().getBindingOperationInfo();
+        if (bop != null) {
+            MethodDispatcher md = (MethodDispatcher) m.getExchange().getService().get(MethodDispatcher.class.getName());
+            return md.getMethod(bop);
+        }
+        Method method = (Method) m.get("org.apache.cxf.resource.method");
+        if (method != null || exceptionSupplier == null) {
+            return method;
+        }
+        throw exceptionSupplier.get();
+    }
 }

--- a/core/src/main/java/org/apache/cxf/message/MessageUtils.java
+++ b/core/src/main/java/org/apache/cxf/message/MessageUtils.java
@@ -20,7 +20,7 @@
 package org.apache.cxf.message;
 
 import java.lang.reflect.Method;
-import java.util.function.Supplier;
+import java.util.Optional;
 import java.util.logging.Logger;
 
 import org.w3c.dom.Node;
@@ -194,16 +194,15 @@ public final class MessageUtils {
         */
     }
 
-    public static Method getTargetMethod(Message m, Supplier<RuntimeException> exceptionSupplier) {
+    public static Optional<Method> getTargetMethod(Message m) {
+        Method method;
         BindingOperationInfo bop = m.getExchange().getBindingOperationInfo();
         if (bop != null) {
             MethodDispatcher md = (MethodDispatcher) m.getExchange().getService().get(MethodDispatcher.class.getName());
-            return md.getMethod(bop);
+            method = md.getMethod(bop);
+        } else {
+            method = (Method) m.get("org.apache.cxf.resource.method");
         }
-        Method method = (Method) m.get("org.apache.cxf.resource.method");
-        if (method != null || exceptionSupplier == null) {
-            return method;
-        }
-        throw exceptionSupplier.get();
+        return Optional.ofNullable(method);
     }
 }

--- a/core/src/main/java/org/apache/cxf/validation/AbstractValidationInterceptor.java
+++ b/core/src/main/java/org/apache/cxf/validation/AbstractValidationInterceptor.java
@@ -107,7 +107,7 @@ public abstract class AbstractValidationInterceptor extends AbstractPhaseInterce
         Message inMessage = message.getExchange().getInMessage();
         Method method = null;
         if (inMessage != null) {
-            method = MessageUtils.getTargetMethod(inMessage, null);
+            method = MessageUtils.getTargetMethod(inMessage).orElse(null);
         }
         if (method == null) {
             method = message.getExchange().get(Method.class);

--- a/core/src/main/java/org/apache/cxf/validation/AbstractValidationInterceptor.java
+++ b/core/src/main/java/org/apache/cxf/validation/AbstractValidationInterceptor.java
@@ -31,11 +31,10 @@ import org.apache.cxf.common.logging.LogUtils;
 import org.apache.cxf.endpoint.Endpoint;
 import org.apache.cxf.message.Message;
 import org.apache.cxf.message.MessageContentsList;
+import org.apache.cxf.message.MessageUtils;
 import org.apache.cxf.phase.AbstractPhaseInterceptor;
 import org.apache.cxf.service.invoker.FactoryInvoker;
 import org.apache.cxf.service.invoker.Invoker;
-import org.apache.cxf.service.invoker.MethodDispatcher;
-import org.apache.cxf.service.model.BindingOperationInfo;
 
 public abstract class AbstractValidationInterceptor extends AbstractPhaseInterceptor< Message > {
     protected static final Logger LOG = LogUtils.getL7dLogger(AbstractValidationInterceptor.class);
@@ -108,15 +107,7 @@ public abstract class AbstractValidationInterceptor extends AbstractPhaseInterce
         Message inMessage = message.getExchange().getInMessage();
         Method method = null;
         if (inMessage != null) {
-            method = (Method)inMessage.get("org.apache.cxf.resource.method");
-            if (method == null) {
-                BindingOperationInfo bop = inMessage.getExchange().getBindingOperationInfo();
-                if (bop != null) {
-                    MethodDispatcher md = (MethodDispatcher)
-                        inMessage.getExchange().getService().get(MethodDispatcher.class.getName());
-                    method = md.getMethod(bop);
-                }
-            }
+            method = MessageUtils.getTargetMethod(inMessage, null);
         }
         if (method == null) {
             method = message.getExchange().get(Method.class);

--- a/core/src/test/java/org/apache/cxf/message/MessageUtilsTest.java
+++ b/core/src/test/java/org/apache/cxf/message/MessageUtilsTest.java
@@ -19,6 +19,7 @@
 package org.apache.cxf.message;
 
 import java.lang.reflect.Method;
+import java.util.Optional;
 
 import javax.xml.namespace.QName;
 
@@ -32,7 +33,8 @@ import org.apache.cxf.service.model.OperationInfo;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 public class MessageUtilsTest {
 
@@ -54,7 +56,9 @@ public class MessageUtilsTest {
         exchange.put(Service.class, serviceImpl);
         exchange.put(BindingOperationInfo.class, boi);
 
-        assertEquals(method, MessageUtils.getTargetMethod(message, null));
+        Optional<Method> optMethod = MessageUtils.getTargetMethod(message);
+        assertTrue(optMethod.isPresent());
+        assertEquals(method, optMethod.get());
     }
 
     @Test
@@ -64,7 +68,9 @@ public class MessageUtilsTest {
         message.setExchange(new ExchangeImpl());
         message.put("org.apache.cxf.resource.method", method);
 
-        assertEquals(method, MessageUtils.getTargetMethod(message, null));
+        Optional<Method> optMethod = MessageUtils.getTargetMethod(message);
+        assertTrue(optMethod.isPresent());
+        assertEquals(method, optMethod.get());
     }
 
     @Test
@@ -72,14 +78,6 @@ public class MessageUtilsTest {
         Message message = new MessageImpl();
         message.setExchange(new ExchangeImpl());
 
-        assertNull(MessageUtils.getTargetMethod(message, null));
-    }
-
-    @Test(expected = NumberFormatException.class)
-    public void getTargetMethodThrowsException() throws Exception {
-        Message message = new MessageImpl();
-        message.setExchange(new ExchangeImpl());
-
-        MessageUtils.getTargetMethod(message, () -> new NumberFormatException());
+        assertFalse(MessageUtils.getTargetMethod(message).isPresent());
     }
 }

--- a/core/src/test/java/org/apache/cxf/message/MessageUtilsTest.java
+++ b/core/src/test/java/org/apache/cxf/message/MessageUtilsTest.java
@@ -1,0 +1,85 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.cxf.message;
+
+import java.lang.reflect.Method;
+
+import javax.xml.namespace.QName;
+
+import org.apache.cxf.service.Service;
+import org.apache.cxf.service.ServiceImpl;
+import org.apache.cxf.service.factory.SimpleMethodDispatcher;
+import org.apache.cxf.service.invoker.MethodDispatcher;
+import org.apache.cxf.service.model.BindingOperationInfo;
+import org.apache.cxf.service.model.OperationInfo;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+public class MessageUtilsTest {
+
+
+    @Test
+    public void getTargetMethodFromBindingOperationInfo() throws Exception {
+        Method method = MessageUtilsTest.class.getMethod("getTargetMethodFromBindingOperationInfo");
+        Message message = new MessageImpl();
+        Exchange exchange = new ExchangeImpl();
+        message.setExchange(exchange);
+        OperationInfo oi = new OperationInfo();
+        oi.setName(QName.valueOf("getTargetMethod_fromBindingOperationInfo"));
+        BindingOperationInfo boi = new BindingOperationInfo(null, oi);
+        ServiceImpl serviceImpl = new ServiceImpl();
+        MethodDispatcher md = new SimpleMethodDispatcher();
+        md.bind(oi, method);
+
+        serviceImpl.put(MethodDispatcher.class.getName(), md);
+        exchange.put(Service.class, serviceImpl);
+        exchange.put(BindingOperationInfo.class, boi);
+
+        assertEquals(method, MessageUtils.getTargetMethod(message, null));
+    }
+
+    @Test
+    public void getTargetMethodFromProperty() throws Exception {
+        Method method = MessageUtilsTest.class.getMethod("getTargetMethodFromProperty");
+        Message message = new MessageImpl();
+        message.setExchange(new ExchangeImpl());
+        message.put("org.apache.cxf.resource.method", method);
+
+        assertEquals(method, MessageUtils.getTargetMethod(message, null));
+    }
+
+    @Test
+    public void getTargetMethodNoMethodNoException() throws Exception {
+        Message message = new MessageImpl();
+        message.setExchange(new ExchangeImpl());
+
+        assertNull(MessageUtils.getTargetMethod(message, null));
+    }
+
+    @Test(expected = NumberFormatException.class)
+    public void getTargetMethodThrowsException() throws Exception {
+        Message message = new MessageImpl();
+        message.setExchange(new ExchangeImpl());
+
+        MessageUtils.getTargetMethod(message, () -> new NumberFormatException());
+    }
+}

--- a/rt/frontend/jaxrs/src/main/java/org/apache/cxf/jaxrs/provider/JAXRSDataBinding.java
+++ b/rt/frontend/jaxrs/src/main/java/org/apache/cxf/jaxrs/provider/JAXRSDataBinding.java
@@ -43,8 +43,6 @@ import org.apache.cxf.message.Message;
 import org.apache.cxf.message.MessageUtils;
 import org.apache.cxf.phase.PhaseInterceptorChain;
 import org.apache.cxf.service.Service;
-import org.apache.cxf.service.invoker.MethodDispatcher;
-import org.apache.cxf.service.model.BindingOperationInfo;
 import org.apache.cxf.service.model.MessagePartInfo;
 
 /**
@@ -97,15 +95,6 @@ public class JAXRSDataBinding extends AbstractDataBinding {
         // Check how to deal with individual parts if needed, build a single JAXBContext, etc
     }
 
-
-    // TODO: The method containing the actual annotations have to retrieved
-    protected Method getTargetMethod(Message m) {
-        BindingOperationInfo bop = m.getExchange().getBindingOperationInfo();
-        MethodDispatcher md = (MethodDispatcher)
-            m.getExchange().getService().get(MethodDispatcher.class.getName());
-        return md.getMethod(bop);
-    }
-
     @SuppressWarnings("unchecked")
     private MultivaluedMap<String, String> getHeaders(Message message) {
         return new MetadataMap<String, String>(
@@ -126,7 +115,7 @@ public class JAXRSDataBinding extends AbstractDataBinding {
         public void write(Object obj, MessagePartInfo part, XMLStreamWriter output) {
             try {
                 Message message = PhaseInterceptorChain.getCurrentMessage();
-                Method method = MessageUtils.getTargetMethod(message, null);
+                Method method = MessageUtils.getTargetMethod(message).orElse(null);
                 MultivaluedMap<String, Object> headers = getWriteHeaders(message);
                 xmlWriter.writeTo(obj,
                                  method.getReturnType(),
@@ -172,7 +161,7 @@ public class JAXRSDataBinding extends AbstractDataBinding {
         @SuppressWarnings("unchecked")
         private <T> T read(Class<T> cls) throws WebApplicationException, IOException {
             Message message = PhaseInterceptorChain.getCurrentMessage();
-            Method method = MessageUtils.getTargetMethod(message, null);
+            Method method = MessageUtils.getTargetMethod(message).orElse(null);
             MessageBodyReader<T> reader = (MessageBodyReader<T>)xmlReader;
 
             return reader.readFrom(cls,

--- a/rt/frontend/jaxrs/src/main/java/org/apache/cxf/jaxrs/provider/JAXRSDataBinding.java
+++ b/rt/frontend/jaxrs/src/main/java/org/apache/cxf/jaxrs/provider/JAXRSDataBinding.java
@@ -40,6 +40,7 @@ import org.apache.cxf.databinding.DataWriter;
 import org.apache.cxf.jaxrs.impl.MetadataMap;
 import org.apache.cxf.message.Attachment;
 import org.apache.cxf.message.Message;
+import org.apache.cxf.message.MessageUtils;
 import org.apache.cxf.phase.PhaseInterceptorChain;
 import org.apache.cxf.service.Service;
 import org.apache.cxf.service.invoker.MethodDispatcher;
@@ -125,7 +126,7 @@ public class JAXRSDataBinding extends AbstractDataBinding {
         public void write(Object obj, MessagePartInfo part, XMLStreamWriter output) {
             try {
                 Message message = PhaseInterceptorChain.getCurrentMessage();
-                Method method = getTargetMethod(message);
+                Method method = MessageUtils.getTargetMethod(message, null);
                 MultivaluedMap<String, Object> headers = getWriteHeaders(message);
                 xmlWriter.writeTo(obj,
                                  method.getReturnType(),
@@ -171,7 +172,7 @@ public class JAXRSDataBinding extends AbstractDataBinding {
         @SuppressWarnings("unchecked")
         private <T> T read(Class<T> cls) throws WebApplicationException, IOException {
             Message message = PhaseInterceptorChain.getCurrentMessage();
-            Method method = getTargetMethod(message);
+            Method method = MessageUtils.getTargetMethod(message, null);
             MessageBodyReader<T> reader = (MessageBodyReader<T>)xmlReader;
 
             return reader.readFrom(cls,

--- a/rt/security/src/main/java/org/apache/cxf/rt/security/claims/interceptor/ClaimsAuthorizingInterceptor.java
+++ b/rt/security/src/main/java/org/apache/cxf/rt/security/claims/interceptor/ClaimsAuthorizingInterceptor.java
@@ -34,6 +34,7 @@ import org.apache.cxf.common.util.ClassHelper;
 import org.apache.cxf.interceptor.Fault;
 import org.apache.cxf.interceptor.security.AccessDeniedException;
 import org.apache.cxf.message.Message;
+import org.apache.cxf.message.MessageUtils;
 import org.apache.cxf.phase.AbstractPhaseInterceptor;
 import org.apache.cxf.phase.Phase;
 import org.apache.cxf.rt.security.claims.ClaimBean;
@@ -43,8 +44,6 @@ import org.apache.cxf.security.SecurityContext;
 import org.apache.cxf.security.claims.authorization.Claim;
 import org.apache.cxf.security.claims.authorization.ClaimMode;
 import org.apache.cxf.security.claims.authorization.Claims;
-import org.apache.cxf.service.invoker.MethodDispatcher;
-import org.apache.cxf.service.model.BindingOperationInfo;
 
 
 public class ClaimsAuthorizingInterceptor extends AbstractPhaseInterceptor<Message> {
@@ -68,7 +67,8 @@ public class ClaimsAuthorizingInterceptor extends AbstractPhaseInterceptor<Messa
             throw new AccessDeniedException("Security Context is unavailable or unrecognized");
         }
 
-        Method method = getTargetMethod(message);
+        Method method = MessageUtils.getTargetMethod(message, () -> new AccessDeniedException(
+                "Method is not available : Unauthorized"));
 
         if (authorize((ClaimsSecurityContext)sc, method)) {
             return;
@@ -79,20 +79,6 @@ public class ClaimsAuthorizingInterceptor extends AbstractPhaseInterceptor<Messa
 
     public void setClaims(Map<String, List<ClaimBean>> claimsMap) {
         claims.putAll(claimsMap);
-    }
-
-    protected Method getTargetMethod(Message m) {
-        BindingOperationInfo bop = m.getExchange().getBindingOperationInfo();
-        if (bop != null) {
-            MethodDispatcher md = (MethodDispatcher)
-                m.getExchange().getService().get(MethodDispatcher.class.getName());
-            return md.getMethod(bop);
-        }
-        Method method = (Method)m.get("org.apache.cxf.resource.method");
-        if (method != null) {
-            return method;
-        }
-        throw new AccessDeniedException("Method is not available : Unauthorized");
     }
 
     protected boolean authorize(ClaimsSecurityContext sc, Method method) {

--- a/rt/security/src/main/java/org/apache/cxf/rt/security/claims/interceptor/ClaimsAuthorizingInterceptor.java
+++ b/rt/security/src/main/java/org/apache/cxf/rt/security/claims/interceptor/ClaimsAuthorizingInterceptor.java
@@ -67,8 +67,8 @@ public class ClaimsAuthorizingInterceptor extends AbstractPhaseInterceptor<Messa
             throw new AccessDeniedException("Security Context is unavailable or unrecognized");
         }
 
-        Method method = MessageUtils.getTargetMethod(message, () -> new AccessDeniedException(
-                "Method is not available : Unauthorized"));
+        Method method = MessageUtils.getTargetMethod(message).orElseThrow(() ->
+            new AccessDeniedException("Method is not available : Unauthorized"));
 
         if (authorize((ClaimsSecurityContext)sc, method)) {
             return;


### PR DESCRIPTION
I was looking at getting the target method in a new interceptor and realized that there are a few different places in the code that is essentially doing the same thing.  So I thought it would be better for maintenance to consolidate that function in one place.

Feedback appreciated.  If nobody objects, I'd like to back port this to 3.3.x too.

Thanks!