### PR TITLE
Remove String.replaceAll JAXRSUtils performance fix

### DIFF
--- a/rt/frontend/jaxrs/src/main/java/org/apache/cxf/jaxrs/utils/JAXRSUtils.java
+++ b/rt/frontend/jaxrs/src/main/java/org/apache/cxf/jaxrs/utils/JAXRSUtils.java
@@ -1997,7 +1997,7 @@ public final class JAXRSUtils {
             return parent;
         } else if (parent.endsWith("/")) {
             // Remove only last slash
-            return parent.replaceAll("/$", "") + child;
+            return parent.substring(0, parent.length() - 1) + child;
         } else {
             return parent + child;
         }


### PR DESCRIPTION
It's much better to use substring to remove the last '/' character than replaceAll from a performance perspective. Certain applications can see up to 2% throughput gains with this change.