### PR TITLE
[CXF-8535] Query missing from signature request-target

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -181,6 +181,7 @@
         <cxf.persistence-api.version>2.2.3</cxf.persistence-api.version>
         <cxf.plexus-archiver.version>4.2.0</cxf.plexus-archiver.version>
         <cxf.plexus-utils.version>3.2.0</cxf.plexus-utils.version>
+        <cxf.powermock.version>2.0.4</cxf.powermock.version>
         <cxf.reactivestreams.version>1.0.3</cxf.reactivestreams.version>
         <cxf.reactor.version>3.4.5</cxf.reactor.version>
         <cxf.rhino.version>1.7.13</cxf.rhino.version>

--- a/rt/rs/security/http-signature/pom.xml
+++ b/rt/rs/security/http-signature/pom.xml
@@ -70,6 +70,26 @@
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-frontend-jaxrs</artifactId>
         </dependency>
+
+        <dependency>
+            <groupId>org.powermock</groupId>
+            <artifactId>powermock-module-junit4</artifactId>
+            <version>${cxf.powermock.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.powermock</groupId>
+            <artifactId>powermock-api-mockito2</artifactId>
+            <version>${cxf.powermock.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>${cxf.mockito.version}</version>
+            <scope>test</scope>
+        </dependency>
+
     </dependencies>
 
 </project>

--- a/rt/rs/security/http-signature/src/main/java/org/apache/cxf/rs/security/httpsignature/filters/CreateSignatureInterceptor.java
+++ b/rt/rs/security/http-signature/src/main/java/org/apache/cxf/rs/security/httpsignature/filters/CreateSignatureInterceptor.java
@@ -18,17 +18,8 @@
  */
 package org.apache.cxf.rs.security.httpsignature.filters;
 
-import org.apache.cxf.helpers.IOUtils;
-import org.apache.cxf.io.CachedOutputStream;
-import org.apache.cxf.jaxrs.utils.HttpUtils;
-import org.apache.cxf.jaxrs.utils.JAXRSUtils;
-import org.apache.cxf.message.Message;
-import org.apache.cxf.message.MessageUtils;
-import org.apache.cxf.phase.PhaseInterceptorChain;
-import org.apache.cxf.rs.security.httpsignature.HTTPSignatureConstants;
-import org.apache.cxf.rs.security.httpsignature.utils.DefaultSignatureConstants;
-import org.apache.cxf.rs.security.httpsignature.utils.SignatureHeaderUtils;
-
+import java.io.*;
+import java.nio.charset.StandardCharsets;
 import javax.annotation.Priority;
 import javax.ws.rs.Priorities;
 import javax.ws.rs.client.ClientRequestContext;
@@ -42,9 +33,16 @@ import javax.ws.rs.core.UriInfo;
 import javax.ws.rs.ext.Provider;
 import javax.ws.rs.ext.WriterInterceptor;
 import javax.ws.rs.ext.WriterInterceptorContext;
-import java.io.IOException;
-import java.io.OutputStream;
-import java.nio.charset.StandardCharsets;
+import org.apache.cxf.helpers.IOUtils;
+import org.apache.cxf.io.CachedOutputStream;
+import org.apache.cxf.jaxrs.utils.HttpUtils;
+import org.apache.cxf.jaxrs.utils.JAXRSUtils;
+import org.apache.cxf.message.Message;
+import org.apache.cxf.message.MessageUtils;
+import org.apache.cxf.phase.PhaseInterceptorChain;
+import org.apache.cxf.rs.security.httpsignature.HTTPSignatureConstants;
+import org.apache.cxf.rs.security.httpsignature.utils.DefaultSignatureConstants;
+import org.apache.cxf.rs.security.httpsignature.utils.SignatureHeaderUtils;
 
 /**
  * RS WriterInterceptor + ClientRequestFilter for outbound HTTP Signature. For requests with no Body
@@ -84,7 +82,8 @@ public class CreateSignatureInterceptor extends AbstractSignatureOutFilter
         // Only sign the request if we have no Body.
         if (requestContext.getEntity() == null) {
             String method = requestContext.getMethod();
-            performSignature(requestContext.getHeaders(), SignatureHeaderUtils.createRequestTarget(requestContext.getUri()), method);
+            performSignature(requestContext.getHeaders(),
+                SignatureHeaderUtils.createRequestTarget(requestContext.getUri()), method);
         }
     }
 
@@ -105,7 +104,7 @@ public class CreateSignatureInterceptor extends AbstractSignatureOutFilter
         // We don't pass the HTTP method + URI for the response case
         if (MessageUtils.isRequestor(m)) {
             method = HttpUtils.getProtocolHeader(JAXRSUtils.getCurrentMessage(),
-                                                 Message.HTTP_REQUEST_METHOD, "");
+                Message.HTTP_REQUEST_METHOD, "");
             path = SignatureHeaderUtils.createRequestTarget(uriInfo.getRequestUri());
         }
 

--- a/rt/rs/security/http-signature/src/main/java/org/apache/cxf/rs/security/httpsignature/filters/VerifySignatureFilter.java
+++ b/rt/rs/security/http-signature/src/main/java/org/apache/cxf/rs/security/httpsignature/filters/VerifySignatureFilter.java
@@ -18,16 +18,14 @@
  */
 package org.apache.cxf.rs.security.httpsignature.filters;
 
-import org.apache.cxf.rs.security.httpsignature.utils.SignatureHeaderUtils;
-
-import java.io.ByteArrayInputStream;
-
+import java.io.*;
 import javax.annotation.Priority;
 import javax.ws.rs.BadRequestException;
 import javax.ws.rs.Priorities;
 import javax.ws.rs.container.ContainerRequestContext;
 import javax.ws.rs.container.ContainerRequestFilter;
 import javax.ws.rs.ext.Provider;
+import org.apache.cxf.rs.security.httpsignature.utils.SignatureHeaderUtils;
 
 /**
  * RS CXF container Filter which verifies the Digest header, and then extracts signature data from the context

--- a/rt/rs/security/http-signature/src/main/java/org/apache/cxf/rs/security/httpsignature/filters/VerifySignatureFilter.java
+++ b/rt/rs/security/http-signature/src/main/java/org/apache/cxf/rs/security/httpsignature/filters/VerifySignatureFilter.java
@@ -18,6 +18,8 @@
  */
 package org.apache.cxf.rs.security.httpsignature.filters;
 
+import org.apache.cxf.rs.security.httpsignature.utils.SignatureHeaderUtils;
+
 import java.io.ByteArrayInputStream;
 
 import javax.annotation.Priority;
@@ -43,7 +45,7 @@ public class VerifySignatureFilter extends AbstractSignatureInFilter implements 
         }
 
         verifySignature(requestCtx.getHeaders(),
-                        requestCtx.getUriInfo().getAbsolutePath().getPath(),
+                SignatureHeaderUtils.createRequestTarget(requestCtx.getUriInfo().getAbsolutePath()),
                         requestCtx.getMethod());
     }
 

