### PR TITLE
[CXF-8346] TCK Changes for URI and hasEntity checks

### DIFF
--- a/rt/frontend/jaxrs/src/main/java/org/apache/cxf/jaxrs/impl/ContainerRequestContextImpl.java
+++ b/rt/frontend/jaxrs/src/main/java/org/apache/cxf/jaxrs/impl/ContainerRequestContextImpl.java
@@ -29,6 +29,7 @@ import javax.ws.rs.core.SecurityContext;
 import javax.ws.rs.core.UriInfo;
 
 import org.apache.cxf.helpers.IOUtils;
+import org.apache.cxf.io.DelegatingInputStream;
 import org.apache.cxf.jaxrs.utils.ExceptionUtils;
 import org.apache.cxf.jaxrs.utils.HttpUtils;
 import org.apache.cxf.message.Message;
@@ -68,12 +69,21 @@ public class ContainerRequestContextImpl extends AbstractRequestContextImpl
 
     @Override
     public boolean hasEntity() {
+        InputStream is = getEntityStream();
+        if (is == null) {
+            return false;
+        }
         // Is Content-Length is explicitly set to 0 ?
         if (HttpUtils.isPayloadEmpty(getHeaders())) {
             return false;
         }
+
+        if (is instanceof DelegatingInputStream) {
+            ((DelegatingInputStream) is).cacheInput();
+        }
+
         try {
-            return !IOUtils.isEmpty(getEntityStream());
+            return !IOUtils.isEmpty(is);
         } catch (IOException ex) {
             throw ExceptionUtils.toInternalServerErrorException(ex, null);
         }
@@ -85,6 +95,7 @@ public class ContainerRequestContextImpl extends AbstractRequestContextImpl
         m.setContent(InputStream.class, is);
     }
 
+    @Override
     public MultivaluedMap<String, String> getHeaders() {
         h = null;
         return HttpUtils.getModifiableStringHeaders(m);
@@ -112,7 +123,8 @@ public class ContainerRequestContextImpl extends AbstractRequestContextImpl
 
     protected void doSetRequestUri(URI requestUri) throws IllegalStateException {
         checkNotPreMatch();
-        HttpUtils.resetRequestURI(m, requestUri.getRawPath());
+        // The JAX-RS TCK requires the full uri toString() rather than just the raw path:
+        HttpUtils.resetRequestURI(m, requestUri.toString());
         String query = requestUri.getRawQuery();
         if (query != null) {
             m.put(Message.QUERY_STRING, query);

--- a/rt/frontend/jaxrs/src/main/java/org/apache/cxf/jaxrs/impl/ResponseImpl.java
+++ b/rt/frontend/jaxrs/src/main/java/org/apache/cxf/jaxrs/impl/ResponseImpl.java
@@ -20,7 +20,6 @@
 package org.apache.cxf.jaxrs.impl;
 
 import java.io.ByteArrayInputStream;
-import java.io.Closeable;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.PushbackInputStream;
@@ -191,9 +190,8 @@ public final class ResponseImpl extends Response {
             } catch (IOException ex) {
                 throw new ProcessingException(ex);
             }
-        } else {
-            return true;
         }
+        return true;
     }
 
     @Override
@@ -478,7 +476,7 @@ public final class ResponseImpl extends Response {
                                                                   responseMessage);
                 // close the entity after readEntity is called.
                 T tCastLastEntity = castLastEntity();
-                shouldClose = shouldClose && !(tCastLastEntity instanceof Closeable)
+                shouldClose = shouldClose && !(tCastLastEntity instanceof AutoCloseable)
                     && !(tCastLastEntity instanceof Source);
                 if (closeAfterRead && shouldClose) {
                     close();
@@ -629,39 +627,8 @@ public final class ResponseImpl extends Response {
         };
     }
 
-    private enum PrimitiveTypes {
-        BYTE(Byte.class, byte.class) { },
-        SHORT(Short.class, short.class) { },
-        INTEGER(Integer.class, int.class) { },
-        LONG(Long.class, long.class) { },
-        FLOAT(Float.class, float.class) { },
-        DOUBLE(Double.class, double.class) { },
-        BOOLEAN(Boolean.class, boolean.class) { },
-        CHAR(Character.class, char.class) { };
-
-        private final Class<?> wrapper;
-        private final Class<?> primitive;
-
-        PrimitiveTypes(Class<?> wrapper, Class<?> primitive) {
-            this.wrapper = wrapper;
-            this.primitive = primitive;
-        }
-
-        public static PrimitiveTypes forType(Class<?> type) {
-            for (PrimitiveTypes primitive : PrimitiveTypes.values()) {
-                if (primitive.supports(type)) {
-                    return primitive;
-                }
-            }
-            return null;
-        }
-
-        public boolean supports(Class<?> type) {
-            return type == wrapper || type == primitive;
-        }
-    }
-
     private static boolean isBasicType(Class<?> type) {
-        return PrimitiveTypes.forType(type) != null || Number.class.isAssignableFrom(type);
+        return type.isPrimitive() || Number.class.isAssignableFrom(type) || Boolean.class.isAssignableFrom(type)
+            || Character.class.isAssignableFrom(type);
     }
 }

