### PR TITLE
CXF-8597: CXF JAXRS client not closing HTTP connections

### DIFF
--- a/systests/jaxrs/src/test/java/org/apache/cxf/systest/jaxrs/ClientHttpConnectionOutInterceptor.java
+++ b/systests/jaxrs/src/test/java/org/apache/cxf/systest/jaxrs/ClientHttpConnectionOutInterceptor.java
@@ -1,0 +1,71 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.cxf.systest.jaxrs;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.HttpURLConnection;
+import java.util.ArrayList;
+import java.util.Collection;
+
+import org.apache.cxf.interceptor.Fault;
+import org.apache.cxf.message.Message;
+import org.apache.cxf.phase.AbstractPhaseInterceptor;
+import org.apache.cxf.phase.Phase;
+
+class ClientHttpConnectionOutInterceptor extends AbstractPhaseInterceptor<Message> {
+    private Collection<HttpURLConnection> connections = new ArrayList<>();
+
+    ClientHttpConnectionOutInterceptor() {
+        super(Phase.SEND_ENDING);
+    }
+
+    @Override
+    public void handleMessage(Message message) throws Fault {
+        final HttpURLConnection connection = (HttpURLConnection) message.get("http.connection");
+        synchronized (connections) {
+            connections.add(connection);
+        }
+    }
+
+    public boolean checkAllClosed() {
+        synchronized (connections) {
+            if (connections.isEmpty()) {
+                return false;
+            }
+            
+            return !connections
+                .stream()
+                .anyMatch(this::hasUnclosedInputStream);
+        }
+    }
+    
+    private boolean hasUnclosedInputStream(HttpURLConnection connection) {
+        try {
+            final InputStream inputStream = connection.getInputStream();
+            inputStream.read(new byte [] {}); /* 0 bytes to read */
+            return true;
+        } catch (IOException ex) {
+            // The HttpInputStream throws an IOException in case the input stream is already
+            // closed (since we actually read nothing).
+            return !ex.getMessage().equals("stream is closed");
+        }
+    }
+}

--- a/systests/jaxrs/src/test/java/org/apache/cxf/systest/jaxrs/JAXRSMultithreadedClientTest.java
+++ b/systests/jaxrs/src/test/java/org/apache/cxf/systest/jaxrs/JAXRSMultithreadedClientTest.java
@@ -33,6 +33,7 @@ import javax.ws.rs.core.Response;
 import org.apache.cxf.helpers.IOUtils;
 import org.apache.cxf.jaxrs.client.Client;
 import org.apache.cxf.jaxrs.client.JAXRSClientFactory;
+import org.apache.cxf.jaxrs.client.JAXRSClientFactoryBean;
 import org.apache.cxf.jaxrs.client.WebClient;
 import org.apache.cxf.testutil.common.AbstractBusClientServerTestBase;
 
@@ -41,7 +42,9 @@ import org.junit.BeforeClass;
 import org.junit.Ignore;
 import org.junit.Test;
 
+import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 public class JAXRSMultithreadedClientTest extends AbstractBusClientServerTestBase {
@@ -101,6 +104,20 @@ public class JAXRSMultithreadedClientTest extends AbstractBusClientServerTestBas
                                                     Collections.emptyList(), true);
 
         runProxies(proxy.echoThroughBookStoreSub(), 10, true, true);
+    }
+    
+    @Test
+    public void testSimpleProxyEnsureResponseStreamIsClosed() throws Exception {
+        final ClientHttpConnectionOutInterceptor interceptor = new ClientHttpConnectionOutInterceptor();
+        final JAXRSClientFactoryBean bean = new JAXRSClientFactoryBean();
+        bean.setAddress("http://localhost:" + PORT);
+        bean.setServiceClass(BookStore.class);
+        bean.getOutInterceptors().add(interceptor);
+        
+        final BookStore proxy = bean.create(BookStore.class);
+        runProxies(proxy, 10, true, false);
+        
+        assertThat(interceptor.checkAllClosed(), is(true));
     }
 
     private void runWebClients(WebClient client, int numberOfClients,


### PR DESCRIPTION
Relates to https://github.com/apache/cxf/pull/697, the entity input stream is indeed not closed after consumption. But according to the specification for `public abstract <T> T readEntity(Class<T> entityType, Annotation[] annotations)`:

> A message instance returned from this method will be cached for subsequent retrievals via getEntity(). Unless the supplied entitytype is an input stream, this method automatically closes the an unconsumed original response entity data stream if open.

- [X] Add Test Case(s) for WebClient
- [X] Add Test Case(s) for JAXRSClientFactoryBean
