### PR TITLE
CXF-8610:Add null check to IOUtils to avoid null CCL

### DIFF
--- a/core/src/main/java/org/apache/cxf/helpers/IOUtils.java
+++ b/core/src/main/java/org/apache/cxf/helpers/IOUtils.java
@@ -32,6 +32,7 @@ import java.io.UnsupportedEncodingException;
 import java.io.Writer;
 import java.nio.charset.Charset;
 import java.nio.file.Files;
+import java.util.Objects;
 
 import org.apache.cxf.io.CopyingOutputStream;
 import org.apache.cxf.io.Transferable;
@@ -208,10 +209,8 @@ public final class IOUtils {
 
     public static int copy(final InputStream input, final OutputStream output,
             int bufferSize) throws IOException {
-        // if input or output is null, a null pointer exception would be occurred!
-        if (input == null || output == null) {
-            return 0;
-        }
+        Objects.requireNonNull(input, "The inputStream is required but null value was provided");
+        Objects.requireNonNull(output, "The outputStream is required but null value was provided");
         int avail = input.available();
         if (avail > 262144) {
             avail = 262144;
@@ -244,9 +243,8 @@ public final class IOUtils {
     public static void copyAtLeast(final InputStream input,
                                final OutputStream output,
                                int atLeast) throws IOException {
-        if (input == null || output == null ) {
-            throw new IOException("The inputStream or outputStream is null,I/O operations cannot be performed!");
-        }
+        Objects.requireNonNull(input, "The inputStream is required but null value was provided");
+        Objects.requireNonNull(output, "The outputStream is required but null value was provided");
         final byte[] buffer = new byte[4096];
         int n = atLeast > buffer.length ? buffer.length : atLeast;
         n = input.read(buffer, 0, n);
@@ -267,9 +265,8 @@ public final class IOUtils {
     public static void copyAtLeast(final Reader input,
                                    final Writer output,
                                    int atLeast) throws IOException {
-        if ( input == null || output == null ) {
-            throw new IOException("The reader or writer is null,I/O operations cannot be performed!");
-        }
+        Objects.requireNonNull(input, "The reader is required but null value was provided");
+        Objects.requireNonNull(output, "The writer is required but null value was provided");
         final char[] buffer = new char[4096];
         int n = atLeast > buffer.length ? buffer.length : atLeast;
         n = input.read(buffer, 0, n);
@@ -290,9 +287,8 @@ public final class IOUtils {
 
     public static void copy(final Reader input, final Writer output,
             final int bufferSize) throws IOException {
-        if ( input == null || output == null ) {
-            throw new IOException("The reader or writer is null,I/O operations cannot be performed!");
-        }
+        Objects.requireNonNull(input, "The reader is required but null value was provided");
+        Objects.requireNonNull(output, "The writer is required but null value was provided");
         final char[] buffer = new char[bufferSize];
         int n = input.read(buffer);
         while (-1 != n) {
@@ -302,12 +298,8 @@ public final class IOUtils {
     }
 
     public static void transferTo(InputStream inputStream, File destinationFile) throws IOException {
-        if ( inputStream == null ) {
-            throw new IOException("The inputStream is null,I/O operations cannot be performed!");
-        }
-        if ( destinationFile == null ){
-            throw new IOException("The destinationFile is null,transfer operation cannot be performed!");
-        }
+        Objects.requireNonNull(inputStream, "The inputStream is required but null value was provided");
+        Objects.requireNonNull(destinationFile, "The destinationFile is required but null value was provided");
         if (Transferable.class.isAssignableFrom(inputStream.getClass())) {
             ((Transferable)inputStream).transferTo(destinationFile);
         } else {
@@ -330,9 +322,7 @@ public final class IOUtils {
     }
     public static String toString(final InputStream input, int bufferSize, String charset)
         throws IOException {
-        if ( input == null ) {
-            throw new IOException("The inputStream is null,,I/O operations cannot be performed!");
-        }
+        Objects.requireNonNull(input, "The inputStream is required but null value was provided");
         int avail = input.available();
         if (avail > bufferSize) {
             bufferSize = avail;
@@ -346,9 +336,7 @@ public final class IOUtils {
         return toString(input, DEFAULT_BUFFER_SIZE);
     }
     public static String toString(final Reader input, int bufSize) throws IOException {
-        if ( input == null ) {
-            throw new IOException("The inputReader is null,I/O operations cannot be performed!");
-        }
+        Objects.requireNonNull(input, "The reader is required but null value was provided");
         StringBuilder buf = new StringBuilder();
         final char[] buffer = new char[bufSize];
         try (Reader r = input) {
@@ -378,9 +366,7 @@ public final class IOUtils {
      */
     public static ByteArrayInputStream loadIntoBAIS(InputStream in)
         throws IOException {
-        if ( in == null ) {
-            throw new IOException("The inputStream is null,I/O operations cannot be performed!");
-        }
+        Objects.requireNonNull(in, "The inputStream is required but null value was provided");
         int i = in.available();
         if (i < DEFAULT_BUFFER_SIZE) {
             i = DEFAULT_BUFFER_SIZE;
@@ -392,9 +378,7 @@ public final class IOUtils {
     }
 
     public static void consume(InputStream in) throws IOException {
-        if ( in == null ) {
-            throw new IOException("The inputStream is null,I/O operations cannot be performed!");
-        }
+        Objects.requireNonNull(in, "The inputStream is required but null value was provided");
         int i = in.available();
         if (i == 0) {
             //if i is 0, then we MAY have already hit the end of the stream
@@ -426,9 +410,7 @@ public final class IOUtils {
      */
     public static void consume(final InputStream input,
                                int atLeast) throws IOException {
-        if ( input == null ) {
-            throw new IOException("The inputStream is null,I/O operations cannot be performed!");
-        }
+        Objects.requireNonNull(input, "The inputStream is required but null value was provided");
         final byte[] buffer = new byte[4096];
         int n = atLeast > buffer.length ? buffer.length : atLeast;
         n = input.read(buffer, 0, n);
@@ -446,9 +428,7 @@ public final class IOUtils {
     }
 
     public static byte[] readBytesFromStream(InputStream in) throws IOException {
-        if ( in == null ) {
-            throw new IOException("The inputStream is null,I/O operations cannot be performed!");
-        }
+        Objects.requireNonNull(in, "The inputStream is required but null value was provided");
         int i = in.available();
         if (i < DEFAULT_BUFFER_SIZE) {
             i = DEFAULT_BUFFER_SIZE;

--- a/core/src/test/java/org/apache/cxf/helpers/IOUtilsTest.java
+++ b/core/src/test/java/org/apache/cxf/helpers/IOUtilsTest.java
@@ -21,17 +21,16 @@ package org.apache.cxf.helpers;
 
 
 import java.io.ByteArrayInputStream;
+import java.io.File;
 import java.io.InputStream;
 import java.io.PushbackInputStream;
-import java.io.File;
-import java.io.IOException;
 
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
 public class IOUtilsTest {
 
@@ -68,9 +67,10 @@ public class IOUtilsTest {
     public void testTransferToWhenEmptyFile() throws Exception {
         InputStream is = new ByteArrayInputStream("Hello".getBytes());
         File destinationFile = null;
-        Exception exception = assertThrows(IOException.class,()->{IOUtils.transferTo(is,destinationFile);
+        Exception exception = assertThrows(Exception.class, () -> { 
+            IOUtils.transferTo(is, destinationFile);
         });
-        String expectedMessage = "The destinationFile is null";
+        String expectedMessage = "The destinationFile is required";
         String actualMessage = exception.getMessage();
         assertTrue(actualMessage.contains(expectedMessage));
     }


### PR DESCRIPTION
Added null check to the part public methods of IOUtils to prevent  null pointer exceptions. 
Code tested against version CXF 3.3.11
links:[CXF-8610](https://issues.apache.org/jira/projects/CXF/issues/CXF-8610?filter=allissues)