### PR TITLE
CXF-8574: MP Rest call on jax-rs interface with long @Path and 3 path params causes error since

### DIFF
--- a/rt/rs/microprofile-client/src/main/java/org/apache/cxf/microprofile/client/proxy/MicroProfileClientProxyImpl.java
+++ b/rt/rs/microprofile-client/src/main/java/org/apache/cxf/microprofile/client/proxy/MicroProfileClientProxyImpl.java
@@ -51,6 +51,7 @@ import org.apache.cxf.jaxrs.client.ClientProxyImpl;
 import org.apache.cxf.jaxrs.client.ClientState;
 import org.apache.cxf.jaxrs.client.JaxrsClientCallback;
 import org.apache.cxf.jaxrs.client.LocalClientState;
+import org.apache.cxf.jaxrs.client.spec.TLSConfiguration;
 import org.apache.cxf.jaxrs.model.ClassResourceInfo;
 import org.apache.cxf.jaxrs.model.OperationResourceInfo;
 import org.apache.cxf.jaxrs.model.Parameter;
@@ -106,15 +107,18 @@ public class MicroProfileClientProxyImpl extends ClientProxyImpl {
     private Map<Class<ClientHeadersFactory>, ProviderInfo<ClientHeadersFactory>> clientHeaderFactories = 
         new WeakHashMap<>();
     private List<Instance<?>> cdiInstances = new LinkedList<>();
+    private final TLSConfiguration tlsConfig;
 
     //CHECKSTYLE:OFF
+    @SuppressWarnings("PMD.ExcessiveParameterList")
     public MicroProfileClientProxyImpl(URI baseURI, ClassLoader loader, ClassResourceInfo cri,
                                        boolean isRoot, boolean inheritHeaders, ExecutorService executorService,
-                                       Configuration configuration, CDIInterceptorWrapper interceptorWrapper, 
-                                       Object... varValues) {
+                                       Configuration configuration, CDIInterceptorWrapper interceptorWrapper,
+                                       TLSConfiguration tlsConfig, Object... varValues) {
         super(new LocalClientState(baseURI, configuration.getProperties()), loader, cri,
             isRoot, inheritHeaders, varValues);
         this.interceptorWrapper = interceptorWrapper;
+        this.tlsConfig = tlsConfig;
         
         if (executorService == null) {
             throw new IllegalArgumentException("The executorService is required and must be provided");
@@ -123,12 +127,14 @@ public class MicroProfileClientProxyImpl extends ClientProxyImpl {
         init(executorService, configuration);
     }
 
+    @SuppressWarnings("PMD.ExcessiveParameterList")
     public MicroProfileClientProxyImpl(ClientState initialState, ClassLoader loader, ClassResourceInfo cri,
                                        boolean isRoot, boolean inheritHeaders, ExecutorService executorService,
                                        Configuration configuration, CDIInterceptorWrapper interceptorWrapper,
-                                       Object... varValues) {
+                                       TLSConfiguration tlsConfig, Object... varValues) {
         super(initialState, loader, cri, isRoot, inheritHeaders, varValues);
         this.interceptorWrapper = interceptorWrapper;
+        this.tlsConfig = tlsConfig;
         init(executorService, configuration);
     }
     //CHECKSTYLE:ON
@@ -543,5 +549,9 @@ public class MicroProfileClientProxyImpl extends ClientProxyImpl {
     public void close() {
         cdiInstances.forEach(Instance::release);
         super.close();
+    }
+    
+    public TLSConfiguration getTlsConfig() {
+        return tlsConfig;
     }
 }

--- a/systests/microprofile/client/jaxrs/src/test/java/org/apache/cxf/systest/microprofile/rest/client/regex/BookStore.java
+++ b/systests/microprofile/client/jaxrs/src/test/java/org/apache/cxf/systest/microprofile/rest/client/regex/BookStore.java
@@ -26,4 +26,9 @@ public class BookStore implements BookStoreClient {
         return book;
     }
 
+    @Override
+    public Book echoXmlBookregexMany(Book book, String id, String language, String format) {
+        return book;
+    }
+
 }

--- a/systests/microprofile/client/jaxrs/src/test/java/org/apache/cxf/systest/microprofile/rest/client/regex/BookStoreClientRoot.java
+++ b/systests/microprofile/client/jaxrs/src/test/java/org/apache/cxf/systest/microprofile/rest/client/regex/BookStoreClientRoot.java
@@ -25,18 +25,10 @@ import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 
-@Path("/bookstore")
-public interface BookStoreClient {
-
-    // Only books with id consisting of 3 or 4 digits of the numbers between 5 and 9 are accepted
+@Path("/bookstore/echoxmlbookregex/{id : [5-9]{3,4}}/{language:en|fr}/{format:pdf|epub|mobi}")
+public interface BookStoreClientRoot {
     @POST
-    @Path("/echoxmlbookregex/{id : [5-9]{3,4}}")
-    @Consumes("application/xml")
-    @Produces("application/xml")
-    Book echoXmlBookregex(Book book, @PathParam("id") String id);
-    
-    @POST
-    @Path("/echoxmlbookregex/{id : [5-9]{3,4}}/{language:en|fr}/{format:pdf|epub|mobi}/many")
+    @Path("/many")
     @Consumes("application/xml")
     @Produces("application/xml")
     Book echoXmlBookregexMany(Book book, @PathParam("id") String id, 

--- a/systests/microprofile/client/jaxrs/src/test/java/org/apache/cxf/systest/microprofile/rest/client/regex/JaxrsPathRegexTest.java
+++ b/systests/microprofile/client/jaxrs/src/test/java/org/apache/cxf/systest/microprofile/rest/client/regex/JaxrsPathRegexTest.java
@@ -114,5 +114,42 @@ public class JaxrsPathRegexTest extends AbstractClientServerTestBase {
         echoedBook = bookStoreClient.echoXmlBookregex(book, "8667");
         assertEquals(id, echoedBook.getId());
     }
+    
+    @Test
+    public void testPathRegularExpressionMany() throws Exception {
+
+        String endpointAddress = "http://localhost:" + PORT + "/";
+        long id = 5678;
+        Book book = new Book();
+        book.setId(id);
+
+        // Successful
+        BookStoreClientRoot bookStoreClient = RestClientBuilder.newBuilder()
+            .baseUri(URI.create(endpointAddress))
+            .build(BookStoreClientRoot.class);
+
+        Book echoedBook = bookStoreClient.echoXmlBookregexMany(book, String.valueOf(id), "en", "pdf");
+        assertEquals(id, echoedBook.getId());
+
+        // Wrong language
+        try {
+            bookStoreClient.echoXmlBookregexMany(book, String.valueOf(id), "ru", "pdf");
+            fail("Failure expected on a failing regex");
+        } catch (IllegalArgumentException ex) {
+            // expected
+        }
+
+        // Wrong format
+        try {
+            bookStoreClient.echoXmlBookregexMany(book, String.valueOf(id), "en", "doc");
+            fail("Failure expected on a failing regex");
+        } catch (IllegalArgumentException ex) {
+            // expected
+        }
+
+        // Finally try another successful call
+        echoedBook = bookStoreClient.echoXmlBookregexMany(book, "8667", "fr", "epub");
+        assertEquals(id, echoedBook.getId());
+    }
 
 }


### PR DESCRIPTION
The usage of varargs made unwanted parameters treated as variables