### PR TITLE
CXF-8393: Umbrella issue to address fixing flaky tests

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -1129,6 +1129,11 @@
             </dependency>
             <dependency>
                 <groupId>org.eclipse.jetty</groupId>
+                <artifactId>jetty-servlets</artifactId>
+                <version>${cxf.jetty.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.jetty</groupId>
                 <artifactId>jetty-util</artifactId>
                 <version>${cxf.jetty.version}</version>
             </dependency>

--- a/systests/microprofile/client/async/pom.xml
+++ b/systests/microprofile/client/async/pom.xml
@@ -117,6 +117,12 @@
                 <artifactId>microprofile-rest-client-tck</artifactId>
                 <version>${cxf.microprofile.rest.client.version}</version>
                 <scope>test</scope>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.testng</groupId>
+                        <artifactId>testng</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>com.github.tomakehurst</groupId>

--- a/systests/microprofile/client/weld/src/test/java/org/apache/cxf/microprofile/AnnotationTransformer.java
+++ b/systests/microprofile/client/weld/src/test/java/org/apache/cxf/microprofile/AnnotationTransformer.java
@@ -1,0 +1,33 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.cxf.microprofile;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Method;
+
+import org.testng.IAnnotationTransformer;
+import org.testng.annotations.ITestAnnotation;
+
+public class AnnotationTransformer implements IAnnotationTransformer {
+    @Override
+    public void transform(ITestAnnotation annotation, Class test, Constructor constructor, Method method) {
+        annotation.setRetryAnalyzer(RetryAnalyzer.class);
+    }
+}

--- a/systests/microprofile/client/weld/src/test/java/org/apache/cxf/microprofile/RetryAnalyzer.java
+++ b/systests/microprofile/client/weld/src/test/java/org/apache/cxf/microprofile/RetryAnalyzer.java
@@ -1,0 +1,39 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.cxf.microprofile;
+
+import org.testng.IRetryAnalyzer;
+import org.testng.ITestResult;
+import org.testng.Reporter;
+
+public class RetryAnalyzer implements IRetryAnalyzer {
+    private static final int RETRIES = 3;
+    private int counter;
+
+    @Override
+    public boolean retry(ITestResult result) {
+        if (++counter < RETRIES) {
+            Reporter.log("Retrying test case '" + result.getName() + "', attempt " + counter);
+            return true;
+        } else {
+            return false;
+        }
+    }
+}

--- a/systests/microprofile/client/weld/testng.xml
+++ b/systests/microprofile/client/weld/testng.xml
@@ -1,6 +1,9 @@
 <!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd" >
  
 <suite name="MPRestClientTCK1.3">
+    <listeners>
+        <listener class-name="org.apache.cxf.microprofile.AnnotationTransformer"/>
+    </listeners>
     <test name="All TCK Tests">
         <packages>
             <package name="org.eclipse.microprofile.rest.client.tck" />


### PR DESCRIPTION
The long term option would be to stabilize CXF or/and MP RestClient TCKs (may need some time), suggesting to use the retrier as the interim solution to the problem, at least to minimize the number of failing builds.

@andymc12 mind please taking a look? thanks!