### PR TITLE
CXF-8429: Illegal reflective access in XercesSchemaValidationUtils

### DIFF
--- a/rt/wsdl/pom.xml
+++ b/rt/wsdl/pom.xml
@@ -41,7 +41,6 @@
         <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-core</artifactId>
-            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>wsdl4j</groupId>
@@ -54,8 +53,7 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <scope>provided</scope>
-            <optional>true</optional>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.easymock</groupId>
@@ -119,4 +117,19 @@
             </plugin>
         </plugins>
     </build>
+    
+    <profiles>
+        <profile>
+            <id>xerces</id>
+            <activation>
+                <jdk>[9,)</jdk>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>xerces</groupId>
+                    <artifactId>xercesImpl</artifactId>
+                </dependency>
+            </dependencies>
+        </profile>
+    </profiles>
 </project>

--- a/services/sts/sts-core/pom.xml
+++ b/services/sts/sts-core/pom.xml
@@ -177,4 +177,27 @@
             </plugin>
         </plugins>
     </build>
+    
+    <profiles>
+        <profile>
+            <id>xerces</id>
+            <activation>
+                <jdk>[9,)</jdk>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <systemPropertyVariables>
+                                <!--  The 'http://javax.xml.XMLConstants/property/accessExternalSchema' is not supported by Xerces -->
+                                <hazelcast.ignoreXxeProtectionFailures>true</hazelcast.ignoreXxeProtectionFailures>
+                            </systemPropertyVariables>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>

--- a/tools/validator/src/main/java/org/apache/cxf/tools/validator/internal/SchemaValidator.java
+++ b/tools/validator/src/main/java/org/apache/cxf/tools/validator/internal/SchemaValidator.java
@@ -51,6 +51,7 @@ import org.w3c.dom.ls.LSResourceResolver;
 import org.xml.sax.ErrorHandler;
 import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
+import org.xml.sax.SAXNotRecognizedException;
 import org.xml.sax.SAXParseException;
 
 import org.apache.cxf.common.i18n.Message;
@@ -125,9 +126,15 @@ public class SchemaValidator extends AbstractDefinitionValidator {
 
         SchemaFactory sf = SchemaFactory.newInstance(XMLConstants.W3C_XML_SCHEMA_NS_URI);
         sf.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, Boolean.TRUE);
-        sf.setProperty(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "file,http,https");
-        SchemaResourceResolver resourceResolver = new SchemaResourceResolver();
+        
+        try {
+            // The 'http://javax.xml.XMLConstants/property/accessExternalSchema' is not supported by Xerces
+            sf.setProperty(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "file,http,https");
+        } catch (final SAXNotRecognizedException ex) {
+            LOG.log(Level.WARNING, "The property '" + XMLConstants.ACCESS_EXTERNAL_SCHEMA + "' is not supported.");
+        }
 
+        SchemaResourceResolver resourceResolver = new SchemaResourceResolver();
         sf.setResourceResolver(resourceResolver);
 
         List<Source> sources = new ArrayList<>();


### PR DESCRIPTION
Using `Xerces` as the substitution of the JDK's implementation (sealed even more in JDK16). Sadly, not all features are supported by `Xerces`, fe `http://javax.xml.XMLConstants/property/accessExternalSchema` is not recognizable. 

@ffang could you please take a look? thank you!