### PR TITLE
[CXF-8535] Include query in request-target

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -181,6 +181,7 @@
         <cxf.persistence-api.version>2.2.3</cxf.persistence-api.version>
         <cxf.plexus-archiver.version>4.2.0</cxf.plexus-archiver.version>
         <cxf.plexus-utils.version>3.2.0</cxf.plexus-utils.version>
+        <cxf.powermock.version>2.0.4</cxf.powermock.version>
         <cxf.reactivestreams.version>1.0.3</cxf.reactivestreams.version>
         <cxf.reactor.version>3.4.5</cxf.reactor.version>
         <cxf.rhino.version>1.7.13</cxf.rhino.version>

--- a/rt/rs/security/http-signature/pom.xml
+++ b/rt/rs/security/http-signature/pom.xml
@@ -70,6 +70,26 @@
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-frontend-jaxrs</artifactId>
         </dependency>
+
+        <dependency>
+            <groupId>org.powermock</groupId>
+            <artifactId>powermock-module-junit4</artifactId>
+            <version>${cxf.powermock.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.powermock</groupId>
+            <artifactId>powermock-api-mockito2</artifactId>
+            <version>${cxf.powermock.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>${cxf.mockito.version}</version>
+            <scope>test</scope>
+        </dependency>
+
     </dependencies>
 
 </project>

--- a/rt/rs/security/http-signature/src/main/java/org/apache/cxf/rs/security/httpsignature/filters/VerifySignatureFilter.java
+++ b/rt/rs/security/http-signature/src/main/java/org/apache/cxf/rs/security/httpsignature/filters/VerifySignatureFilter.java
@@ -18,6 +18,8 @@
  */
 package org.apache.cxf.rs.security.httpsignature.filters;
 
+import org.apache.cxf.rs.security.httpsignature.utils.SignatureHeaderUtils;
+
 import java.io.ByteArrayInputStream;
 
 import javax.annotation.Priority;
@@ -43,7 +45,7 @@ public class VerifySignatureFilter extends AbstractSignatureInFilter implements 
         }
 
         verifySignature(requestCtx.getHeaders(),
-                        requestCtx.getUriInfo().getAbsolutePath().getPath(),
+                SignatureHeaderUtils.createRequestTarget(requestCtx.getUriInfo().getAbsolutePath()),
                         requestCtx.getMethod());
     }
 

--- a/rt/rs/security/http-signature/src/main/java/org/apache/cxf/rs/security/httpsignature/utils/SignatureHeaderUtils.java
+++ b/rt/rs/security/http-signature/src/main/java/org/apache/cxf/rs/security/httpsignature/utils/SignatureHeaderUtils.java
@@ -18,6 +18,7 @@
  */
 package org.apache.cxf.rs.security.httpsignature.utils;
 
+import java.net.URI;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.time.Clock;
@@ -101,4 +102,14 @@ public final class SignatureHeaderUtils {
         });
     }
 
+    public static String createRequestTarget(URI uri) {
+        StringBuilder stringBuilder = new StringBuilder();
+        stringBuilder.append(uri.getPath());
+
+        if(uri.getRawQuery() != null) {
+            stringBuilder.append("?");
+            stringBuilder.append(uri.getRawQuery());
+        }
+        return stringBuilder.toString();
+    }
 }


### PR DESCRIPTION
Changed Interceptor and Filter to include query component in request-target.

Added test methods to include interceptor/filter in testing the cases from the spec. These tests previously only tested the objects used within the interceptor/filter (MessageSigner/Verifier) which led to this issue not being discovered by tests. I also had to include PowerMock to mock the static PhaseInterceptorChain class used by the VerifySignatureFilter.