### PR TITLE
Adds CachedJAXBDataBinding

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -163,7 +163,7 @@
         <cxf.logback.classic.version>1.2.3</cxf.logback.classic.version>
         <cxf.lucene.version>8.2.0</cxf.lucene.version>
         <cxf.maven.core.version>3.6.3</cxf.maven.core.version>
-        <cxf.micrometer.version>1.6.4</cxf.micrometer.version>
+        <cxf.micrometer.version>1.6.5</cxf.micrometer.version>
         <cxf.microprofile.config.version>2.0</cxf.microprofile.config.version>
         <cxf.microprofile.rest.client.version>2.0</cxf.microprofile.rest.client.version>
         <cxf.microprofile.openapi.version>2.0</cxf.microprofile.openapi.version>

--- a/rt/databinding/jaxb/src/main/java/org/apache/cxf/jaxb/CachedJAXBDataBinding.java
+++ b/rt/databinding/jaxb/src/main/java/org/apache/cxf/jaxb/CachedJAXBDataBinding.java
@@ -1,0 +1,152 @@
+package org.apache.cxf.jaxb;
+
+import javax.xml.bind.JAXBContext;
+import javax.xml.bind.JAXBException;
+import javax.xml.transform.dom.DOMResult;
+import javax.xml.transform.dom.DOMSource;
+import java.io.IOException;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.Collection;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import org.apache.cxf.common.jaxb.JAXBContextCache;
+import org.apache.cxf.common.logging.LogUtils;
+import org.apache.cxf.common.xmlschema.SchemaCollection;
+import org.apache.cxf.jaxb.attachment.JAXBAttachmentSchemaValidationHack;
+import org.apache.cxf.service.Service;
+import org.apache.cxf.service.factory.ServiceConstructionException;
+import org.apache.cxf.service.model.ServiceInfo;
+import org.w3c.dom.Document;
+
+/**
+ * Provides support for reusing databinding context between multiple CXF
+ * clients/servers. This is useful for fat WSDLs that produce multiple
+ * interfaces and share classes between them.
+ */
+public class CachedJAXBDataBinding extends JAXBDataBinding {
+    private static final Logger LOG = LogUtils.getLogger(CachedJAXBDataBinding.class);
+    private JAXBContextCache.CachedContextAndSchemas cachedContextAndSchemas;
+    public CachedJAXBDataBinding() {
+        super();
+    }
+
+    public CachedJAXBDataBinding(boolean q) {
+        super(q);
+    }
+
+    public CachedJAXBDataBinding(Class<?>... classes) throws JAXBException {
+        super(classes);
+    }
+
+    public CachedJAXBDataBinding(boolean qualified, Map<String, Object> props) throws JAXBException {
+        super(qualified, props);
+    }
+
+    public CachedJAXBDataBinding(JAXBContext context) {
+        super(context);
+    }
+
+    @Override
+    public synchronized void initialize(Service service) {
+        inInterceptors.addIfAbsent(JAXBAttachmentSchemaValidationHack.INSTANCE);
+        inFaultInterceptors.addIfAbsent(JAXBAttachmentSchemaValidationHack.INSTANCE);
+        String tns = getNamespaceToUse(service);
+
+        if(contextClasses == null) {
+            contextClasses = new LinkedHashSet<>();
+        }
+
+        for (ServiceInfo serviceInfo : service.getServiceInfos()) {
+            JAXBContextInitializer initializer = new JAXBContextInitializer(getBus(), serviceInfo, contextClasses,
+                    typeRefs, this.getUnmarshallerProperties());
+            initializer.walk();
+            if (serviceInfo.getProperty("extra.class") != null) {
+                Set<Class<?>> exClasses = serviceInfo.getProperty("extra.class", Set.class);
+                contextClasses.addAll(exClasses);
+            }
+
+        }
+        if (context == null) {
+            JAXBContext ctx = null;
+            try {
+                cachedContextAndSchemas = createJAXBContextAndSchemas(contextClasses, tns);
+            } catch (JAXBException e1) {
+                throw new ServiceConstructionException(e1);
+            }
+            ctx = cachedContextAndSchemas.getContext();
+            if (LOG.isLoggable(Level.FINE)) {
+                LOG.log(Level.FINE, "CREATED_JAXB_CONTEXT", new Object[]{ctx, contextClasses});
+            }
+            setContext(ctx);
+        }
+
+
+        for (ServiceInfo serviceInfo : service.getServiceInfos()) {
+            SchemaCollection col = serviceInfo.getXmlSchemaCollection();
+
+            if (col.getXmlSchemas().length > 1) {
+                // someone has already filled in the types
+                justCheckForJAXBAnnotations(serviceInfo);
+                continue;
+            }
+
+            boolean schemasFromCache = false;
+            Collection<DOMSource> schemas = getSchemas();
+            if (schemas == null || schemas.isEmpty()) {
+                schemas = cachedContextAndSchemas.getSchemas();
+                if (schemas != null) {
+                    schemasFromCache = true;
+                }
+            } else {
+                schemasFromCache = true;
+            }
+            Set<DOMSource> bi = new LinkedHashSet<>();
+            if (schemas == null) {
+                schemas = new LinkedHashSet<>();
+                try {
+                    for (DOMResult r : generateJaxbSchemas()) {
+                        DOMSource src = new DOMSource(r.getNode(), r.getSystemId());
+                        if (BUILT_IN_SCHEMAS.containsValue(r)) {
+                            bi.add(src);
+                        } else {
+                            schemas.add(src);
+                        }
+                    }
+                    //put any builtins at the end.   Anything that DOES import them
+                    //will cause it to load automatically and we'll skip them later
+                    schemas.addAll(bi);
+                } catch (IOException e) {
+                    throw new ServiceConstructionException("SCHEMA_GEN_EXC", LOG, e);
+                }
+            }
+            for (DOMSource r : schemas) {
+                if (bi.contains(r)) {
+                    String ns = ((Document)r.getNode()).getDocumentElement().getAttribute("targetNamespace");
+                    if (serviceInfo.getSchema(ns) != null) {
+                        continue;
+                    }
+                }
+                //StaxUtils.print(r.getNode());
+                //System.out.println();
+                addSchemaDocument(serviceInfo,
+                        col,
+                        (Document)r.getNode(),
+                        r.getSystemId());
+            }
+
+            JAXBSchemaInitializer schemaInit = new JAXBSchemaInitializer(serviceInfo, col, context, getQualifiedSchemas(), tns);
+            schemaInit.walk();
+            if (!schemasFromCache) {
+                cachedContextAndSchemas.setSchemas(schemas);
+            }
+        }
+    }
+
+}

