### PR TITLE
CXF-8536 Conditional log for NamespaceMapper not found

### DIFF
--- a/core/src/main/java/org/apache/cxf/common/spi/NamespaceClassGenerator.java
+++ b/core/src/main/java/org/apache/cxf/common/spi/NamespaceClassGenerator.java
@@ -75,7 +75,9 @@ public class NamespaceClassGenerator extends ClassGeneratorClassLoader implement
                 t = ex2;
             }
         }
-        LOG.log(Level.INFO, "Could not create a NamespaceMapper compatible with Marshaller class " + mcls.getName(), t);
+        if (cls == null) {
+            LOG.log(Level.INFO, "Could not create a NamespaceMapper compatible with Marshaller class " + mcls.getName(), t);
+        }
         return cls;
     }
 


### PR DESCRIPTION
Only logs the message "Could not create a NamespaceMapper ..." if it really is the case