### PR TITLE
CXF-8324: Allow wider range of values for attachment properties

### DIFF
--- a/core/src/main/java/org/apache/cxf/attachment/AttachmentDeserializer.java
+++ b/core/src/main/java/org/apache/cxf/attachment/AttachmentDeserializer.java
@@ -19,6 +19,7 @@
 
 package org.apache.cxf.attachment;
 
+import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.PushbackInputStream;
@@ -47,10 +48,21 @@ import org.apache.cxf.message.MessageUtils;
 
 public class AttachmentDeserializer {
     public static final String ATTACHMENT_PART_HEADERS = AttachmentDeserializer.class.getName() + ".headers";
+
+    /**
+     * Allowed value is any instance of {@link File} or {@link String}.
+     */
     public static final String ATTACHMENT_DIRECTORY = "attachment-directory";
 
+    /**
+     * The memory threshold of attachments. Allowed value is any instance of {@link Number} or {@link String}.
+     * The default is {@link AttachmentDeserializer#THRESHOLD}.
+     */
     public static final String ATTACHMENT_MEMORY_THRESHOLD = "attachment-memory-threshold";
 
+    /**
+     * The maximum size of the attachment. Allowed value is any of {@link Number} or {@link String}.
+     */
     public static final String ATTACHMENT_MAX_SIZE = "attachment-max-size";
 
     /**

--- a/core/src/test/java/org/apache/cxf/attachment/AttachmentUtilTest.java
+++ b/core/src/test/java/org/apache/cxf/attachment/AttachmentUtilTest.java
@@ -18,8 +18,19 @@
  */
 package org.apache.cxf.attachment;
 
+import java.io.File;
+import java.io.IOException;
+import java.math.BigInteger;
+
+import org.apache.cxf.io.CachedOutputStream;
+import org.apache.cxf.message.Message;
+import org.apache.cxf.message.MessageImpl;
+
 import org.junit.Test;
 
+import static org.easymock.EasyMock.createMock;
+import static org.easymock.EasyMock.replay;
+import static org.easymock.EasyMock.verify;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 
@@ -122,4 +133,204 @@ public class AttachmentUtilTest {
         assertNotEquals(AttachmentUtil.createContentID(null), AttachmentUtil.createContentID(null));
     }
 
+    private CachedOutputStream testSetStreamedAttachmentProperties(final String property, final Object value)
+            throws IOException {
+        return testSetStreamedAttachmentProperties(property, value, new CachedOutputStream());
+    }
+
+    private CachedOutputStream testSetStreamedAttachmentProperties(final String property, final Object value,
+            final CachedOutputStream cos) throws IOException {
+        Message message = new MessageImpl();
+        message.put(property, value);
+        AttachmentUtil.setStreamedAttachmentProperties(message, cos);
+
+        return cos;
+    }
+
+    @Test
+    public void bigIntAsAttachmentMemoryThreshold() throws IOException {
+        BigInteger bigInteger = new BigInteger(String.valueOf(Long.MAX_VALUE));
+        try (CachedOutputStream cos = testSetStreamedAttachmentProperties(
+                AttachmentDeserializer.ATTACHMENT_MEMORY_THRESHOLD, bigInteger)) {
+            assertEquals(bigInteger.longValue(), cos.getThreshold());
+        }
+        // Overflow long value
+        bigInteger = bigInteger.add(BigInteger.ONE);
+        try (CachedOutputStream cos = testSetStreamedAttachmentProperties(
+                AttachmentDeserializer.ATTACHMENT_MEMORY_THRESHOLD, bigInteger)) {
+            assertEquals(AttachmentDeserializer.THRESHOLD, cos.getThreshold());
+        }
+    }
+
+    @Test
+    public void longAsAttachmentMemoryThreshold() throws IOException {
+        try (CachedOutputStream cos = testSetStreamedAttachmentProperties(
+                AttachmentDeserializer.ATTACHMENT_MEMORY_THRESHOLD, Long.MAX_VALUE)) {
+            assertEquals(Long.MAX_VALUE, cos.getThreshold());
+        }
+    }
+
+    @Test
+    public void integerAsAttachmentMemoryThreshold() throws IOException {
+        try (CachedOutputStream cos = testSetStreamedAttachmentProperties(
+                AttachmentDeserializer.ATTACHMENT_MEMORY_THRESHOLD, Integer.MAX_VALUE)) {
+            assertEquals(Integer.MAX_VALUE, cos.getThreshold());
+        }
+    }
+
+    @Test
+    public void shortAsAttachmentMemoryThreshold() throws IOException {
+        try (CachedOutputStream cos = testSetStreamedAttachmentProperties(
+                AttachmentDeserializer.ATTACHMENT_MEMORY_THRESHOLD, Short.MAX_VALUE)) {
+            assertEquals(Short.MAX_VALUE, cos.getThreshold());
+        }
+    }
+
+    @Test
+    public void byteAsAttachmentMemoryThreshold() throws IOException {
+        try (CachedOutputStream cos = testSetStreamedAttachmentProperties(
+                AttachmentDeserializer.ATTACHMENT_MEMORY_THRESHOLD, Byte.MAX_VALUE)) {
+            assertEquals(Byte.MAX_VALUE, cos.getThreshold());
+        }
+    }
+
+    @Test
+    public void numberStringAsAttachmentMemoryThreshold() throws IOException {
+        try (CachedOutputStream cos = testSetStreamedAttachmentProperties(
+                AttachmentDeserializer.ATTACHMENT_MEMORY_THRESHOLD, "12345")) {
+            assertEquals(12345, cos.getThreshold());
+        }
+    }
+
+    @Test(expected = IOException.class)
+    public void nonNumberStringAsAttachmentMemoryThreshold() throws IOException {
+        try (CachedOutputStream cos = testSetStreamedAttachmentProperties(
+                AttachmentDeserializer.ATTACHMENT_MEMORY_THRESHOLD, "test")) {
+            // Will throw exception
+        }
+    }
+
+    @Test(expected = IOException.class)
+    public void objectAsAttachmentMemoryThreshold() throws IOException {
+        try (CachedOutputStream cos = testSetStreamedAttachmentProperties(
+                AttachmentDeserializer.ATTACHMENT_MEMORY_THRESHOLD, new Object())) {
+            // Will throw exception
+        }
+    }
+
+    @Test
+    public void bigIntAsAttachmentMaxSize() throws IOException {
+        CachedOutputStream cos = createMock(CachedOutputStream.class);
+        BigInteger bigInteger = new BigInteger(String.valueOf(Long.MAX_VALUE));
+        cos = testSetStreamedAttachmentProperties(AttachmentDeserializer.ATTACHMENT_MAX_SIZE, bigInteger, cos);
+        replay(cos);
+        cos.setMaxSize(bigInteger.longValue());
+        cos.setThreshold(102400L);
+        verify(cos);
+        // Overflow long value
+        bigInteger = bigInteger.add(BigInteger.ONE);
+        cos = createMock(CachedOutputStream.class);
+        cos = testSetStreamedAttachmentProperties(AttachmentDeserializer.ATTACHMENT_MAX_SIZE, bigInteger, cos);
+        replay(cos);
+        cos.setThreshold(102400L);
+        verify(cos);
+    }
+
+    @Test
+    public void longAsAttachmentMaxSize() throws IOException {
+        CachedOutputStream cos = createMock(CachedOutputStream.class);
+        cos = testSetStreamedAttachmentProperties(AttachmentDeserializer.ATTACHMENT_MAX_SIZE, Long.MAX_VALUE, cos);
+        replay(cos);
+        cos.setMaxSize(Long.MAX_VALUE);
+        cos.setThreshold(102400L);
+        verify(cos);
+    }
+
+    @Test
+    public void integerAsAttachmentMaxSize() throws IOException {
+        CachedOutputStream cos = createMock(CachedOutputStream.class);
+        cos = testSetStreamedAttachmentProperties(AttachmentDeserializer.ATTACHMENT_MAX_SIZE, Integer.MAX_VALUE, cos);
+        replay(cos);
+        cos.setMaxSize(Integer.MAX_VALUE);
+        cos.setThreshold(102400L);
+        verify(cos);
+    }
+
+    @Test
+    public void shortAsAttachmentMaxSize() throws IOException {
+        CachedOutputStream cos = createMock(CachedOutputStream.class);
+        cos = testSetStreamedAttachmentProperties(AttachmentDeserializer.ATTACHMENT_MAX_SIZE, Short.MAX_VALUE, cos);
+        replay(cos);
+        cos.setMaxSize(Short.MAX_VALUE);
+        cos.setThreshold(102400L);
+        verify(cos);
+    }
+
+    @Test
+    public void byteAsAttachmentMaxSize() throws IOException {
+        CachedOutputStream cos = createMock(CachedOutputStream.class);
+        cos = testSetStreamedAttachmentProperties(AttachmentDeserializer.ATTACHMENT_MAX_SIZE, Byte.MAX_VALUE, cos);
+        replay(cos);
+        cos.setMaxSize(Byte.MAX_VALUE);
+        cos.setThreshold(102400L);
+        verify(cos);
+    }
+
+    @Test
+    public void numberStringAsAttachmentMaxSize() throws IOException {
+        CachedOutputStream cos = createMock(CachedOutputStream.class);
+        cos = testSetStreamedAttachmentProperties(AttachmentDeserializer.ATTACHMENT_MAX_SIZE, "12345", cos);
+        replay(cos);
+        cos.setMaxSize(12345);
+        cos.setThreshold(102400L);
+        verify(cos);
+    }
+
+    @Test(expected = IOException.class)
+    public void nonNumberStringAsAttachmentMaxSize() throws IOException {
+        try (CachedOutputStream cos = testSetStreamedAttachmentProperties(AttachmentDeserializer.ATTACHMENT_MAX_SIZE,
+                "test")) {
+            // Will throw exception
+        }
+    }
+
+    @Test(expected = IOException.class)
+    public void objectAsAttachmentMaxSize() throws IOException {
+        try (CachedOutputStream cos = testSetStreamedAttachmentProperties(AttachmentDeserializer.ATTACHMENT_MAX_SIZE,
+                new Object())) {
+            // Will throw exception
+        }
+    }
+
+    @Test
+    public void fileAsAttachmentDirectory() throws IOException {
+        File attachmentDirectory = new File("/dev/null");
+        CachedOutputStream cos = createMock(CachedOutputStream.class);
+        cos = testSetStreamedAttachmentProperties(AttachmentDeserializer.ATTACHMENT_DIRECTORY, attachmentDirectory,
+                cos);
+        replay(cos);
+        cos.setOutputDir(attachmentDirectory);
+        cos.setThreshold(102400L);
+        verify(cos);
+    }
+
+    @Test
+    public void stringAsAttachmentDirectory() throws IOException {
+        String attachmentDirectory = "/dev/null";
+        CachedOutputStream cos = createMock(CachedOutputStream.class);
+        cos = testSetStreamedAttachmentProperties(AttachmentDeserializer.ATTACHMENT_DIRECTORY, attachmentDirectory,
+                cos);
+        replay(cos);
+        cos.setOutputDir(new File(attachmentDirectory));
+        cos.setThreshold(102400L);
+        verify(cos);
+    }
+
+    @Test(expected = IOException.class)
+    public void objectAsAttachmentDirectory() throws IOException {
+        try (CachedOutputStream cos = testSetStreamedAttachmentProperties(AttachmentDeserializer.ATTACHMENT_DIRECTORY,
+                new Object())) {
+            // Will throw exception
+        }
+    }
 }


### PR DESCRIPTION
Provide better error if the given value is not allowed
Document allowed values for properties

I also had to do some special handling if someone provides a BigInteger which has a larger value than `Long.MAX_VALUE`.