### PR TITLE
CXF-8387: Allow special characters to be used for a queryParam name.

### DIFF
--- a/rt/frontend/jaxrs/src/main/java/org/apache/cxf/jaxrs/utils/JAXRSUtils.java
+++ b/rt/frontend/jaxrs/src/main/java/org/apache/cxf/jaxrs/utils/JAXRSUtils.java
@@ -1368,7 +1368,11 @@ public final class JAXRSUtils {
             }
         }
 
-        queries.add(HttpUtils.urlDecode(name), value);
+        if (decode) {
+            queries.add(HttpUtils.urlDecode(name), value);
+        } else {
+            queries.add(name, value);
+        }
     }
 
     private static Object readFromMessageBody(Class<?> targetTypeClass,

--- a/rt/frontend/jaxrs/src/test/java/org/apache/cxf/jaxrs/impl/UriBuilderImplTest.java
+++ b/rt/frontend/jaxrs/src/test/java/org/apache/cxf/jaxrs/impl/UriBuilderImplTest.java
@@ -21,6 +21,7 @@ package org.apache.cxf.jaxrs.impl;
 
 import java.lang.reflect.Method;
 import java.net.URI;
+import java.net.URLEncoder;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -1744,5 +1745,88 @@ public class UriBuilderImplTest {
             return Response.ok(test).build();
         }
 
+    }
+    
+    @Test
+    public void testURIWithSpecialCharacters() {
+        final String expected = "http://localhost:8080/xy%22";
+        
+        final URI uri = UriBuilder
+            .fromUri("http://localhost:8080")
+            .path(URLEncoder.encode("xy\"")).build();
+        
+        assertEquals(expected, uri.toString());
+    }
+
+    @Test
+    public void testURIWithSpecialCharacters2() {
+        final String expected = "http://localhost:8080/xy%09";
+        
+        final URI uri = UriBuilder
+            .fromUri("http://localhost:8080")
+            .path(URLEncoder.encode("xy\t"))
+            .buildFromEncoded();
+        
+        assertEquals(expected, uri.toString());
+    }
+
+    @Test
+    public void testURIWithSpecialCharactersPreservePath() {
+        final String expected = "http://localhost:8080/xy/%22/abc";
+        
+        final URI uri = UriBuilder.fromPath("")
+            .replacePath("http://localhost:8080")
+            .path("/{a}/{b}/{c}")
+            .buildFromEncoded("xy", "\"", "abc");
+        
+        assertEquals(expected, uri.toString());
+    }
+
+    @Test
+    public void testURIWithSpecialCharactersPreservePath2() {
+        final String expected = "http://localhost:8080/xy/%09/abc";
+        
+        final URI uri = UriBuilder.fromPath("")
+            .replacePath("http://localhost:8080")
+            .path("/{a}/{b}/{c}")
+            .buildFromEncoded("xy", "\t", "abc");
+        
+        assertEquals(expected, uri.toString());
+    }
+
+    @Test
+    public void testIllegalURI() {
+        final String path = "invalidpath";
+        
+        final URI uri = UriBuilder
+            .fromPath(path)
+            .build();
+        
+        assertEquals(path, uri.toString());
+    }
+    
+    @Test
+    @SuppressWarnings({"checkstyle:linelength"})
+    public void queryParamSpecialCharacters() {
+        final String expected = "http://localhost:8080?%2F%3FabcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-._%7E%251A%21%24%27%28%29*%2B%2C%3B%3A%40=apiKeyQueryParam1Value";
+        
+        final URI uri = UriBuilder
+            .fromUri("http://localhost:8080")
+            .queryParam(URLEncoder.encode("/?abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-._~%1A!$'()*+,;:@"), "apiKeyQueryParam1Value")
+            .build();
+        
+        assertEquals(expected, uri.toString());
+    }
+    @Test
+    @SuppressWarnings({"checkstyle:linelength"})
+    public void queryParamSpecialCharactersFromEncoded() {
+        final String expected = "http://localhost:8080?%2F%3FabcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-._%7E%251A%21%24%27%28%29*%2B%2C%3B%3A%40=apiKeyQueryParam1Value";
+        
+        final URI uri = UriBuilder
+            .fromUri("http://localhost:8080")
+            .queryParam(URLEncoder.encode("/?abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-._~%1A!$'()*+,;:@"), "apiKeyQueryParam1Value")
+            .buildFromEncoded();
+        
+        assertEquals(expected, uri.toString());
     }
 }

