### PR TITLE
CXF-8556: Null AbstractEndpointFactory Properties Interferes with Class-Level PathParam When Creating Proxies with Defined ClientState

### DIFF
--- a/rt/rs/client/src/main/java/org/apache/cxf/jaxrs/client/JAXRSClientFactoryBean.java
+++ b/rt/rs/client/src/main/java/org/apache/cxf/jaxrs/client/JAXRSClientFactoryBean.java
@@ -344,7 +344,7 @@ public class JAXRSClientFactoryBean extends AbstractJAXRSFactoryBean {
                                     inheritHeaders, getProperties(), varValues);
         } else {
             return new ClientProxyImpl(actualState, proxyLoader, cri, isRoot,
-                                    inheritHeaders, getProperties(), varValues);
+                                    inheritHeaders, varValues);
         }
     }
 

--- a/rt/rs/client/src/test/java/org/apache/cxf/jaxrs/client/spring/JAXRSClientFactoryBeanTest.java
+++ b/rt/rs/client/src/test/java/org/apache/cxf/jaxrs/client/spring/JAXRSClientFactoryBeanTest.java
@@ -94,4 +94,20 @@ public class JAXRSClientFactoryBeanTest {
                 endsWith("?list=1&list=2"));
         }
     }
+    
+    @Test
+    public void testClientPropertiesWithState() throws Exception {
+        try (ClassPathXmlApplicationContext ctx =
+                new ClassPathXmlApplicationContext(new String[] {"/org/apache/cxf/jaxrs/client/spring/clients.xml"})) {
+            Client bean = (Client) ctx.getBean("client3");
+            assertNotNull(bean);
+            assertThat(bean.query("list", "1").query("list", "2").getCurrentURI().toString(),
+                endsWith("?list=1,2"));
+            
+            bean = (Client) ctx.getBean("client1");
+            assertNotNull(bean);
+            assertThat(bean.query("list", "1").query("list", "2").getCurrentURI().toString(),
+                endsWith("?list=1&list=2"));
+        }
+    }
 }

--- a/rt/rs/client/src/test/java/org/apache/cxf/jaxrs/client/spring/clients.xml
+++ b/rt/rs/client/src/test/java/org/apache/cxf/jaxrs/client/spring/clients.xml
@@ -54,4 +54,9 @@
             <entry key="expand.query.value.as.collection" value="true" />
         </jaxrs:properties>
     </jaxrs:client>
+    <jaxrs:client id="client3" serviceClass="org.apache.cxf.jaxrs.resources.BookStore" address="http://localhost:9000/foo" threadSafe="true">
+        <jaxrs:properties>
+            <entry key="expand.query.value.as.collection" value="true" />
+        </jaxrs:properties>
+    </jaxrs:client>
 </beans>

--- a/systests/jaxrs/src/test/java/org/apache/cxf/systest/jaxrs/BookServer.java
+++ b/systests/jaxrs/src/test/java/org/apache/cxf/systest/jaxrs/BookServer.java
@@ -93,7 +93,7 @@ public class BookServer extends AbstractServerTestServerBase {
         bus.setProperty(ExceptionMapper.class.getName(), new BusMapperExceptionMapper());
 
         JAXRSServerFactoryBean sf = new JAXRSServerFactoryBean();
-        sf.setResourceClasses(BookStore.class, SimpleBookStore.class, BookStorePerRequest.class);
+        sf.setResourceClasses(BookStore.class, SimpleBookStore.class, BookStorePerRequest.class, BookStoreRegex.class);
 
         //default lifecycle is per-request, change it to singleton
         final BinaryDataProvider<Object> p = new BinaryDataProvider<>();

--- a/systests/jaxrs/src/test/java/org/apache/cxf/systest/jaxrs/BookStoreRegex.java
+++ b/systests/jaxrs/src/test/java/org/apache/cxf/systest/jaxrs/BookStoreRegex.java
@@ -1,0 +1,36 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.cxf.systest.jaxrs;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.UriInfo;
+
+@Path("/regex/{type:book|store}")
+public class BookStoreRegex {
+    @Context private UriInfo uriInfo;
+    
+    @Path("/{id}")
+    @GET
+    public Book getBook(@PathParam("id") long id) {
+        return new Book(uriInfo.getPathParameters().getFirst("type"), id);
+    }
+}

--- a/systests/jaxrs/src/test/java/org/apache/cxf/systest/jaxrs/JAXRSClientServerBookTest.java
+++ b/systests/jaxrs/src/test/java/org/apache/cxf/systest/jaxrs/JAXRSClientServerBookTest.java
@@ -257,7 +257,6 @@ public class JAXRSClientServerBookTest extends AbstractBusClientServerTestBase {
         }
     }
 
