### PR TITLE
MicroProfile REST client: enable SPI/ServiceLoader under OSGi 

### DIFF
--- a/rt/rs/microprofile-client/pom.xml
+++ b/rt/rs/microprofile-client/pom.xml
@@ -185,6 +185,25 @@
           <scope>test</scope>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <configuration>
+                    <instructions>
+                        <Require-Capability>osgi.extender; filter:="(osgi.extender=osgi.serviceloader.registrar)"; resolution:=optional</Require-Capability>
+                        <Provide-Capability>
+                            osgi.serviceloader; osgi.serviceloader=org.eclipse.microprofile.rest.client.spi.RestClientBuilderResolver;
+                            register:=org.apache.cxf.microprofile.client.spi.CxfRestClientBuilderResolver
+                        </Provide-Capability>
+                    </instructions>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
     <profiles>
         <profile>
             <id>setup.eclipse</id>


### PR DESCRIPTION
* Using OSGi's [Service Loader Mediator](https://blog.osgi.org/2013/02/javautilserviceloader-in-osgi.html) (i.e. Apache Aries [SPI Fly](https://aries.apache.org/documentation/modules/spi-fly.html))
* Made all requirements optional (minimally invasive change)
* ~~Removing `Bundle-ActivationPolicy` header _locally_ as it prevents the OSGi ServiceLoader Mediator (SPI Fly) to work when set to [`Lazy`](https://github.com/apache/cxf/blob/master/parent/pom.xml#L653) (in the parent POM). I committed this separately should there be a better solution.~~

Based on the following discussion: https://github.com/eclipse/microprofile-rest-client/issues/308#issuecomment-813638983

Cheers