--- a/rt/rs/security/http-signature/src/main/java/org/apache/cxf/rs/security/httpsignature/utils/SignatureHeaderUtils.java
+++ b/rt/rs/security/http-signature/src/main/java/org/apache/cxf/rs/security/httpsignature/utils/SignatureHeaderUtils.java
@@ -18,7 +18,7 @@
  */
 package org.apache.cxf.rs.security.httpsignature.utils;
 
-import java.net.URI;
+import java.net.*;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.time.Clock;
@@ -27,7 +27,6 @@ import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 import java.util.*;
 import java.util.stream.Stream;
-
 import org.apache.cxf.rs.security.httpsignature.exception.DigestFailureException;
 
 public final class SignatureHeaderUtils {
@@ -106,7 +105,7 @@ public final class SignatureHeaderUtils {
         StringBuilder stringBuilder = new StringBuilder();
         stringBuilder.append(uri.getPath());
 
-        if(uri.getRawQuery() != null) {
+        if (uri.getRawQuery() != null) {
             stringBuilder.append("?");
             stringBuilder.append(uri.getRawQuery());
         }

--- a/rt/rs/security/http-signature/src/main/java/org/apache/cxf/rs/security/httpsignature/utils/SignatureHeaderUtils.java
+++ b/rt/rs/security/http-signature/src/main/java/org/apache/cxf/rs/security/httpsignature/utils/SignatureHeaderUtils.java
@@ -18,6 +18,7 @@
  */
 package org.apache.cxf.rs.security.httpsignature.utils;
 
+import java.net.URI;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.time.Clock;
@@ -101,4 +102,14 @@ public final class SignatureHeaderUtils {
         });
     }
 
+    public static String createRequestTarget(URI uri) {
+        StringBuilder stringBuilder = new StringBuilder();
+        stringBuilder.append(uri.getPath());
+
+        if(uri.getRawQuery() != null) {
+            stringBuilder.append("?");
+            stringBuilder.append(uri.getRawQuery());
+        }
+        return stringBuilder.toString();
+    }
 }

