### PR TITLE
CXF-8337: wsdl2java generates exceptions fields which do not follow naming convention

### DIFF
--- a/tools/wsdlto/frontend/jaxws/src/main/java/org/apache/cxf/tools/wsdlto/frontend/jaxws/template/fault.vm
+++ b/tools/wsdlto/frontend/jaxws/src/main/java/org/apache/cxf/tools/wsdlto/frontend/jaxws/template/fault.vm
@@ -56,7 +56,7 @@ public class $expClass.Name extends $exceptionSuperclass {
 #if ($markGenerated == "true")
     @Generated(value = "org.apache.cxf.tools.wsdlto.WSDLToJava", date = "$currentdate")
 #end
-    $field.Modifier $field.ClassName $paraName;
+    $field.Modifier $field.ClassName faultInfo;
 
 #if ($markGenerated == "true")
     @Generated(value = "org.apache.cxf.tools.wsdlto.WSDLToJava", date = "$currentdate")
@@ -84,7 +84,7 @@ public class $expClass.Name extends $exceptionSuperclass {
 #end
     public ${expClass.Name}(String message, $field.ClassName $paraName) {
         super(message);
-        this.$paraName = $paraName;
+        this.faultInfo = $paraName;
     }
 
 #if ($markGenerated == "true")
@@ -92,14 +92,14 @@ public class $expClass.Name extends $exceptionSuperclass {
 #end
     public ${expClass.Name}(String message, $field.ClassName $paraName, java.lang.Throwable cause) {
         super(message, cause);
-        this.$paraName = $paraName;
+        this.faultInfo = $paraName;
     }
 
 #if ($markGenerated == "true")
     @Generated(value = "org.apache.cxf.tools.wsdlto.WSDLToJava", date = "$currentdate")
 #end
     public $field.ClassName getFaultInfo() {
-        return this.$paraName;
+        return this.faultInfo;
     }
 #end
 }

--- a/tools/wsdlto/test/src/test/java/org/apache/cxf/tools/wsdlto/jaxws/CodeGenBugTest.java
+++ b/tools/wsdlto/test/src/test/java/org/apache/cxf/tools/wsdlto/jaxws/CodeGenBugTest.java
@@ -56,10 +56,13 @@ import org.eclipse.jetty.server.handler.ResourceHandler;
 
 import org.junit.Test;
 
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.CoreMatchers.nullValue;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -1042,6 +1045,15 @@ public class CodeGenBugTest extends AbstractCodeGenTest {
         Class<?> clz = classLoader.loadClass("org.apache.intfault.BadRecordLitFault");
         WebFault webFault = AnnotationUtil.getPrivClassAnnotation(clz, WebFault.class);
         assertEquals("int", webFault.name());
+    }
+    
+    @Test
+    public void testCXF8337() throws Exception {
+        env.put(ToolConstants.CFG_WSDLURL, getLocation("/wsdl2java_wsdl/cxf964/hello_world_fault.wsdl"));
+        processor.setContext(env);
+        processor.execute();
+        Class<?> clz = classLoader.loadClass("org.apache.intfault.BadRecordLitFault");
+        assertThat(clz.getDeclaredField("faultInfo"), not(nullValue()));
     }
 
     @Test


### PR DESCRIPTION
wsdl2java generates wrapper exception class for fault bean. The generated exception has method getFaultInfo(). This method name is correct according to JAX-WS specification. However this method returns fault bean stored in a field called "name of fault bean". The name of the field and getter do not follow the naming convention. 

In general, it does not cause issue unless such fault beans becomes serialization / deserialization targets (the absence of the setter method `setFaultInfo`  makes the matter difficult).

@coheigea @dkulp may I ask you please to take a look? thanks!