### PR TITLE
CXF-8518: Fixing jaxrs.spec.provider.standardnotnull clientJaxbProviderTest

### DIFF
--- a/systests/jaxrs/src/test/java/org/apache/cxf/systest/jaxrs/provider/CXFResource.java
+++ b/systests/jaxrs/src/test/java/org/apache/cxf/systest/jaxrs/provider/CXFResource.java
@@ -30,4 +30,10 @@ public class CXFResource {
     public JAXBElement<String> jaxb(JAXBElement<String> jaxb) {
         return jaxb;
     }
+    
+    @Path("null")
+    @POST
+    public JAXBElement<String> jaxbnull(JAXBElement<String> jaxb) {
+        return null;
+    }
 }

--- a/systests/jaxrs/src/test/java/org/apache/cxf/systest/jaxrs/provider/JAXBProviderTest.java
+++ b/systests/jaxrs/src/test/java/org/apache/cxf/systest/jaxrs/provider/JAXBProviderTest.java
@@ -21,6 +21,7 @@ package org.apache.cxf.systest.jaxrs.provider;
 import java.util.ArrayList;
 import java.util.List;
 
+import javax.ws.rs.core.GenericType;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.xml.bind.JAXBElement;
@@ -37,6 +38,8 @@ import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 public class JAXBProviderTest extends AbstractClientServerTestBase {
@@ -78,5 +81,22 @@ public class JAXBProviderTest extends AbstractClientServerTestBase {
         String result = response.readEntity(String.class);
         assertTrue(result.contains("<jaxbelement xmlns=\"org.apache.cxf\">test</jaxbelement>"));
         Assert.assertFalse(result.contains("WriteInCXFJaxbProvider"));
+    }
+    
+    @Test
+    public void testNoContentIsReturned() throws Exception {
+        WebClient client = WebClient.create("http://localhost:" + PORT + "/resource/null");
+        WebClient.getConfig(client).getHttpConduit().getClient().setReceiveTimeout(3000000);
+
+        List<String> values = new ArrayList<>();
+        values.add(MediaType.APPLICATION_XML);
+        client.getHeaders().put("content-type", values);
+        JAXBElement<String> test = new JAXBElement<>(new QName("org.apache.cxf", "jaxbelement"),
+                                                           String.class, "test");
+        Response response = client.post(test);
+        GenericType<JAXBElement<String>> type = new GenericType<JAXBElement<String>>() {
+        };
+        JAXBElement<String> result = response.readEntity(type);
+        assertThat(result, nullValue());
     }
 }


### PR DESCRIPTION
Per specification:
```
for a zero-length response entities returns a corresponding
Java object that represents zero-length data. In case no zero-length representation
is defined for the Java type, a {@link ProcessingException} wrapping the
underlying {@link NoContentException} is thrown.
```

For JAXB serialization / desearialization, the empty input stream (empty response) leads to `javax.xml.bind.UnmarshalException`, for example:
```
[com.ctc.wstx.exc.WstxEOFException: Unexpected EOF in prolog
 at [row,col {unknown-source}]: [1,0]]
	at com.sun.xml.internal.bind.v2.runtime.unmarshaller.UnmarshallerImpl.handleStreamException(UnmarshallerImpl.java:470)
	at com.sun.xml.internal.bind.v2.runtime.unmarshaller.UnmarshallerImpl.unmarshal0(UnmarshallerImpl.java:402)
	at com.sun.xml.internal.bind.v2.runtime.unmarshaller.UnmarshallerImpl.unmarshal(UnmarshallerImpl.java:379)
	at org.apache.cxf.jaxrs.provider.JAXBElementProvider.readFrom(JAXBElementProvider.java:177)
	at org.apache.cxf.jaxrs.provider.JAXBElementTypedProvider.readFrom(JAXBElementTypedProvider.java:41)
	at org.apache.cxf.jaxrs.provider.JAXBElementTypedProvider.readFrom(JAXBElementTypedProvider.java:34)
	at org.apache.cxf.jaxrs.utils.JAXRSUtils.readFromMessageBodyReader(JAXRSUtils.java:1444)
	at org.apache.cxf.jaxrs.impl.ResponseImpl.doReadEntity(ResponseImpl.java:472)
	at org.apache.cxf.jaxrs.impl.ResponseImpl.readEntity(ResponseImpl.java:415)
	at org.apache.cxf.jaxrs.impl.ResponseImpl.readEntity(ResponseImpl.java:403)
```