### PR TITLE
[CXF-8603]  Add null check to XPathUtils.getValue() to avoid setting null CCL

### DIFF
--- a/core/src/main/java/org/apache/cxf/helpers/XPathUtils.java
+++ b/core/src/main/java/org/apache/cxf/helpers/XPathUtils.java
@@ -69,8 +69,11 @@ public class XPathUtils {
     }
 
     public Object getValue(String xpathExpression, Node node, QName type) {
-        ClassLoaderHolder loader
-            = ClassLoaderUtils.setThreadContextClassloader(getClassLoader(xpath.getClass()));
+        ClassLoader currentLoader = getClassLoader(xpath.getClass());
+        ClassLoaderHolder loader = null;
+        if (currentLoader != null) {
+            loader = ClassLoaderUtils.setThreadContextClassloader(currentLoader);
+        }
         try {
             return xpath.evaluate(xpathExpression, node, type);
         } catch (Exception e) {


### PR DESCRIPTION
Added null check to XPathUtils.getValue() to prevent setting null CCL - similar pattern as used for other instances of ClassLoaderUtils.setThreadContextClassLoader()
Code tested against version CXF 3.1.18