### PR TITLE
CXF-8557: Incorrect Proxy Path Segmenting when @Path Annotation RegexExpression Contains '/'

### DIFF
--- a/rt/frontend/jaxrs/src/test/java/org/apache/cxf/jaxrs/impl/UriBuilderImplTest.java
+++ b/rt/frontend/jaxrs/src/test/java/org/apache/cxf/jaxrs/impl/UriBuilderImplTest.java
@@ -1895,6 +1895,16 @@ public class UriBuilderImplTest {
     }
     
     @Test
+    public void pathParamFromNestedTemplateWithRegex() {
+        // The nested templates are not supported and are not detected 
+        final URI uri = UriBuilder
+            .fromUri("my/path")
+            .path("{{p:his/him}}")
+            .build();
+        assertEquals("my/path/%7B%7Bp:his/him%7D%7D", uri.toString());
+    }
+    
+    @Test
     public void pathParamFromBadTemplateNested() {
         final URI uri = UriBuilder
             .fromUri("my/path")
@@ -1918,7 +1928,7 @@ public class UriBuilderImplTest {
             .fromUri("my/path")
             .path("{p/{d}")
             .build("my");
-        assertEquals("my/path/%7Bp/%7Bd%7D", uri.toString());
+        assertEquals("my/path/%7Bp/my", uri.toString());
     }
     
     @Test
@@ -1937,5 +1947,32 @@ public class UriBuilderImplTest {
             .path("   /   ")
             .build();
         assertEquals("/%20%20%20/%20%20%20", uri.toString());
+    }
+    
+    @Test
+    public void pathParamFromBadTemplateUnopenedAndEnclosedSlash() {
+        final URI uri = UriBuilder
+            .fromUri("my/path")
+            .path("p{d:my/day}/}")
+            .buildFromEncoded("my/day");
+        assertEquals("my/path/pmy/day/%7D", uri.toString());
+    }
+    
+    @Test
+    public void pathParamFromBadTemplateUnclosedAndEnclosedSlash() {
+        final URI uri = UriBuilder
+            .fromUri("my/path")
+            .path("{p/{d:my/day}")
+            .build();
+        assertEquals("my/path/%7Bp/%7Bd:my/day%7D", uri.toString());
+    }
+    
+    @Test
+    public void pathParamFromBadTemplate() {
+        final URI uri = UriBuilder
+            .fromUri("/")
+            .path("{")
+            .build();
+        assertEquals("/%7B", uri.toString());
     }
 }

--- a/rt/frontend/jaxrs/src/test/java/org/apache/cxf/jaxrs/impl/UriBuilderImplTest.java
+++ b/rt/frontend/jaxrs/src/test/java/org/apache/cxf/jaxrs/impl/UriBuilderImplTest.java
@@ -1875,4 +1875,67 @@ public class UriBuilderImplTest {
             .toTemplate();
         assertEquals("my/path?p=%25250%25", template);
     }
+    
+    @Test
+    public void pathParamFromTemplateWithOrRegex() {
+        final URI uri = UriBuilder
+            .fromUri("my/path")
+            .path("{p:my|his}")
+            .build("my");
+        assertEquals("my/path/my", uri.toString());
+    }
+    
+    @Test
+    public void pathParamFromTemplateWithRegex() {
+        final URI uri = UriBuilder
+            .fromUri("my/path")
+            .path("{p:his/him}")
+            .buildFromEncoded("his/him");
+        assertEquals("my/path/his/him", uri.toString());
+    }
+    
+    @Test
+    public void pathParamFromBadTemplateNested() {
+        final URI uri = UriBuilder
+            .fromUri("my/path")
+            .path("{p{d}}")
+            .build("my");
+        assertEquals("my/path/%7Bp%7Bd%7D%7D", uri.toString());
+    }
+    
+    @Test
+    public void pathParamFromBadTemplateUnopened() {
+        final URI uri = UriBuilder
+            .fromUri("my/path")
+            .path("p{d}/}")
+            .build("my");
+        assertEquals("my/path/pmy/%7D", uri.toString());
+    }
+    
+    @Test
+    public void pathParamFromBadTemplateUnclosed() {
+        final URI uri = UriBuilder
+            .fromUri("my/path")
+            .path("{p/{d}")
+            .build("my");
+        assertEquals("my/path/%7Bp/%7Bd%7D", uri.toString());
+    }
+    
+    @Test
+    public void pathParamFromEmpty() {
+        final URI uri = UriBuilder
+            .fromUri("/")
+            .path("/")
+            .build();
+        assertEquals("/", uri.toString());
+    }
+    
+    @Test
+    public void pathParamFromEmptyWithSpaces() {
+        final URI uri = UriBuilder
+            .fromUri("/")
+            .path("   /   ")
+            .build();
+        assertEquals("/%20%20%20/%20%20%20", uri.toString());
+    }
 }


### PR DESCRIPTION
A service in question needs to be reachable via multiple paths. The @Path parameter allows for regex matching on a class-level like the following: @Path("/{a: regex}"). A class-level `@PathParam` is created by the name of a. On the server side, the following annotations both correctly receive requests at `/foo/bar`:

```
@Path("/{a : foo/bar}")
@Path("/{a : foo\\/bar}")
```

However, on the client side, the following URI(s)
```
final URI uri = UriBuilder
            .fromUri("/")
            .path("{a : foo/bar}")
            .buildFromEncoded("foo/bar");
```
are not properly constructed due to the fact that `/` is used as path segment separator without taking into account the URI template expression.