--- a/rt/frontend/jaxrs/src/main/java/org/apache/cxf/jaxrs/impl/ResponseImpl.java
+++ b/rt/frontend/jaxrs/src/main/java/org/apache/cxf/jaxrs/impl/ResponseImpl.java
@@ -20,8 +20,10 @@
 package org.apache.cxf.jaxrs.impl;
 
 import java.io.ByteArrayInputStream;
+import java.io.Closeable;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.PushbackInputStream;
 import java.io.Reader;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
@@ -48,11 +50,13 @@ import javax.ws.rs.core.Link;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.NewCookie;
+import javax.ws.rs.core.NoContentException;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status.Family;
 import javax.ws.rs.ext.ReaderInterceptor;
 import javax.ws.rs.ext.RuntimeDelegate.HeaderDelegate;
 import javax.xml.stream.XMLStreamReader;
+import javax.xml.transform.Source;
 
 import org.apache.cxf.helpers.IOUtils;
 import org.apache.cxf.io.ReaderInputStream;
@@ -124,10 +128,12 @@ public final class ResponseImpl extends Response {
         return this.outMessage;
     }
 
+    @Override
     public int getStatus() {
         return status.getStatusCode();
     }
 
+    @Override
     public StatusType getStatusInfo() {
         return status;
     }
@@ -137,22 +143,70 @@ public final class ResponseImpl extends Response {
         return lastEntity != null ? lastEntity : entity;
     }
 
+    @Override
     public Object getEntity() {
         return InjectionUtils.getEntity(getActualEntity());
     }
 
+    @Override
     public boolean hasEntity() {
-        return getActualEntity() != null;
+        // per spec, need to check if the stream exists and if it has data.
+        Object actualEntity = getActualEntity();
+        if (actualEntity == null) {
+            return false;
+        } else if (actualEntity instanceof InputStream) {
+            final InputStream is = (InputStream) actualEntity;
+            try {
+                if (is.markSupported()) {
+                    is.mark(1);
+                    int i = is.read();
+                    is.reset();
+                    return i != -1;
+                } else {
+                    try {
+                        if (is.available() > 0) {
+                            return true;
+                        }
+                    } catch (IOException ioe) {
+                        //Do nothing
+                    }
+                    int b = is.read();
+                    if (b == -1) {
+                        return false;
+                    }
+                    PushbackInputStream pbis;
+                    if (is instanceof PushbackInputStream) {
+                        pbis = (PushbackInputStream) is;
+                    } else {
+                        pbis = new PushbackInputStream(is, 1);
+                        if (lastEntity != null) {
+                            lastEntity = pbis;
+                        } else {
+                            entity = pbis;
+                        }
+                    }
+                    pbis.unread(b);
+                    return true;
+                }
+            } catch (IOException ex) {
+                throw new ProcessingException(ex);
+            }
+        } else {
+            return true;
+        }
     }
 
+    @Override
     public MultivaluedMap<String, Object> getMetadata() {
         return getHeaders();
     }
 
+    @Override
     public MultivaluedMap<String, Object> getHeaders() {
         return metadata;
     }
 
