### PR TITLE
CXF-8344: org.apache.cxf.jaxrs.utils.AnnotationUtils#getNameBindings does not use ClassUnwrapper

### DIFF
--- a/rt/frontend/jaxrs/src/main/java/org/apache/cxf/jaxrs/JAXRSServerFactoryBean.java
+++ b/rt/frontend/jaxrs/src/main/java/org/apache/cxf/jaxrs/JAXRSServerFactoryBean.java
@@ -100,11 +100,10 @@ public class JAXRSServerFactoryBean extends AbstractJAXRSFactoryBean {
 
     public void setApplicationInfo(ApplicationInfo provider) {
         appProvider = provider;
-        Set<String> appNameBindings = AnnotationUtils.getNameBindings(provider.getProvider()
-                                                                      .getClass().getAnnotations());
+        Set<String> appNameBindings = AnnotationUtils.getNameBindings(bus, provider.getProvider().getClass());
         for (ClassResourceInfo cri : getServiceFactory().getClassResourceInfo()) {
             Set<String> clsNameBindings = new LinkedHashSet<>(appNameBindings);
-            clsNameBindings.addAll(AnnotationUtils.getNameBindings(cri.getServiceClass().getAnnotations()));
+            clsNameBindings.addAll(AnnotationUtils.getNameBindings(bus, cri.getServiceClass()));
             cri.setNameBindings(clsNameBindings);
         }
     }

--- a/rt/frontend/jaxrs/src/main/java/org/apache/cxf/jaxrs/model/ClassResourceInfo.java
+++ b/rt/frontend/jaxrs/src/main/java/org/apache/cxf/jaxrs/model/ClassResourceInfo.java
@@ -89,7 +89,7 @@ public class ClassResourceInfo extends BeanResourceInfo {
         super(theResourceClass, theServiceClass, theRoot, theRoot || enableStatic, bus);
         this.enableStatic = enableStatic;
         if (resourceClass != null) {
-            nameBindings = AnnotationUtils.getNameBindings(serviceClass.getAnnotations());
+            nameBindings = AnnotationUtils.getNameBindings(bus, serviceClass);
         }
     }
     //CHECKSTYLE:OFF

--- a/rt/frontend/jaxrs/src/main/java/org/apache/cxf/jaxrs/provider/ProviderFactory.java
+++ b/rt/frontend/jaxrs/src/main/java/org/apache/cxf/jaxrs/provider/ProviderFactory.java
@@ -1349,8 +1349,7 @@ public abstract class ProviderFactory {
 
     }
     protected static Set<String> getFilterNameBindings(Bus bus, Object provider) {
-        Class<?> pClass = ClassHelper.getRealClass(bus, provider);
-        Set<String> names = AnnotationUtils.getNameBindings(pClass.getAnnotations());
+        Set<String> names = AnnotationUtils.getInstanceNameBindings(bus, provider);
         if (names.isEmpty()) {
             names = Collections.singleton(DEFAULT_FILTER_NAME_BINDING);
         }

--- a/rt/frontend/jaxrs/src/main/java/org/apache/cxf/jaxrs/utils/AnnotationUtils.java
+++ b/rt/frontend/jaxrs/src/main/java/org/apache/cxf/jaxrs/utils/AnnotationUtils.java
@@ -44,7 +44,9 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.Context;
 
+import org.apache.cxf.Bus;
 import org.apache.cxf.common.logging.LogUtils;
+import org.apache.cxf.common.util.ClassHelper;
 
 public final class AnnotationUtils {
     private static final Logger LOG = LogUtils.getL7dLogger(AnnotationUtils.class);
@@ -115,6 +117,17 @@ public final class AnnotationUtils {
             return Priorities.USER;
         }
     }
+    
+    public static Set<String> getInstanceNameBindings(Bus bus, Object obj) {
+        final Class<?> realClazz = ClassHelper.getRealClass(bus, obj);
+        return getNameBindings(realClazz.getAnnotations());
+    }
+    
+    public static Set<String> getNameBindings(Bus bus, Class<?> clazz) {
+        final Class<?> realClazz = ClassHelper.getRealClassFromClass(bus, clazz);
+        return getNameBindings(realClazz.getAnnotations());
+    }
+    
     public static Set<String> getNameBindings(Annotation[] targetAnns) {
         if (targetAnns.length == 0) {
             return Collections.emptySet();

--- a/systests/cdi/base/src/main/java/org/apache/cxf/systests/cdi/base/AbstractCdiMultiAppTest.java
+++ b/systests/cdi/base/src/main/java/org/apache/cxf/systests/cdi/base/AbstractCdiMultiAppTest.java
@@ -34,6 +34,7 @@ import org.junit.Test;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.CoreMatchers.startsWith;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
@@ -47,6 +48,7 @@ public abstract class AbstractCdiMultiAppTest extends AbstractCdiSingleAppTest {
                 new Form()
                         .param("id", id));
         assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), r.getStatus());
+        assertThat(r.getHeaderString("X-Logged"), nullValue());
     }
 
     @Test
@@ -64,6 +66,20 @@ public abstract class AbstractCdiMultiAppTest extends AbstractCdiSingleAppTest {
         assertThat(r2.readEntity(String.class), not(equalTo(r1.readEntity(String.class))));
     }
 
+    @Test
+    public void testResponseHasBeenReceivedWhenQueringCustomScopedBookstore() {
+        Response r = createWebClient("/rest/v2/bookstore/request/books").get();
+        assertEquals(Response.Status.OK.getStatusCode(), r.getStatus());
+        assertThat(r.getHeaderString("X-Logged"), equalTo("true"));
+    }
+    
+    @Test
+    public void testResponseHasBeenReceivedWhenQueringMethodWithNameBinding() {
+        Response r = createWebClient("/rest/v2/bookstore/books").get();
+        assertEquals(Response.Status.OK.getStatusCode(), r.getStatus());
+        assertThat(r.getHeaderString("X-Logged"), equalTo("true"));
+    }
+    
     protected WebClient createWebClient(final String url) {
         return createWebClient(url, MediaType.APPLICATION_JSON);
     }

--- a/systests/cdi/base/src/main/java/org/apache/cxf/systests/cdi/base/AbstractCdiMultiAppTest.java
+++ b/systests/cdi/base/src/main/java/org/apache/cxf/systests/cdi/base/AbstractCdiMultiAppTest.java
@@ -67,8 +67,15 @@ public abstract class AbstractCdiMultiAppTest extends AbstractCdiSingleAppTest {
     }
 
     @Test
-    public void testResponseHasBeenReceivedWhenQueringCustomScopedBookstore() {
+    public void testResponseHasBeenReceivedWhenQueringRequestScopedBookstore() {
         Response r = createWebClient("/rest/v2/bookstore/request/books").get();
+        assertEquals(Response.Status.OK.getStatusCode(), r.getStatus());
+        assertThat(r.getHeaderString("X-Logged"), equalTo("true"));
+    }
+    
+    @Test
+    public void testResponseHasBeenReceivedWhenQueringCustomScopedBookstore() {
+        Response r = createWebClient("/rest/v2/bookstore/custom/books").get();
         assertEquals(Response.Status.OK.getStatusCode(), r.getStatus());
         assertThat(r.getHeaderString("X-Logged"), equalTo("true"));
     }

--- a/systests/cdi/base/src/main/java/org/apache/cxf/systests/cdi/base/CustomScopedBookStore.java
+++ b/systests/cdi/base/src/main/java/org/apache/cxf/systests/cdi/base/CustomScopedBookStore.java
@@ -1,0 +1,61 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.cxf.systests.cdi.base;
+
+import javax.inject.Inject;
+import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.UriInfo;
+
+import org.apache.cxf.systests.cdi.base.bindings.Logged;
+import org.apache.cxf.systests.cdi.base.scope.CustomScoped;
+
+@Path("/bookstore/custom")
+@CustomScoped
+@Logged
+public class CustomScopedBookStore {
+    private BookStoreService service;
+    private UriInfo uriInfo;
+
+    public CustomScopedBookStore() {
+    }
+
+    @Inject
+    public CustomScopedBookStore(BookStoreService service, UriInfo uriInfo) {
+        this.service = service;
+        this.uriInfo = uriInfo;
+    }
+
+    @GET
+    @Path("/books")
+    @NotNull @Valid
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response getBooks() {
+        return Response
+          .ok()
+          .entity(service.all())
+          .contentLocation(uriInfo.getAbsolutePath())
+          .build();
+    }
+}

--- a/systests/cdi/base/src/main/java/org/apache/cxf/systests/cdi/base/PerRequestBookStore.java
+++ b/systests/cdi/base/src/main/java/org/apache/cxf/systests/cdi/base/PerRequestBookStore.java
@@ -18,77 +18,44 @@
  */
 package org.apache.cxf.systests.cdi.base;
 
-import java.util.Collection;
-
 import javax.inject.Inject;
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
-import javax.validation.constraints.Size;
-import javax.ws.rs.FormParam;
 import javax.ws.rs.GET;
-import javax.ws.rs.POST;
 import javax.ws.rs.Path;
-import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriInfo;
 
 import org.apache.cxf.systests.cdi.base.bindings.Logged;
+import org.apache.cxf.systests.cdi.base.scope.CustomScoped;
 
-@Path("/bookstore/")
-public class BookStore {
+@Path("/bookstore/request")
+@CustomScoped
+@Logged
+public class PerRequestBookStore {
     private BookStoreService service;
-    private BookStoreVersion bookStoreVersion;
     private UriInfo uriInfo;
-    private Injections injections;
 
-    public BookStore() {
+    public PerRequestBookStore() {
     }
 
     @Inject
-    public BookStore(BookStoreService service, BookStoreVersion bookStoreVersion, UriInfo uriInfo,
-                     Injections injections) {
+    public PerRequestBookStore(BookStoreService service, UriInfo uriInfo) {
         this.service = service;
-        this.bookStoreVersion = bookStoreVersion;
         this.uriInfo = uriInfo;
-        this.injections = injections;
-    }
-
-    @GET
-    @Path("injections")
-    public String injections() {
-        return injections.state();
-    }
-
-    @Path("/version")
-    public BookStoreVersion getVersion() {
-        return bookStoreVersion;
-    }
-
-    @GET
-    @Path("/books/{bookId}")
-    @NotNull
-    @Produces(MediaType.APPLICATION_JSON)
-    public Book getBook(@PathParam("bookId") String id) {
-        return service.get(id);
     }
 
     @GET
     @Path("/books")
     @NotNull @Valid
     @Produces(MediaType.APPLICATION_JSON)
-    @Logged
-    public Collection< Book > getBooks() {
-        return service.all();
-    }
-
-    @POST
-    @Path("/books")
-    @Produces(MediaType.APPLICATION_JSON)
-    public Response addBook(@NotNull @Size(min = 1, max = 50) @FormParam("id") String id,
-                            @NotNull @FormParam("name") String name) {
-        final Book book = service.store(id, name);
-        return Response.created(uriInfo.getRequestUriBuilder().path(id).build()).entity(book).build();
+    public Response getBooks() {
+        return Response
+          .ok()
+          .entity(service.all())
+          .contentLocation(uriInfo.getAbsolutePath())
+          .build();
     }
 }

--- a/systests/cdi/base/src/main/java/org/apache/cxf/systests/cdi/base/RequestScopedBookStore.java
+++ b/systests/cdi/base/src/main/java/org/apache/cxf/systests/cdi/base/RequestScopedBookStore.java
@@ -18,6 +18,7 @@
  */
 package org.apache.cxf.systests.cdi.base;
 
+import javax.enterprise.context.RequestScoped;
 import javax.inject.Inject;
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
@@ -29,20 +30,19 @@ import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriInfo;
 
 import org.apache.cxf.systests.cdi.base.bindings.Logged;
-import org.apache.cxf.systests.cdi.base.scope.CustomScoped;
 
 @Path("/bookstore/request")
-@CustomScoped
+@RequestScoped
 @Logged
-public class PerRequestBookStore {
+public class RequestScopedBookStore {
     private BookStoreService service;
     private UriInfo uriInfo;
 
-    public PerRequestBookStore() {
+    public RequestScopedBookStore() {
     }
 
     @Inject
-    public PerRequestBookStore(BookStoreService service, UriInfo uriInfo) {
+    public RequestScopedBookStore(BookStoreService service, UriInfo uriInfo) {
         this.service = service;
         this.uriInfo = uriInfo;
     }

--- a/systests/cdi/base/src/main/java/org/apache/cxf/systests/cdi/base/bindings/Logged.java
+++ b/systests/cdi/base/src/main/java/org/apache/cxf/systests/cdi/base/bindings/Logged.java
@@ -1,0 +1,33 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.cxf.systests.cdi.base.bindings;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import javax.ws.rs.NameBinding;
+
+@Target({ ElementType.TYPE, ElementType.METHOD })
+@Retention(value = RetentionPolicy.RUNTIME)
+@NameBinding
+public @interface Logged {
+}

--- a/systests/cdi/base/src/main/java/org/apache/cxf/systests/cdi/base/bindings/LoggingFilter.java
+++ b/systests/cdi/base/src/main/java/org/apache/cxf/systests/cdi/base/bindings/LoggingFilter.java
@@ -1,0 +1,35 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.cxf.systests.cdi.base.bindings;
+
+import java.io.IOException;
+
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ContainerResponseContext;
+import javax.ws.rs.container.ContainerResponseFilter;
+
+@Logged
+public class LoggingFilter implements ContainerResponseFilter {
+    @Override
+    public void filter(ContainerRequestContext requestContext, 
+            ContainerResponseContext responseContext) throws IOException {
+        responseContext.getHeaders().putSingle("X-Logged", true);
+    }
+}

--- a/systests/cdi/base/src/main/java/org/apache/cxf/systests/cdi/base/scope/CustomContext.java
+++ b/systests/cdi/base/src/main/java/org/apache/cxf/systests/cdi/base/scope/CustomContext.java
@@ -1,0 +1,55 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.cxf.systests.cdi.base.scope;
+
+import java.lang.annotation.Annotation;
+
+import javax.enterprise.context.spi.Context;
+import javax.enterprise.context.spi.Contextual;
+import javax.enterprise.context.spi.CreationalContext;
+import javax.enterprise.inject.spi.BeanManager;
+
+public class CustomContext implements Context {
+    private final BeanManager beanManager;
+    
+    public CustomContext(BeanManager beanManager) {
+        this.beanManager = beanManager;
+    }
+    
+    @Override
+    public Class<? extends Annotation> getScope() {
+        return CustomScoped.class;
+    }
+
+    @Override
+    public <T> T get(Contextual<T> contextual, CreationalContext<T> creationalContext) {
+        return contextual.create(creationalContext);
+    }
+
+    @Override
+    public <T> T get(Contextual<T> contextual) {
+        return contextual.create(beanManager.createCreationalContext(contextual));
+    }
+
+    @Override
+    public boolean isActive() {
+        return true;
+    }
+}

--- a/systests/cdi/base/src/main/java/org/apache/cxf/systests/cdi/base/scope/CustomScopeExtension.java
+++ b/systests/cdi/base/src/main/java/org/apache/cxf/systests/cdi/base/scope/CustomScopeExtension.java
@@ -1,0 +1,33 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.cxf.systests.cdi.base.scope;
+
+import javax.enterprise.context.spi.Context;
+import javax.enterprise.event.Observes;
+import javax.enterprise.inject.spi.AfterBeanDiscovery;
+import javax.enterprise.inject.spi.BeanManager;
+import javax.enterprise.inject.spi.Extension;
+
+public class CustomScopeExtension implements Extension {
+    public void afterBeanDiscovery(@Observes AfterBeanDiscovery event, BeanManager manager) {
+        final Context context = new CustomContext(manager);
+        event.addContext(context);
+    }
+}

--- a/systests/cdi/base/src/main/java/org/apache/cxf/systests/cdi/base/scope/CustomScoped.java
+++ b/systests/cdi/base/src/main/java/org/apache/cxf/systests/cdi/base/scope/CustomScoped.java
@@ -1,0 +1,39 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.cxf.systests.cdi.base.scope;
+
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import javax.inject.Scope;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Target({ METHOD, TYPE, FIELD })
+@Retention(RUNTIME)
+@Scope
+@Inherited
+public @interface CustomScoped {
+
+}

--- a/systests/cdi/base/src/main/resources/META-INF/services/javax.enterprise.inject.spi.Extension
+++ b/systests/cdi/base/src/main/resources/META-INF/services/javax.enterprise.inject.spi.Extension
@@ -1,0 +1,1 @@
+org.apache.cxf.systests.cdi.base.scope.CustomScopeExtension

--- a/systests/cdi/cdi-owb/cdi-multiple-apps-owb/src/test/java/org/apache/cxf/systest/jaxrs/BookStoreCustomApplication.java
+++ b/systests/cdi/cdi-owb/cdi-multiple-apps-owb/src/test/java/org/apache/cxf/systest/jaxrs/BookStoreCustomApplication.java
@@ -32,7 +32,8 @@ import org.apache.cxf.jaxrs.validation.JAXRSBeanValidationFeature;
 import org.apache.cxf.jaxrs.validation.ValidationExceptionMapper;
 import org.apache.cxf.systests.cdi.base.BookStore;
 import org.apache.cxf.systests.cdi.base.BookStoreByIds;
-import org.apache.cxf.systests.cdi.base.PerRequestBookStore;
+import org.apache.cxf.systests.cdi.base.CustomScopedBookStore;
+import org.apache.cxf.systests.cdi.base.RequestScopedBookStore;
 import org.apache.cxf.systests.cdi.base.bindings.LoggingFilter;
 
 @ApplicationPath("/v2")
@@ -49,6 +50,7 @@ public class BookStoreCustomApplication extends Application {
 
     @Override
     public Set<Class<?>> getClasses() {
-        return new LinkedHashSet<>(Arrays.asList(BookStore.class, BookStoreByIds.class, PerRequestBookStore.class));
+        return new LinkedHashSet<>(Arrays.asList(BookStore.class, BookStoreByIds.class, 
+             CustomScopedBookStore.class, RequestScopedBookStore.class));
     }
 }

--- a/systests/cdi/cdi-owb/cdi-multiple-apps-owb/src/test/java/org/apache/cxf/systest/jaxrs/BookStoreCustomApplication.java
+++ b/systests/cdi/cdi-owb/cdi-multiple-apps-owb/src/test/java/org/apache/cxf/systest/jaxrs/BookStoreCustomApplication.java
@@ -32,6 +32,8 @@ import org.apache.cxf.jaxrs.validation.JAXRSBeanValidationFeature;
 import org.apache.cxf.jaxrs.validation.ValidationExceptionMapper;
 import org.apache.cxf.systests.cdi.base.BookStore;
 import org.apache.cxf.systests.cdi.base.BookStoreByIds;
+import org.apache.cxf.systests.cdi.base.PerRequestBookStore;
+import org.apache.cxf.systests.cdi.base.bindings.LoggingFilter;
 
 @ApplicationPath("/v2")
 public class BookStoreCustomApplication extends Application {
@@ -41,11 +43,12 @@ public class BookStoreCustomApplication extends Application {
         singletons.add(new JacksonJsonProvider());
         singletons.add(new ValidationExceptionMapper());
         singletons.add(new JAXRSBeanValidationFeature());
+        singletons.add(new LoggingFilter());
         return singletons;
     }
 
     @Override
     public Set<Class<?>> getClasses() {
-        return new LinkedHashSet<>(Arrays.asList(BookStore.class, BookStoreByIds.class));
+        return new LinkedHashSet<>(Arrays.asList(BookStore.class, BookStoreByIds.class, PerRequestBookStore.class));
     }
 }

--- a/systests/cdi/cdi-weld/cdi-multiple-apps-weld/src/test/java/org/apache/cxf/systest/jaxrs/BookStoreCustomApplication.java
+++ b/systests/cdi/cdi-weld/cdi-multiple-apps-weld/src/test/java/org/apache/cxf/systest/jaxrs/BookStoreCustomApplication.java
@@ -31,7 +31,8 @@ import com.fasterxml.jackson.jaxrs.json.JacksonJsonProvider;
 import org.apache.cxf.jaxrs.validation.JAXRSBeanValidationFeature;
 import org.apache.cxf.jaxrs.validation.ValidationExceptionMapper;
 import org.apache.cxf.systests.cdi.base.BookStore;
-import org.apache.cxf.systests.cdi.base.PerRequestBookStore;
+import org.apache.cxf.systests.cdi.base.CustomScopedBookStore;
+import org.apache.cxf.systests.cdi.base.RequestScopedBookStore;
 import org.apache.cxf.systests.cdi.base.bindings.LoggingFilter;
 
 @ApplicationPath("/v2")
@@ -48,6 +49,7 @@ public class BookStoreCustomApplication extends Application {
 
     @Override
     public Set<Class<?>> getClasses() {
-        return new LinkedHashSet<>(Arrays.asList(BookStore.class, PerRequestBookStore.class));
+        return new LinkedHashSet<>(Arrays.asList(BookStore.class, RequestScopedBookStore.class, 
+            CustomScopedBookStore.class));
     }
 }

--- a/systests/cdi/cdi-weld/cdi-multiple-apps-weld/src/test/java/org/apache/cxf/systest/jaxrs/BookStoreCustomApplication.java
+++ b/systests/cdi/cdi-weld/cdi-multiple-apps-weld/src/test/java/org/apache/cxf/systest/jaxrs/BookStoreCustomApplication.java
@@ -18,8 +18,9 @@
  */
 package org.apache.cxf.systest.jaxrs;
 
-import java.util.Collections;
+import java.util.Arrays;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.Set;
 
 import javax.ws.rs.ApplicationPath;
@@ -30,6 +31,8 @@ import com.fasterxml.jackson.jaxrs.json.JacksonJsonProvider;
 import org.apache.cxf.jaxrs.validation.JAXRSBeanValidationFeature;
 import org.apache.cxf.jaxrs.validation.ValidationExceptionMapper;
 import org.apache.cxf.systests.cdi.base.BookStore;
+import org.apache.cxf.systests.cdi.base.PerRequestBookStore;
+import org.apache.cxf.systests.cdi.base.bindings.LoggingFilter;
 
 @ApplicationPath("/v2")
 public class BookStoreCustomApplication extends Application {
@@ -39,11 +42,12 @@ public class BookStoreCustomApplication extends Application {
         singletons.add(new JacksonJsonProvider());
         singletons.add(new ValidationExceptionMapper());
         singletons.add(new JAXRSBeanValidationFeature());
+        singletons.add(new LoggingFilter());
         return singletons;
     }
 
     @Override
     public Set<Class<?>> getClasses() {
-        return Collections.<Class<?>>singleton(BookStore.class);
+        return new LinkedHashSet<>(Arrays.asList(BookStore.class, PerRequestBookStore.class));
     }
 }


### PR DESCRIPTION
I also added a couple of tests for `@NameBinding` and custom CDI scopes (which would be using `PerRequestResourceProvider` invocation), it turned out we had none.

@rmannibucau mind taking a look please?  thanks a lot!