### PR TITLE
CXF-8422: Unclosed input streams after using org.apache.cxf.tools.wsdlto.WSDLToJava

### DIFF
--- a/core/src/main/java/org/apache/cxf/catalog/OASISCatalogManager.java
+++ b/core/src/main/java/org/apache/cxf/catalog/OASISCatalogManager.java
@@ -99,11 +99,9 @@ public class OASISCatalogManager {
                 public String getResolvedEntity(String publicId, String systemId) {
                     String s = super.getResolvedEntity(publicId, systemId);
                     if (s != null && s.startsWith("classpath:")) {
-                        try {
-                            try (URIResolver r = new URIResolver(s)) {
-                                if (r.isResolved()) {
-                                    return r.getURL().toExternalForm();
-                                }
+                        try (URIResolver r = new URIResolver(s)) {
+                            if (r.isResolved()) {
+                                return r.getURL().toExternalForm();
                             }
                         } catch (IOException e) {
                             //ignore

--- a/core/src/main/java/org/apache/cxf/catalog/OASISCatalogManager.java
+++ b/core/src/main/java/org/apache/cxf/catalog/OASISCatalogManager.java
@@ -100,10 +100,10 @@ public class OASISCatalogManager {
                     String s = super.getResolvedEntity(publicId, systemId);
                     if (s != null && s.startsWith("classpath:")) {
                         try {
-                            URIResolver r = new URIResolver(s);
-                            if (r.isResolved()) {
-                                r.getInputStream().close();
-                                return r.getURL().toExternalForm();
+                            try (URIResolver r = new URIResolver(s)) {
+                                if (r.isResolved()) {
+                                    return r.getURL().toExternalForm();
+                                }
                             }
                         } catch (IOException e) {
                             //ignore

--- a/core/src/main/java/org/apache/cxf/resource/URIResolver.java
+++ b/core/src/main/java/org/apache/cxf/resource/URIResolver.java
@@ -54,7 +54,7 @@ import org.apache.cxf.helpers.LoadingByteArrayOutputStream;
  * <li>If the classpath doesn't exist, try to create URL from the URI.</li>
  * </ul>
  */
-public class URIResolver {
+public class URIResolver implements AutoCloseable {
     private static final Logger LOG = LogUtils.getLogger(URIResolver.class);
 
     private Map<String, LoadingByteArrayOutputStream> cache = new HashMap<>();
@@ -449,5 +449,13 @@ public class URIResolver {
 
     public boolean isResolved() {
         return is != null;
+    }
+    
+    @Override
+    public void close() throws IOException {
+        if (isResolved()) {
+            is.close();
+            unresolve();
+        }
     }
 }

--- a/core/src/main/java/org/apache/cxf/service/factory/AbstractServiceFactoryBean.java
+++ b/core/src/main/java/org/apache/cxf/service/factory/AbstractServiceFactoryBean.java
@@ -133,16 +133,14 @@ public abstract class AbstractServiceFactoryBean {
         for (String l : schemaLocations) {
             URL url = rr.resolveResource(l, URL.class);
             if (url == null) {
-                URIResolver res;
-                try {
-                    res = new URIResolver(l);
+                try (URIResolver res = new URIResolver(l)) {
+                    if (!res.isResolved()) {
+                        throw new ServiceConstructionException(new Message("INVALID_SCHEMA_URL", LOG, l));
+                    }
+                    url = res.getURL();
                 } catch (IOException e) {
                     throw new ServiceConstructionException(new Message("INVALID_SCHEMA_URL", LOG, l), e);
                 }
-                if (!res.isResolved()) {
-                    throw new ServiceConstructionException(new Message("INVALID_SCHEMA_URL", LOG, l));
-                }
-                url = res.getURL();
             }
             Document d;
             try {

--- a/distribution/src/main/release/samples/jax_rs/basic/src/main/java/demo/jaxrs/client/Client.java
+++ b/distribution/src/main/release/samples/jax_rs/basic/src/main/java/demo/jaxrs/client/Client.java
@@ -67,44 +67,46 @@ public final class Client {
         System.out.println("Sent HTTP PUT request to update customer info");
         Client client = new Client();
         String inputFile = client.getClass().getResource("/update_customer.xml").getFile();
-        URIResolver resolver = new URIResolver(inputFile);
-        File input = new File(resolver.getURI());
-
-        HttpPut put = new HttpPut("http://localhost:9000/customerservice/customers");
-        put.setEntity(new FileEntity(input, ContentType.TEXT_XML));
-        CloseableHttpClient httpClient = HttpClientBuilder.create().build();
-        try {
-            CloseableHttpResponse response = httpClient.execute(put);
-            System.out.println("Response status code: " + response.getStatusLine().getStatusCode());
-            System.out.println("Response body: ");
-            System.out.println(EntityUtils.toString(response.getEntity()));
-        } finally {
-            // Release current connection to the connection pool once you are
-            // done
-            put.releaseConnection();
+        try (URIResolver resolver = new URIResolver(inputFile)) {
+            File input = new File(resolver.getURI());
+    
+            HttpPut put = new HttpPut("http://localhost:9000/customerservice/customers");
+            put.setEntity(new FileEntity(input, ContentType.TEXT_XML));
+            CloseableHttpClient httpClient = HttpClientBuilder.create().build();
+            try {
+                CloseableHttpResponse response = httpClient.execute(put);
+                System.out.println("Response status code: " + response.getStatusLine().getStatusCode());
+                System.out.println("Response body: ");
+                System.out.println(EntityUtils.toString(response.getEntity()));
+            } finally {
+                // Release current connection to the connection pool once you are
+                // done
+                put.releaseConnection();
+            }
         }
 
         // Sent HTTP POST request to add customer
         System.out.println("\n");
         System.out.println("Sent HTTP POST request to add customer");
         inputFile = client.getClass().getResource("/add_customer.xml").getFile();
-        resolver = new URIResolver(inputFile);
-        input = new File(resolver.getURI());
-
-        HttpPost post = new HttpPost("http://localhost:9000/customerservice/customers");
-        post.addHeader("Accept", "text/xml");
-        post.setEntity(new FileEntity(input, ContentType.TEXT_XML));
-        httpClient = HttpClientBuilder.create().build();
-
-        try {
-            CloseableHttpResponse response = httpClient.execute(post);
-            System.out.println("Response status code: " + response.getStatusLine().getStatusCode());
-            System.out.println("Response body: ");
-            System.out.println(EntityUtils.toString(response.getEntity()));
-        } finally {
-            // Release current connection to the connection pool once you are
-            // done
-            post.releaseConnection();
+        try (URIResolver resolver = new URIResolver(inputFile)) {
+            File input = new File(resolver.getURI());
+    
+            HttpPost post = new HttpPost("http://localhost:9000/customerservice/customers");
+            post.addHeader("Accept", "text/xml");
+            post.setEntity(new FileEntity(input, ContentType.TEXT_XML));
+            CloseableHttpClient httpClient = HttpClientBuilder.create().build();
+    
+            try {
+                CloseableHttpResponse response = httpClient.execute(post);
+                System.out.println("Response status code: " + response.getStatusLine().getStatusCode());
+                System.out.println("Response body: ");
+                System.out.println(EntityUtils.toString(response.getEntity()));
+            } finally {
+                // Release current connection to the connection pool once you are
+                // done
+                post.releaseConnection();
+            }
         }
 
         System.out.println("\n");

--- a/rt/databinding/jaxb/src/main/java/org/apache/cxf/jaxb/JAXBDataBinding.java
+++ b/rt/databinding/jaxb/src/main/java/org/apache/cxf/jaxb/JAXBDataBinding.java
@@ -149,42 +149,45 @@ public class JAXBDataBinding extends AbstractInterceptorProvidingDataBinding
     }
     private static final Map<String, DOMResult> BUILT_IN_SCHEMAS = new HashMap<>();
     static {
-        URIResolver resolver = new URIResolver();
-        try {
-            resolver.resolve("", "classpath:/schemas/wsdl/ws-addr-wsdl.xsd", JAXBDataBinding.class);
-            if (resolver.isResolved()) {
-                resolver.getInputStream().close();
-                DOMResult dr = new DelayedDOMResult(resolver.getURL(),
-                                                    "classpath:/schemas/wsdl/ws-addr-wsdl.xsd",
-                                                    "http://www.w3.org/2005/02/addressing/wsdl");
-                BUILT_IN_SCHEMAS.put("http://www.w3.org/2005/02/addressing/wsdl", dr);
-                resolver.unresolve();
+        try (URIResolver resolver = new URIResolver()) {
+            try {
+                resolver.resolve("", "classpath:/schemas/wsdl/ws-addr-wsdl.xsd", JAXBDataBinding.class);
+                if (resolver.isResolved()) {
+                    resolver.getInputStream().close();
+                    DOMResult dr = new DelayedDOMResult(resolver.getURL(),
+                                                        "classpath:/schemas/wsdl/ws-addr-wsdl.xsd",
+                                                        "http://www.w3.org/2005/02/addressing/wsdl");
+                    BUILT_IN_SCHEMAS.put("http://www.w3.org/2005/02/addressing/wsdl", dr);
+                    resolver.unresolve();
+                }
+            } catch (Exception e) {
+                //IGNORE
             }
-        } catch (Exception e) {
-            //IGNORE
-        }
-        try {
-            resolver.resolve("", "classpath:/schemas/wsdl/ws-addr.xsd", JAXBDataBinding.class);
-            if (resolver.isResolved()) {
-                resolver.getInputStream().close();
-                DOMResult dr = new DelayedDOMResult(resolver.getURL(),
-                                                    "classpath:/schemas/wsdl/ws-addr.xsd",
-                                                    "http://www.w3.org/2005/08/addressing");
-                BUILT_IN_SCHEMAS.put("http://www.w3.org/2005/08/addressing", dr);
-                resolver.unresolve();
+            try {
+                resolver.resolve("", "classpath:/schemas/wsdl/ws-addr.xsd", JAXBDataBinding.class);
+                if (resolver.isResolved()) {
+                    resolver.getInputStream().close();
+                    DOMResult dr = new DelayedDOMResult(resolver.getURL(),
+                                                        "classpath:/schemas/wsdl/ws-addr.xsd",
+                                                        "http://www.w3.org/2005/08/addressing");
+                    BUILT_IN_SCHEMAS.put("http://www.w3.org/2005/08/addressing", dr);
+                    resolver.unresolve();
+                }
+            } catch (Exception e) {
+                //IGNORE
             }
-        } catch (Exception e) {
-            //IGNORE
-        }
-        try {
-            resolver.resolve("", "classpath:/schemas/wsdl/wsrm.xsd", JAXBDataBinding.class);
-            if (resolver.isResolved()) {
-                resolver.getInputStream().close();
-                DOMResult dr = new DelayedDOMResult(resolver.getURL(),
-                                                    "classpath:/schemas/wsdl/wsrm.xsd",
-                                                    "http://schemas.xmlsoap.org/ws/2005/02/rm");
-                BUILT_IN_SCHEMAS.put("http://schemas.xmlsoap.org/ws/2005/02/rm", dr);
-                resolver.unresolve();
+            try {
+                resolver.resolve("", "classpath:/schemas/wsdl/wsrm.xsd", JAXBDataBinding.class);
+                if (resolver.isResolved()) {
+                    resolver.getInputStream().close();
+                    DOMResult dr = new DelayedDOMResult(resolver.getURL(),
+                                                        "classpath:/schemas/wsdl/wsrm.xsd",
+                                                        "http://schemas.xmlsoap.org/ws/2005/02/rm");
+                    BUILT_IN_SCHEMAS.put("http://schemas.xmlsoap.org/ws/2005/02/rm", dr);
+                    resolver.unresolve();
+                }
+            } catch (Exception e) {
+                //IGNORE
             }
         } catch (Exception e) {
             //IGNORE

--- a/rt/frontend/simple/src/main/java/org/apache/cxf/endpoint/dynamic/DynamicClientFactory.java
+++ b/rt/frontend/simple/src/main/java/org/apache/cxf/endpoint/dynamic/DynamicClientFactory.java
@@ -923,11 +923,9 @@ public class DynamicClientFactory {
         }
 
 
-        try {
-            try (URIResolver resolver = new URIResolver(base, target)) {
-                if (resolver.isResolved()) {
-                    target = resolver.getURI().toString();
-                }
+        try (URIResolver resolver = new URIResolver(base, target)) {
+            if (resolver.isResolved()) {
+                target = resolver.getURI().toString();
             }
         } catch (Exception ex) {
             //ignore

--- a/rt/frontend/simple/src/main/java/org/apache/cxf/endpoint/dynamic/DynamicClientFactory.java
+++ b/rt/frontend/simple/src/main/java/org/apache/cxf/endpoint/dynamic/DynamicClientFactory.java
@@ -728,16 +728,15 @@ public class DynamicClientFactory {
     }
 
     private URL composeUrl(String s) {
-        try {
-            try (URIResolver resolver = new URIResolver(null, s, getClass())) {
-                if (resolver.isResolved()) {
-                    return resolver.getURI().toURL();
-                }
+        try (URIResolver resolver = new URIResolver(null, s, getClass())) {
+            if (resolver.isResolved()) {
+                return resolver.getURI().toURL();
             }
-            throw new ServiceConstructionException(new Message("COULD_NOT_RESOLVE_URL", LOG, s));
         } catch (IOException e) {
             throw new ServiceConstructionException(new Message("COULD_NOT_RESOLVE_URL", LOG, s), e);
         }
+        
+        throw new ServiceConstructionException(new Message("COULD_NOT_RESOLVE_URL", LOG, s));
     }
 
     static class InnerErrorListener {

--- a/rt/frontend/simple/src/main/java/org/apache/cxf/endpoint/dynamic/DynamicClientFactory.java
+++ b/rt/frontend/simple/src/main/java/org/apache/cxf/endpoint/dynamic/DynamicClientFactory.java
@@ -729,10 +729,10 @@ public class DynamicClientFactory {
 
     private URL composeUrl(String s) {
         try {
-            URIResolver resolver = new URIResolver(null, s, getClass());
-
-            if (resolver.isResolved()) {
-                return resolver.getURI().toURL();
+            try (URIResolver resolver = new URIResolver(null, s, getClass())) {
+                if (resolver.isResolved()) {
+                    return resolver.getURI().toURL();
+                }
             }
             throw new ServiceConstructionException(new Message("COULD_NOT_RESOLVE_URL", LOG, s));
         } catch (IOException e) {
@@ -924,9 +924,10 @@ public class DynamicClientFactory {
 
 
         try {
-            URIResolver resolver = new URIResolver(base, target);
-            if (resolver.isResolved()) {
-                target = resolver.getURI().toString();
+            try (URIResolver resolver = new URIResolver(base, target)) {
+                if (resolver.isResolved()) {
+                    target = resolver.getURI().toString();
+                }
             }
         } catch (Exception ex) {
             //ignore

--- a/tools/validator/src/main/java/org/apache/cxf/tools/validator/internal/SchemaValidator.java
+++ b/tools/validator/src/main/java/org/apache/cxf/tools/validator/internal/SchemaValidator.java
@@ -403,12 +403,12 @@ class SchemaResourceResolver implements LSResourceResolver {
             }
         }
 
-        URIResolver resolver;
         try {
             msg = new Message("RESOLVE_FROM_LOCAL", LOG, localFile);
             LOG.log(Level.FINE, msg.toString());
 
-            resolver = new URIResolver(localFile);
+            @SuppressWarnings("resource")
+            final URIResolver resolver = new URIResolver(localFile);
             if (resolver.isResolved()) {
                 lsin = new LSInputImpl();
                 lsin.setSystemId(localFile);

--- a/tools/wadlto/jaxrs/src/main/java/org/apache/cxf/tools/wadlto/jaxb/CustomizationParser.java
+++ b/tools/wadlto/jaxrs/src/main/java/org/apache/cxf/tools/wadlto/jaxb/CustomizationParser.java
@@ -118,8 +118,9 @@ public final class CustomizationParser {
 
         Element root = null;
         try {
-            URIResolver resolver = new URIResolver(bindingFile);
-            root = StaxUtils.read(resolver.getInputStream()).getDocumentElement();
+            try (URIResolver resolver = new URIResolver(bindingFile)) {
+                root = StaxUtils.read(resolver.getInputStream()).getDocumentElement();
+            }
         } catch (Exception e1) {
             Message msg = new Message("CAN_NOT_READ_AS_ELEMENT", LOG, new Object[] {bindingFile});
             throw new ToolException(msg, e1);

--- a/tools/wadlto/jaxrs/src/main/java/org/apache/cxf/tools/wadlto/jaxb/CustomizationParser.java
+++ b/tools/wadlto/jaxrs/src/main/java/org/apache/cxf/tools/wadlto/jaxb/CustomizationParser.java
@@ -117,10 +117,8 @@ public final class CustomizationParser {
     private void addBinding(String bindingFile) throws XMLStreamException {
 
         Element root = null;
-        try {
-            try (URIResolver resolver = new URIResolver(bindingFile)) {
-                root = StaxUtils.read(resolver.getInputStream()).getDocumentElement();
-            }
+        try (URIResolver resolver = new URIResolver(bindingFile)) {
+            root = StaxUtils.read(resolver.getInputStream()).getDocumentElement();
         } catch (Exception e1) {
             Message msg = new Message("CAN_NOT_READ_AS_ELEMENT", LOG, new Object[] {bindingFile});
             throw new ToolException(msg, e1);

--- a/tools/wsdlto/databinding/jaxb/src/main/java/org/apache/cxf/tools/wsdlto/databinding/jaxb/JAXBDataBinding.java
+++ b/tools/wsdlto/databinding/jaxb/src/main/java/org/apache/cxf/tools/wsdlto/databinding/jaxb/JAXBDataBinding.java
@@ -1304,11 +1304,9 @@ public class JAXBDataBinding implements DataBindingProfile {
         }
 
 
-        try {
-            try (URIResolver resolver = new URIResolver(base, target)) {
-                if (resolver.isResolved()) {
-                    target = resolver.getURI().toString();
-                }
+        try (URIResolver resolver = new URIResolver(base, target)) {
+            if (resolver.isResolved()) {
+                target = resolver.getURI().toString();
             }
         } catch (Exception ex) {
             //ignore

--- a/tools/wsdlto/databinding/jaxb/src/main/java/org/apache/cxf/tools/wsdlto/databinding/jaxb/JAXBDataBinding.java
+++ b/tools/wsdlto/databinding/jaxb/src/main/java/org/apache/cxf/tools/wsdlto/databinding/jaxb/JAXBDataBinding.java
@@ -1305,9 +1305,10 @@ public class JAXBDataBinding implements DataBindingProfile {
 
 
         try {
-            URIResolver resolver = new URIResolver(base, target);
-            if (resolver.isResolved()) {
-                target = resolver.getURI().toString();
+            try (URIResolver resolver = new URIResolver(base, target)) {
+                if (resolver.isResolved()) {
+                    target = resolver.getURI().toString();
+                }
             }
         } catch (Exception ex) {
             //ignore

--- a/tools/wsdlto/frontend/jaxws/src/main/java/org/apache/cxf/tools/wsdlto/frontend/jaxws/JAXWSContainer.java
+++ b/tools/wsdlto/frontend/jaxws/src/main/java/org/apache/cxf/tools/wsdlto/frontend/jaxws/JAXWSContainer.java
@@ -70,16 +70,14 @@ public class JAXWSContainer extends WSDLToJavaContainer {
         super.validate(env);
         if (env.containsKey(ToolConstants.CFG_BINDING)) {
             String[] bindings = (String[])env.get(ToolConstants.CFG_BINDING);
-            URIResolver resolver = null;
             for (int i = 0; i < bindings.length; i++) {
-                try {
-                    resolver = new URIResolver(bindings[i]);
+                try (URIResolver resolver = new URIResolver(bindings[i])) {
+                    if (!resolver.isResolved()) {
+                        Message msg = new Message("FILE_NOT_EXIST", LOG, bindings[i]);
+                        throw new ToolException(msg);
+                    }
                 } catch (IOException ioe) {
                     throw new ToolException(ioe);
-                }
-                if (!resolver.isResolved()) {
-                    Message msg = new Message("FILE_NOT_EXIST", LOG, bindings[i]);
-                    throw new ToolException(msg);
                 }
             }
             env.put(ToolConstants.CFG_BINDING, bindings);

--- a/tools/wsdlto/frontend/jaxws/src/main/java/org/apache/cxf/tools/wsdlto/frontend/jaxws/customization/CustomizationParser.java
+++ b/tools/wsdlto/frontend/jaxws/src/main/java/org/apache/cxf/tools/wsdlto/frontend/jaxws/customization/CustomizationParser.java
@@ -477,11 +477,9 @@ public final class CustomizationParser {
 
         Element root = null;
         XMLStreamReader xmlReader = null;
-        try {
-            try (URIResolver resolver = new URIResolver(bindingFile)) {
-                xmlReader = StaxUtils.createXMLStreamReader(resolver.getURI().toString(), resolver.getInputStream());
-                root = StaxUtils.read(xmlReader, true).getDocumentElement();
-            }
+        try (URIResolver resolver = new URIResolver(bindingFile)) {
+            xmlReader = StaxUtils.createXMLStreamReader(resolver.getURI().toString(), resolver.getInputStream());
+            root = StaxUtils.read(xmlReader, true).getDocumentElement();
         } catch (Exception e1) {
             Message msg = new Message("CAN_NOT_READ_AS_ELEMENT", LOG, new Object[] {bindingFile});
             throw new ToolException(msg, e1);


### PR DESCRIPTION
Multiple input stream leaks where `URIResolver` is used. Marked `URIResolver`  as `AutoCloseable` and refactored its usage to `try-with-resources` in most places.