### PR TITLE
CXF-8442 Java 16 & CachedOutputStream Fix IOException closed after multiple close() & postClose() calls 

### DIFF
--- a/core/src/main/java/org/apache/cxf/io/CacheAndWriteOutputStream.java
+++ b/core/src/main/java/org/apache/cxf/io/CacheAndWriteOutputStream.java
@@ -29,7 +29,7 @@ import java.io.OutputStream;
  *
  */
 public class CacheAndWriteOutputStream extends CachedOutputStream {
-    private boolean isClosed = true;
+    private boolean isClosed = false;
     OutputStream flowThroughStream;
     long count;
     long limit = Long.MAX_VALUE;

--- a/core/src/main/java/org/apache/cxf/io/CacheAndWriteOutputStream.java
+++ b/core/src/main/java/org/apache/cxf/io/CacheAndWriteOutputStream.java
@@ -29,7 +29,7 @@ import java.io.OutputStream;
  *
  */
 public class CacheAndWriteOutputStream extends CachedOutputStream {
-
+    private boolean isClosed = true;
     OutputStream flowThroughStream;
     long count;
     long limit = Long.MAX_VALUE;
@@ -47,19 +47,32 @@ public class CacheAndWriteOutputStream extends CachedOutputStream {
     }
 
     public void closeFlowthroughStream() throws IOException {
-        flowThroughStream.flush();
-        flowThroughStream.close();
+        postClose();
     }
 
     protected void postClose() throws IOException {
-        flowThroughStream.flush();
-        flowThroughStream.close();
+        if (!isClosed) {
+            flowThroughStream.flush();
+            flowThroughStream.close();
+            isClosed = true;
+        }
     }
 
     public OutputStream getFlowThroughStream() {
         return flowThroughStream;
     }
 
+    @Override
+    protected void doClose() throws IOException {
+        super.doClose();
+        isClosed = true;
+    }
+
+    @Override
+    public void close() throws IOException {
+        super.close();
+        isClosed = true;
+    }
 
     @Override
     protected void onWrite() throws IOException {

--- a/core/src/main/java/org/apache/cxf/io/CachedOutputStream.java
+++ b/core/src/main/java/org/apache/cxf/io/CachedOutputStream.java
@@ -225,7 +225,11 @@ public class CachedOutputStream extends OutputStream {
             ciphers.clean();
         }
         if (!maybeDeleteTempFile(currentStream)) {
-            postClose();
+            try {
+                postClose();
+            } catch (IOException e) {
+                // ignore
+            }
         }
     }
 

--- a/core/src/main/java/org/apache/cxf/io/CachedOutputStream.java
+++ b/core/src/main/java/org/apache/cxf/io/CachedOutputStream.java
@@ -225,11 +225,7 @@ public class CachedOutputStream extends OutputStream {
             ciphers.clean();
         }
         if (!maybeDeleteTempFile(currentStream)) {
-            try {
-                postClose();
-            } catch (IOException e) {
-                // ignore
-            }
+            postClose();
         }
     }
 

--- a/core/src/test/java/org/apache/cxf/io/CacheAndWriteOutputStreamTest.java
+++ b/core/src/test/java/org/apache/cxf/io/CacheAndWriteOutputStreamTest.java
@@ -18,6 +18,8 @@
  */
 package org.apache.cxf.io;
 
+import org.junit.Test;
+
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 
@@ -37,5 +39,15 @@ public class CacheAndWriteOutputStreamTest extends CachedOutputStreamTest {
     @Override
     protected Object createCache() {
         return new CacheAndWriteOutputStream(baos);
+    }
+
+    @Test
+    public void testCloseMultipleTimes() throws IOException {
+        CacheAndWriteOutputStream cacheAndWriteOutputStream = new CacheAndWriteOutputStream(baos);
+        cacheAndWriteOutputStream.close();
+        cacheAndWriteOutputStream.close();
+        cacheAndWriteOutputStream.close();
+        cacheAndWriteOutputStream.close();
+
     }
 }


### PR DESCRIPTION
see https://issues.apache.org/jira/browse/CXF-8442