### PR TITLE
[CXF-8294][CXF-8295] Proxy and followRedirect APIs for MicroProfile Rest Client 2.0

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -161,7 +161,7 @@
         <cxf.lucene.version>8.2.0</cxf.lucene.version>
         <cxf.maven.core.version>3.6.3</cxf.maven.core.version>
         <cxf.microprofile.config.version>1.2</cxf.microprofile.config.version>
-        <cxf.microprofile.rest.client.version>2.0-m1</cxf.microprofile.rest.client.version>
+        <cxf.microprofile.rest.client.version>2.0-RC1</cxf.microprofile.rest.client.version>
         <cxf.microprofile.openapi.version>1.1.2</cxf.microprofile.openapi.version>        
         <cxf.mina.version>2.0.21</cxf.mina.version>
         <cxf.mockito.version>3.3.3</cxf.mockito.version>

--- a/rt/rs/microprofile-client/src/main/java/org/apache/cxf/microprofile/client/CxfTypeSafeClientBuilder.java
+++ b/rt/rs/microprofile-client/src/main/java/org/apache/cxf/microprofile/client/CxfTypeSafeClientBuilder.java
@@ -41,6 +41,7 @@ import javax.ws.rs.ProcessingException;
 import javax.ws.rs.core.Configurable;
 import javax.ws.rs.core.Configuration;
 
+import org.apache.cxf.jaxrs.client.ClientProperties;
 import org.apache.cxf.jaxrs.client.spec.TLSConfiguration;
 import org.apache.cxf.microprofile.client.sse.SseMessageBodyReader;
 import org.eclipse.microprofile.rest.client.RestClientBuilder;
@@ -246,6 +247,25 @@ public class CxfTypeSafeClientBuilder implements RestClientBuilder, Configurable
     @Override
     public RestClientBuilder hostnameVerifier(HostnameVerifier verifier) {
         secConfig.getTlsClientParams().setHostnameVerifier(verifier);
+        return this;
+    }
+
+    @Override
+    public RestClientBuilder followRedirects(boolean follows) {
+        configImpl.property(ClientProperties.HTTP_AUTOREDIRECT_PROP, Boolean.toString(follows));
+        return this;
+    }
+
+    @Override
+    public RestClientBuilder proxyAddress(String proxyHost, int proxyPort) {
+        if (proxyHost == null) {
+            throw new IllegalArgumentException("proxyHost must not be null");
+        }
+        if (proxyPort < 1 || proxyPort > 65535) {
+            throw new IllegalArgumentException("proxyPort must be between 1 and 65535");
+        }
+        configImpl.property(ClientProperties.HTTP_PROXY_SERVER_PROP, proxyHost);
+        configImpl.property(ClientProperties.HTTP_PROXY_SERVER_PORT_PROP, proxyPort);
         return this;
     }
 }

--- a/rt/rs/microprofile-client/src/main/java/org/apache/cxf/microprofile/client/MicroProfileClientFactoryBean.java
+++ b/rt/rs/microprofile-client/src/main/java/org/apache/cxf/microprofile/client/MicroProfileClientFactoryBean.java
@@ -31,9 +31,11 @@ import javax.ws.rs.client.ClientResponseFilter;
 import javax.ws.rs.core.Configuration;
 
 import org.apache.cxf.common.util.ClassHelper;
+import org.apache.cxf.common.util.PropertyUtils;
 import org.apache.cxf.configuration.jsse.TLSClientParameters;
 import org.apache.cxf.endpoint.Endpoint;
 import org.apache.cxf.jaxrs.client.AbstractClient;
+import org.apache.cxf.jaxrs.client.ClientProperties;
 import org.apache.cxf.jaxrs.client.ClientProxyImpl;
 import org.apache.cxf.jaxrs.client.ClientState;
 import org.apache.cxf.jaxrs.client.JAXRSClientFactoryBean;
