### PR TITLE
[CXF-8338] Add missing getters to JweJsonConsumer

### DIFF
--- a/rt/rs/security/jose-parent/jose/src/main/java/org/apache/cxf/rs/security/jose/jwe/JweJsonConsumer.java
+++ b/rt/rs/security/jose-parent/jose/src/main/java/org/apache/cxf/rs/security/jose/jwe/JweJsonConsumer.java
@@ -189,6 +189,37 @@ public class JweJsonConsumer {
         }
         return new String(aad, StandardCharsets.UTF_8);
     }
+
+    public byte[] getIvBytes() {
+        return iv;
+    }
+    public String getIvText() {
+        if (iv == null) {
+            return null;
+        }
+        return new String(iv, StandardCharsets.UTF_8);
+    }
+
+    public byte[] getCipherBytes() {
+        return cipherBytes;
+    }
+    public String getCipherText() {
+        if (cipherBytes == null) {
+            return null;
+        }
+        return new String(cipherBytes, StandardCharsets.UTF_8);
+    }
+
+    public byte[] getAuthTagBytes() {
+        return authTag;
+    }
+    public String getAuthTagText() {
+        if (authTag == null) {
+            return null;
+        }
+        return new String(authTag, StandardCharsets.UTF_8);
+    }
+
     public List<JweJsonEncryptionEntry> getRecipients() {
         return recipients;
     }


### PR DESCRIPTION
I'm using cxf-rt-rs-security-jose's JweJsonConsumer to parse a Json JWE (that I just created and encrypted using JweJsonProducer).

I'm doing this because I need to pass its components (headers, kid, iv, aad, ciphertext, auth tag, ...) to another API individually (the API does not accept the full JsonJWE).

Currently however, only getAad(), getAadText() and some getters for the headers are available. There's no getIv(), getCipherText(), etc

This pull request add the missing getters