### PR TITLE
[CXF-8345] Improve performance by avoiding resize of MessageImpl

### DIFF
--- a/core/src/main/java/org/apache/cxf/interceptor/ServiceInvokerInterceptor.java
+++ b/core/src/main/java/org/apache/cxf/interceptor/ServiceInvokerInterceptor.java
@@ -62,7 +62,7 @@ public class ServiceInvokerInterceptor extends AbstractPhaseInterceptor<Message>
 
                     Message outMessage = runableEx.getOutMessage();
                     if (outMessage == null) {
-                        outMessage = new MessageImpl();
+                        outMessage = new MessageImpl(16, 1); // perf: size 16 / factor 1 to avoid resize operation
                         outMessage.setExchange(exchange);
                         outMessage = ep.getBinding().createMessage(outMessage);
                         exchange.setOutMessage(outMessage);

--- a/core/src/main/java/org/apache/cxf/message/MessageImpl.java
+++ b/core/src/main/java/org/apache/cxf/message/MessageImpl.java
@@ -51,6 +51,11 @@ public class MessageImpl extends StringMapImpl implements Message {
     public MessageImpl() {
         //nothing
     }
+
+    public MessageImpl(int initialSize, float factor) {
+        super(initialSize, factor);
+    }
+
     public MessageImpl(Message m) {
         super(m);
         if (m instanceof MessageImpl) {

--- a/core/src/main/java/org/apache/cxf/message/StringMapImpl.java
+++ b/core/src/main/java/org/apache/cxf/message/StringMapImpl.java
@@ -34,6 +34,11 @@ public class StringMapImpl
 
     public StringMapImpl() {
     }
+
+    public StringMapImpl(int initialSize, float factor) {
+        super(initialSize, factor);
+    }
+
     public StringMapImpl(Map<String, Object> i) {
         super(i);
     }


### PR DESCRIPTION
Hi All,

While trying to consume the new 3.4.0 release into Open Liberty, we noticed that we had made a number of changes that has effectively forked Open Liberty's implementation of CXF.  We'd like to contribute those back to Apache as much as possible.

This PR includes some of the changes that are easy to "disentangle" and include some fixes we needed to make in order to pass some JAX-RS TCK tests, improve performance (the change to MessageImpl in particular made a large difference by avoiding resizing the underlying data store), etc.

Unfortunately, many of our forked classes contains references to Open Liberty-specific code, so we'll need to sort those out before we can contribute them back.  One thing we did in this PR to was to add an extension point (the new `RunnableWrapperFactory` class) so that we can avoid that.  

Comments and questions welcome - and also, please let me know how to "record" these changes.  I could open one JIRA for all of them, or separate them out by different areas (i.e. one for the MessageImpl performance change, one for the URITemplate change, etc.) so that it is clear to users what changed between releases.

Thanks in advance!

Andy