@@ -100,6 +102,17 @@ public class MicroProfileClientFactoryBean extends JAXRSClientFactoryBean {
             || tlsParams.getTrustManagers() != null
             || tlsParams.getHostnameVerifier() != null) {
             client.getConfiguration().getHttpConduit().setTlsClientParameters(tlsParams);
+        }
+
+        if (PropertyUtils.isTrue(configuration.getProperty(ClientProperties.HTTP_AUTOREDIRECT_PROP))) {
+            client.getConfiguration().getHttpConduit().getClient().setAutoRedirect(true);
+        }
+
+        String proxyHost = (String) configuration.getProperty(ClientProperties.HTTP_PROXY_SERVER_PROP);
+        if (proxyHost != null) {
+            client.getConfiguration().getHttpConduit().getClient().setProxyServer(proxyHost);
+            int proxyPort = (int) configuration.getProperty(ClientProperties.HTTP_PROXY_SERVER_PORT_PROP);
+            client.getConfiguration().getHttpConduit().getClient().setProxyServerPort(proxyPort);
         }
 
         MicroProfileClientProviderFactory factory = MicroProfileClientProviderFactory.createInstance(getBus(),

--- a/rt/rs/microprofile-client/src/test/java/org/apache/cxf/microprofile/client/CxfTypeSafeClientBuilderTest.java
+++ b/rt/rs/microprofile-client/src/test/java/org/apache/cxf/microprofile/client/CxfTypeSafeClientBuilderTest.java
@@ -191,4 +191,36 @@ public class CxfTypeSafeClientBuilderTest {
         Assert.fail(failureMessage);
     }
 
+    @Test
+    public void testFollowRedirectSetsProperty() {
+        CxfTypeSafeClientBuilder builder = (CxfTypeSafeClientBuilder) RestClientBuilder.newBuilder()
+                                                                                       .followRedirects(true);
+        assertEquals("true", builder.getConfiguration().getProperty("http.autoredirect"));
+
+        builder = (CxfTypeSafeClientBuilder) RestClientBuilder.newBuilder().followRedirects(false);
+        assertEquals("false", builder.getConfiguration().getProperty("http.autoredirect"));
+    }
+
+    @Test
+    public void testProxyAddressSetsProperty() {
+        CxfTypeSafeClientBuilder builder = (CxfTypeSafeClientBuilder)
+            RestClientBuilder.newBuilder().proxyAddress("cxf.apache.org", 8080);
+        assertEquals("cxf.apache.org", builder.getConfiguration().getProperty("http.proxy.server.uri"));
+        assertEquals(8080, builder.getConfiguration().getProperty("http.proxy.server.port"));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testProxyAddressInvalidPort1() {
+        RestClientBuilder.newBuilder().proxyAddress("cxf.apache.org", -1);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testProxyAddressInvalidPort2() {
+        RestClientBuilder.newBuilder().proxyAddress("a.com", Integer.MAX_VALUE);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testProxyAddressNullHost() {
+        RestClientBuilder.newBuilder().proxyAddress(null, 8080);
+    }
 }

--- a/rt/transports/http/src/main/java/org/apache/cxf/transport/http/HTTPConduit.java
+++ b/rt/transports/http/src/main/java/org/apache/cxf/transport/http/HTTPConduit.java
@@ -1455,6 +1455,7 @@ public abstract class HTTPConduit
             case HttpURLConnection.HTTP_MOVED_TEMP:
             case HttpURLConnection.HTTP_SEE_OTHER:
             case 307:
+            case 308:
                 return redirectRetransmit();
             case HttpURLConnection.HTTP_UNAUTHORIZED:
             case HttpURLConnection.HTTP_PROXY_AUTH:


### PR DESCRIPTION
This PR covers two JIRAs [CXF-8294](https://issues.apache.org/jira/browse/CXF-8294) and [CXF-8295](https://issues.apache.org/jira/browse/CXF-8295) - proxy server support and auto follow redirect support.  Both of these features already exist in the CXF client, but now are made part of the MicroProfile Rest Client API.  This PR maps the MP API to the existing CXF properties.

On a related note, I have added a separate commit that will auto-redirect on 308 responses too.   Per [MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/308), 308s are a permanent redirect - and the Jakarta JAX-RS community is planning to include official support for it in a future spec release (3.1, I think...).  This is not strictly required in order to implement the MP spec, but I thought it would make a nice addition.  If anybody feels strongly that we should not redirect on 308s, I'm fine with removing that commit.

Thanks, Andy