+    @Override
     public MultivaluedMap<String, String> getStringHeaders() {
         MetadataMap<String, String> headers = new MetadataMap<>(metadata.size());
         for (Map.Entry<String, List<Object>> entry : metadata.entrySet()) {
@@ -162,6 +216,7 @@ public final class ResponseImpl extends Response {
         return headers;
     }
 
+    @Override
     public String getHeaderString(String header) {
         List<Object> methodValues = metadata.get(header);
         return HttpUtils.getHeaderString(toListOfStrings(methodValues));
@@ -181,6 +236,7 @@ public final class ResponseImpl extends Response {
         return stringValues;
     }
 
+    @Override
     public Set<String> getAllowedMethods() {
         List<Object> methodValues = metadata.get(HttpHeaders.ALLOW);
         if (methodValues == null) {
@@ -193,8 +249,7 @@ public final class ResponseImpl extends Response {
         return methods;
     }
 
-
-
+    @Override
     public Map<String, NewCookie> getCookies() {
         List<Object> cookieValues = metadata.get(HttpHeaders.SET_COOKIE);
         if (cookieValues == null) {
@@ -208,6 +263,7 @@ public final class ResponseImpl extends Response {
         return cookies;
     }
 
+    @Override
     public Date getDate() {
         return doGetDate(HttpHeaders.DATE);
     }
@@ -218,42 +274,46 @@ public final class ResponseImpl extends Response {
             : HttpUtils.getHttpDate(value.toString());
     }
 
+    @Override
     public EntityTag getEntityTag() {
         Object header = metadata.getFirst(HttpHeaders.ETAG);
         return header == null || header instanceof EntityTag ? (EntityTag)header
             : EntityTag.valueOf(header.toString());
     }
 
+    @Override
     public Locale getLanguage() {
         Object header = metadata.getFirst(HttpHeaders.CONTENT_LANGUAGE);
         return header == null || header instanceof Locale ? (Locale)header
             : HttpUtils.getLocale(header.toString());
     }
 
+    @Override
     public Date getLastModified() {
         return doGetDate(HttpHeaders.LAST_MODIFIED);
     }
 
+    @Override
     public int getLength() {
         Object header = metadata.getFirst(HttpHeaders.CONTENT_LENGTH);
         return HttpUtils.getContentLength(header == null ? null : header.toString());
     }
 
+    @Override
     public URI getLocation() {
         Object header = metadata.getFirst(HttpHeaders.LOCATION);
-        if (header == null && outMessage != null) {
-            header = outMessage.get(Message.REQUEST_URI);
-        }
-        return header == null || header instanceof URI ? (URI) header
+        return header == null || header instanceof URI ? (URI)header
             : URI.create(header.toString());
     }
 
+    @Override
     public MediaType getMediaType() {
         Object header = metadata.getFirst(HttpHeaders.CONTENT_TYPE);
         return header == null || header instanceof MediaType ? (MediaType)header
             : (MediaType)JAXRSUtils.toMediaType(header.toString());
     }
 
+    @Override
     public boolean hasLink(String relation) {
         List<Object> linkValues = metadata.get(HttpHeaders.LINK);
         if (linkValues != null) {
@@ -274,6 +334,7 @@ public final class ResponseImpl extends Response {
         return false;
     }
 
+    @Override
     public Link getLink(String relation) {
         Set<Link> links = getAllLinks();
         for (Link link : links) {
@@ -284,11 +345,13 @@ public final class ResponseImpl extends Response {
         return null;
     }
 
+    @Override
     public Link.Builder getLinkBuilder(String relation) {
         Link link = getLink(relation);
         return link == null ? null : Link.fromLink(link);
     }
 
+    @Override
     public Set<Link> getLinks() {
         return new HashSet<>(getAllLinks());
     }
@@ -332,31 +395,40 @@ public final class ResponseImpl extends Response {
         return Collections.unmodifiableList(links);
     }
 
+    @Override
     public <T> T readEntity(Class<T> cls) throws ProcessingException, IllegalStateException {
         return readEntity(cls, new Annotation[]{});
     }
 
+    @Override
     public <T> T readEntity(GenericType<T> genType) throws ProcessingException, IllegalStateException {
         return readEntity(genType, new Annotation[]{});
     }
 
-    public <T> T readEntity(Class<T> cls, Annotation[] anns) throws ProcessingException,
-        IllegalStateException {
-
-        return doReadEntity(cls, cls, anns);
+    @Override
+    public <T> T readEntity(Class<T> cls, Annotation[] anns) throws ProcessingException, IllegalStateException {
+        return doReadEntity(cls, cls, anns, true);
     }
 
+    @Override
     @SuppressWarnings("unchecked")
-    public <T> T readEntity(GenericType<T> genType, Annotation[] anns) throws ProcessingException,
-        IllegalStateException {
-        return doReadEntity((Class<T>)genType.getRawType(),
-                            genType.getType(), anns);
+    public <T> T readEntity(GenericType<T> genType, Annotation[] anns)
+        throws ProcessingException, IllegalStateException {
+        return doReadEntity((Class<T>) genType.getRawType(),
+                            genType.getType(), anns, true);
     }
 
-    public <T> T doReadEntity(Class<T> cls, Type t, Annotation[] anns) throws ProcessingException,
-        IllegalStateException {
+    public <T> T doReadEntity(Class<T> cls, Type t, Annotation[] anns)
+        throws ProcessingException, IllegalStateException {
+        return doReadEntity(cls, t, anns, false);
+    }
+
+    public <T> T doReadEntity(Class<T> cls, Type t, Annotation[] anns, boolean closeAfterRead)
+        throws ProcessingException, IllegalStateException {
 
         checkEntityIsClosed();
+        //according to javadoc, should close when is not buffered.
+        boolean shouldClose = !this.entityBufferred;
 
         if (lastEntity != null && cls.isAssignableFrom(lastEntity.getClass())
             && !(lastEntity instanceof InputStream)) {
@@ -400,12 +472,30 @@ public final class ResponseImpl extends Response {
                 responseMessage.put(Message.PROTOCOL_HEADERS, getHeaders());
 
                 lastEntity = JAXRSUtils.readFromMessageBodyReader(readers, cls, t,
-                                                                       anns,
-                                                                       entityStream,
-                                                                       mediaType,
-                                                                       responseMessage);
-                autoClose(cls, false);
-                return castLastEntity();
+                                                                  anns,
+                                                                  entityStream,
+                                                                  mediaType,
+                                                                  responseMessage);
+                // close the entity after readEntity is called.
+                T tCastLastEntity = castLastEntity();
+                shouldClose = shouldClose && !(tCastLastEntity instanceof Closeable)
+                    && !(tCastLastEntity instanceof Source);
+                if (closeAfterRead && shouldClose) {
+                    close();
+                }
+                return tCastLastEntity;
+            } catch (NoContentException ex) {
+                //when content is empty, return null instead of throw exception to pass TCK
+                //check if basic type. Basic type throw exception, else return null.
+                if (isBasicType(cls)) {
+                    autoClose(cls, true);
+                    reportMessageHandlerProblem("MSG_READER_PROBLEM", cls, mediaType, ex);
+                } else {
+                    if (closeAfterRead && shouldClose) {
+                        close();
+                    }
+                    return null;
+                }
             } catch (Exception ex) {
                 autoClose(cls, true);
                 reportMessageHandlerProblem("MSG_READER_PROBLEM", cls, mediaType, ex);
@@ -476,6 +566,7 @@ public final class ResponseImpl extends Response {
         }
     }
 
+    @Override
     public boolean bufferEntity() throws ProcessingException {
         checkEntityIsClosed();
         if (!entityBufferred && entity instanceof InputStream) {
@@ -491,6 +582,7 @@ public final class ResponseImpl extends Response {
         return entityBufferred;
     }
 
+    @Override
     public void close() throws ProcessingException {
         if (!entityClosed) {
             if (!entityBufferred && entity instanceof InputStream) {
@@ -515,10 +607,12 @@ public final class ResponseImpl extends Response {
     private Response.StatusType createStatusType(int statusCode, String reasonPhrase) {
         return new Response.StatusType() {
 
+            @Override
             public Family getFamily() {
                 return Response.Status.Family.familyOf(statusCode);
             }
 
+            @Override
             public String getReasonPhrase() {
                 if (reasonPhrase != null) {
                     return reasonPhrase;
@@ -527,10 +621,47 @@ public final class ResponseImpl extends Response {
                 return statusEnum != null ? statusEnum.getReasonPhrase() : "";
             }
 
+            @Override
             public int getStatusCode() {
                 return statusCode;
             }
 
         };
+    }
+
+    private enum PrimitiveTypes {
+        BYTE(Byte.class, byte.class) { },
+        SHORT(Short.class, short.class) { },
+        INTEGER(Integer.class, int.class) { },
+        LONG(Long.class, long.class) { },
+        FLOAT(Float.class, float.class) { },
+        DOUBLE(Double.class, double.class) { },
+        BOOLEAN(Boolean.class, boolean.class) { },
+        CHAR(Character.class, char.class) { };
+
+        private final Class<?> wrapper;
+        private final Class<?> primitive;
+
+        PrimitiveTypes(Class<?> wrapper, Class<?> primitive) {
+            this.wrapper = wrapper;
+            this.primitive = primitive;
+        }
+
+        public static PrimitiveTypes forType(Class<?> type) {
+            for (PrimitiveTypes primitive : PrimitiveTypes.values()) {
+                if (primitive.supports(type)) {
+                    return primitive;
+                }
+            }
+            return null;
+        }
+
+        public boolean supports(Class<?> type) {
+            return type == wrapper || type == primitive;
+        }
+    }
+
+    private static boolean isBasicType(Class<?> type) {
+        return PrimitiveTypes.forType(type) != null || Number.class.isAssignableFrom(type);
     }
 }

--- a/rt/frontend/jaxrs/src/test/java/org/apache/cxf/jaxrs/impl/ResponseImplTest.java
+++ b/rt/frontend/jaxrs/src/test/java/org/apache/cxf/jaxrs/impl/ResponseImplTest.java
@@ -20,6 +20,7 @@
 package org.apache.cxf.jaxrs.impl;
 
 import java.io.ByteArrayInputStream;
+import java.io.InputStream;
 import java.net.URI;
 import java.util.List;
 import java.util.Locale;
@@ -176,6 +177,62 @@ public class ResponseImplTest {
     public void testHasEntity() {
         assertTrue(new ResponseImpl(200, "").hasEntity());
         assertFalse(new ResponseImpl(200).hasEntity());
+    }
+
+    @Test
+    public void testHasEntityWithEmptyStreamThatIsMarkSupported() throws Exception {
+        InputStream entityStream = EasyMock.createStrictMock(InputStream.class);
+        EasyMock.expect(entityStream.markSupported()).andReturn(true);
+        entityStream.mark(1);
+        EasyMock.expect(entityStream.read()).andReturn(-1);
+        entityStream.reset();
+        EasyMock.replay(entityStream);
+        assertFalse(new ResponseImpl(200, entityStream).hasEntity());
+        EasyMock.verify(entityStream);
+    }
+
+    @Test
+    public void testHasEntityWithNonEmptyStreamThatIsMarkSupported() throws Exception {
+        InputStream entityStream = EasyMock.createStrictMock(InputStream.class);
+        EasyMock.expect(entityStream.markSupported()).andReturn(true);
+        entityStream.mark(1);
+        EasyMock.expect(entityStream.read()).andReturn(0);
+        entityStream.reset();
+        EasyMock.replay(entityStream);
+        assertTrue(new ResponseImpl(200, entityStream).hasEntity());
+        EasyMock.verify(entityStream);
+    }
+
+    @Test
+    public void testHasEntityWithEmptyStreamThatIsNotMarkSupported() throws Exception {
+        InputStream entityStream = EasyMock.createStrictMock(InputStream.class);
+        EasyMock.expect(entityStream.markSupported()).andReturn(false);
+        EasyMock.expect(entityStream.available()).andReturn(0);
+        EasyMock.expect(entityStream.read()).andReturn(-1);
+        EasyMock.replay(entityStream);
+        assertFalse(new ResponseImpl(200, entityStream).hasEntity());
+        EasyMock.verify(entityStream);
+    }
+
+    @Test
+    public void testHasEntityWithNonEmptyStreamThatIsNotMarkSupportedButIsAvailableSupported() throws Exception {
+        InputStream entityStream = EasyMock.createStrictMock(InputStream.class);
+        EasyMock.expect(entityStream.markSupported()).andReturn(false);
+        EasyMock.expect(entityStream.available()).andReturn(10);
+        EasyMock.replay(entityStream);
+        assertTrue(new ResponseImpl(200, entityStream).hasEntity());
+        EasyMock.verify(entityStream);
+    }
+
+    @Test
+    public void testHasEntityWithnNonEmptyStreamThatIsNotMarkSupportedNorAvailableSupported() throws Exception {
+        InputStream entityStream = EasyMock.createStrictMock(InputStream.class);
+        EasyMock.expect(entityStream.markSupported()).andReturn(false).once();
+        EasyMock.expect(entityStream.available()).andReturn(0).once();
+        EasyMock.expect(entityStream.read()).andReturn(0).once();
+        EasyMock.replay(entityStream);
+        assertTrue(new ResponseImpl(200, entityStream).hasEntity());
+        EasyMock.verify(entityStream);
     }
 
     @Test


### PR DESCRIPTION
Fixes various "hasEntity" TCK tests where the entityStream is non-null, but empty.  Also fixes an issue with `ContainerRequestContext.setRequestUri(...)` methods.

Resolves [CXF-8346](https://issues.apache.org/jira/browse/CXF-8346).