### PR TITLE
[CXF-8299] Impl for QueryParamStyles in RestClient

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -161,7 +161,7 @@
         <cxf.lucene.version>8.2.0</cxf.lucene.version>
         <cxf.maven.core.version>3.6.3</cxf.maven.core.version>
         <cxf.microprofile.config.version>1.2</cxf.microprofile.config.version>
-        <cxf.microprofile.rest.client.version>2.0-RC1</cxf.microprofile.rest.client.version>
+        <cxf.microprofile.rest.client.version>2.0-RC2</cxf.microprofile.rest.client.version>
         <cxf.microprofile.openapi.version>1.1.2</cxf.microprofile.openapi.version>        
         <cxf.mina.version>2.0.21</cxf.mina.version>
         <cxf.mockito.version>3.3.3</cxf.mockito.version>

--- a/rt/frontend/jaxrs/src/main/java/org/apache/cxf/jaxrs/impl/UriBuilderImpl.java
+++ b/rt/frontend/jaxrs/src/main/java/org/apache/cxf/jaxrs/impl/UriBuilderImpl.java
@@ -48,6 +48,7 @@ import org.apache.cxf.jaxrs.utils.JAXRSUtils;
 
 public class UriBuilderImpl extends UriBuilder implements Cloneable {
     private static final String EXPAND_QUERY_VALUE_AS_COLLECTION = "expand.query.value.as.collection";
+    private static final String USE_ARRAY_SYNTAX_FOR_QUERY_VALUES = "use.array.syntax.for.query.values";
 
     private String scheme;
     private String userInfo;
@@ -66,6 +67,7 @@ public class UriBuilderImpl extends UriBuilder implements Cloneable {
     private Map<String, Object> resolvedEncodedTemplates;
 
     private boolean queryValueIsCollection;
+    private boolean useArraySyntaxForQueryParams;
 
     /**
      * Creates builder with empty URI.
@@ -78,6 +80,7 @@ public class UriBuilderImpl extends UriBuilder implements Cloneable {
      */
     public UriBuilderImpl(Map<String, Object> properties) {
         queryValueIsCollection = PropertyUtils.isTrue(properties, EXPAND_QUERY_VALUE_AS_COLLECTION);
+        useArraySyntaxForQueryParams = PropertyUtils.isTrue(properties, USE_ARRAY_SYNTAX_FOR_QUERY_VALUES);
     }
 
     /**
@@ -444,6 +447,7 @@ public class UriBuilderImpl extends UriBuilder implements Cloneable {
             resolvedTemplates == null ? null : new HashMap<String, Object>(resolvedTemplates);
         builder.resolvedTemplatesPathEnc =
             resolvedTemplatesPathEnc == null ? null : new HashMap<String, Object>(resolvedTemplatesPathEnc);
+        builder.useArraySyntaxForQueryParams = useArraySyntaxForQueryParams;
         return builder;
     }
     // CHECKSTYLE:ON
@@ -865,7 +869,11 @@ public class UriBuilderImpl extends UriBuilder implements Cloneable {
 
             // Expand query parameter as "name=v1,v2,v3"
             if (isQuery && queryValueIsCollection) {
-                b.append(entry.getKey()).append('=');
+                b.append(entry.getKey());
+                if (useArraySyntaxForQueryParams) {
+                    b.append("[]");
+                }
+                b.append('=');
 
                 for (Iterator<String> sit = entry.getValue().iterator(); sit.hasNext();) {
                     String val = sit.next();
@@ -899,6 +907,9 @@ public class UriBuilderImpl extends UriBuilder implements Cloneable {
                 for (Iterator<String> sit = entry.getValue().iterator(); sit.hasNext();) {
                     String val = sit.next();
                     b.append(entry.getKey());
+                    if (useArraySyntaxForQueryParams) {
+                        b.append("[]");
+                    }
                     if (val != null) {
                         boolean templateValue = val.startsWith("{") && val.endsWith("}");
                         if (!templateValue) {

--- a/rt/frontend/jaxrs/src/test/java/org/apache/cxf/jaxrs/impl/UriBuilderImplTest.java
+++ b/rt/frontend/jaxrs/src/test/java/org/apache/cxf/jaxrs/impl/UriBuilderImplTest.java
@@ -1688,6 +1688,30 @@ public class UriBuilderImplTest {
         assertEquals(url, uri.toString());
     }
 
+    @Test
+    public void testExpandQueryValueAsCollection() {
+        Map<String, Object> props = Collections.singletonMap("expand.query.value.as.collection", true);
+        URI uri = new UriBuilderImpl(props).queryParam("foo", "v1", "v2", "v3").build();
+        assertEquals("foo=v1,v2,v3", uri.getQuery());
+    }
+
+    @Test
+    public void testUseArraySyntaxForQueryParams() {
+        Map<String, Object> props = Collections.singletonMap("use.array.syntax.for.query.values", true);
+        URI uri = new UriBuilderImpl(props).queryParam("foo", "v1", "v2", "v3").build();
+        assertEquals("foo[]=v1&foo[]=v2&foo[]=v3", uri.getQuery());
+    }
+
+    @Test
+    public void testUseArraySyntaxForQueryParamsBuildFromEncodedNormalize() {
+        Map<String, Object> props = Collections.singletonMap("use.array.syntax.for.query.values", true);
+        URI uri = new UriBuilderImpl(props).queryParam("foo", "v1")
+                                           .queryParam("foo", "v2")
+                                           .queryParam("foo", "v3")
+                                           .buildFromEncoded().normalize();
+        assertEquals("foo[]=v1&foo[]=v2&foo[]=v3", uri.getQuery());
+    }
+
     @Path(value = "/TestPath")
     public static class TestPath {
 

--- a/rt/rs/microprofile-client/src/main/java/org/apache/cxf/microprofile/client/CxfTypeSafeClientBuilder.java
+++ b/rt/rs/microprofile-client/src/main/java/org/apache/cxf/microprofile/client/CxfTypeSafeClientBuilder.java
@@ -46,6 +46,7 @@ import org.apache.cxf.jaxrs.client.spec.TLSConfiguration;
 import org.apache.cxf.microprofile.client.sse.SseMessageBodyReader;
 import org.eclipse.microprofile.rest.client.RestClientBuilder;
 import org.eclipse.microprofile.rest.client.annotation.RegisterProvider;
+import org.eclipse.microprofile.rest.client.ext.QueryParamStyle;
 import org.eclipse.microprofile.rest.client.spi.RestClientListener;
 
 import static org.apache.cxf.jaxrs.client.ClientProperties.HTTP_CONNECTION_TIMEOUT_PROP;
@@ -266,6 +267,16 @@ public class CxfTypeSafeClientBuilder implements RestClientBuilder, Configurable
         }
         configImpl.property(ClientProperties.HTTP_PROXY_SERVER_PROP, proxyHost);
         configImpl.property(ClientProperties.HTTP_PROXY_SERVER_PORT_PROP, proxyPort);
+        return this;
+    }
+
+    @Override
+    public RestClientBuilder queryParamStyle(QueryParamStyle style) {
+        switch(style) {
+        case ARRAY_PAIRS: configImpl.property("use.array.syntax.for.query.values", true); break;
+        case COMMA_SEPARATED: configImpl.property("expand.query.value.as.collection", true); break;
+        default:
+        }
         return this;
     }
 }

--- a/rt/rs/microprofile-client/src/main/java/org/apache/cxf/microprofile/client/MicroProfileClientFactoryBean.java
+++ b/rt/rs/microprofile-client/src/main/java/org/apache/cxf/microprofile/client/MicroProfileClientFactoryBean.java
@@ -68,6 +68,7 @@ public class MicroProfileClientFactoryBean extends JAXRSClientFactoryBean {
         super.setAddress(baseUri);
         super.setServiceClass(aClass);
         super.setProviderComparator(comparator);
+        super.setProperties(this.configuration.getProperties());
         registeredProviders = new ArrayList<>();
         registeredProviders.addAll(processProviders());
         if (!configuration.isDefaultExceptionMapperDisabled()) {

--- a/rt/rs/microprofile-client/src/main/java/org/apache/cxf/microprofile/client/cdi/RestClientBean.java
+++ b/rt/rs/microprofile-client/src/main/java/org/apache/cxf/microprofile/client/cdi/RestClientBean.java
@@ -57,6 +57,7 @@ import org.apache.cxf.common.util.PropertyUtils;
 import org.apache.cxf.common.util.ReflectionUtil;
 import org.apache.cxf.microprofile.client.CxfTypeSafeClientBuilder;
 import org.apache.cxf.microprofile.client.config.ConfigFacade;
+import org.eclipse.microprofile.rest.client.ext.QueryParamStyle;
 import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
 import org.eclipse.microprofile.rest.client.inject.RestClient;
 
@@ -77,6 +78,7 @@ public class RestClientBean implements Bean<Object>, PassivationCapable {
     public static final String REST_KEY_STORE_TYPE_FORMAT = "%s/mp-rest/keyStoreType";
     public static final String REST_FOLLOW_REDIRECTS_FORMAT = "%s/mp-rest/followRedirects";
     public static final String REST_PROXY_ADDRESS_FORMAT = "%s/mp-rest/proxyAddress";
+    public static final String QUERY_PARAM_STYLE_FORMAT = "%s/mp-rest/queryParamStyle";
     private static final Logger LOG = LogUtils.getL7dLogger(RestClientBean.class);
     private static final Default DEFAULT_LITERAL = new DefaultLiteral();
     private final Class<?> clientInterface;
@@ -123,6 +125,7 @@ public class RestClientBean implements Bean<Object>, PassivationCapable {
         setSSLConfig(builder);
         setFollowRedirects(builder);
         setProxyAddress(builder);
+        setQueryParamStyle(builder);
         return builder.build(clientInterface);
     }
 
@@ -307,6 +310,23 @@ public class RestClientBean implements Bean<Object>, PassivationCapable {
                     LOG.finest("proxyAddress set by MP Config: " + address);
                 }
             });
+    }
+
+    private void setQueryParamStyle(CxfTypeSafeClientBuilder builder) {
+        ConfigFacade.getOptionalValue(QUERY_PARAM_STYLE_FORMAT, clientInterface, String.class).ifPresent(
+            styleString -> {
+                try {
+                    builder.queryParamStyle(QueryParamStyle.valueOf(styleString));
+                    if (LOG.isLoggable(Level.FINEST)) {
+                        LOG.finest("queryParamStyle set by MP Config: " + styleString);
+                    }
+                } catch (Throwable t) {
+                    throw new IllegalStateException(String.format("Invalid queryParamStyle value specified for %s: %s",
+                                                                  clientInterface.getName(),
+                                                                  styleString));
+                }
+            });
+    
     }
 
     private void setSSLConfig(CxfTypeSafeClientBuilder builder) {


### PR DESCRIPTION
This is a draft PR for now since the new API (new builder method and enum) is not yet available in Maven.  

When ready, this will resolve JIRA [CXF-8299](https://issues.apache.org/jira/browse/CXF-8299).

It allows users to configure the style of query parameters when multiple values are specified for the same parameter key.  This may be useful in scenarios where the client developer has little to no control over the RESTful endpoint - which might require PHP-style query parameters, or comma-separated values.



