### PR TITLE
Guard against null NetworkInterface.getNetworkInterfaces()

### DIFF
--- a/rt/transports/udp/src/main/java/org/apache/cxf/transport/udp/UDPDestination.java
+++ b/rt/transports/udp/src/main/java/org/apache/cxf/transport/udp/UDPDestination.java
@@ -196,22 +196,21 @@ public class UDPDestination extends AbstractDestination {
         }
         if (ret == null) {
             Enumeration<NetworkInterface> ifcs = NetworkInterface.getNetworkInterfaces();
-            List<NetworkInterface> possibles = new ArrayList<>();
-            while (ifcs.hasMoreElements()) {
-                NetworkInterface ni = ifcs.nextElement();
-                if (ni.supportsMulticast()
-                    && ni.isUp()) {
-                    for (InterfaceAddress ia : ni.getInterfaceAddresses()) {
-                        if (ia.getAddress() instanceof java.net.Inet4Address
-                            && !ia.getAddress().isLoopbackAddress()
-                            && !ni.getDisplayName().startsWith("vnic")) {
-                            possibles.add(ni);
+            if (ifcs != null) {
+                List<NetworkInterface> possibles = new ArrayList<>();
+                while (ifcs.hasMoreElements()) {
+                    NetworkInterface ni = ifcs.nextElement();
+                    if (ni.supportsMulticast() && ni.isUp()) {
+                        for (InterfaceAddress ia : ni.getInterfaceAddresses()) {
+                            if (ia.getAddress() instanceof java.net.Inet4Address && !ia.getAddress().isLoopbackAddress()
+                                    && !ni.getDisplayName().startsWith("vnic")) {
+                                possibles.add(ni);
+                            }
                         }
                     }
                 }
+                ret = possibles.isEmpty() ? null : possibles.get(possibles.size() - 1);
             }
-            ret = possibles.isEmpty() ? null : possibles.get(possibles.size() - 1);
-
         }
         return ret;
     }

--- a/rt/transports/udp/src/test/java/org/apache/cxf/transport/udp/UDPTransportTest.java
+++ b/rt/transports/udp/src/test/java/org/apache/cxf/transport/udp/UDPTransportTest.java
@@ -102,12 +102,14 @@ public class UDPTransportTest {
 
         Enumeration<NetworkInterface> interfaces = NetworkInterface.getNetworkInterfaces();
         int count = 0;
-        while (interfaces.hasMoreElements()) {
-            NetworkInterface networkInterface = interfaces.nextElement();
-            if (!networkInterface.isUp() || networkInterface.isLoopback()) {
-                continue;
+        if (interfaces != null) {
+            while (interfaces.hasMoreElements()) {
+                NetworkInterface networkInterface = interfaces.nextElement();
+                if (!networkInterface.isUp() || networkInterface.isLoopback()) {
+                    continue;
+                }
+                count++;
             }
-            count++;
         }
         if (count == 0) {
             //no non-loopbacks, cannot do broadcasts

--- a/services/ws-discovery/ws-discovery-api/src/test/java/org/apache/cxf/ws/discovery/WSDiscoveryClientTest.java
+++ b/services/ws-discovery/ws-discovery-api/src/test/java/org/apache/cxf/ws/discovery/WSDiscoveryClientTest.java
@@ -61,15 +61,15 @@ public final class WSDiscoveryClientTest {
     static NetworkInterface findIpv4Interface() throws Exception {
         Enumeration<NetworkInterface> ifcs = NetworkInterface.getNetworkInterfaces();
         List<NetworkInterface> possibles = new ArrayList<>();
-        while (ifcs.hasMoreElements()) {
-            NetworkInterface ni = ifcs.nextElement();
-            if (ni.supportsMulticast()
-                && ni.isUp()) {
-                for (InterfaceAddress ia : ni.getInterfaceAddresses()) {
-                    if (ia.getAddress() instanceof java.net.Inet4Address
-                        && !ia.getAddress().isLoopbackAddress()
-                        && !ni.getDisplayName().startsWith("vnic")) {
-                        possibles.add(ni);
+        if (ifcs != null) {
+            while (ifcs.hasMoreElements()) {
+                NetworkInterface ni = ifcs.nextElement();
+                if (ni.supportsMulticast() && ni.isUp()) {
+                    for (InterfaceAddress ia : ni.getInterfaceAddresses()) {
+                        if (ia.getAddress() instanceof java.net.Inet4Address && !ia.getAddress().isLoopbackAddress()
+                                && !ni.getDisplayName().startsWith("vnic")) {
+                            possibles.add(ni);
+                        }
                     }
                 }
             }
@@ -88,12 +88,14 @@ public final class WSDiscoveryClientTest {
 
         Enumeration<NetworkInterface> interfaces = NetworkInterface.getNetworkInterfaces();
         int count = 0;
-        while (interfaces.hasMoreElements()) {
-            NetworkInterface networkInterface = interfaces.nextElement();
-            if (!networkInterface.isUp() || networkInterface.isLoopback()) {
-                continue;
+        if (interfaces != null) {
+            while (interfaces.hasMoreElements()) {
+                NetworkInterface networkInterface = interfaces.nextElement();
+                if (!networkInterface.isUp() || networkInterface.isLoopback()) {
+                    continue;
+                }
+                count++;
             }
-            count++;
         }
         if (count == 0) {
             //no non-loopbacks, cannot do broadcasts


### PR DESCRIPTION
Guard against null return value from `java.net.NetworkInterface.getNetworkInterfaces()`.