### PR TITLE
CXF-8411: Improve FastInfoset interceptors' compatibility with GraalVM native compilation

### DIFF
--- a/core/src/main/java/org/apache/cxf/interceptor/FIStaxInInterceptor.java
+++ b/core/src/main/java/org/apache/cxf/interceptor/FIStaxInInterceptor.java
@@ -51,7 +51,7 @@ public class FIStaxInInterceptor extends AbstractPhaseInterceptor<Message> {
         return Boolean.TRUE.equals(message.containsKey(Message.REQUESTOR_ROLE));
     }
 
-    private StAXDocumentParser getParser(InputStream in) {
+    private XMLStreamReader getParser(InputStream in) {
         StAXDocumentParser parser = new StAXDocumentParser(in);
         parser.setStringInterning(true);
         parser.setForceStreamClose(true);

--- a/core/src/main/java/org/apache/cxf/interceptor/FIStaxOutInterceptor.java
+++ b/core/src/main/java/org/apache/cxf/interceptor/FIStaxOutInterceptor.java
@@ -113,7 +113,7 @@ public class FIStaxOutInterceptor extends AbstractPhaseInterceptor<Message> {
 
         if (force
             || PropertyUtils.isTrue(o)) {
-            StAXDocumentSerializer serializer = getOutput(out);
+            XMLStreamWriter serializer = getOutput(out);
             message.setContent(XMLStreamWriter.class, serializer);
 
             message.removeContent(OutputStream.class);
@@ -138,7 +138,7 @@ public class FIStaxOutInterceptor extends AbstractPhaseInterceptor<Message> {
         }
     }
 
-    private StAXDocumentSerializer getOutput(OutputStream out) {
+    private XMLStreamWriter getOutput(OutputStream out) {
         /*
         StAXDocumentSerializer serializer = (StAXDocumentSerializer)m.getExchange().getEndpoint()
             .remove(StAXDocumentSerializer.class.getName());


### PR DESCRIPTION
Applies the changes discussed in [CXF-8411](https://issues.apache.org/jira/browse/CXF-8411).