### PR TITLE
[CXF-8353] MediaType validation

### DIFF
--- a/rt/frontend/jaxrs/src/main/java/org/apache/cxf/jaxrs/impl/MediaTypeHeaderProvider.java
+++ b/rt/frontend/jaxrs/src/main/java/org/apache/cxf/jaxrs/impl/MediaTypeHeaderProvider.java
@@ -87,7 +87,7 @@ public class MediaTypeHeaderProvider implements HeaderDelegate<MediaType> {
 
         String type = mType.substring(0, i);
         String subtype = mType.substring(i + 1, end);
-        if (subtype.indexOf('/') != -1) {
+        if (!isValid(type) || !isValid(subtype)) {
             throw new IllegalArgumentException("Invalid media type string: " + mType);
         }
 
@@ -189,5 +189,36 @@ public class MediaTypeHeaderProvider implements HeaderDelegate<MediaType> {
             return mt;
         }
         throw new IllegalArgumentException("Media type separator is missing");
+    }
+
+    // Determines whether the type or subtype contains any of the tspecials characters defined at:
+    // https://tools.ietf.org/html/rfc2045#section-5.1
+    private static boolean isValid(String str) {
+        final int len = str.length();
+        if (len == 0) {
+            return false;
+        }
+        for (int i = 0; i < len; i++) {
+            switch (str.charAt(i)) {
+            case '/':
+            case '\\':
+            case '?':
+            case ':':
+            case '<':
+            case '>':
+            case ';':
+            case '(':
+            case ')':
+            case '@':
+            case ',':
+            case '[':
+            case ']':
+            case '=':
+                return false;
+            default:
+                continue;
+            }
+        }
+        return true;
     }
 }

--- a/rt/frontend/jaxrs/src/main/java/org/apache/cxf/jaxrs/impl/MediaTypeHeaderProvider.java
+++ b/rt/frontend/jaxrs/src/main/java/org/apache/cxf/jaxrs/impl/MediaTypeHeaderProvider.java
@@ -85,8 +85,8 @@ public class MediaTypeHeaderProvider implements HeaderDelegate<MediaType> {
         int paramsStart = mType.indexOf(';', i + 1);
         int end = paramsStart == -1  ? mType.length() : paramsStart;
 
-        String type = mType.substring(0, i);
-        String subtype = mType.substring(i + 1, end);
+        String type = mType.substring(0, i).trim();
+        String subtype = mType.substring(i + 1, end).trim();
         if (!isValid(type) || !isValid(subtype)) {
             throw new IllegalArgumentException("Invalid media type string: " + mType);
         }
@@ -111,8 +111,8 @@ public class MediaTypeHeaderProvider implements HeaderDelegate<MediaType> {
             }
         }
 
-        return new MediaType(type.trim().toLowerCase(),
-                             subtype.trim().toLowerCase(),
+        return new MediaType(type.toLowerCase(),
+                             subtype.toLowerCase(),
                              parameters);
     }
 

--- a/rt/frontend/jaxrs/src/test/java/org/apache/cxf/jaxrs/impl/MediaTypeHeaderProviderTest.java
+++ b/rt/frontend/jaxrs/src/test/java/org/apache/cxf/jaxrs/impl/MediaTypeHeaderProviderTest.java
@@ -158,6 +158,48 @@ public class MediaTypeHeaderProviderTest {
         } catch (IllegalArgumentException pe) {
             // expected
         }
+
+        try {
+            new MediaTypeHeaderProvider().fromString("@pplication/json");
+            fail("Parse exception expected");
+        } catch (IllegalArgumentException pe) {
+            // expected
+        }
+
+        try {
+            new MediaTypeHeaderProvider().fromString("application/<xml>");
+            fail("Parse exception expected");
+        } catch (IllegalArgumentException pe) {
+            // expected
+        }
+
+        try {
+            new MediaTypeHeaderProvider().fromString("application/xml,json");
+            fail("Parse exception expected");
+        } catch (IllegalArgumentException pe) {
+            // expected
+        }
+
+        try {
+            new MediaTypeHeaderProvider().fromString("t[ext]/plain");
+            fail("Parse exception expected");
+        } catch (IllegalArgumentException pe) {
+            // expected
+        }
+
+        try {
+            new MediaTypeHeaderProvider().fromString("text/pla:n");
+            fail("Parse exception expected");
+        } catch (IllegalArgumentException pe) {
+            // expected
+        }
+
+        try {
+            new MediaTypeHeaderProvider().fromString("text/reg(ex)");
+            fail("Parse exception expected");
+        } catch (IllegalArgumentException pe) {
+            // expected
+        }
     }
 
     @Test


### PR DESCRIPTION
Performs validation on the type and subtype of the MediaType string passed-in according to https://tools.ietf.org/html/rfc2045#section-5.1