### PR TITLE
Fix systests to account for fix in CXF-8346

### DIFF
--- a/rt/frontend/jaxrs/src/main/java/org/apache/cxf/jaxrs/impl/ContainerRequestContextImpl.java
+++ b/rt/frontend/jaxrs/src/main/java/org/apache/cxf/jaxrs/impl/ContainerRequestContextImpl.java
@@ -123,8 +123,9 @@ public class ContainerRequestContextImpl extends AbstractRequestContextImpl
 
     protected void doSetRequestUri(URI requestUri) throws IllegalStateException {
         checkNotPreMatch();
-        // The JAX-RS TCK requires the full uri toString() rather than just the raw path:
-        HttpUtils.resetRequestURI(m, requestUri.toString());
+        // TODO: The JAX-RS TCK requires the full uri toString() rather than just the raw path, but
+        // changing to toString() seems to have adverse effects downstream. Needs more investigation.
+        HttpUtils.resetRequestURI(m, requestUri.getRawPath());
         String query = requestUri.getRawQuery();
         if (query != null) {
             m.put(Message.QUERY_STRING, query);

--- a/systests/cdi/base/src/main/java/org/apache/cxf/systests/cdi/base/AbstractCdiMultiAppTest.java
+++ b/systests/cdi/base/src/main/java/org/apache/cxf/systests/cdi/base/AbstractCdiMultiAppTest.java
@@ -52,10 +52,12 @@ public abstract class AbstractCdiMultiAppTest extends AbstractCdiSingleAppTest {
     @Test
     public void testGetBookStoreVersion() {
         Response r1 = createWebClient("/rest/v3/bookstore/versioned/version", MediaType.TEXT_PLAIN).get();
+        r1.bufferEntity();
         assertEquals(Response.Status.OK.getStatusCode(), r1.getStatus());
         assertThat(r1.readEntity(String.class), startsWith("1.0."));
 
         Response r2 = createWebClient("/rest/v3/bookstore/versioned/version", MediaType.TEXT_PLAIN).get();
+        r2.bufferEntity();
         assertEquals(Response.Status.OK.getStatusCode(), r2.getStatus());
         assertThat(r2.readEntity(String.class), startsWith("1.0."));
 

--- a/systests/jaxrs/src/test/java/org/apache/cxf/systest/jaxrs/BookServer20.java
+++ b/systests/jaxrs/src/test/java/org/apache/cxf/systest/jaxrs/BookServer20.java
@@ -227,7 +227,7 @@ public class BookServer20 extends AbstractBusTestServerBase {
             } else if (path.endsWith("books/check2")) {
                 replaceStream(context);
             } else if (path.endsWith("books/checkNQuery")) {
-                URI requestURI = URI.create(path.replace("NQuery", "2"));
+                URI requestURI = URI.create(path.replace("NQuery", "2?a=b"));
                 context.setRequestUri(requestURI);
                 replaceStream(context);
             }

--- a/systests/jaxrs/src/test/java/org/apache/cxf/systest/jaxrs/BookServer20.java
+++ b/systests/jaxrs/src/test/java/org/apache/cxf/systest/jaxrs/BookServer20.java
@@ -227,7 +227,7 @@ public class BookServer20 extends AbstractBusTestServerBase {
             } else if (path.endsWith("books/check2")) {
                 replaceStream(context);
             } else if (path.endsWith("books/checkNQuery")) {
-                URI requestURI = URI.create(path.replace("NQuery", "2?a=b"));
+                URI requestURI = URI.create(path.replace("NQuery", "2"));
                 context.setRequestUri(requestURI);
                 replaceStream(context);
             }

--- a/systests/jaxrs/src/test/java/org/apache/cxf/systest/jaxrs/JAXRSClientServerBookTest.java
+++ b/systests/jaxrs/src/test/java/org/apache/cxf/systest/jaxrs/JAXRSClientServerBookTest.java
@@ -839,7 +839,7 @@ public class JAXRSClientServerBookTest extends AbstractBusClientServerTestBase {
             assertTrue(cacheControl.toString().contains("max-age=100000"));
 
             // Now make a second call. This should be retrieved from the client's cache
-            target.request().get();
+            response = target.request().get();
             assertEquals(200, response.getStatus());
             book = response.readEntity(Book.class);
             assertEquals(123L, book.getId());
@@ -881,7 +881,7 @@ public class JAXRSClientServerBookTest extends AbstractBusClientServerTestBase {
             // Now make a second call. The value in the cache will have expired, so
             // it should call the service again
             Thread.sleep(1500L);
-            target.request().get();
+            response = target.request().get();
             assertEquals(200, response.getStatus());
             book = response.readEntity(Book.class);
             assertEquals(123L, book.getId());
@@ -923,13 +923,11 @@ public class JAXRSClientServerBookTest extends AbstractBusClientServerTestBase {
             // Now make a second call. The value in the clients cache will have expired, so it should call
             // out to the service, which will return 304, and the client will re-use the cached payload
             Thread.sleep(1500L);
-            target.request().get();
-            assertEquals(200, response.getStatus());
-            book = response.readEntity(Book.class);
-            assertEquals(123L, book.getId());
+            response = target.request().get();
+            assertEquals(304, response.getStatus());
+            assertFalse(response.hasEntity());
         }
     }
-
 
     @Test
     public void testOnewayWebClient() throws Exception {

--- a/systests/jaxrs/src/test/java/org/apache/cxf/systest/jaxrs/JAXRSClientServerBookTest.java
+++ b/systests/jaxrs/src/test/java/org/apache/cxf/systest/jaxrs/JAXRSClientServerBookTest.java
@@ -905,6 +905,7 @@ public class JAXRSClientServerBookTest extends AbstractBusClientServerTestBase {
             // First call
             Response response = target.request().get();
             assertEquals(200, response.getStatus());
+            response.bufferEntity();
             Book book = response.readEntity(Book.class);
             assertEquals(123L, book.getId());
 
@@ -923,9 +924,11 @@ public class JAXRSClientServerBookTest extends AbstractBusClientServerTestBase {
             // Now make a second call. The value in the clients cache will have expired, so it should call
             // out to the service, which will return 304, and the client will re-use the cached payload
             Thread.sleep(1500L);
-            response = target.request().get();
-            assertEquals(304, response.getStatus());
-            assertFalse(response.hasEntity());
+            Response response2 = target.request().get();
+            assertEquals(304, response2.getStatus());
+            assertFalse(response2.hasEntity());
+            Book book2 = response.readEntity(Book.class);
+            assertEquals(123L, book2.getId());
         }
     }
 

--- a/systests/rs-security/src/test/java/org/apache/cxf/systest/jaxrs/security/oidc/OIDCNegativeTest.java
+++ b/systests/rs-security/src/test/java/org/apache/cxf/systest/jaxrs/security/oidc/OIDCNegativeTest.java
@@ -47,6 +47,7 @@ import org.junit.runners.Parameterized.Parameters;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -113,12 +114,7 @@ public class OIDCNegativeTest extends AbstractBusClientServerTestBase {
         client.path("authorize-implicit/");
         Response response = client.get();
 
-        try {
-            response.readEntity(OAuthAuthorizationData.class);
-            fail("Failure expected on a bad prompt");
-        } catch (Exception ex) {
-            // expected
-        }
+        assertNull(response.readEntity(OAuthAuthorizationData.class));
     }
 
     @org.junit.Test
@@ -196,12 +192,7 @@ public class OIDCNegativeTest extends AbstractBusClientServerTestBase {
         client.path("authorize-implicit/");
         Response response = client.get();
 
-        try {
-            response.readEntity(OAuthAuthorizationData.class);
-            fail("Failure expected on no nonce");
-        } catch (Exception ex) {
-            // expected
-        }
+        assertNull(response.readEntity(OAuthAuthorizationData.class));
 
         // Add a nonce and it should succeed
         String nonce = "1234565635";


### PR DESCRIPTION
This should resolve 4 errors/failures in systests that resulted from runtime changes in CXF-8346 / PR #697.  

The first change is to remove query parameters.  These should need to be "replaced" as the query parameter was specified on the original request.  By replacing them, it actually appended them, making the request URI look something like: `http://localhost:8080/bookstore/books/check2?a=b?a=b` which is not allowed (the extra question mark).

The other changes were to re-acquire the Response object rather than just re-using them.  This was a clear test bug, since it was previously checking the response from the first request twice rather than checking the response from both requests.

This should resolve 8 failures in the master builds since these 4 tests are run twice (once for Java 8 and once for Java 11).