### PR TITLE
[CXF-8299][CXF-8304] QueryParamStyles and CDI-managed providers for MP Rest Client 2.0

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -161,7 +161,7 @@
         <cxf.lucene.version>8.2.0</cxf.lucene.version>
         <cxf.maven.core.version>3.6.3</cxf.maven.core.version>
         <cxf.microprofile.config.version>1.2</cxf.microprofile.config.version>
-        <cxf.microprofile.rest.client.version>2.0-RC1</cxf.microprofile.rest.client.version>
+        <cxf.microprofile.rest.client.version>2.0-RC2</cxf.microprofile.rest.client.version>
         <cxf.microprofile.openapi.version>1.1.2</cxf.microprofile.openapi.version>        
         <cxf.mina.version>2.0.21</cxf.mina.version>
         <cxf.mockito.version>3.3.3</cxf.mockito.version>

--- a/rt/frontend/jaxrs/src/main/java/org/apache/cxf/jaxrs/impl/UriBuilderImpl.java
+++ b/rt/frontend/jaxrs/src/main/java/org/apache/cxf/jaxrs/impl/UriBuilderImpl.java
@@ -48,6 +48,7 @@ import org.apache.cxf.jaxrs.utils.JAXRSUtils;
 
 public class UriBuilderImpl extends UriBuilder implements Cloneable {
     private static final String EXPAND_QUERY_VALUE_AS_COLLECTION = "expand.query.value.as.collection";
+    private static final String USE_ARRAY_SYNTAX_FOR_QUERY_VALUES = "use.array.syntax.for.query.values";
 
     private String scheme;
     private String userInfo;
@@ -66,6 +67,7 @@ public class UriBuilderImpl extends UriBuilder implements Cloneable {
     private Map<String, Object> resolvedEncodedTemplates;
 
     private boolean queryValueIsCollection;
+    private boolean useArraySyntaxForQueryParams;
 
     /**
      * Creates builder with empty URI.
@@ -78,6 +80,7 @@ public class UriBuilderImpl extends UriBuilder implements Cloneable {
      */
     public UriBuilderImpl(Map<String, Object> properties) {
         queryValueIsCollection = PropertyUtils.isTrue(properties, EXPAND_QUERY_VALUE_AS_COLLECTION);
+        useArraySyntaxForQueryParams = PropertyUtils.isTrue(properties, USE_ARRAY_SYNTAX_FOR_QUERY_VALUES);
     }
 
     /**
@@ -444,6 +447,7 @@ public class UriBuilderImpl extends UriBuilder implements Cloneable {
             resolvedTemplates == null ? null : new HashMap<String, Object>(resolvedTemplates);
         builder.resolvedTemplatesPathEnc =
             resolvedTemplatesPathEnc == null ? null : new HashMap<String, Object>(resolvedTemplatesPathEnc);
+        builder.useArraySyntaxForQueryParams = useArraySyntaxForQueryParams;
         return builder;
     }
     // CHECKSTYLE:ON
@@ -865,7 +869,11 @@ public class UriBuilderImpl extends UriBuilder implements Cloneable {
 
             // Expand query parameter as "name=v1,v2,v3"
             if (isQuery && queryValueIsCollection) {
-                b.append(entry.getKey()).append('=');
+                b.append(entry.getKey());
+                if (useArraySyntaxForQueryParams) {
+                    b.append("[]");
+                }
+                b.append('=');
 
                 for (Iterator<String> sit = entry.getValue().iterator(); sit.hasNext();) {
                     String val = sit.next();
@@ -899,6 +907,9 @@ public class UriBuilderImpl extends UriBuilder implements Cloneable {
                 for (Iterator<String> sit = entry.getValue().iterator(); sit.hasNext();) {
                     String val = sit.next();
                     b.append(entry.getKey());
+                    if (useArraySyntaxForQueryParams) {
+                        b.append("[]");
+                    }
                     if (val != null) {
                         boolean templateValue = val.startsWith("{") && val.endsWith("}");
                         if (!templateValue) {

--- a/rt/frontend/jaxrs/src/test/java/org/apache/cxf/jaxrs/impl/UriBuilderImplTest.java
+++ b/rt/frontend/jaxrs/src/test/java/org/apache/cxf/jaxrs/impl/UriBuilderImplTest.java
@@ -1688,6 +1688,30 @@ public class UriBuilderImplTest {
         assertEquals(url, uri.toString());
     }
 
+    @Test
+    public void testExpandQueryValueAsCollection() {
+        Map<String, Object> props = Collections.singletonMap("expand.query.value.as.collection", true);
+        URI uri = new UriBuilderImpl(props).queryParam("foo", "v1", "v2", "v3").build();
+        assertEquals("foo=v1,v2,v3", uri.getQuery());
+    }
+
+    @Test
+    public void testUseArraySyntaxForQueryParams() {
+        Map<String, Object> props = Collections.singletonMap("use.array.syntax.for.query.values", true);
+        URI uri = new UriBuilderImpl(props).queryParam("foo", "v1", "v2", "v3").build();
+        assertEquals("foo[]=v1&foo[]=v2&foo[]=v3", uri.getQuery());
+    }
+
+    @Test
+    public void testUseArraySyntaxForQueryParamsBuildFromEncodedNormalize() {
+        Map<String, Object> props = Collections.singletonMap("use.array.syntax.for.query.values", true);
+        URI uri = new UriBuilderImpl(props).queryParam("foo", "v1")
+                                           .queryParam("foo", "v2")
+                                           .queryParam("foo", "v3")
+                                           .buildFromEncoded().normalize();
+        assertEquals("foo[]=v1&foo[]=v2&foo[]=v3", uri.getQuery());
+    }
+
     @Path(value = "/TestPath")
     public static class TestPath {
 

--- a/rt/rs/microprofile-client/src/main/java/org/apache/cxf/microprofile/client/CxfTypeSafeClientBuilder.java
+++ b/rt/rs/microprofile-client/src/main/java/org/apache/cxf/microprofile/client/CxfTypeSafeClientBuilder.java
@@ -279,4 +279,8 @@ public class CxfTypeSafeClientBuilder implements RestClientBuilder, Configurable
         }
         return this;
     }
+
+    public void close() {
+        configImpl.close();
+    }
 }

--- a/rt/rs/microprofile-client/src/main/java/org/apache/cxf/microprofile/client/CxfTypeSafeClientBuilder.java
+++ b/rt/rs/microprofile-client/src/main/java/org/apache/cxf/microprofile/client/CxfTypeSafeClientBuilder.java
@@ -46,6 +46,7 @@ import org.apache.cxf.jaxrs.client.spec.TLSConfiguration;
 import org.apache.cxf.microprofile.client.sse.SseMessageBodyReader;
 import org.eclipse.microprofile.rest.client.RestClientBuilder;
 import org.eclipse.microprofile.rest.client.annotation.RegisterProvider;
+import org.eclipse.microprofile.rest.client.ext.QueryParamStyle;
 import org.eclipse.microprofile.rest.client.spi.RestClientListener;
 
 import static org.apache.cxf.jaxrs.client.ClientProperties.HTTP_CONNECTION_TIMEOUT_PROP;
@@ -266,6 +267,16 @@ public class CxfTypeSafeClientBuilder implements RestClientBuilder, Configurable
         }
         configImpl.property(ClientProperties.HTTP_PROXY_SERVER_PROP, proxyHost);
         configImpl.property(ClientProperties.HTTP_PROXY_SERVER_PORT_PROP, proxyPort);
+        return this;
+    }
+
+    @Override
+    public RestClientBuilder queryParamStyle(QueryParamStyle style) {
+        switch(style) {
+        case ARRAY_PAIRS: configImpl.property("use.array.syntax.for.query.values", true); break;
+        case COMMA_SEPARATED: configImpl.property("expand.query.value.as.collection", true); break;
+        default:
+        }
         return this;
     }
 }

--- a/rt/rs/microprofile-client/src/main/java/org/apache/cxf/microprofile/client/MicroProfileClientConfigurableImpl.java
+++ b/rt/rs/microprofile-client/src/main/java/org/apache/cxf/microprofile/client/MicroProfileClientConfigurableImpl.java
@@ -31,6 +31,7 @@ import javax.ws.rs.ext.WriterInterceptor;
 import org.apache.cxf.common.util.PropertyUtils;
 import org.apache.cxf.jaxrs.impl.ConfigurableImpl;
 import org.apache.cxf.jaxrs.impl.ConfigurationImpl;
+import org.apache.cxf.microprofile.client.cdi.CDIFacade;
 import org.apache.cxf.microprofile.client.config.ConfigFacade;
 import org.eclipse.microprofile.rest.client.ext.ResponseExceptionMapper;
 
@@ -41,6 +42,8 @@ public class MicroProfileClientConfigurableImpl<C extends Configurable<C>>
         ClientResponseFilter.class, ReaderInterceptor.class, WriterInterceptor.class,
         MessageBodyWriter.class, MessageBodyReader.class, ResponseExceptionMapper.class};
     private static final String CONFIG_KEY_DISABLE_MAPPER = "microprofile.rest.client.disable.default.mapper";
+
+    private Instantiator instantiator = CDIFacade.getInstantiator().orElse(super.getInstantiator());
 
     public MicroProfileClientConfigurableImpl(C configurable) {
         this(configurable, null);
@@ -58,5 +61,10 @@ public class MicroProfileClientConfigurableImpl<C extends Configurable<C>>
         }
         return ConfigFacade.getOptionalValue(CONFIG_KEY_DISABLE_MAPPER,
                                              Boolean.class).orElse(false);
+    }
+
+    @Override
+    protected Instantiator getInstantiator() {
+        return instantiator;
     }
 }

--- a/rt/rs/microprofile-client/src/main/java/org/apache/cxf/microprofile/client/MicroProfileClientConfigurableImpl.java
+++ b/rt/rs/microprofile-client/src/main/java/org/apache/cxf/microprofile/client/MicroProfileClientConfigurableImpl.java
@@ -43,7 +43,7 @@ public class MicroProfileClientConfigurableImpl<C extends Configurable<C>>
         MessageBodyWriter.class, MessageBodyReader.class, ResponseExceptionMapper.class};
     private static final String CONFIG_KEY_DISABLE_MAPPER = "microprofile.rest.client.disable.default.mapper";
 
-    private Instantiator instantiator = CDIFacade.getInstantiator().orElse(super.getInstantiator());
+    private final Instantiator instantiator = CDIFacade.getInstantiator().orElse(super.getInstantiator());
 
     public MicroProfileClientConfigurableImpl(C configurable) {
         this(configurable, null);

--- a/rt/rs/microprofile-client/src/main/java/org/apache/cxf/microprofile/client/MicroProfileClientFactoryBean.java
+++ b/rt/rs/microprofile-client/src/main/java/org/apache/cxf/microprofile/client/MicroProfileClientFactoryBean.java
@@ -68,6 +68,7 @@ public class MicroProfileClientFactoryBean extends JAXRSClientFactoryBean {
         super.setAddress(baseUri);
         super.setServiceClass(aClass);
         super.setProviderComparator(comparator);
+        super.setProperties(this.configuration.getProperties());
         registeredProviders = new ArrayList<>();
         registeredProviders.addAll(processProviders());
         if (!configuration.isDefaultExceptionMapperDisabled()) {

--- a/rt/rs/microprofile-client/src/main/java/org/apache/cxf/microprofile/client/cdi/CDIFacade.java
+++ b/rt/rs/microprofile-client/src/main/java/org/apache/cxf/microprofile/client/cdi/CDIFacade.java
@@ -23,6 +23,7 @@ import java.util.Optional;
 import java.util.concurrent.Callable;
 
 import org.apache.cxf.Bus;
+import org.apache.cxf.jaxrs.impl.ConfigurableImpl.Instantiator;
 
 
 public final class CDIFacade {
@@ -62,6 +63,10 @@ public final class CDIFacade {
 
     public static <T> Optional<Instance<T>> getInstanceFromCDI(Class<T> clazz) {
         return nullableOptional(() -> CDIUtils.getInstanceFromCDI(clazz));
+    }
+
+    public static Optional<Instantiator> getInstantiator() {
+        return Optional.ofNullable(CDI_AVAILABLE ? CDIInstantiator.INSTANCE : null);
     }
 
     private static <T> Optional<T> nullableOptional(Callable<T> callable) {

--- a/rt/rs/microprofile-client/src/main/java/org/apache/cxf/microprofile/client/cdi/CDIInstantiator.java
+++ b/rt/rs/microprofile-client/src/main/java/org/apache/cxf/microprofile/client/cdi/CDIInstantiator.java
@@ -19,7 +19,7 @@
 
 package org.apache.cxf.microprofile.client.cdi;
 
-import java.util.HashMap;
+import java.util.IdentityHashMap;
 import java.util.Map;
 
 import org.apache.cxf.jaxrs.impl.ConfigurableImpl.Instantiator;
@@ -29,7 +29,7 @@ public final class CDIInstantiator implements Instantiator {
 
     static final CDIInstantiator INSTANCE = new CDIInstantiator();
 
-    private final Map<Object, Instance<?>> cdiInstances = new HashMap<>();
+    private final Map<Object, Instance<?>> cdiInstances = new IdentityHashMap<>();
 
     private CDIInstantiator() {
     }

--- a/rt/rs/microprofile-client/src/main/java/org/apache/cxf/microprofile/client/cdi/CDIInstantiator.java
+++ b/rt/rs/microprofile-client/src/main/java/org/apache/cxf/microprofile/client/cdi/CDIInstantiator.java
@@ -1,0 +1,61 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.cxf.microprofile.client.cdi;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.cxf.jaxrs.impl.ConfigurableImpl.Instantiator;
+
+
+public final class CDIInstantiator implements Instantiator {
+
+    static final CDIInstantiator INSTANCE = new CDIInstantiator();
+
+    private final Map<Object, Instance<?>> cdiInstances = new HashMap<>();
+
+    private CDIInstantiator() {
+    }
+
+    @Override
+    public <T> Object create(Class<T> cls) {
+        try {
+            return CDIFacade.getInstanceFromCDI(cls)
+                            .map(i -> {
+                                Object instance = i.getValue();
+                                if (instance != null) {
+                                    cdiInstances.put(instance, i);
+                                }
+                                return instance;
+                            })
+                            .orElse(cls.newInstance());
+        } catch (Throwable t) {
+            throw new RuntimeException(t);
+        }
+    }
+
+    @Override
+    public void release(Object instance) {
+        Instance<?> cdiInstance = cdiInstances.remove(instance);
+        if (cdiInstance != null) {
+            cdiInstance.release();
+        }
+    }
+}

--- a/rt/rs/microprofile-client/src/main/java/org/apache/cxf/microprofile/client/cdi/RestClientBean.java
+++ b/rt/rs/microprofile-client/src/main/java/org/apache/cxf/microprofile/client/cdi/RestClientBean.java
@@ -57,6 +57,7 @@ import org.apache.cxf.common.util.PropertyUtils;
 import org.apache.cxf.common.util.ReflectionUtil;
 import org.apache.cxf.microprofile.client.CxfTypeSafeClientBuilder;
 import org.apache.cxf.microprofile.client.config.ConfigFacade;
+import org.eclipse.microprofile.rest.client.ext.QueryParamStyle;
 import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
 import org.eclipse.microprofile.rest.client.inject.RestClient;
 
@@ -77,6 +78,7 @@ public class RestClientBean implements Bean<Object>, PassivationCapable {
     public static final String REST_KEY_STORE_TYPE_FORMAT = "%s/mp-rest/keyStoreType";
     public static final String REST_FOLLOW_REDIRECTS_FORMAT = "%s/mp-rest/followRedirects";
     public static final String REST_PROXY_ADDRESS_FORMAT = "%s/mp-rest/proxyAddress";
+    public static final String QUERY_PARAM_STYLE_FORMAT = "%s/mp-rest/queryParamStyle";
     private static final Logger LOG = LogUtils.getL7dLogger(RestClientBean.class);
     private static final Default DEFAULT_LITERAL = new DefaultLiteral();
     private final Class<?> clientInterface;
@@ -123,6 +125,7 @@ public class RestClientBean implements Bean<Object>, PassivationCapable {
         setSSLConfig(builder);
         setFollowRedirects(builder);
         setProxyAddress(builder);
+        setQueryParamStyle(builder);
         return builder.build(clientInterface);
     }
 
@@ -307,6 +310,23 @@ public class RestClientBean implements Bean<Object>, PassivationCapable {
                     LOG.finest("proxyAddress set by MP Config: " + address);
                 }
             });
+    }
+
+    private void setQueryParamStyle(CxfTypeSafeClientBuilder builder) {
+        ConfigFacade.getOptionalValue(QUERY_PARAM_STYLE_FORMAT, clientInterface, String.class).ifPresent(
+            styleString -> {
+                try {
+                    builder.queryParamStyle(QueryParamStyle.valueOf(styleString));
+                    if (LOG.isLoggable(Level.FINEST)) {
+                        LOG.finest("queryParamStyle set by MP Config: " + styleString);
+                    }
+                } catch (Throwable t) {
+                    throw new IllegalStateException(String.format("Invalid queryParamStyle value specified for %s: %s",
+                                                                  clientInterface.getName(),
+                                                                  styleString));
+                }
+            });
+    
     }
 
     private void setSSLConfig(CxfTypeSafeClientBuilder builder) {

--- a/rt/rs/microprofile-client/src/main/java/org/apache/cxf/microprofile/client/proxy/MicroProfileClientProxyImpl.java
+++ b/rt/rs/microprofile-client/src/main/java/org/apache/cxf/microprofile/client/proxy/MicroProfileClientProxyImpl.java
@@ -428,7 +428,7 @@ public class MicroProfileClientProxyImpl extends ClientProxyImpl {
         }
     }
 
-    private ClientHeadersFactory mapClientHeadersInstance(Instance<ClientHeadersFactory> instance) {
+    private <T> T mapInstance(Instance<T> instance) {
         cdiInstances.add(instance);
         return instance.getValue();
     }
@@ -443,7 +443,7 @@ public class MicroProfileClientProxyImpl extends ClientProxyImpl {
 
             if (m != null) {
                 factory = CDIFacade.getInstanceFromCDI(factoryCls, m.getExchange().getBus())
-                                   .map(this::mapClientHeadersInstance)
+                                   .map(this::mapInstance)
                                    .orElse(factoryCls.newInstance());
                 ProviderInfo<ClientHeadersFactory> pi = clientHeaderFactories.computeIfAbsent(factoryCls, k -> {
                     return new ProviderInfo<ClientHeadersFactory>(factory, m.getExchange().getBus(), true);
@@ -451,7 +451,7 @@ public class MicroProfileClientProxyImpl extends ClientProxyImpl {
                 InjectionUtils.injectContexts(factory, pi, m);
             } else {
                 factory = CDIFacade.getInstanceFromCDI(factoryCls)
-                                   .map(this::mapClientHeadersInstance)
+                                   .map(this::mapInstance)
                                    .orElse(factoryCls.newInstance());
             }
 


### PR DESCRIPTION
This PR fixes [CXF-8299](https://issues.apache.org/jira/browse/CXF-8299) (QueryParamStyles) and [CXF-8304](https://issues.apache.org/jira/browse/CXF-8304) (CDI-managed providers), and supersedes PR #678. 

For 8299, this allows the client to specify how collections should be handle when using query parameters - i.e. expanded, expanded with array syntax (required for PHP servers), or with a single key but comma-separated values.

For 8304, this changes the way providers are instantiated. If CDI is managing an instance of the provider class, then the client implementation should use that instance rather than creating a new instance.  This should only apply in cases where the interface registers the provider _class_, and not cases where it registers an _instance_ of the provider.
