### PR TITLE
Update RxJava3 to 3.1.0

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -187,7 +187,7 @@
         <cxf.rhino.version>1.7.13</cxf.rhino.version>
         <cxf.rxjava.version>1.3.8</cxf.rxjava.version>
         <cxf.rxjava2.version>2.2.21</cxf.rxjava2.version>
-        <cxf.rxjava3.version>3.0.13</cxf.rxjava3.version>
+        <cxf.rxjava3.version>3.1.0</cxf.rxjava3.version>
         <cxf.saaj-impl.version>1.5.3</cxf.saaj-impl.version>
         <cxf.servlet-api.artifact>jakarta.servlet-api</cxf.servlet-api.artifact>
         <cxf.servlet-api.group>jakarta.servlet</cxf.servlet-api.group>


### PR DESCRIPTION
The 3.0.x patch line won't be developed further.