### PR TITLE
CXF-8578: Bridge methods for covariant return types cannot be invoked on client proxies

### DIFF
--- a/rt/frontend/jaxrs/src/test/java/org/apache/cxf/jaxrs/utils/ResourceUtilsTest.java
+++ b/rt/frontend/jaxrs/src/test/java/org/apache/cxf/jaxrs/utils/ResourceUtilsTest.java
@@ -21,6 +21,7 @@ package org.apache.cxf.jaxrs.utils;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Method;
 import java.lang.reflect.Type;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -48,12 +49,14 @@ import org.apache.cxf.jaxrs.model.UserResource;
 import org.apache.cxf.jaxrs.resources.Book;
 import org.apache.cxf.jaxrs.resources.BookInterface;
 import org.apache.cxf.jaxrs.resources.Chapter;
+import org.apache.cxf.jaxrs.resources.SuperBook;
 
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 public class ResourceUtilsTest {
@@ -166,6 +169,76 @@ public class ResourceUtilsTest {
         OperationResourceInfo ori = cri.getMethodDispatcher().getOperationResourceInfo(m);
         assertNotNull(ori);
         assertEquals("GET", ori.getHttpMethod());
+    }
+    
+    @Test
+    public void testClassResourceInfoWithBridgeMethod() throws Exception {
+        ClassResourceInfo cri =
+            ResourceUtils.createClassResourceInfo(ExampleBridgeImpl.class, ExampleBridgeImpl.class, true, true);
+        assertNotNull(cri);
+        assertEquals(1, cri.getMethodDispatcher().getOperationResourceInfos().size());
+        
+        Method m = ExampleBridgeImpl.class.getMethod("get");
+        OperationResourceInfo ori = cri.getMethodDispatcher().getOperationResourceInfo(m);
+        assertNotNull(ori);
+        assertEquals("GET", ori.getHttpMethod());
+        
+        m = Arrays
+            .stream(ExampleBridgeImpl.class.getMethods())
+            .filter(method -> method.getName().equals("get"))
+            .filter(Method::isBridge)
+            .findAny()
+            .orElse(null);
+        
+        ori = cri.getMethodDispatcher().getOperationResourceInfo(m);
+        assertNotNull(ori);
+        assertEquals("GET", ori.getHttpMethod());
+    }
+    
+    @Test
+    public void testGenericClassResourceInfoWithBridgeMethod() throws Exception {
+        ClassResourceInfo cri = ResourceUtils.createClassResourceInfo(GenericExampleBridgeImpl.class, 
+            GenericExampleBridgeImpl.class, true, true);
+        assertNotNull(cri);
+        assertEquals(1, cri.getMethodDispatcher().getOperationResourceInfos().size());
+        
+        Method m = GenericExampleBridgeImpl.class.getMethod("get");
+        OperationResourceInfo ori = cri.getMethodDispatcher().getOperationResourceInfo(m);
+        assertNotNull(ori);
+        assertEquals("GET", ori.getHttpMethod());
+        
+        m = Arrays
+            .stream(GenericExampleBridgeImpl.class.getMethods())
+            .filter(method -> method.getName().equals("get"))
+            .filter(Method::isBridge)
+            .findAny()
+            .orElse(null);
+        
+        ori = cri.getMethodDispatcher().getOperationResourceInfo(m);
+        assertNotNull(ori);
+        assertEquals("GET", ori.getHttpMethod());
+    }
+    
+    @Test
+    public void testGenericClassResourceInfo() throws Exception {
+        ClassResourceInfo cri = ResourceUtils.createClassResourceInfo(GenericExampleImpl.class, 
+                GenericExampleImpl.class, true, true);
+        assertNotNull(cri);
+        assertEquals(1, cri.getMethodDispatcher().getOperationResourceInfos().size());
+        
+        Method m = GenericExampleImpl.class.getMethod("get");
+        OperationResourceInfo ori = cri.getMethodDispatcher().getOperationResourceInfo(m);
+        assertNotNull(ori);
+        assertEquals("GET", ori.getHttpMethod());
+        
+        m = Arrays
+            .stream(GenericExampleImpl.class.getMethods())
+            .filter(method -> method.getName().equals("get"))
+            .filter(Method::isBridge)
+            .findAny()
+            .orElse(null);
+        
+        assertNull(m);
     }
 
     @Path("/synth-hello")
@@ -301,11 +374,42 @@ public class ResourceUtilsTest {
         @GET
         Book get();
     }
+    
+    @Path("example")
+    public interface GenericExample<T extends Book> {
+
+        @GET
+        T get();
+    }
 
     public static class ExampleImpl implements Example {
 
         @Override
         public Book get() {
+            return null;
+        }
+    }
+    
+    public static class ExampleBridgeImpl implements Example {
+
+        @Override
+        public SuperBook get() {
+            return null;
+        }
+    }
+    
+    public static class GenericExampleImpl implements GenericExample<Book> {
+
+        @Override
+        public Book get() {
+            return null;
+        }
+    }
+    
+    public static class GenericExampleBridgeImpl implements GenericExample<Book> {
+
+        @Override
+        public SuperBook get() {
             return null;
         }
     }

--- a/rt/rs/client/src/test/java/org/apache/cxf/jaxrs/client/JAXRSClientFactoryBeanTest.java
+++ b/rt/rs/client/src/test/java/org/apache/cxf/jaxrs/client/JAXRSClientFactoryBeanTest.java
@@ -44,6 +44,9 @@ import org.apache.cxf.jaxrs.resources.Book;
 import org.apache.cxf.jaxrs.resources.BookInterface;
 import org.apache.cxf.jaxrs.resources.BookStore;
 import org.apache.cxf.jaxrs.resources.BookStoreSubresourcesOnly;
+import org.apache.cxf.jaxrs.resources.BookSuperClass;
+import org.apache.cxf.jaxrs.resources.SuperBook;
+import org.apache.cxf.jaxrs.resources.SuperBookStore;
 import org.apache.cxf.message.Message;
 import org.apache.cxf.phase.AbstractPhaseInterceptor;
 import org.apache.cxf.phase.Phase;
@@ -202,6 +205,19 @@ public class JAXRSClientFactoryBeanTest {
         assertNotNull(parts);
         IProductResource productResourceElement = parts.elementAt("1");
         assertNotNull(productResourceElement);
+    }
+    
+    @Test
+    public void testBookAndBridgeMethods() throws Exception {
+        SuperBookStore superBookResource = JAXRSClientFactory.create("http://localhost:9000",
+                SuperBookStore.class);
+        assertNotNull(superBookResource);
+        
+        Book book = ((BookSuperClass)superBookResource).getNewBook("id4", true);
+        assertNotNull(book);
+        
+        SuperBook superBook = (SuperBook)superBookResource.getNewBook("id4", true);
+        assertNotNull(superBook);
     }
 
     @Test

--- a/rt/rs/client/src/test/java/org/apache/cxf/jaxrs/resources/SuperBook.java
+++ b/rt/rs/client/src/test/java/org/apache/cxf/jaxrs/resources/SuperBook.java
@@ -1,0 +1,44 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.cxf.jaxrs.resources;
+
+import javax.xml.bind.annotation.XmlRootElement;
+
+
+@XmlRootElement(name = "SuperBook")
+public class SuperBook extends Book {
+    private long superId;
+    public SuperBook() {
+    }
+
+    public SuperBook(String name, long id, long superId) {
+        super(name, id);
+        this.superId = superId;
+    }
+
+    public void setSuperId(long i) {
+        superId = i;
+    }
+
+    public long getSuperId() {
+        return superId;
+    }
+
+}

--- a/rt/rs/client/src/test/java/org/apache/cxf/jaxrs/resources/SuperBookStore.java
+++ b/rt/rs/client/src/test/java/org/apache/cxf/jaxrs/resources/SuperBookStore.java
@@ -1,0 +1,74 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+
+package org.apache.cxf.jaxrs.resources;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.DELETE;
+import javax.ws.rs.POST;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+@Path("/bookstore/")
+public class SuperBookStore extends BookSuperClass implements BookInterface {
+    public SuperBookStore() {
+    }
+
+    public SuperBook getBook(String id) {
+        return null;
+    }
+
+    @Override
+    public SuperBook getNewBook(String id, Boolean isNew) {
+        return null;
+    }
+
+    @POST
+    @Path("/books")
+    @Consumes(MediaType.APPLICATION_XML)
+    public void addBook(Book book) {
+    }
+
+    @PUT
+    @Path("/books/")
+    public Response updateBook(SuperBook book) {
+        return null;
+    }
+
+    @DELETE
+    @Path("/books/{bookId}/")
+    public Response deleteBook(@PathParam("bookId") String id) {
+        return null;
+    }
+
+    @Override
+    public String getDescription() {
+        return null;
+    }
+
+    public String getAuthor() {
+        return null;
+    }
+}
+
+


### PR DESCRIPTION
Bridge methods for covariant return types cannot be invoked on client proxies