--- a/rt/frontend/jaxrs/src/test/java/org/apache/cxf/jaxrs/impl/UriBuilderImplTest.java
+++ b/rt/frontend/jaxrs/src/test/java/org/apache/cxf/jaxrs/impl/UriBuilderImplTest.java
@@ -1817,6 +1817,7 @@ public class UriBuilderImplTest {
         
         assertEquals(expected, uri.toString());
     }
+    
     @Test
     @SuppressWarnings({"checkstyle:linelength"})
     public void queryParamSpecialCharactersFromEncoded() {
@@ -1826,6 +1827,32 @@ public class UriBuilderImplTest {
             .fromUri("http://localhost:8080")
             .queryParam(URLEncoder.encode("/?abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-._~%1A!$'()*+,;:@"), "apiKeyQueryParam1Value")
             .buildFromEncoded();
+        
+        assertEquals(expected, uri.toString());
+    }
+    
+    @Test
+    @SuppressWarnings({"checkstyle:linelength"})
+    public void queryParamSpecialCharactersFromEncodedTemplate() {
+        final String expected = "http://localhost:8080?%2F%3FabcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-._%7E%251A%21%24%27%28%29*%2B%2C%3B%3A%40=apiKeyQueryParam1Value";
+        
+        final URI uri = UriBuilder
+            .fromUri("http://localhost:8080")
+            .queryParam("{a}", "{b}")
+            .buildFromEncoded(URLEncoder.encode("/?abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-._~%1A!$'()*+,;:@"), "apiKeyQueryParam1Value");
+        
+        assertEquals(expected, uri.toString());
+    }
+    
+    @Test
+    @SuppressWarnings({"checkstyle:linelength"})
+    public void queryParamSpecialCharactersFromTemplate() {
+        final String expected = "http://localhost:8080?/?abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-._%7E%251A%21%24%27%28%29*%2B,%3B%3A%40=apiKeyQueryParam1Value";
+        
+        final URI uri = UriBuilder
+            .fromUri("http://localhost:8080")
+            .queryParam("{a}", "{b}")
+            .build("/?abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-._~%1A!$'()*+,;:@", "apiKeyQueryParam1Value");
         
         assertEquals(expected, uri.toString());
     }

--- a/systests/jaxrs/src/test/java/org/apache/cxf/systest/jaxrs/BookStore.java
+++ b/systests/jaxrs/src/test/java/org/apache/cxf/systest/jaxrs/BookStore.java
@@ -1798,6 +1798,17 @@ public class BookStore {
     public Response echoEntity(String entity) {
         return Response.ok().entity(entity).build();
     }
+    
+    @GET
+    @Path("/queryParamSpecialCharacters")
+    @Produces("text/plain")
+    @SuppressWarnings({"checkstyle:linelength"})
+    public Response queryParamSpecialCharacters(@QueryParam("/?abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-._~%1A!$'()*+,;:@") String queryParm1) {
+        return Response
+            .ok(queryParm1)
+            .type(MediaType.TEXT_PLAIN)
+            .build();
+    }
 
     public final String init() {
         books.clear();

--- a/systests/jaxrs/src/test/java/org/apache/cxf/systest/jaxrs/JAXRS20ClientServerBookTest.java
+++ b/systests/jaxrs/src/test/java/org/apache/cxf/systest/jaxrs/JAXRS20ClientServerBookTest.java
@@ -24,6 +24,7 @@ import java.io.InputStream;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
 import java.net.URI;
+import java.net.URLEncoder;
 import java.net.UnknownHostException;
 import java.util.Arrays;
 import java.util.Collections;
@@ -925,6 +926,28 @@ public class JAXRS20ClientServerBookTest extends AbstractBusClientServerTestBase
             assertThat(response.getStatus(), equalTo(404));
         }
     }
+
+    @Test
+    @SuppressWarnings({"checkstyle:linelength"})
+    public void testQueryParamSpecialCharactersEncoded() throws Exception {
+        final String address = "http://localhost:" + PORT + "/bookstore/queryParamSpecialCharacters";
+
+        try (Response response = ClientBuilder.newClient()
+                .register(AddHeaderClientResponseFilter.class)
+                .target(address)
+                .queryParam(URLEncoder.encode("/?abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-._~%1A!$'()*+,;:@"), 
+                    "apiKeyQueryParam1Value")
+                .request(MediaType.TEXT_PLAIN)
+                .get()) {
+            assertEquals(200, response.getStatus());
+            
+            final String actual = response.readEntity(String.class);
+            final String expected = "apiKeyQueryParam1Value";
+            
+            assertEquals(expected, actual);
+        }
+    }
+
 
     private static class ReplaceBodyFilter implements ClientRequestFilter {
 


### PR DESCRIPTION
Allow special characters to be used for a queryParam name.