### PR TITLE
Update to Jetty 9.4.35.v20201120

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -148,7 +148,7 @@
         <cxf.jdom.version>1.0</cxf.jdom.version>
         <cxf.jettison.version>1.4.1</cxf.jettison.version>
         <cxf.jetty.osgi.version>[9.2,10)</cxf.jetty.osgi.version>
-        <cxf.jetty9.version>9.4.34.v20201102</cxf.jetty9.version>
+        <cxf.jetty9.version>9.4.35.v20201120</cxf.jetty9.version>
         <cxf.jetty.version>${cxf.jetty9.version}</cxf.jetty.version>
         <cxf.jexl.version>3.1</cxf.jexl.version>
         <cxf.joda.time.version>2.9.4</cxf.joda.time.version>

--- a/systests/jaxrs/src/test/java/org/apache/cxf/systest/jaxrs/security/BookLoginModule.java
+++ b/systests/jaxrs/src/test/java/org/apache/cxf/systest/jaxrs/security/BookLoginModule.java
@@ -78,7 +78,8 @@ public class BookLoginModule implements LoginModule {
         Map<String, String> customOptions = new HashMap<>();
         customOptions.put("file", fileResource);
 
-        module.initialize(subject, handler, sharedState, customOptions);
+        // See please https://github.com/eclipse/jetty.project/issues/5486
+        BookLoginService.withInstance(() -> module.initialize(subject, handler, sharedState, customOptions));
     }
 
     public boolean login() throws LoginException {

--- a/systests/jaxrs/src/test/java/org/apache/cxf/systest/jaxrs/security/BookLoginService.java
+++ b/systests/jaxrs/src/test/java/org/apache/cxf/systest/jaxrs/security/BookLoginService.java
@@ -1,0 +1,74 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.cxf.systest.jaxrs.security;
+
+import java.lang.reflect.Field;
+
+import org.eclipse.jetty.jaas.JAASLoginService;
+
+/**
+ * Since BookLoginModule delegates to PropertyFileLoginModule, the access to JAASLoginService.INSTANCE 
+ * is required 9.4.35.v20201120+ (see please https://github.com/eclipse/jetty.project/issues/5486).
+ */
+public class BookLoginService extends JAASLoginService {
+    private static JAASLoginService globalInstance;
+    private static Field instanceField;
+    
+    public BookLoginService() {
+        globalInstance = this;
+        
+        try {
+            instanceField = JAASLoginService.class.getField("INSTANCE");
+        } catch (final Exception ex) {
+            /* do nothing, older Jetty version where field is not available */
+        }
+    }
+    
+    public static void withInstance(Runnable r) {
+        final ThreadLocal<JAASLoginService> instance = getCurrentInstance();
+        boolean managed = false;
+        
+        try {
+            if (instance.get() == null) {
+                instance.set(globalInstance);
+                managed = true;
+            }
+            
+            r.run();
+        } finally {
+            if (managed) {
+                instance.remove();
+            }
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private static ThreadLocal<JAASLoginService> getCurrentInstance() {
+        if (instanceField == null) {
+            return new ThreadLocal<JAASLoginService>();
+        } else {
+            try {
+                return (ThreadLocal<JAASLoginService>)instanceField.get(null);
+            } catch (final Exception ex) {
+                return new ThreadLocal<JAASLoginService>();
+            }
+        }
+    }
+}

--- a/systests/jaxrs/src/test/resources/jaxrs_jaas_security/WEB-INF/beans.xml
+++ b/systests/jaxrs/src/test/resources/jaxrs_jaas_security/WEB-INF/beans.xml
@@ -94,5 +94,10 @@
         <entry key="getThatBook" value="ROLE_BOOK_OWNER"/>
         <entry key="getBook" value="ROLE_BOOK_OWNER"/>
     </util:map>
+    <bean id="loginService" class="org.apache.cxf.systest.jaxrs.security.BookLoginService" init-method="start">
+        <property name="name" value="BookStoreRealm"/>
+        <property name="loginModuleName" value="org.apache.cxf.systest.jaxrs.security.BookLoginModule"/>
+        <property name="configuration" ref="bookLoginConfig"/>
+    </bean>
 </beans>
 <!-- END SNIPPET: beans -->


### PR DESCRIPTION
The change in PropertyFileLoginModule  caused tests to fail (dependency on thread-local static `JAASLoginService.INSTANCE` has been introduced), see please https://github.com/eclipse/jetty.project/issues/5486