### PR TITLE
CXF-8572: Incorrectly parsed ETag when contains 'W/' as part of the content

### DIFF
--- a/rt/frontend/jaxrs/src/main/java/org/apache/cxf/jaxrs/impl/EntityTagHeaderProvider.java
+++ b/rt/frontend/jaxrs/src/main/java/org/apache/cxf/jaxrs/impl/EntityTagHeaderProvider.java
@@ -39,16 +39,17 @@ public class EntityTagHeaderProvider implements HeaderDelegate<EntityTag> {
 
         String tag;
         boolean weak = false;
-        int i = header.indexOf(WEAK_PREFIX);
-        if (i != -1) {
+        final String trimmed = header.trim();
+        // See please https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/ETag for weak validator 
+        if (trimmed.startsWith(WEAK_PREFIX)) {
             weak = true;
-            if (i + 2 < header.length()) {
-                tag = header.substring(i + 2);
+            if (trimmed.length() > 2) {
+                tag = trimmed.substring(2);
             } else {
                 return new EntityTag("", weak);
             }
         }  else {
-            tag = header;
+            tag = trimmed;
         }
         if (tag.length() > 0 && !tag.startsWith("\"") && !tag.endsWith("\"")) {
             return new EntityTag(tag, weak);

--- a/rt/frontend/jaxrs/src/test/java/org/apache/cxf/jaxrs/impl/EntityTagHeaderProviderTest.java
+++ b/rt/frontend/jaxrs/src/test/java/org/apache/cxf/jaxrs/impl/EntityTagHeaderProviderTest.java
@@ -39,7 +39,9 @@ public class EntityTagHeaderProviderTest {
         tag = EntityTag.valueOf("W/\"12345\"");
         assertTrue(tag.isWeak() && "12345".equals(tag.getValue()));
         tag = EntityTag.valueOf("\"12345\"");
-        assertFalse(tag.isWeak() && "12345".equals(tag.getValue()));
+        assertTrue(!tag.isWeak() && "12345".equals(tag.getValue()));
+        tag = EntityTag.valueOf("\"wyoBLW/ye71RgN/0LNyj4eA5rfE1ovtlM03aakuGr2Y=\"");
+        assertTrue(!tag.isWeak() && "wyoBLW/ye71RgN/0LNyj4eA5rfE1ovtlM03aakuGr2Y=".equals(tag.getValue()));
     }
 
     @Test


### PR DESCRIPTION
With  following ETag being generated `wyoBLW/ye71RgN/0LNyj4eA5rfE1ovtlM03aakuGr2Y=`,  the `EntityTag.valueOf(etag)` throws following error:

```
java.lang.IllegalArgumentException: Misformatted ETag : "wyoBLW/ye71RgN/0LNyj4eA5rfE1ovtlM03aakuGr2Y="
	at org.apache.cxf.jaxrs.impl.EntityTagHeaderProvider.fromString(EntityTagHeaderProvider.java:57)
```

As per specification, the ETag should start from `W/` to indicate weak validator.