--- a/rt/databinding/jaxb/src/main/java/org/apache/cxf/jaxb/JAXBDataBinding.java
+++ b/rt/databinding/jaxb/src/main/java/org/apache/cxf/jaxb/JAXBDataBinding.java
@@ -147,7 +147,7 @@ public class JAXBDataBinding extends AbstractInterceptorProvidingDataBinding
             return nd;
         }
     }
-    private static final Map<String, DOMResult> BUILT_IN_SCHEMAS = new HashMap<>();
+    protected static final Map<String, DOMResult> BUILT_IN_SCHEMAS = new HashMap<>();
     static {
         try (URIResolver resolver = new URIResolver()) {
             try {
@@ -214,7 +214,7 @@ public class JAXBDataBinding extends AbstractInterceptorProvidingDataBinding
 
     private boolean unwrapJAXBElement = true;
     private boolean scanPackages = true;
-    private boolean qualifiedSchemas;
+    protected boolean qualifiedSchemas;
 
     public JAXBDataBinding() {
     }
@@ -248,7 +248,11 @@ public class JAXBDataBinding extends AbstractInterceptorProvidingDataBinding
         this();
         setContext(context);
     }
-    
+
+    protected boolean getQualifiedSchemas() {
+        return qualifiedSchemas;
+    }
+
     public JAXBContext getContext() {
         return context;
     }
@@ -423,7 +427,7 @@ public class JAXBDataBinding extends AbstractInterceptorProvidingDataBinding
         }
     }
 
-    private void justCheckForJAXBAnnotations(ServiceInfo serviceInfo) {
+    protected void justCheckForJAXBAnnotations(ServiceInfo serviceInfo) {
         for (MessageInfo mi: serviceInfo.getMessages().values()) {
             for (MessagePartInfo mpi : mi.getMessageParts()) {
                 checkForJAXBAnnotations(mpi, serviceInfo.getXmlSchemaCollection(), serviceInfo.getTargetNamespace());
@@ -444,7 +448,7 @@ public class JAXBDataBinding extends AbstractInterceptorProvidingDataBinding
         }
     }
 
-    private String getNamespaceToUse(Service service) {
+    protected String getNamespaceToUse(Service service) {
         if ("true".equals(service.get("org.apache.cxf.databinding.namespace"))) {
             return null;
         }


### PR DESCRIPTION
Creates a reordered JAXBDataBinding implementation that permits expanding internal class list and permits reuse between multiple CXF services.