### PR TITLE
Delete temporary queue when it is used

### DIFF
--- a/rt/transports/jms/src/main/java/org/apache/cxf/transport/jms/JMSConduit.java
+++ b/rt/transports/jms/src/main/java/org/apache/cxf/transport/jms/JMSConduit.java
@@ -510,8 +510,8 @@ public class JMSConduit extends AbstractConduit implements JMSExchangeSender, Me
         }
     }
     public synchronized void close() {
-        jmsConfig.resetCachedReplyDestination();
         shutdownListeners();
+        jmsConfig.resetCachedReplyDestination();
         ResourceCloser.close(connection);
         connection = null;
         LOG.log(Level.FINE, "JMSConduit closed ");

--- a/rt/transports/jms/src/main/java/org/apache/cxf/transport/jms/JMSConduit.java
+++ b/rt/transports/jms/src/main/java/org/apache/cxf/transport/jms/JMSConduit.java
@@ -130,11 +130,7 @@ public class JMSConduit extends AbstractConduit implements JMSExchangeSender, Me
 
                 @Override
                 public void onException(JMSException exception) {
-                    try {
-                        jmsConfig.resetCachedReplyDestination();
-                    } catch (JMSException e) {
-                        // setException is not supported on all providers
-                    }
+                    jmsConfig.resetCachedReplyDestination();
                     staticReplyDestination = null;
                 }
             });
@@ -192,11 +188,7 @@ public class JMSConduit extends AbstractConduit implements JMSExchangeSender, Me
                 }
                 ResourceCloser.close(connection);
                 this.connection = null;
-                try {
-                    jmsConfig.resetCachedReplyDestination();
-                } catch (JMSException jmsException) {
-                    // Ignore
-                }
+                jmsConfig.resetCachedReplyDestination();
             }
             this.staticReplyDestination = null;
             try {
@@ -518,11 +510,7 @@ public class JMSConduit extends AbstractConduit implements JMSExchangeSender, Me
         }
     }
     public synchronized void close() {
-        try {
-            jmsConfig.resetCachedReplyDestination();
-        } catch (JMSException e) {
-            // do nothing
-        }
+        jmsConfig.resetCachedReplyDestination();
         shutdownListeners();
         ResourceCloser.close(connection);
         connection = null;

--- a/rt/transports/jms/src/main/java/org/apache/cxf/transport/jms/JMSConduit.java
+++ b/rt/transports/jms/src/main/java/org/apache/cxf/transport/jms/JMSConduit.java
@@ -36,6 +36,7 @@ import javax.jms.ExceptionListener;
 import javax.jms.JMSException;
 import javax.jms.MessageListener;
 import javax.jms.Session;
+import javax.jms.TemporaryQueue;
 
 import org.apache.cxf.Bus;
 import org.apache.cxf.buslifecycle.BusLifeCycleListener;
@@ -282,6 +283,9 @@ public class JMSConduit extends AbstractConduit implements JMSExchangeSender, Me
                                                                      jmsConfig.getReceiveTimeout(),
                                                                      jmsConfig.isPubSubNoLocal(),
                                                                      exchange);
