### PR TITLE
CXF-8354: removed remaining references to old Log4jLogger

### DIFF
--- a/core/src/main/java/org/apache/cxf/common/logging/LogUtils.java
+++ b/core/src/main/java/org/apache/cxf/common/logging/LogUtils.java
@@ -105,21 +105,14 @@ public final class LogUtils {
                     if (clsName.contains("NOPLogger")) {
                         //no real slf4j implementation, use j.u.l
                         cname = null;
-                    } else if (clsName.contains("Log4j")) {
-                        cname = "org.apache.cxf.common.logging.Log4jLogger";
-                    } else if (clsName.contains("JCL")) {
-                        cls = Class.forName("org.apache.commons.logging.LogFactory");
-                        fcls = cls.getMethod("getFactory").invoke(null).getClass();
-                        if (fcls.getName().contains("Log4j")) {
-                            cname = "org.apache.cxf.common.logging.Log4jLogger";
-                        }
                     } else if (clsName.contains("JDK14")
                         || clsName.contains("pax.logging")) {
                         //both of these we can use the appropriate j.u.l API's
                         //directly and have it work properly
                         cname = null;
                     } else {
-                        // Cannot really detect where it's logging so we'll
+                        // Either we cannot really detect where it's logging
+                        // or we don't want to use a custom logger, so we'll
                         // go ahead and use the Slf4jLogger directly
                         cname = "org.apache.cxf.common.logging.Slf4jLogger";
                     }


### PR DESCRIPTION
I'm not sure how I could test this fix, because it would require alternating between different SLF4J bindings to make sure we always get the correct logger implementation. This means we would need a different classpath for each test, and SLF4J would need to be reinitialized from scratch.