### PR TITLE
CXF-8588: Micrometer operation UNKNOWN for clients

### DIFF
--- a/rt/features/metrics/src/main/java/org/apache/cxf/metrics/micrometer/provider/jaxrs/JaxrsTags.java
+++ b/rt/features/metrics/src/main/java/org/apache/cxf/metrics/micrometer/provider/jaxrs/JaxrsTags.java
@@ -39,6 +39,15 @@ public class JaxrsTags {
             .flatMap(MessageUtils::getTargetMethod)
             .map(Method::getName)
             .map(operation -> Tag.of("operation", operation))
+            .orElseGet(() -> method(request));
+    }
+    
+    public Tag method(Message request) {
+        return ofNullable(request)
+            .map(Message::getExchange)
+            .map(ex -> ex.get(Method.class))
+            .map(Method::getName)
+            .map(operation -> Tag.of("operation", operation))
             .orElse(OPERATION_UNKNOWN);
     }
 }

--- a/systests/spring-boot/src/test/java/org/apache/cxf/systest/jaxrs/spring/boot/SpringJaxrsApplicationTest.java
+++ b/systests/spring-boot/src/test/java/org/apache/cxf/systest/jaxrs/spring/boot/SpringJaxrsApplicationTest.java
@@ -337,7 +337,7 @@ public class SpringJaxrsApplicationTest {
             .containsOnly(
                 entry("exception", "None"),
                 entry("method", "GET"),
-                entry("operation", "UNKNOWN"),
+                entry("operation", "getBooks"),
                 entry("uri", "http://localhost:" + port + "/api/app/library"),
                 entry("outcome", "SUCCESS"),
                 entry("status", "200"));
@@ -378,7 +378,7 @@ public class SpringJaxrsApplicationTest {
             .containsOnly(
                 entry("exception", "None"),
                 entry("method", "DELETE"),
-                entry("operation", "UNKNOWN"),
+                entry("operation", "deleteBooks"),
                 entry("uri", "http://localhost:" + port + "/api/app/library"),
                 entry("outcome", "SERVER_ERROR"),
                 entry("status", "500"));
@@ -419,7 +419,7 @@ public class SpringJaxrsApplicationTest {
             .containsOnly(
                 entry("exception", "None"),
                 entry("method", "GET"),
-                entry("operation", "UNKNOWN"),
+                entry("operation", "getBook"),
                 entry("uri", "http://localhost:" + port + "/api/app/library/100"),
                 entry("outcome", "CLIENT_ERROR"),
                 entry("status", "404"));
@@ -447,7 +447,7 @@ public class SpringJaxrsApplicationTest {
             .containsOnly(
                 entry("exception", "None"),
                 entry("method", "DELETE"),
-                entry("operation", "UNKNOWN"),
+                entry("operation", "deleteBooks"),
                 entry("uri", "http://localhost:" + fakePort + "/api/app/library"),
                 entry("outcome", "UNKNOWN"),
                 entry("status", "UNKNOWN"));

--- a/systests/spring-boot/src/test/java/org/apache/cxf/systest/jaxrs/spring/boot/SpringJaxrsTest.java
+++ b/systests/spring-boot/src/test/java/org/apache/cxf/systest/jaxrs/spring/boot/SpringJaxrsTest.java
@@ -297,7 +297,7 @@ public class SpringJaxrsTest {
             .containsOnly(
                 entry("exception", "None"),
                 entry("method", "GET"),
-                entry("operation", "UNKNOWN"),
+                entry("operation", "getBooks"),
                 entry("uri", "http://localhost:" + port + "/api/library"),
                 entry("outcome", "SUCCESS"),
                 entry("status", "200"));
@@ -338,7 +338,7 @@ public class SpringJaxrsTest {
             .containsOnly(
                 entry("exception", "None"),
                 entry("method", "DELETE"),
-                entry("operation", "UNKNOWN"),
+                entry("operation", "deleteBooks"),
                 entry("uri", "http://localhost:" + port + "/api/library"),
                 entry("outcome", "SERVER_ERROR"),
                 entry("status", "500"));
@@ -379,7 +379,7 @@ public class SpringJaxrsTest {
             .containsOnly(
                 entry("exception", "None"),
                 entry("method", "GET"),
-                entry("operation", "UNKNOWN"),
+                entry("operation", "getBook"),
                 entry("uri", "http://localhost:" + port + "/api/library/100"),
                 entry("outcome", "CLIENT_ERROR"),
                 entry("status", "404"));
@@ -407,7 +407,7 @@ public class SpringJaxrsTest {
             .containsOnly(
                 entry("exception", "None"),
                 entry("method", "DELETE"),
-                entry("operation", "UNKNOWN"),
+                entry("operation", "deleteBooks"),
                 entry("uri", "http://localhost:" + fakePort + "/api/library"),
                 entry("outcome", "UNKNOWN"),
                 entry("status", "UNKNOWN"));


### PR DESCRIPTION
The method for the client proxy is stored in exchange and could be picked from there.