### PR TITLE
Update Checkstyle to 8.41.1

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -382,11 +382,11 @@
                             <artifactId>cxf-buildtools</artifactId>
                             <version>${cxf.build-utils.version}</version>
                         </dependency>
-                        <!--<dependency>
+                        <dependency>
                             <groupId>com.puppycrawl.tools</groupId>
                             <artifactId>checkstyle</artifactId>
-                            <version>8.35</version>
-                        </dependency>-->
+                            <version>8.41.1</version>
+                        </dependency>
                     </dependencies>
                     <configuration>
                         <encoding>UTF-8</encoding>

--- a/rt/rs/client/src/main/java/org/apache/cxf/jaxrs/client/WebClient.java
+++ b/rt/rs/client/src/main/java/org/apache/cxf/jaxrs/client/WebClient.java
@@ -1309,7 +1309,7 @@ public class WebClient extends AbstractClient {
     }
 
     @SuppressWarnings({
-     "rawtypes", "unchecked"
+        "rawtypes", "unchecked"
     })
     public <T extends RxInvoker> T rx(Class<T> rxCls, ExecutorService executorService) {
         if (CompletionStageRxInvoker.class.isAssignableFrom(rxCls)) {


### PR DESCRIPTION
Fixing this warning in the build:

```
[WARNING] Old version of checkstyle detected. Consider updating to >= v8.30
[WARNING] For more information see: https://maven.apache.org/plugins/maven-checkstyle-plugin/examples/upgrading-checkstyle.html
```

@amarkevich it seems like you have commented out the previous dependency change, any concerns / issues with it? Thank you!