### PR TITLE
CXF-8601: [Regression] jaxrs.ee.rs.core.response tests

### DIFF
--- a/rt/frontend/jaxrs/src/test/java/org/apache/cxf/jaxrs/impl/ResponseImplTest.java
+++ b/rt/frontend/jaxrs/src/test/java/org/apache/cxf/jaxrs/impl/ResponseImplTest.java
@@ -21,6 +21,8 @@ package org.apache.cxf.jaxrs.impl;
 
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
+import java.io.Reader;
+import java.lang.annotation.Annotation;
 import java.net.URI;
 import java.util.List;
 import java.util.Locale;
@@ -71,6 +73,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
 
@@ -598,6 +601,42 @@ public class ResponseImplTest {
         }
     }
 
+    @Test
+    public void testReadEntityAndGetEntityAfter() {
+        final String str = "ouch";
+
+        final ResponseImpl response = new ResponseImpl(500, str);
+        final Message outMessage = createMessage();
+        outMessage.put(Message.REQUEST_URI, "http://localhost");
+        response.setOutMessage(outMessage);
+
+        final MultivaluedMap<String, Object> headers = new MetadataMap<>();
+        headers.putSingle("Content-Type", "text/xml");
+        response.addMetadata(headers);
+
+        assertEquals(str, response.readEntity(String.class));
+        assertThrows(IllegalStateException.class, () -> response.getEntity());
+    }
+    
+    @Test
+    public void testReadEntityWithAnnotations() {
+        final String str = "ouch";
+
+        final ResponseImpl response = new ResponseImpl(500, str);
+        final Message outMessage = createMessage();
+        outMessage.put(Message.REQUEST_URI, "http://localhost");
+        response.setOutMessage(outMessage);
+
+        final MultivaluedMap<String, Object> headers = new MetadataMap<>();
+        headers.putSingle("Content-Type", "text/xml");
+        response.addMetadata(headers);
+
+        final Annotation[] annotations = String.class.getAnnotations();
+        assertEquals(str, response.readEntity(String.class, annotations));
+        assertThrows(IllegalStateException.class, 
+            () -> response.readEntity(Reader.class, annotations));
+    }
+    
     public static class StringBean {
         private String header;
 

--- a/rt/rs/client/src/main/java/org/apache/cxf/jaxrs/client/AbstractClient.java
+++ b/rt/rs/client/src/main/java/org/apache/cxf/jaxrs/client/AbstractClient.java
@@ -554,7 +554,7 @@ public abstract class AbstractClient implements Client {
 
     protected boolean responseStreamCanBeClosed(Message outMessage, Class<?> cls) {
         return !JAXRSUtils.isStreamingOutType(cls)
-            && MessageUtils.getContextualBoolean(outMessage, "response.stream.auto.close");
+            && MessageUtils.getContextualBoolean(outMessage, ResponseImpl.RESPONSE_STREAM_AUTO_CLOSE);
     }
 
     protected void completeExchange(Exchange exchange, boolean proxy) {


### PR DESCRIPTION
By default, the response entity is never closed automatically which is not compliant with JAX-RS specification and TCK. The auto-close behavior is controlled by `ResponseImpl#RESPONSE_STREAM_AUTO_CLOSE` property which is set to "false" by default.

One of the possible solutions which tries to minimize the impact of the change as much as possible is to introduce the `autoCloseHint`. It alters the default value of this property to be "true" for all non-streaming and non-streaming like responses  in order to follow the specification. The additional set of streaming-like responses, including `MultipartBody`, `Attachment`, ... and all supported reactive types have been introduced.

Fixing following tests:
- com/sun/ts/tests/jaxrs/ee/rs/core/response/JAXRSClient.java#getEntityThrowsIllegalStateExceptionWhenConsumedTest_from_standalone: JAXRSClient_getEntityThrowsIllegalStateExceptionWhenConsumedTest_from_standalone
com/sun/ts/tests/jaxrs/ee/rs/core/response
Regression causes jaxrs.ee.rs.core.response TCK tests to fail:

- /JAXRSClient.java#readEntityClassAnnotationThrowsIllegalStateExceptionTest_from_standalone: JAXRSClient_readEntityClassAnnotationThrowsIllegalStateExceptionTest_from_standalone
com/sun/ts/tests/jaxrs/ee/rs/core/response

- /JAXRSClient.java#readEntityClassThrowsIllegalStateExceptionTest_from_standalone: JAXRSClient_readEntityClassThrowsIllegalStateExceptionTest_from_standalone
com/sun/ts/tests/jaxrs/ee/rs/core/response

- /JAXRSClient.java#readEntityGenericTypeAnnotationThrowsIllegalStateExceptionTest_from_standalone: JAXRSClient_readEntityGenericTypeAnnotationThrowsIllegalStateExceptionTest_from_standalone
com/sun/ts/tests/jaxrs/ee/rs/core/response

- /JAXRSClient.java#readEntityGenericTypeThrowsIllegalStateExceptionTest_from_standalone: JAXRSClient_readEntityGenericTypeThrowsIllegalStateExceptionTest_from_standalone