-
     @Test
     public void testGetBookRelativeUriAutoRedirect() throws Exception {
         String address = "http://localhost:" + PORT + "/bookstore/redirect/relative?loop=false";
@@ -309,6 +308,7 @@ public class JAXRSClientServerBookTest extends AbstractBusClientServerTestBase {
         Response r = wc.form(new Form());
         assertEquals("empty form", r.readEntity(String.class));
     }
+    
     @Test
     public void testEchoForm() throws Exception {
         String address = "http://localhost:" + PORT + "/bookstore/form";
@@ -368,7 +368,6 @@ public class JAXRSClientServerBookTest extends AbstractBusClientServerTestBase {
         assertEquals("OK", r.getHeaderString("customresponse"));
     }
 
-
     @Test
     public void testGetCustomBookText() {
         String address = "http://localhost:" + PORT + "/bookstore/customtext";
@@ -378,7 +377,6 @@ public class JAXRSClientServerBookTest extends AbstractBusClientServerTestBase {
         assertEquals("Good book", name);
         assertEquals("text/custom;charset=us-ascii", r.getMediaType().toString());
         assertEquals("CustomValue", r.getHeaderString("CustomHeader"));
-
     }
 
     @Test
@@ -456,7 +454,6 @@ public class JAXRSClientServerBookTest extends AbstractBusClientServerTestBase {
     }
 
     private void doTestGetChapterFromSelectedBook(String address) {
-
         WebClient wc = WebClient.create(address);
         wc.accept("application/xml");
         Chapter chapter = wc.get(Chapter.class);
@@ -505,8 +502,8 @@ public class JAXRSClientServerBookTest extends AbstractBusClientServerTestBase {
 
         Book book = store.getBeanParamBook(bean);
         assertEquals(123L, book.getId());
-
     }
+    
     @Test
     public void testProxyBeanParam2() throws Exception {
         BookStore store = JAXRSClientFactory.create("http://localhost:" + PORT, BookStore.class);
@@ -517,7 +514,6 @@ public class JAXRSClientServerBookTest extends AbstractBusClientServerTestBase {
         nested.setId4(123);
         Book book = store.getTwoBeanParamsBook(bean, nested);
         assertEquals(123L, book.getId());
-
     }
     
     @Test
@@ -558,7 +554,6 @@ public class JAXRSClientServerBookTest extends AbstractBusClientServerTestBase {
 
     @Test
     public void testGetBookWithCustomHeader() throws Exception {
-
         String endpointAddress =
             "http://localhost:" + PORT + "/bookstore/books/123";
         WebClient wc = WebClient.create(endpointAddress);
@@ -584,7 +579,6 @@ public class JAXRSClientServerBookTest extends AbstractBusClientServerTestBase {
 
     @Test
     public void testGetBookWithNameInQuery() throws Exception {
-
         String endpointAddress =
             "http://localhost:" + PORT + "/bookstore/name-in-query";
         WebClient wc = WebClient.create(endpointAddress);
@@ -596,7 +590,6 @@ public class JAXRSClientServerBookTest extends AbstractBusClientServerTestBase {
 
     @Test
     public void testGetBookAsObject() throws Exception {
-
         String endpointAddress =
             "http://localhost:" + PORT + "/bookstore/object";
         WebClient wc = WebClient.create(endpointAddress);
@@ -620,7 +613,6 @@ public class JAXRSClientServerBookTest extends AbstractBusClientServerTestBase {
 
     @Test
     public void testGetBookWithColonMarks() throws Exception {
-
         // URLEncoder will turn ":" into "%3A" but ':' is actually
         // not disallowed in the path components
         String endpointAddressUrlEncoded =
@@ -639,7 +631,6 @@ public class JAXRSClientServerBookTest extends AbstractBusClientServerTestBase {
 
     @Test
     public void testPostAnd401WithText() throws Exception {
-
         String endpointAddress =
             "http://localhost:" + PORT + "/bookstore/post401";
         WebClient wc = WebClient.create(endpointAddress);
@@ -653,7 +644,6 @@ public class JAXRSClientServerBookTest extends AbstractBusClientServerTestBase {
 
     @Test
     public void testCapturedServerInFault() throws Exception {
-
         String endpointAddress =
             "http://localhost:" + PORT + "/bookstore/infault";
         WebClient wc = WebClient.create(endpointAddress);
@@ -663,7 +653,6 @@ public class JAXRSClientServerBookTest extends AbstractBusClientServerTestBase {
 
     @Test
     public void testCapturedServerOutFault() throws Exception {
-
         String endpointAddress =
             "http://localhost:" + PORT + "/bookstore/outfault";
         WebClient wc = WebClient.create(endpointAddress);
@@ -673,7 +662,6 @@ public class JAXRSClientServerBookTest extends AbstractBusClientServerTestBase {
 
     @Test
     public void testGetCollectionOfBooks() throws Exception {
-
         String endpointAddress =
             "http://localhost:" + PORT + "/bookstore/collections";
         WebClient wc = WebClient.create(endpointAddress);
@@ -686,7 +674,6 @@ public class JAXRSClientServerBookTest extends AbstractBusClientServerTestBase {
 
     @Test
     public void testPostCollectionGetBooksWebClient() throws Exception {
-
         String endpointAddress =
             "http://localhost:" + PORT + "/bookstore/collections3";
         WebClient wc = WebClient.create(endpointAddress);
@@ -704,7 +691,6 @@ public class JAXRSClientServerBookTest extends AbstractBusClientServerTestBase {
 
     @Test
     public void testPostCollectionGenericEntityWebClient() throws Exception {
-
         String endpointAddress =
             "http://localhost:" + PORT + "/bookstore/collections3";
         WebClient wc = WebClient.create(endpointAddress);
@@ -726,7 +712,6 @@ public class JAXRSClientServerBookTest extends AbstractBusClientServerTestBase {
 
     @Test
     public void testPostGetCollectionGenericEntityAndType() throws Exception {
-
         String endpointAddress =
             "http://localhost:" + PORT + "/bookstore/collections";
         WebClient wc = WebClient.create(endpointAddress);
@@ -759,7 +744,6 @@ public class JAXRSClientServerBookTest extends AbstractBusClientServerTestBase {
 
     @Test
     public void testPostCollectionOfBooksWebClient() throws Exception {
-
         String endpointAddress =
             "http://localhost:" + PORT + "/bookstore/collections";
         WebClient wc = WebClient.create(endpointAddress);
@@ -784,7 +768,6 @@ public class JAXRSClientServerBookTest extends AbstractBusClientServerTestBase {
 
     @Test
     public void testPostNullGetEmptyCollectionProxy() throws Exception {
-
         String endpointAddress = "http://localhost:" + PORT;
         BookStore bs = JAXRSClientFactory.create(endpointAddress, BookStore.class);
         List<Book> books = bs.postBookGetCollection(null);
@@ -795,7 +778,6 @@ public class JAXRSClientServerBookTest extends AbstractBusClientServerTestBase {
 
     @Test
     public void testPostObjectGetCollection() throws Exception {
-
         String endpointAddress =
             "http://localhost:" + PORT + "/bookstore/collectionBook";
         WebClient wc = WebClient.create(endpointAddress);
@@ -811,7 +793,6 @@ public class JAXRSClientServerBookTest extends AbstractBusClientServerTestBase {
 
     @Test
     public void testCaching() throws Exception {
-
         String endpointAddress =
             "http://localhost:" + PORT + "/bookstore/books/response/123";
 
@@ -851,7 +832,6 @@ public class JAXRSClientServerBookTest extends AbstractBusClientServerTestBase {
 
     @Test
     public void testCachingExpires() throws Exception {
-
         String endpointAddress =
             "http://localhost:" + PORT + "/bookstore/books/response2/123";
 
@@ -893,7 +873,6 @@ public class JAXRSClientServerBookTest extends AbstractBusClientServerTestBase {
 
     @Test
     public void testCachingExpiresUsingETag() throws Exception {
-
         String endpointAddress =
             "http://localhost:" + PORT + "/bookstore/books/response3/123";
 
@@ -1029,7 +1008,6 @@ public class JAXRSClientServerBookTest extends AbstractBusClientServerTestBase {
         } catch (BookNotFoundFault ex) {
             assertEquals("notFound", ex.getMessage());
         }
-
     }
 
     @Test
@@ -1112,7 +1090,6 @@ public class JAXRSClientServerBookTest extends AbstractBusClientServerTestBase {
         assertTrue("Did not contain dummy", hasDummy1);
         assertTrue("Did not contain dummy2", hasDummy2);
     }
-
 
     @Test
     public void testOnewayProxy() throws Exception {
@@ -1416,7 +1393,6 @@ public class JAXRSClientServerBookTest extends AbstractBusClientServerTestBase {
         Book book = wc.get(Book.class);
         assertNotNull(book);
         assertEquals(123L, book.getId());
-
     }
 
     @Test
@@ -1581,7 +1557,6 @@ public class JAXRSClientServerBookTest extends AbstractBusClientServerTestBase {
         assertEquals(3, arr[2], 0.0);
     }
 
-
     @Test
     public void testGetStringList() throws Exception {
         String address = "http://localhost:" + PORT;
@@ -1603,6 +1578,40 @@ public class JAXRSClientServerBookTest extends AbstractBusClientServerTestBase {
         BookStore store = bean.create(BookStore.class);
         store.emptypostNoPath();
         assertEquals(204, WebClient.client(store).getResponse().getStatus());
+    }
+
+    @Test
+    public void testBookWithRegexThreadSafe() throws Exception {
+        JAXRSClientFactoryBean bean = new JAXRSClientFactoryBean();
+        bean.setServiceClass(BookStoreRegex.class);
+        bean.setAddress("http://localhost:" + PORT);
+        bean.setProperties(Collections.<String, Object>singletonMap("url.encode.client.parameters", Boolean.TRUE));
+        bean.setThreadSafe(true);
+        
+        final String[] templates = new String [] {"book", "store"};
+        for (String template: templates) {
+            BookStoreRegex store = bean.create(BookStoreRegex.class, template);
+            Book book = store.getBook(123);
+            assertEquals(123L, book.getId());
+            assertEquals(template, book.getName());
+        }
+    }
+    
+    @Test
+    public void testBookWithRegexNonThreadSafe() throws Exception {
+        JAXRSClientFactoryBean bean = new JAXRSClientFactoryBean();
+        bean.setServiceClass(BookStoreRegex.class);
+        bean.setAddress("http://localhost:" + PORT);
+        bean.setProperties(Collections.<String, Object>singletonMap("url.encode.client.parameters", Boolean.TRUE));
+        bean.setThreadSafe(false);
+        
+        final String[] templates = new String [] {"book", "store"};
+        for (String template: templates) {
+            BookStoreRegex store = bean.create(BookStoreRegex.class, template);
+            Book book = store.getBook(123);
+            assertEquals(123L, book.getId());
+            assertEquals(template, book.getName());
+        }
     }
 
     @Test
@@ -1659,7 +1668,6 @@ public class JAXRSClientServerBookTest extends AbstractBusClientServerTestBase {
         assertEquals("text/custom+plain", r.getMediaType().toString());
         assertEquals("CustomValue", r.getHeaderString("CustomHeader"));
         assertEquals("Response is not available", r.readEntity(String.class));
-
     }
 
     @Test
@@ -1741,7 +1749,6 @@ public class JAXRSClientServerBookTest extends AbstractBusClientServerTestBase {
 
     @Test
     public void testNoMessageReaderFound() throws Exception {
-
         String endpointAddress =
             "http://localhost:" + PORT + "/bookstore/binarybooks";
 
@@ -1962,7 +1969,6 @@ public class JAXRSClientServerBookTest extends AbstractBusClientServerTestBase {
         WebClient client = WebClient.create(address);
         Book b = client.query("_s", "name==CXF*;id=ge=123;id=lt=124").get(Book.class);
         assertEquals(b.getId(), 123L);
-
     }
 
     @Test
@@ -2108,7 +2114,6 @@ public class JAXRSClientServerBookTest extends AbstractBusClientServerTestBase {
         assertTrue(response.endsWith("}"));
         assertTrue(response.contains("\"Book\":{"));
         assertNotEquals(1, response.indexOf("\"Book\":{"));
-
     }
 
     @Test
@@ -2146,7 +2151,6 @@ public class JAXRSClientServerBookTest extends AbstractBusClientServerTestBase {
         getAndCompareAsStrings("http://localhost:" + PORT + "/bookstore/books/123",
                                "resources/expected_get_book123.txt",
                                "*/*", "application/xml", 200);
-
     }
 
     @Test
@@ -2399,7 +2403,6 @@ public class JAXRSClientServerBookTest extends AbstractBusClientServerTestBase {
 
     @Test
     public void testGetChapter() throws Exception {
-
         getAndCompareAsStrings("http://localhost:" + PORT + "/bookstore/booksubresource/123/chapters/1",
                                "resources/expected_get_chapter1.txt",
                                "application/xml", "application/xml;charset=ISO-8859-1", 200);
@@ -2447,7 +2450,6 @@ public class JAXRSClientServerBookTest extends AbstractBusClientServerTestBase {
 
     @Test
     public void testGetChapterEncodingDefault() throws Exception {
-
         getAndCompareAsStrings("http://localhost:"
                                + PORT + "/bookstore/booksubresource/123/chapters/badencoding/1",
                                "resources/expected_get_chapter1_utf.txt",
@@ -2456,7 +2458,6 @@ public class JAXRSClientServerBookTest extends AbstractBusClientServerTestBase {
 
     @Test
     public void testGetChapterAcceptEncoding() throws Exception {
-
         getAndCompareAsStrings("http://localhost:"
                                + PORT + "/bookstore/booksubresource/123/chapters/acceptencoding/1",
                                "resources/expected_get_chapter1.txt",
@@ -2466,7 +2467,6 @@ public class JAXRSClientServerBookTest extends AbstractBusClientServerTestBase {
 
     @Test
     public void testGetChapterChapter() throws Exception {
-
         getAndCompareAsStrings("http://localhost:"
                                + PORT + "/bookstore/booksubresource/123/chapters/sub/1/recurse",
                                "resources/expected_get_chapter1_utf.txt",
@@ -2479,7 +2479,6 @@ public class JAXRSClientServerBookTest extends AbstractBusClientServerTestBase {
 
     @Test
     public void testGetChapterWithParentIds() throws Exception {
-
         getAndCompareAsStrings(
             "http://localhost:" + PORT + "/bookstore/booksubresource/123/chapters/sub/1/recurse2/ids",
             "resources/expected_get_chapter1.txt",
@@ -2551,7 +2550,6 @@ public class JAXRSClientServerBookTest extends AbstractBusClientServerTestBase {
             post.releaseConnection();
         }
     }
-
 
     @Test
     public void testAddBookCustomFailureStatus() throws Exception {
@@ -2649,7 +2647,6 @@ public class JAXRSClientServerBookTest extends AbstractBusClientServerTestBase {
 
     @Test
     public void testGetCDs() throws Exception {
-
         WebClient wc = WebClient.create("http://localhost:" + PORT + "/bookstore/cds");
         CDs cds = wc.get(CDs.class);
         Collection<CD> collection = cds.getCD();
@@ -2664,7 +2661,6 @@ public class JAXRSClientServerBookTest extends AbstractBusClientServerTestBase {
         getAndCompareAsStrings("http://localhost:" + PORT + "/bookstore/cd/123",
                                "resources/expected_get_cdjson.txt",
                                "application/json", "application/json", 200);
-
     }
 
     @Test
@@ -2687,7 +2683,6 @@ public class JAXRSClientServerBookTest extends AbstractBusClientServerTestBase {
             post.releaseConnection();
         }
     }
-
 
     @Test
     public void testMutipleAcceptHeader() throws Exception {
@@ -2746,7 +2741,6 @@ public class JAXRSClientServerBookTest extends AbstractBusClientServerTestBase {
 
     @Test
     public void testGetCDsJSON() throws Exception {
-
         String endpointAddress =
             "http://localhost:" + PORT + "/bookstore/cds";
 
@@ -2773,7 +2767,6 @@ public class JAXRSClientServerBookTest extends AbstractBusClientServerTestBase {
 
     @Test
     public void testGetCDXML() throws Exception {
-
         getAndCompareAsStrings("http://localhost:" + PORT + "/bookstore/cd/123",
                                "resources/expected_get_cd.txt",
                                "application/xml", "application/xml", 200);
@@ -2781,7 +2774,6 @@ public class JAXRSClientServerBookTest extends AbstractBusClientServerTestBase {
 
     @Test
     public void testGetCDWithMultiContentTypesXML() throws Exception {
-
         getAndCompareAsStrings("http://localhost:" + PORT + "/bookstore/cdwithmultitypes/123",
                                "resources/expected_get_cd.txt",
                                "application/json;q=0.8,application/xml,*/*", "application/xml", 200);
@@ -2789,7 +2781,6 @@ public class JAXRSClientServerBookTest extends AbstractBusClientServerTestBase {
 
     @Test
     public void testGetCDWithMultiContentTypesCustomXML() throws Exception {
-
         getAndCompareAsStrings("http://localhost:" + PORT + "/bookstore/cdwithmultitypes/123",
                                "resources/expected_get_cd.txt",
                                "application/bar+xml", "application/bar+xml", 200);
@@ -2838,7 +2829,6 @@ public class JAXRSClientServerBookTest extends AbstractBusClientServerTestBase {
 
     @Test
     public void testQuotedHeaders() throws Exception {
-
         String endpointAddress =
             "http://localhost:" + PORT + "/bookstore/quotedheaders";
         WebClient wc = WebClient.create(endpointAddress);
@@ -2862,7 +2852,6 @@ public class JAXRSClientServerBookTest extends AbstractBusClientServerTestBase {
         List<Object> header4 = r.getMetadata().get("SomeHeader4");
         assertEquals(1, header4.size());
         assertEquals("\"\"", header4.get(0));
-
     }
 
     @Test
@@ -2911,7 +2900,6 @@ public class JAXRSClientServerBookTest extends AbstractBusClientServerTestBase {
         assertEquals("\"other quoted\"", r3values.get(1));
         assertEquals("text", r3values.get(2));
         assertEquals("blah", r3values.get(3));
-
     }
 
     @Test
@@ -2935,7 +2923,6 @@ public class JAXRSClientServerBookTest extends AbstractBusClientServerTestBase {
         }
     }
 
-
     private ReaderInterceptor getReaderInterceptor() {
         return readerInterceptorContext -> {
             InputStream is = new BufferedInputStream(readerInterceptorContext.getInputStream());
@@ -2943,7 +2930,6 @@ public class JAXRSClientServerBookTest extends AbstractBusClientServerTestBase {
             return readerInterceptorContext.proceed();
         };
     }
-
 
     private static void getAndCompareAsStrings(String address, String resourcePath, String acceptType,
             String expectedContentType, int status) throws Exception {
@@ -2995,5 +2981,4 @@ public class JAXRSClientServerBookTest extends AbstractBusClientServerTestBase {
         }
         return str;
     }
-
 }


### PR DESCRIPTION
CXF-8556: Null AbstractEndpointFactory Properties Interferes with Class-Level PathParam When Creating Proxies with Defined ClientState