### PR TITLE
CXF-7543: JAX-RS Features not used in proxies or WebClients

### DIFF
--- a/rt/rs/client/src/test/java/org/apache/cxf/jaxrs/client/cache/ClientCacheTest.java
+++ b/rt/rs/client/src/test/java/org/apache/cxf/jaxrs/client/cache/ClientCacheTest.java
@@ -89,6 +89,29 @@ public class ClientCacheTest {
     }
 
     @Test
+    public void testGetTimeStringUsingClientFactory() {
+        CacheControlFeature feature = new CacheControlFeature();
+        try {
+            JAXRSClientFactoryBean bean = new JAXRSClientFactoryBean();
+            bean.setAddress(ADDRESS);
+            bean.setProviders(Collections.singletonList(feature));
+            bean.setTransportId(LocalTransportFactory.TRANSPORT_ID);
+            
+            final WebClient cached = bean.createWebClient()
+                .accept("text/plain")
+                .header(HttpHeaders.CACHE_CONTROL, "public");
+            
+            final Response r = cached.get();
+            assertEquals(Response.Status.OK.getStatusCode(), r.getStatus());
+            final String r1 = r.readEntity(String.class);
+            waitABit();
+            assertEquals(r1, cached.get().readEntity(String.class));
+        } finally {
+            feature.close();
+        }
+    }
+
+    @Test
     public void testGetTimeStringAsInputStream() throws Exception {
         CacheControlFeature feature = new CacheControlFeature();
         try {

--- a/rt/rs/client/src/test/java/org/apache/cxf/jaxrs/client/spring/JAXRSClientFactoryBeanTest.java
+++ b/rt/rs/client/src/test/java/org/apache/cxf/jaxrs/client/spring/JAXRSClientFactoryBeanTest.java
@@ -18,20 +18,28 @@
  */
 package org.apache.cxf.jaxrs.client.spring;
 
+import java.util.List;
+
+import javax.ws.rs.core.Feature;
+import javax.ws.rs.core.FeatureContext;
 import javax.xml.namespace.QName;
 
 import org.apache.cxf.BusFactory;
 import org.apache.cxf.jaxrs.client.Client;
 import org.apache.cxf.jaxrs.client.JAXRSClientFactoryBean;
+import org.apache.cxf.jaxrs.client.cache.CacheControlClientReaderInterceptor;
 import org.springframework.context.support.ClassPathXmlApplicationContext;
 
 import org.junit.After;
 import org.junit.Test;
 
 import static org.hamcrest.CoreMatchers.endsWith;
+import static org.hamcrest.CoreMatchers.hasItem;
+import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
+
 
 
 public class JAXRSClientFactoryBeanTest {
@@ -108,6 +116,32 @@ public class JAXRSClientFactoryBeanTest {
             assertNotNull(bean);
             assertThat(bean.query("list", "1").query("list", "2").getCurrentURI().toString(),
                 endsWith("?list=1&list=2"));
+        }
+    }
+    
+    @Test
+    public void testClientWithFeatures() throws Exception {
+        try (ClassPathXmlApplicationContext ctx =
+                new ClassPathXmlApplicationContext(new String[] {"/org/apache/cxf/jaxrs/client/spring/clients.xml"})) {
+            final Client bean = (Client) ctx.getBean("client4");
+            assertNotNull(bean);
+            
+            final JAXRSClientFactoryBean cfb = (JAXRSClientFactoryBean)ctx.getBean("client4.proxyFactory");
+            assertNotNull(bean);
+            
+            assertThat((List<Object>)cfb.getProviders(), 
+                hasItem(instanceOf(CacheControlClientReaderInterceptor.class)));
+            
+            assertThat((List<Object>)cfb.getProviders(), 
+                hasItem(instanceOf(SpringParameterHandler.class)));
+        }
+    }
+    
+    public static class SomeFeature implements Feature {
+        @Override
+        public boolean configure(FeatureContext context) {
+            context.register(SpringParameterHandler.class);
+            return true;
         }
     }
 }

--- a/rt/rs/client/src/test/java/org/apache/cxf/jaxrs/client/spring/SpringParameterHandler.java
+++ b/rt/rs/client/src/test/java/org/apache/cxf/jaxrs/client/spring/SpringParameterHandler.java
@@ -1,0 +1,58 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.cxf.jaxrs.client.spring;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+import java.util.Objects;
+
+import javax.ws.rs.ext.ParamConverter;
+import javax.ws.rs.ext.ParamConverterProvider;
+
+import org.apache.cxf.jaxrs.client.Customer;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationContext;
+
+public class SpringParameterHandler implements ParamConverterProvider, ParamConverter<Customer> {
+    @Autowired
+    public SpringParameterHandler(ApplicationContext context) {
+        Objects.requireNonNull(context);
+    }
+    
+    @SuppressWarnings("unchecked")
+    @Override
+    public <T> ParamConverter<T> getConverter(Class<T> cls, Type arg1, Annotation[] arg2) {
+        if (Customer.class == cls) {
+            return (ParamConverter<T>)this;
+        }
+        return null;
+    }
+
+    public Customer fromString(String s) throws IllegalArgumentException {
+        Customer c = new Customer();
+        c.setName(s);
+        return c;
+    }
+
+    @Override
+    public String toString(Customer arg0) throws IllegalArgumentException {
+        return null;
+    }
+}

--- a/rt/rs/client/src/test/java/org/apache/cxf/jaxrs/client/spring/clients.xml
+++ b/rt/rs/client/src/test/java/org/apache/cxf/jaxrs/client/spring/clients.xml
@@ -59,4 +59,10 @@
             <entry key="expand.query.value.as.collection" value="true" />
         </jaxrs:properties>
     </jaxrs:client>
+    <jaxrs:client id="client4" serviceClass="org.apache.cxf.jaxrs.resources.BookStore" address="http://localhost:9000/foo" threadSafe="true">
+        <jaxrs:providers>
+            <bean class="org.apache.cxf.jaxrs.client.cache.CacheControlFeature"/>
+            <bean class="org.apache.cxf.jaxrs.client.spring.JAXRSClientFactoryBeanTest.SomeFeature"/>
+        </jaxrs:providers>
+    </jaxrs:client>
 </beans>

--- a/rt/rs/microprofile-client/src/test/java/org/apache/cxf/microprofile/client/CxfTypeSafeClientBuilderTest.java
+++ b/rt/rs/microprofile-client/src/test/java/org/apache/cxf/microprofile/client/CxfTypeSafeClientBuilderTest.java
@@ -24,6 +24,8 @@ import java.net.URL;
 
 import javax.ws.rs.PathParam;
 import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.Feature;
+import javax.ws.rs.core.FeatureContext;
 import javax.ws.rs.core.Response;
 
 import org.apache.cxf.jaxrs.client.WebClientUtil;
@@ -115,6 +117,30 @@ public class CxfTypeSafeClientBuilderTest {
         // so that interceptor won't be called in this test.
         // TODO: add a test for writer interceptors - possibly in systests
         //assertEquals(TestWriterInterceptor.getAndResetValue(), 1);
+    }
+    
+    @Test
+    public void testInvokesPostOperationWithRegisteredFeature() throws Exception {
+        String inputBody = "input body will be removed";
+        String expectedResponseBody = TestMessageBodyReader.REPLACED_BODY;
+
+        InterfaceWithoutProvidersDefined api = new CxfTypeSafeClientBuilder()
+                .register(SomeFeature.class)
+                .property("microprofile.rest.client.disable.default.mapper", true)
+                .baseUrl(new URL("http://localhost/null"))
+                .build(InterfaceWithoutProvidersDefined.class);
+
+        Response response = api.executePost(inputBody);
+
+        String body = response.readEntity(String.class);
+
+        response.close();
+
+        assertEquals(expectedResponseBody, body);
+
+        assertEquals(TestClientResponseFilter.getAndResetValue(), 1);
+        assertEquals(TestClientRequestFilter.getAndResetValue(), 1);
+        assertEquals(TestReaderInterceptor.getAndResetValue(), 1);
     }
 
     @Test(expected = NoSuchEntityException.class)
@@ -222,5 +248,21 @@ public class CxfTypeSafeClientBuilderTest {
     @Test(expected = IllegalArgumentException.class)
     public void testProxyAddressNullHost() {
         RestClientBuilder.newBuilder().proxyAddress(null, 8080);
+    }
+    
+    public static class SomeFeature implements Feature {
+        @Override
+        public boolean configure(FeatureContext context) {
+            context
+                .register(TestClientRequestFilter.class)
+                .register(TestClientResponseFilter.class)
+                .register(TestMessageBodyReader.class, 4999)
+                .register(TestMessageBodyWriter.class)
+                .register(TestParamConverterProvider.class)
+                .register(TestReaderInterceptor.class)
+                .register(TestWriterInterceptor.class)
+                .register(EchoClientReqFilter.class);
+            return true;
+        }
     }
 }

--- a/rt/rs/microprofile-client/src/test/java/org/apache/cxf/microprofile/client/MicroProfileClientFactoryBeanTest.java
+++ b/rt/rs/microprofile-client/src/test/java/org/apache/cxf/microprofile/client/MicroProfileClientFactoryBeanTest.java
@@ -1,0 +1,94 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.cxf.microprofile.client;
+
+import java.util.List;
+
+import javax.ws.rs.core.Feature;
+import javax.ws.rs.core.FeatureContext;
+
+import org.apache.cxf.jaxrs.client.spec.TLSConfiguration;
+import org.apache.cxf.microprofile.client.mock.MyClient;
+import org.eclipse.microprofile.rest.client.RestClientBuilder;
+import org.eclipse.microprofile.rest.client.tck.providers.TestClientRequestFilter;
+
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.hasItem;
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+
+public class MicroProfileClientFactoryBeanTest {
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testCreateClientEnabledFeature() throws Exception {
+        final MicroProfileClientConfigurableImpl<RestClientBuilder> configurable = 
+                new MicroProfileClientConfigurableImpl<>(RestClientBuilder.newBuilder());
+
+        final MicroProfileClientFactoryBean bean = new MicroProfileClientFactoryBean(configurable, 
+                "http://bar", MyClient.class, null, new TLSConfiguration());
+        
+        final SomeFeature feature = new SomeFeature(true);
+        bean.setProvider(feature);
+
+        assertTrue(bean.create() instanceof MyClient);
+        assertTrue(configurable.getConfiguration().isRegistered(SomeFeature.class));
+        assertTrue(configurable.getConfiguration().isRegistered(TestClientRequestFilter.class));
+        assertTrue(configurable.getConfiguration().isEnabled(SomeFeature.class));
+        
+        assertThat((List<Object>)bean.getProviders(), hasItem(instanceOf(TestClientRequestFilter.class)));
+    }
+    
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testCreateClientDisabledFeature() throws Exception {
+        final MicroProfileClientConfigurableImpl<RestClientBuilder> configurable = 
+                new MicroProfileClientConfigurableImpl<>(RestClientBuilder.newBuilder());
+
+        final MicroProfileClientFactoryBean bean = new MicroProfileClientFactoryBean(configurable, 
+                "http://bar", MyClient.class, null, new TLSConfiguration());
+        
+        final SomeFeature feature = new SomeFeature(false);
+        bean.setProvider(feature);
+
+        assertTrue(bean.create() instanceof MyClient);
+        assertTrue(configurable.getConfiguration().isRegistered(SomeFeature.class));
+        assertTrue(configurable.getConfiguration().isRegistered(TestClientRequestFilter.class));
+        assertFalse(configurable.getConfiguration().isEnabled(SomeFeature.class));
+        
+        assertThat((List<Object>)bean.getProviders(), hasItem(instanceOf(TestClientRequestFilter.class)));
+    }
+    
+    public static class SomeFeature implements Feature {
+        private final boolean enabled;
+        
+        public SomeFeature(boolean enabled) {
+            this.enabled = enabled;
+        }
+        
+        @Override
+        public boolean configure(FeatureContext context) {
+            context.register(TestClientRequestFilter.class);
+            return enabled;
+        }
+    }
+}


### PR DESCRIPTION
The `JAXRSClientFactoryBean` does not support JAX-RS features, as such if the feature registers additional providers, then those providers are never considered for use on the proxy or `WebClient` instance created.  