--- a/rt/rs/security/http-signature/src/test/java/org/apache/cxf/rs/security/httpsignature/SpecExamplesTest.java
+++ b/rt/rs/security/http-signature/src/test/java/org/apache/cxf/rs/security/httpsignature/SpecExamplesTest.java
@@ -18,31 +18,8 @@
  */
 package org.apache.cxf.rs.security.httpsignature;
 
-import org.apache.cxf.message.Message;
-import org.apache.cxf.message.MessageImpl;
-import org.apache.cxf.phase.PhaseInterceptorChain;
-import org.apache.cxf.rs.security.httpsignature.filters.CreateSignatureInterceptor;
-import org.apache.cxf.rs.security.httpsignature.filters.VerifySignatureFilter;
-import org.apache.cxf.rs.security.httpsignature.provider.KeyProvider;
-import org.apache.cxf.rs.security.httpsignature.provider.MockAlgorithmProvider;
-import org.apache.cxf.rs.security.httpsignature.provider.MockSecurityProvider;
-
-import org.junit.BeforeClass;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
-
-import javax.ws.rs.client.ClientRequestContext;
-import javax.ws.rs.container.ContainerRequestContext;
-import javax.ws.rs.core.MultivaluedHashMap;
-import javax.ws.rs.core.MultivaluedMap;
-import javax.ws.rs.core.UriInfo;
-import java.io.ByteArrayInputStream;
-import java.io.File;
-import java.io.IOException;
-import java.io.InputStream;
-import java.net.URI;
+import java.io.*;
+import java.net.*;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.FileSystems;
 import java.nio.file.Files;
@@ -55,10 +32,28 @@ import java.security.spec.InvalidKeySpecException;
 import java.security.spec.PKCS8EncodedKeySpec;
 import java.security.spec.X509EncodedKeySpec;
 import java.util.*;
-import java.util.stream.Collectors;
-
+import javax.ws.rs.client.ClientRequestContext;
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.core.MultivaluedHashMap;
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.core.UriInfo;
+import org.apache.cxf.message.Message;
+import org.apache.cxf.message.MessageImpl;
+import org.apache.cxf.phase.PhaseInterceptorChain;
+import org.apache.cxf.rs.security.httpsignature.filters.CreateSignatureInterceptor;
+import org.apache.cxf.rs.security.httpsignature.filters.VerifySignatureFilter;
+import org.apache.cxf.rs.security.httpsignature.provider.KeyProvider;
+import org.apache.cxf.rs.security.httpsignature.provider.MockAlgorithmProvider;
+import org.apache.cxf.rs.security.httpsignature.provider.MockSecurityProvider;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
 import static org.junit.Assert.assertEquals;
