### PR TITLE
Update Netty to 4.1.51.Final

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -170,7 +170,7 @@
         <cxf.msv.version>2013.6.1</cxf.msv.version>
         <cxf.neethi.version>3.1.1</cxf.neethi.version>
         <cxf.netty.version.range>[4,5)</cxf.netty.version.range>
-        <cxf.netty.version>4.1.50.Final</cxf.netty.version>
+        <cxf.netty.version>4.1.51.Final</cxf.netty.version>
         <cxf.oauth.version>20100527</cxf.oauth.version>
         <cxf.olingo.version>2.0.11</cxf.olingo.version>
         <cxf.openjpa.version>3.1.2</cxf.openjpa.version>


### PR DESCRIPTION
This PR proposes to update Netty to its latest bugfix 4.1.51.Final.