+                    if (replyDestination instanceof TemporaryQueue) {
+                        ((TemporaryQueue) replyDestination).delete();
+                    }
                     processReplyMessage(exchange, replyMessage);
                 } else {
                     try {

--- a/rt/transports/jms/src/main/java/org/apache/cxf/transport/jms/JMSConduit.java
+++ b/rt/transports/jms/src/main/java/org/apache/cxf/transport/jms/JMSConduit.java
@@ -186,9 +186,9 @@ public class JMSConduit extends AbstractConduit implements JMSExchangeSender, Me
                 if (exchange.get(JMSUtil.JMS_MESSAGE_CONSUMER) != null) {
                     ResourceCloser.close(exchange.get(JMSUtil.JMS_MESSAGE_CONSUMER));
                 }
+                jmsConfig.resetCachedReplyDestination();
                 ResourceCloser.close(connection);
                 this.connection = null;
-                jmsConfig.resetCachedReplyDestination();
             }
             this.staticReplyDestination = null;
             try {

--- a/rt/transports/jms/src/main/java/org/apache/cxf/transport/jms/JMSConfiguration.java
+++ b/rt/transports/jms/src/main/java/org/apache/cxf/transport/jms/JMSConfiguration.java
@@ -25,6 +25,7 @@ import javax.jms.Destination;
 import javax.jms.JMSException;
 import javax.jms.Message;
 import javax.jms.Session;
+import javax.jms.TemporaryQueue;
 import javax.naming.NamingException;
 import javax.transaction.TransactionManager;
 
@@ -487,8 +488,11 @@ public class JMSConfiguration {
             : destinationResolver.resolveDestinationName(session, replyDestination, replyPubSubDomain);
     }
 
-    public void resetCachedReplyDestination() {
+    public void resetCachedReplyDestination() throws JMSException {
         synchronized (this) {
+            if (replyDestinationDest instanceof TemporaryQueue) {
+                ((TemporaryQueue) replyDestinationDest).delete();
+            }
             this.replyDestinationDest = null;
         }
     }

--- a/rt/transports/jms/src/main/java/org/apache/cxf/transport/jms/JMSConfiguration.java
+++ b/rt/transports/jms/src/main/java/org/apache/cxf/transport/jms/JMSConfiguration.java
@@ -19,6 +19,8 @@
 package org.apache.cxf.transport.jms;
 
 import java.util.Properties;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 import javax.jms.ConnectionFactory;
 import javax.jms.Destination;
@@ -30,12 +32,16 @@ import javax.naming.NamingException;
 import javax.transaction.TransactionManager;
 
 import org.apache.cxf.common.injection.NoJSR250Annotations;
+import org.apache.cxf.common.logging.LogUtils;
 import org.apache.cxf.transport.jms.util.DestinationResolver;
 import org.apache.cxf.transport.jms.util.JMSDestinationResolver;
 import org.apache.cxf.transport.jms.util.JndiHelper;
 
 @NoJSR250Annotations
 public class JMSConfiguration {
+
+    private static final Logger LOG = LogUtils.getL7dLogger(JMSConfiguration.class);
+
     /**
      * Default value to mark as unset
      */
@@ -488,10 +494,14 @@ public class JMSConfiguration {
             : destinationResolver.resolveDestinationName(session, replyDestination, replyPubSubDomain);
     }
 
-    public void resetCachedReplyDestination() throws JMSException {
+    public void resetCachedReplyDestination() {
         synchronized (this) {
             if (replyDestinationDest instanceof TemporaryQueue) {
-                ((TemporaryQueue) replyDestinationDest).delete();
+                try {
+                    ((TemporaryQueue) replyDestinationDest).delete();
+                } catch (JMSException exception) {
+                    LOG.log(Level.WARNING, "Exception on temporary queue deletion", exception);
+                }
             }
             this.replyDestinationDest = null;
         }

--- a/rt/transports/jms/src/main/java/org/apache/cxf/transport/jms/JMSConfiguration.java
+++ b/rt/transports/jms/src/main/java/org/apache/cxf/transport/jms/JMSConfiguration.java
@@ -39,13 +39,12 @@ import org.apache.cxf.transport.jms.util.JndiHelper;
 
 @NoJSR250Annotations
 public class JMSConfiguration {
-
-    private static final Logger LOG = LogUtils.getL7dLogger(JMSConfiguration.class);
-
     /**
      * Default value to mark as unset
      */
     public static final int DEFAULT_VALUE = -1;
+
+    private static final Logger LOG = LogUtils.getL7dLogger(JMSConfiguration.class);
 
     private volatile ConnectionFactory connectionFactory;
     private Properties jndiEnvironment;


### PR DESCRIPTION
Temporary queues are never deleted when the are used.
This patch provides fixes for this behavior.