### PR TITLE
Make CDI and MP Config dependencies optional for MicroProfile REST client

### DIFF
--- a/rt/rs/microprofile-client/pom.xml
+++ b/rt/rs/microprofile-client/pom.xml
@@ -134,15 +134,20 @@
         <dependency>
             <groupId>org.eclipse.microprofile.config</groupId>
             <artifactId>microprofile-config-api</artifactId>
+            <scope>provided</scope>
+            <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>jakarta.annotation</groupId>
             <artifactId>jakarta.annotation-api</artifactId>
+            <scope>provided</scope>
+            <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>jakarta.enterprise</groupId>
             <artifactId>jakarta.enterprise.cdi-api</artifactId>
             <scope>provided</scope>
+            <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>cglib</groupId>


### PR DESCRIPTION
* The Rest Client for MicroProfile specification defines CDI and MP Config as optional
* Analogous upstream change: https://github.com/eclipse/microprofile-rest-client/pull/309

Cheers