### PR TITLE
Fix not unique JAXRS method candidates WARN caused by CrossOriginResourceSharingFilter 

### DIFF
--- a/rt/rs/security/cors/src/main/java/org/apache/cxf/rs/security/cors/CrossOriginResourceSharingFilter.java
+++ b/rt/rs/security/cors/src/main/java/org/apache/cxf/rs/security/cors/CrossOriginResourceSharingFilter.java
@@ -45,6 +45,7 @@ import javax.ws.rs.core.Response;
 import javax.ws.rs.ext.Provider;
 
 import org.apache.cxf.common.util.ReflectionUtil;
+import org.apache.cxf.helpers.CastUtils;
 import org.apache.cxf.jaxrs.impl.MetadataMap;
 import org.apache.cxf.jaxrs.model.ClassResourceInfo;
 import org.apache.cxf.jaxrs.model.OperationResourceInfo;
@@ -290,8 +291,21 @@ public class CrossOriginResourceSharingFilter implements ContainerRequestFilter,
                                                       String httpMethod,
                                                       MultivaluedMap<String, String> values,
                                                       Message m) {
-        final String contentType = MediaType.WILDCARD;
-        final MediaType acceptType = MediaType.WILDCARD_TYPE;
+        Map<String, List<String>> protocolHeaders = CastUtils.cast((Map<?, ?>)m.get(Message.PROTOCOL_HEADERS));
+        String contentType;
+        List<String> ctHeaderValues = protocolHeaders.get(Message.CONTENT_TYPE);
+        if (ctHeaderValues != null && !ctHeaderValues.isEmpty()) {
+            contentType = ctHeaderValues.get(0);
+        } else {
+            contentType = MediaType.WILDCARD;
+        }
+        String acceptType;
+        List<String> acceptHeaderValues = protocolHeaders.get(Message.ACCEPT_CONTENT_TYPE);
+        if (acceptHeaderValues != null && !acceptHeaderValues.isEmpty()) {
+            acceptType = acceptHeaderValues.get(0);
+        } else {
+            acceptType = MediaType.WILDCARD;
+        }
         OperationResourceInfo ori = JAXRSUtils.findTargetMethod(matchedResources,
                                     m, httpMethod, values,
                                     contentType,


### PR DESCRIPTION
Fix 'JAXRSUtils : Both Resource#method1 and Resource#method2 are equal candidates for handling the current request which can lead to unpredictable results' warning by using real 'Accept' and 'Content-Type' values for operation lookup.