### PR TITLE
CXF-8593: Error when installing CXF OpenAPI v3 under Karaf 4.2.11

### DIFF
--- a/osgi/bundle/pom.xml
+++ b/osgi/bundle/pom.xml
@@ -32,5 +32,6 @@
     </parent>
     <modules>
         <module>compatible</module>
+        <module>servlet-compatible</module>
     </modules>
 </project>

--- a/osgi/bundle/servlet-compatible/pom.xml
+++ b/osgi/bundle/servlet-compatible/pom.xml
@@ -1,0 +1,66 @@
+<?xml version="1.0"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements. See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership. The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License. You may obtain a copy of the License at
+ 
+  http://www.apache.org/licenses/LICENSE-2.0
+ 
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied. See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <artifactId>cxf-servlet-compatible</artifactId>
+    <packaging>bundle</packaging>
+    <name>Apache CXF Servlet Compatibility Bundle Jar</name>
+    <description>Apache CXF Servlet Compatibility Bundle Jar</description>
+    <url>https://cxf.apache.org</url>
+    <parent>
+        <groupId>org.apache.cxf</groupId>
+        <artifactId>cxf-bundle-parent</artifactId>
+        <version>3.4.5-SNAPSHOT</version>
+    </parent>
+    
+    <properties>
+        <cxf.osgi.symbolic.name>${project.groupId}.bundle.servlet</cxf.osgi.symbolic.name>
+        <cxf.module.name>org.apache.cxf.bundle.servlet</cxf.module.name>
+    </properties>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <extensions>true</extensions>
+                <configuration>
+                    <instructions>
+                        <Bundle-SymbolicName>${cxf.osgi.symbolic.name}</Bundle-SymbolicName>
+                        <Implementation-Title>Apache CXF Servlet Compatibility Bundle</Implementation-Title>
+                        <Implementation-Vendor>The Apache Software Foundation</Implementation-Vendor>
+                        <Implementation-Vendor-Id>org.apache</Implementation-Vendor-Id>
+                        <Implementation-Version>${cxf.osgi.version.clean}</Implementation-Version>
+                        <Specification-Title>Apache CXF Servlet Compatibility Bundle</Specification-Title>
+                        <Specification-Vendor>The Apache Software Foundation</Specification-Vendor>
+                        <Specification-Version>${cxf.osgi.version.clean}</Specification-Version>
+                        <Fragment-Host>javax.servlet-api</Fragment-Host>
+                        <Export-Package>
+                            javax.servlet;uses:="javax.servlet.annotation,javax.servlet.descriptor";version=4.0.0,
+                            javax.servlet.annotation;uses:=javax.servlet;version=4.0.0,
+                            javax.servlet.http;uses:=javax.servlet;version=4.0.0,
+                            javax.servlet.descriptor;version=4.0.0
+                        </Export-Package>
+                    </instructions>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/osgi/karaf/features/pom.xml
+++ b/osgi/karaf/features/pom.xml
@@ -102,6 +102,11 @@
             <artifactId>cxf-rt-ws-security</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.apache.cxf</groupId>
+            <artifactId>cxf-servlet-compatible</artifactId>
+            <version>${project.version}</version>
+        </dependency>
     </dependencies>
     <build>
         <resources>
@@ -158,6 +163,7 @@
                             <goal>verify</goal>
                         </goals>
                         <configuration>
+                            <featureProcessingInstructions>${project.build.directory}/classes/org.apache.karaf.features.xml</featureProcessingInstructions>
                             <descriptors>
                                 <descriptor>mvn:org.apache.karaf.features/framework/${cxf.karaf.version}/xml/features</descriptor>
                                 <descriptor>mvn:org.apache.karaf.features/standard/${cxf.karaf.version}/xml/features</descriptor>

--- a/osgi/karaf/features/src/main/resources/org.apache.karaf.features.xml
+++ b/osgi/karaf/features/src/main/resources/org.apache.karaf.features.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements. See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership. The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License. You may obtain a copy of the License at
+ 
+  http://www.apache.org/licenses/LICENSE-2.0
+ 
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied. See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+<featuresProcessing xmlns="http://karaf.apache.org/xmlns/features-processing/v1.0.0" xmlns:f="http://karaf.apache.org/xmlns/features/v1.6.0">
+   <featureReplacements>
+        <replacement mode="merge">
+            <feature name="pax-http-undertow" version="7.2.23">
+                <f:bundle start-level="35">mvn:org.apache.cxf/cxf-servlet-compatible/${project.version}</f:bundle>
+            </feature>
+            <feature name="pax-http-jetty" version="7.2.23">
+                <f:bundle start-level="35">mvn:org.apache.cxf/cxf-servlet-compatible/${project.version}</f:bundle>
+            </feature>
+        </replacement>
+    </featureReplacements>
+</featuresProcessing>


### PR DESCRIPTION
Thanks to @ffang for identifying the root cause: the root cause of this error is that in the container two `javax.servlet` versions are required.