### PR TITLE
[CXF-7996] Fix `@Encode` TCK test

### DIFF
--- a/rt/frontend/jaxrs/src/test/java/org/apache/cxf/jaxrs/Customer.java
+++ b/rt/frontend/jaxrs/src/test/java/org/apache/cxf/jaxrs/Customer.java
@@ -37,6 +37,7 @@ import javax.ws.rs.BeanParam;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.CookieParam;
 import javax.ws.rs.DefaultValue;
+import javax.ws.rs.Encoded;
 import javax.ws.rs.FormParam;
 import javax.ws.rs.GET;
 import javax.ws.rs.HeaderParam;
@@ -262,6 +263,11 @@ public class Customer extends AbstractCustomer implements CustomerInfo {
     public void testBeanParam(@BeanParam CustomerBean cb) {
 
     }
+
+    public void testEncodedFormParams(@FormParam("p1") String p1, @FormParam("p2") @Encoded String p2) {
+
+    }
+
     public Application getApplication1() {
         return application1;
     }

--- a/rt/frontend/jaxrs/src/test/java/org/apache/cxf/jaxrs/utils/JAXRSUtilsTest.java
+++ b/rt/frontend/jaxrs/src/test/java/org/apache/cxf/jaxrs/utils/JAXRSUtilsTest.java
@@ -1634,6 +1634,24 @@ public class JAXRSUtilsTest {
         assertEquals("3", list.get(1));
     }
 
+    @Test
+    public void testEncodedFormParameters() throws Exception {
+        Class<?>[] argType = {String.class, String.class};
+        Method m = Customer.class.getMethod("testEncodedFormParams", argType);
+        final Message messageImpl = createMessage();
+        String body = "p1=yay&p2=%21";
+        messageImpl.put(Message.REQUEST_URI, "/foo");
+        messageImpl.put("Content-Type", MediaType.APPLICATION_FORM_URLENCODED);
+        messageImpl.setContent(InputStream.class, new ByteArrayInputStream(body.getBytes()));
+
+        List<Object> params = JAXRSUtils.processParameters(new OperationResourceInfo(m,
+                                                               new ClassResourceInfo(Customer.class)),
+                                                           new MetadataMap<String, String>(), messageImpl);
+        assertEquals("2 params should've been identified", 2, params.size());
+        assertEquals("yay", (String)params.get(0));
+        assertEquals("%21", (String)params.get(1)); // if decoded, this will return "!" instead of "%21"
+    }
+
     private static Map<ClassResourceInfo, MultivaluedMap<String, String>> getMap(ClassResourceInfo cri) {
         return Collections.singletonMap(cri, new MetadataMap<String, String>());
     }


### PR DESCRIPTION
This should fix the following Jakarta RESTful WS TCK failures:
> com/sun/ts/tests/jaxrs/ee/rs/beanparam/form/plain/JAXRSClient.java#formFieldParamEntityWithEncodedTest_from_standalone: JAXRSClient_formFieldParamEntityWithEncodedTest_from_standalone

> com/sun/ts/tests/jaxrs/ee/rs/beanparam/form/plain/JAXRSClient.java#formParamEntityWithEncodedTest_from_standalone: JAXRSClient_formParamEntityWithEncodedTest_from_standalone

The issue is that (prior to this fix) form parameters are read into a map as either decoded or encoded based on whether the first parameter has the `@Encoded` annotation or not.  This can result in the `@Encoded` annotation on second or subsequent parameters getting ignored.

The fix is to read the parameters into the map without performing any decoding until it is determined which parameters should be decoded.