### PR TITLE
[CXF-8578] Bind bridge methods to operations

### DIFF
--- a/core/src/main/java/org/apache/cxf/common/util/ReflectionUtil.java
+++ b/core/src/main/java/org/apache/cxf/common/util/ReflectionUtil.java
@@ -32,7 +32,11 @@ import java.security.PrivilegedAction;
 import java.security.PrivilegedActionException;
 import java.security.PrivilegedExceptionAction;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 import org.apache.cxf.common.classloader.ClassLoaderUtils;
 
@@ -286,4 +290,29 @@ public final class ReflectionUtil {
         }
         return null;
     }
+
+    /**
+     * Find all bridge methods corresponding to the real method {@param m}.
+     * @param m A real method.
+     * @return The bridge methods as a Collection.
+     */
+    public static Collection<Method> findBridges(Method m) {
+        Set<Method> bridges = new HashSet<>();
+
+        if (m.isBridge() || m.isSynthetic()) {
+            return bridges;
+        }
+
+        Class<?> c = m.getDeclaringClass();
+        for (Method candidate : c.getMethods()) {
+            if (candidate.isBridge()
+                && candidate.getName().equals(m.getName())
+                && Arrays.equals(candidate.getParameterTypes(), m.getParameterTypes())) {
+                bridges.add(candidate);
+            }
+        }
+
+        return bridges;
+    }
+
 }

--- a/core/src/test/java/org/apache/cxf/common/util/ReflectionUtilTest.java
+++ b/core/src/test/java/org/apache/cxf/common/util/ReflectionUtilTest.java
@@ -1,0 +1,81 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.cxf.common.util;
+
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+public class ReflectionUtilTest {
+
+    private static class MultiBridgeExample {
+        public MultiBridgeExample returnThis() {
+            return this;
+        }
+    }
+
+    private static class MultiBridgeExample2 extends MultiBridgeExample {
+        public MultiBridgeExample2 returnThis() {
+            return this;
+        }
+    }
+
+    private static class MultiBridgeExample3 extends MultiBridgeExample2 {
+        public MultiBridgeExample3 returnThis() {
+            return this;
+        }
+
+        // Also has two bridge methods.
+    }
+
+    @Test
+    public void testFindBridges() {
+        MultiBridgeExample3 example = new MultiBridgeExample3();
+
+        Method real = null;
+        List<Method> bridges = new ArrayList<>(2);
+
+        for (Method m : example.getClass().getDeclaredMethods()) {
+            if (m.isBridge()) {
+                bridges.add(m);
+            } else {
+                assertNull(real);
+                real = m;
+            }
+        }
+
+        assertEquals(2, bridges.size());
+        assertNotNull(real);
+
+        Collection<Method> bridgesOfReal = ReflectionUtil.findBridges(real);
+        Collection<Method> bridgesOfBridge = ReflectionUtil.findBridges(bridges.get(0));
+
+        assertEquals(bridges, new ArrayList<>(bridgesOfReal));
+        assertTrue(bridgesOfBridge.isEmpty());
+
+    }
+}

--- a/distribution/src/main/appended-resources/META-INF/NOTICE
+++ b/distribution/src/main/appended-resources/META-INF/NOTICE
@@ -58,3 +58,5 @@ This product includes code from the Nimbus JOSE + JWT project, under the Apache
 license 2.0 (https://github.com/felx/nimbus-jose-jwt). Copyright 2012-2017,
 Connect2id Ltd.
 
+Portions of this software were developed at
+Cloudera, Inc (https://www.cloudera.com/).


### PR DESCRIPTION
For each real method bound to an operation, add the corresponding bridge
methods of the class as secondary bindings. This gives them a
method-to-operation mapping each, enabling them to be used in client
proxies. On the other hand, only the real method gets an
operation-to-method mapping, which avoids re-introducing CXF-7670.