-import static org.powermock.api.mockito.PowerMockito.*;
+import static org.powermock.api.mockito.PowerMockito.mock;
+import static org.powermock.api.mockito.PowerMockito.mockStatic;
+import static org.powermock.api.mockito.PowerMockito.when;
 
 /**
  * Some examples from the Appendix C of the spec.
@@ -151,9 +146,9 @@ public class SpecExamplesTest {
         requestStringHeaders.add("Signature", signatureHeader);
 
         String expectedHeader = "keyId=\"Test\",algorithm=\"rsa-sha256\","
-                + "signature=\"SjWJWbWN7i0wzBvtPl8rbASWz5xQW6mcJmn+ibttBqtifLN7Sazz"
-                + "6m79cNfwwb8DMJ5cou1s7uEGKKCs+FLEEaDV5lp7q25WqS+lavg7T8hc0GppauB"
-                + "6hbgEKTwblDHYGEtbGmtdHgVCk9SuS13F0hZ8FD0k/5OxEPXe5WozsbM=\"";
+            + "signature=\"SjWJWbWN7i0wzBvtPl8rbASWz5xQW6mcJmn+ibttBqtifLN7Sazz"
+            + "6m79cNfwwb8DMJ5cou1s7uEGKKCs+FLEEaDV5lp7q25WqS+lavg7T8hc0GppauB"
+            + "6hbgEKTwblDHYGEtbGmtdHgVCk9SuS13F0hZ8FD0k/5OxEPXe5WozsbM=\"";
 
         assertEquals(signatureHeader.replaceAll("headers=\"date\",", ""), expectedHeader);
 
@@ -166,7 +161,8 @@ public class SpecExamplesTest {
         VerifySignatureFilter verifySignatureFilter = new VerifySignatureFilter();
         verifySignatureFilter.setMessageVerifier(messageVerifier);
 
-        ContainerRequestContext containerRequestContext = getContainerRequestContextMock(uri, method, requestStringHeaders);
+        ContainerRequestContext containerRequestContext =
+            getContainerRequestContextMock(uri, method, requestStringHeaders);
 
         verifySignatureFilter.filter(containerRequestContext);
     }
@@ -176,7 +172,7 @@ public class SpecExamplesTest {
         Map<String, List<String>> headers = createMockHeaders();
 
         MessageSigner messageSigner = new MessageSigner(keyProvider, "Test",
-                                                        Arrays.asList("(request-target)", "host", "Date"));
+            Arrays.asList("(request-target)", "host", "Date"));
         messageSigner.sign(headers, "/foo?param=value&pet=dog", "POST");
         String signatureHeader = headers.get("Signature").get(0);
 
@@ -200,7 +196,7 @@ public class SpecExamplesTest {
         URI uri = URI.create("https://www.example.com/foo?param=value&pet=dog");
         String method = "POST";
         MessageSigner messageSigner = new MessageSigner(keyProvider, "Test",
-                Arrays.asList("(request-target)", "host", "Date"));
+            Arrays.asList("(request-target)", "host", "Date"));
 
         CreateSignatureInterceptor interceptor = new CreateSignatureInterceptor();
         interceptor.setMessageSigner(messageSigner);
@@ -225,10 +221,10 @@ public class SpecExamplesTest {
         requestStringHeaders.add("Signature", signatureHeader);
 
         String expectedHeader = "keyId=\"Test\",algorithm=\"rsa-sha256\","
-                + "headers=\"(request-target) host date\",signature=\"qdx+H7PHHDZgy4"
-                + "y/Ahn9Tny9V3GP6YgBPyUXMmoxWtLbHpUnXS2mg2+SbrQDMCJypxBLSPQR2aAjn"
-                + "7ndmw2iicw3HMbe8VfEdKFYRqzic+efkb3nndiv/x1xSHDJWeSWkx3ButlYSuBs"
-                + "kLu6kd9Fswtemr3lgdDEmn04swr2Os0=\"";
+            + "headers=\"(request-target) host date\",signature=\"qdx+H7PHHDZgy4"
+            + "y/Ahn9Tny9V3GP6YgBPyUXMmoxWtLbHpUnXS2mg2+SbrQDMCJypxBLSPQR2aAjn"
+            + "7ndmw2iicw3HMbe8VfEdKFYRqzic+efkb3nndiv/x1xSHDJWeSWkx3ButlYSuBs"
+            + "kLu6kd9Fswtemr3lgdDEmn04swr2Os0=\"";
 
         assertEquals(signatureHeader, expectedHeader);
 
@@ -241,7 +237,8 @@ public class SpecExamplesTest {
         VerifySignatureFilter verifySignatureFilter = new VerifySignatureFilter();
         verifySignatureFilter.setMessageVerifier(messageVerifier);
 
-        ContainerRequestContext containerRequestContext = getContainerRequestContextMock(uri, method, requestStringHeaders);
+        ContainerRequestContext containerRequestContext =
+            getContainerRequestContextMock(uri, method, requestStringHeaders);
 
         verifySignatureFilter.filter(containerRequestContext);
     }
@@ -275,8 +272,8 @@ public class SpecExamplesTest {
         URI uri = URI.create("https://www.example.com/foo?param=value&pet=dog");
         String method = "POST";
         MessageSigner messageSigner = new MessageSigner(keyProvider, "Test",
-                Arrays.asList("(request-target)", "host", "date",
-                        "content-type", "digest", "content-length"));
+            Arrays.asList("(request-target)", "host", "date",
+                "content-type", "digest", "content-length"));
 
         CreateSignatureInterceptor interceptor = new CreateSignatureInterceptor();
 
@@ -302,10 +299,10 @@ public class SpecExamplesTest {
         requestStringHeaders.add("Signature", signatureHeader);
 
         String expectedHeader = "keyId=\"Test\",algorithm=\"rsa-sha256\","
-                + "headers=\"(request-target) host date content-type digest content-length\","
-                + "signature=\"vSdrb+dS3EceC9bcwHSo4MlyKS59iFIrhgYkz8+oVLEEzmYZZvRs"
-                + "8rgOp+63LEM3v+MFHB32NfpB2bEKBIvB1q52LaEUHFv120V01IL+TAD48XaERZF"
-                + "ukWgHoBTLMhYS2Gb51gWxpeIq8knRmPnYePbF5MOkR0Zkly4zKH7s1dE=\"";
+            + "headers=\"(request-target) host date content-type digest content-length\","
+            + "signature=\"vSdrb+dS3EceC9bcwHSo4MlyKS59iFIrhgYkz8+oVLEEzmYZZvRs"
+            + "8rgOp+63LEM3v+MFHB32NfpB2bEKBIvB1q52LaEUHFv120V01IL+TAD48XaERZF"
+            + "ukWgHoBTLMhYS2Gb51gWxpeIq8knRmPnYePbF5MOkR0Zkly4zKH7s1dE=\"";
 
         assertEquals(signatureHeader, expectedHeader);
 
@@ -318,14 +315,16 @@ public class SpecExamplesTest {
         VerifySignatureFilter verifySignatureFilter = new VerifySignatureFilter();
         verifySignatureFilter.setMessageVerifier(messageVerifier);
 
-        ContainerRequestContext containerRequestContext = getContainerRequestContextMock(uri, method, requestStringHeaders);
+        ContainerRequestContext containerRequestContext =
+            getContainerRequestContextMock(uri, method, requestStringHeaders);
         InputStream stream = new ByteArrayInputStream("{\"hello\": \"world\"}".getBytes(StandardCharsets.UTF_8));
         when(containerRequestContext.getEntityStream()).thenReturn(stream);
 
         verifySignatureFilter.filter(containerRequestContext);
     }
 
-    private ClientRequestContext getClientRequestContextMock(URI uri, String method, MultivaluedMap<String, Object> requestHeaders) {
+    private ClientRequestContext getClientRequestContextMock(URI uri, String method,
+                                                             MultivaluedMap<String, Object> requestHeaders) {
         ClientRequestContext requestContext = mock(ClientRequestContext.class);
         when(requestContext.getEntity()).thenReturn(null);
         when(requestContext.getMethod()).thenReturn(method);
@@ -334,7 +333,9 @@ public class SpecExamplesTest {
         return requestContext;
     }
 
-    private ContainerRequestContext getContainerRequestContextMock(URI uri, String method, MultivaluedMap<String, String> requestStringHeaders) {
+    private ContainerRequestContext getContainerRequestContextMock(URI uri, String method,
+                                                                   MultivaluedMap<String, String>
+                                                                       requestStringHeaders) {
         ContainerRequestContext containerRequestContext = mock(ContainerRequestContext.class);
         UriInfo uriInfo = mock(UriInfo.class);
         when(uriInfo.getAbsolutePath()).thenReturn(uri);


### PR DESCRIPTION
Changed Interceptor and Filter to include query component in request-target.

Added test methods to include interceptor/filter in testing the cases from the spec. These tests previously only tested the objects used within the interceptor/filter (MessageSigner/Verifier) which led to this issue not being discovered by tests.

I also had to include PowerMock to mock the static PhaseInterceptorChain class used by the VerifySignatureFilter.