### PR TITLE
CXF-8534: Fix org.apache.cxf.jaxrs.client.logging.RESTLoggingTest.testBinary

### DIFF
--- a/rt/rs/client/src/test/java/org/apache/cxf/jaxrs/client/logging/RESTLoggingTest.java
+++ b/rt/rs/client/src/test/java/org/apache/cxf/jaxrs/client/logging/RESTLoggingTest.java
@@ -62,31 +62,48 @@ public class RESTLoggingTest {
         LoggingFeature loggingFeature = new LoggingFeature();
         TestEventSender sender = new TestEventSender();
         loggingFeature.setSender(sender);
+        loggingFeature.setLogBinary(true);
+
         Server server = createService(SERVICE_URI_BINARY, new TestServiceRestBinary(), loggingFeature);
         server.start();
         WebClient client = createClient(SERVICE_URI_BINARY, loggingFeature);
         client.get(InputStream.class).close();
-        loggingFeature.setLogBinary(true);
-        client.get(InputStream.class).close();
         client.close();
+
         List<LogEvent> events = sender.getEvents();
-        await().until(() -> events.size(), is(8));
+        await().until(() -> events.size(), is(4));
         server.stop();
         server.destroy();
 
-        Assert.assertEquals(8, events.size());
+        Assert.assertEquals(4, events.size());
         
-        // First call with binary logging false
+        assertContentLogged(events.get(0));
+        assertContentLogged(events.get(1));
+        assertContentLogged(events.get(2));
+        assertContentLogged(events.get(3));
+    }
+    
+    @Test
+    public void testNonBinary() throws IOException, InterruptedException {
+        LoggingFeature loggingFeature = new LoggingFeature();
+        TestEventSender sender = new TestEventSender();
+        loggingFeature.setSender(sender);
+        Server server = createService(SERVICE_URI_BINARY, new TestServiceRestBinary(), loggingFeature);
+        server.start();
+        WebClient client = createClient(SERVICE_URI_BINARY, loggingFeature);
+        client.get(InputStream.class).close();
+        client.close();
+        List<LogEvent> events = sender.getEvents();
+        await().until(() -> events.size(), is(4));
+        server.stop();
+        server.destroy();
+
+        Assert.assertEquals(4, events.size());
+        
         assertContentLogged(events.get(0));
         assertContentLogged(events.get(1));
         assertContentNotLogged(events.get(2));
         assertContentNotLogged(events.get(3));
-        
-        // Second call with binary logging true
-        assertContentLogged(events.get(4));
-        assertContentLogged(events.get(5));
-        assertContentLogged(events.get(6));
-        assertContentLogged(events.get(7));
     }
 
     @Test


### PR DESCRIPTION
The `org.apache.cxf.jaxrs.client.logging.RESTLoggingTest.testBinary` occasionally fails on Jenkins with:

```
org.junit.ComparisonFailure: expected:<[--- Content suppressed ---]> but was:<&amp#1;&amp#2;&amp#3;&amp#4;&amp#5;&amp#6;&amp#8;> at org.apache.cxf.jaxrs.client.logging.RESTLoggingTest.assertContentNotLogged(RESTLoggingTest.java:121) at org.apache.cxf.jaxrs.client.logging.RESTLoggingTest.testBinary(RESTLoggingTest.java:83)
```

It seems like the root cause is in-place `loggingFeature.setLogBinary(true)` modification: the feature's interceptors are called in the scope of different threads (execution thread + CXF's async working queue) but the feature was not supposed to be used from multiple threads. As such, the hypothesis is that `logBinary` flag change may not be visible by all threads. 

The test case was split into 2: binary and non-binary.