### PR TITLE
[CXF-8568] DefaultLogEventMapper Method Overload

### DIFF
--- a/rt/features/logging/src/main/java/org/apache/cxf/ext/logging/event/DefaultLogEventMapper.java
+++ b/rt/features/logging/src/main/java/org/apache/cxf/ext/logging/event/DefaultLogEventMapper.java
@@ -72,6 +72,10 @@ public class DefaultLogEventMapper {
         }
     }
 
+    public LogEvent map(final Message message) {
+        return this.map(message, Collections.emptySet());
+    }
+
     public LogEvent map(final Message message, final Set<String> sensitiveProtocolHeaders) {
         final LogEvent event = new LogEvent();
         event.setMessageId(getMessageId(message));
@@ -90,7 +94,9 @@ public class DefaultLogEventMapper {
         event.setContentType(safeGet(message, Message.CONTENT_TYPE));
 
         Map<String, String> headerMap = getHeaders(message);
-        maskSensitiveHelper.maskHeaders(headerMap, sensitiveProtocolHeaders);
+        if (sensitiveProtocolHeaders != null && !sensitiveProtocolHeaders.isEmpty()) {
+            maskSensitiveHelper.maskHeaders(headerMap, sensitiveProtocolHeaders);
+        }
         event.setHeaders(headerMap);
 
         event.setAddress(getAddress(message, event));

--- a/rt/features/logging/src/test/java/org/apache/cxf/ext/logging/DefaultLogEventMapperTest.java
+++ b/rt/features/logging/src/test/java/org/apache/cxf/ext/logging/DefaultLogEventMapperTest.java
@@ -119,4 +119,32 @@ public class DefaultLogEventMapperTest {
         assertEquals(MASKED_HEADER_VALUE, event.getHeaders().get(TEST_HEADER_NAME));
     }
 
+    @Test
+    public void testMapNullSensitiveProtocolHeaders() {
+        DefaultLogEventMapper mapper = new DefaultLogEventMapper();
+        Message message = new MessageImpl();
+        message.put(Message.HTTP_REQUEST_METHOD, "POST");
+        message.put(Message.REQUEST_URI, "nullTest");
+        Exchange exchange = new ExchangeImpl();
+        message.setExchange(exchange);
+
+        LogEvent event = mapper.map(message, null);
+
+        assertEquals("POST[nullTest]", event.getOperationName());
+    }
+
+    @Test
+    public void testMap() {
+        DefaultLogEventMapper mapper = new DefaultLogEventMapper();
+        Message message = new MessageImpl();
+        message.put(Message.HTTP_REQUEST_METHOD, "PUT");
+        message.put(Message.REQUEST_URI, "test");
+        Exchange exchange = new ExchangeImpl();
+        message.setExchange(exchange);
+
+        LogEvent event = mapper.map(message);
+
+        assertEquals("PUT[test]", event.getOperationName());
+    }
+
 }


### PR DESCRIPTION
[CXF-8568] Added overloaded map method, added null check for sensitiveProtocolHeaders in DefaultLogEventMapper