### PR TITLE
CXF-8559: SseInterceptor uses PROTOCOL_HEADERS from request (in) message, not from response (out) one

### DIFF
--- a/systests/rs-sse/rs-sse-base/src/main/java/org/apache/cxf/systest/jaxrs/sse/AbstractSseTest.java
+++ b/systests/rs-sse/rs-sse-base/src/main/java/org/apache/cxf/systest/jaxrs/sse/AbstractSseTest.java
@@ -325,6 +325,16 @@ public abstract class AbstractSseTest extends AbstractSseBaseTest {
         assertTrue(stats.getCompleted() == 2 || stats.getCompleted() == 1);
     }
 
+    @Test
+    public void testBooksSseContainerResponseAddedHeaders() throws InterruptedException {
+        final WebTarget target = createWebTarget("/rest/api/bookstore/headers/sse");
+        try (Response response = target.request(MediaType.SERVER_SENT_EVENTS).get()) {
+            assertThat(response.getStatus(), equalTo(202));
+            assertThat(response.getHeaderString("X-My-Header"), equalTo("headers"));
+            assertThat(response.getHeaderString("X-My-ProtocolHeader"), equalTo("protocol-headers"));
+        }
+    }
+
     /**
      * Jetty / Undertow do not propagate errors from the runnable passed to
      * AsyncContext::start() up to the AsyncEventListener::onError(). Tomcat however

--- a/systests/rs-sse/rs-sse-base/src/main/java/org/apache/cxf/systest/jaxrs/sse/BookStore.java
+++ b/systests/rs-sse/rs-sse-base/src/main/java/org/apache/cxf/systest/jaxrs/sse/BookStore.java
@@ -183,7 +183,23 @@ public class BookStore extends BookStoreClientCloseable {
             }
         }.start();
     }
-    
+
+    @GET
+    @Path("/headers/sse")
+    @Produces(MediaType.SERVER_SENT_EVENTS)
+    public void headers(@Context SseEventSink sink) {
+        new Thread() {
+            public void run() {
+                try {
+                    Thread.sleep(200);
+                    sink.close();
+                } catch (final InterruptedException ex) {
+                    LOG.error("Communication error", ex);
+                }
+            }
+        }.start();
+    }
+
     @GET
     @Path("/filtered/stats")
     @Produces(MediaType.TEXT_PLAIN)


### PR DESCRIPTION
`SseInterceptor` uses PROTOCOL_HEADERS from request (in) message, not from response (out) one, as such the request headers are leaking into the response.