### PR TITLE
CXF-8516: Fixing jaxrs.spec.provider.jaxbcontext readWriteProviderTest

### DIFF
--- a/rt/frontend/jaxrs/src/main/java/org/apache/cxf/jaxrs/provider/ProviderFactory.java
+++ b/rt/frontend/jaxrs/src/main/java/org/apache/cxf/jaxrs/provider/ProviderFactory.java
@@ -890,19 +890,21 @@ public abstract class ProviderFactory {
             MessageBodyWriter<?> e1 = p1.getProvider();
             MessageBodyWriter<?> e2 = p2.getProvider();
 
-            int result = compareClasses(e1, e2);
-            if (result != 0) {
-                return result;
-            }
             List<MediaType> types1 =
                 JAXRSUtils.sortMediaTypes(JAXRSUtils.getProviderProduceTypes(e1), JAXRSUtils.MEDIA_TYPE_QS_PARAM);
             List<MediaType> types2 =
                 JAXRSUtils.sortMediaTypes(JAXRSUtils.getProviderProduceTypes(e2), JAXRSUtils.MEDIA_TYPE_QS_PARAM);
 
-            result = JAXRSUtils.compareSortedMediaTypes(types1, types2, JAXRSUtils.MEDIA_TYPE_QS_PARAM);
+            int result = JAXRSUtils.compareSortedMediaTypes(types1, types2, JAXRSUtils.MEDIA_TYPE_QS_PARAM);
             if (result != 0) {
                 return result;
             }
+            
+            result = compareClasses(e1, e2);
+            if (result != 0) {
+                return result;
+            }
+
             result = compareCustomStatus(p1, p2);
             if (result != 0) {
                 return result;

--- a/rt/frontend/jaxrs/src/main/java/org/apache/cxf/jaxrs/provider/ProviderFactory.java
+++ b/rt/frontend/jaxrs/src/main/java/org/apache/cxf/jaxrs/provider/ProviderFactory.java
@@ -890,21 +890,20 @@ public abstract class ProviderFactory {
             MessageBodyWriter<?> e1 = p1.getProvider();
             MessageBodyWriter<?> e2 = p2.getProvider();
 
+            int result = compareClasses(e1, e2);
+            if (result != 0) {
+                return result;
+            }
             List<MediaType> types1 =
                 JAXRSUtils.sortMediaTypes(JAXRSUtils.getProviderProduceTypes(e1), JAXRSUtils.MEDIA_TYPE_QS_PARAM);
             List<MediaType> types2 =
                 JAXRSUtils.sortMediaTypes(JAXRSUtils.getProviderProduceTypes(e2), JAXRSUtils.MEDIA_TYPE_QS_PARAM);
 
-            int result = JAXRSUtils.compareSortedMediaTypes(types1, types2, JAXRSUtils.MEDIA_TYPE_QS_PARAM);
+            result = JAXRSUtils.compareSortedMediaTypes(types1, types2, JAXRSUtils.MEDIA_TYPE_QS_PARAM);
             if (result != 0) {
                 return result;
             }
             
-            result = compareClasses(e1, e2);
-            if (result != 0) {
-                return result;
-            }
-
             result = compareCustomStatus(p1, p2);
             if (result != 0) {
                 return result;
@@ -1133,8 +1132,13 @@ public abstract class ProviderFactory {
         if (realClass1.isAssignableFrom(realClass2)) {
             // subclass should go first
             return 1;
+        } else if (realClass2.isAssignableFrom(realClass1)) {
+            // superclass should go last
+            return -1;
         }
-        return -1;
+        
+        // there is no relation between the types returned by the providers
+        return 0;
     }
 
     private static Type[] getGenericInterfaces(Class<?> cls, Class<?> expectedClass) {

--- a/rt/frontend/jaxrs/src/test/java/org/apache/cxf/jaxrs/provider/CustomJaxbProvider.java
+++ b/rt/frontend/jaxrs/src/test/java/org/apache/cxf/jaxrs/provider/CustomJaxbProvider.java
@@ -1,0 +1,70 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.cxf.jaxrs.provider;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.ext.MessageBodyReader;
+import javax.ws.rs.ext.MessageBodyWriter;
+import javax.ws.rs.ext.Provider;
+import javax.xml.bind.JAXBElement;
+
+@Provider
+public class CustomJaxbProvider implements MessageBodyReader<JAXBElement<String>>, 
+        MessageBodyWriter<JAXBElement<String>> {
+
+    @Override
+    public boolean isWriteable(Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType) {
+        return JAXBElement.class.isAssignableFrom(type);
+    }
+
+    @Override
+    public long getSize(JAXBElement<String> t, Class<?> type, Type genericType, Annotation[] annotations,
+                        MediaType mediaType) {
+        return t.getValue().toString().length() + 2;
+    }
+
+    @Override
+    public void writeTo(JAXBElement<String> t, Class<?> type, Type genericType, Annotation[] annotations,
+                        MediaType mediaType, MultivaluedMap<String, Object> httpHeaders,
+                        OutputStream entityStream) throws IOException, WebApplicationException {
+        entityStream.write("WriteInCXFJaxbProvider".getBytes());
+    }
+
+    @Override
+    public boolean isReadable(Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType) {
+        return isWriteable(type, genericType, annotations, mediaType);
+    }
+
+    @Override
+    public JAXBElement<String> readFrom(Class<JAXBElement<String>> type, Type genericType,
+                                        Annotation[] annotations, MediaType mediaType,
+                                        MultivaluedMap<String, String> httpHeaders, InputStream entityStream)
+        throws IOException, WebApplicationException {
+        return null;
+    }
+
+}

--- a/rt/frontend/jaxrs/src/test/java/org/apache/cxf/jaxrs/provider/ProviderFactoryTest.java
+++ b/rt/frontend/jaxrs/src/test/java/org/apache/cxf/jaxrs/provider/ProviderFactoryTest.java
@@ -56,6 +56,7 @@ import javax.ws.rs.ext.ReaderInterceptor;
 import javax.ws.rs.ext.WriterInterceptor;
 import javax.ws.rs.ext.WriterInterceptorContext;
 import javax.xml.bind.JAXBContext;
+import javax.xml.bind.JAXBElement;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.validation.Schema;
 
@@ -82,12 +83,14 @@ import org.easymock.EasyMock;
 import org.junit.Before;
 import org.junit.Test;
 
+import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 public class ProviderFactoryTest {
@@ -424,6 +427,21 @@ public class ProviderFactoryTest {
         MessageBodyWriter<Book> customJaxbWriter = pf.createMessageBodyWriter(Book.class, null, null,
                                                               MediaType.TEXT_XML_TYPE, new MessageImpl());
         assertSame(customJaxbWriter, provider);
+    }
+    
+    @Test
+    public void testCustomProviderAndJaxbProvider() {
+        ProviderFactory pf = ServerProviderFactory.getInstance();
+        CustomJaxbProvider provider = new CustomJaxbProvider();
+        pf.registerUserProvider(provider);
+        
+        MessageBodyReader<JAXBElement> customJaxbReader = pf.createMessageBodyReader(JAXBElement.class, 
+            String.class, null, MediaType.TEXT_XML_TYPE, new MessageImpl());
+        assertThat(customJaxbReader, instanceOf(JAXBElementTypedProvider.class));
+
+        MessageBodyWriter<JAXBElement> customJaxbWriter = pf.createMessageBodyWriter(JAXBElement.class, 
+            String.class, null, MediaType.TEXT_XML_TYPE, new MessageImpl());
+        assertThat(customJaxbWriter, instanceOf(JAXBElementTypedProvider.class));
     }
 
     @Test

--- a/systests/jaxrs/src/test/java/org/apache/cxf/systest/jaxrs/JAXRSAsyncClientTest.java
+++ b/systests/jaxrs/src/test/java/org/apache/cxf/systest/jaxrs/JAXRSAsyncClientTest.java
@@ -35,6 +35,7 @@ import javax.annotation.Priority;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.NotFoundException;
 import javax.ws.rs.ProcessingException;
+import javax.ws.rs.Produces;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.client.Client;
 import javax.ws.rs.client.ClientBuilder;
@@ -493,6 +494,7 @@ public class JAXRSAsyncClientTest extends AbstractBusClientServerTestBase {
         };
     }
 
+    @Produces("application/xml")
     private static class FaultyBookWriter implements MessageBodyWriter<Book> {
 
         @Override

--- a/systests/jaxrs/src/test/java/org/apache/cxf/systest/jaxrs/provider/CXFJaxbElementProvider.java
+++ b/systests/jaxrs/src/test/java/org/apache/cxf/systest/jaxrs/provider/CXFJaxbElementProvider.java
@@ -1,0 +1,70 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.cxf.systest.jaxrs.provider;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.ext.MessageBodyReader;
+import javax.ws.rs.ext.MessageBodyWriter;
+import javax.ws.rs.ext.Provider;
+import javax.xml.bind.JAXBElement;
+
+@Provider
+public class CXFJaxbElementProvider implements MessageBodyReader<JAXBElement<String>>, 
+        MessageBodyWriter<JAXBElement<String>> {
+
+    @Override
+    public boolean isWriteable(Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType) {
+        return JAXBElement.class.isAssignableFrom(type);
+    }
+
+    @Override
+    public long getSize(JAXBElement<String> t, Class<?> type, Type genericType, Annotation[] annotations,
+                        MediaType mediaType) {
+        return t.getValue().toString().length() + 2;
+    }
+
+    @Override
+    public void writeTo(JAXBElement<String> t, Class<?> type, Type genericType, Annotation[] annotations,
+                        MediaType mediaType, MultivaluedMap<String, Object> httpHeaders,
+                        OutputStream entityStream) throws IOException, WebApplicationException {
+        entityStream.write("WriteInCXFJaxbProvider".getBytes());
+    }
+
+    @Override
+    public boolean isReadable(Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType) {
+        return isWriteable(type, genericType, annotations, mediaType);
+    }
+
+    @Override
+    public JAXBElement<String> readFrom(Class<JAXBElement<String>> type, Type genericType,
+                                        Annotation[] annotations, MediaType mediaType,
+                                        MultivaluedMap<String, String> httpHeaders, InputStream entityStream)
+        throws IOException, WebApplicationException {
+        return null;
+    }
+
+}

--- a/systests/jaxrs/src/test/java/org/apache/cxf/systest/jaxrs/provider/JAXBContextResolverTest.java
+++ b/systests/jaxrs/src/test/java/org/apache/cxf/systest/jaxrs/provider/JAXBContextResolverTest.java
@@ -48,7 +48,9 @@ public class JAXBContextResolverTest extends AbstractClientServerTestBase {
         protected org.apache.cxf.endpoint.Server createServer(Bus bus) throws Exception {
             final JAXRSServerFactoryBean sf = new JAXRSServerFactoryBean();
             sf.setResourceClasses(CXFResource.class);
+            sf.setProvider(new CXFJaxbElementProvider());
             sf.setProvider(new CXFJaxbContextResolver());
+            sf.setProvider(new CXFJaxbProvider());
             sf.setAddress("http://localhost:" + PORT + "/");
             return sf.create();
         }


### PR DESCRIPTION
While troubleshooting the TCK test case in question discovered that sorting of message body readers and writers ~~is not symmetrical~~ does not handle all subclasses combinations correctly. 
  - ~~readers are sorted first by media type~~ 
  - ~~writers are sorted first by classes comparison which **does not look right**~~
 
~~Fixed the message body writers sorting by starting with media types, the same as for message body readers.~~