### PR TITLE
CXF-8616: Calling oneway methods using async client hangs response indefinitely

### DIFF
--- a/core/src/main/java/org/apache/cxf/message/Message.java
+++ b/core/src/main/java/org/apache/cxf/message/Message.java
@@ -92,6 +92,13 @@ public interface Message extends StringMap {
      * Default value is true
      */
     String PROCESS_202_RESPONSE_ONEWAY_OR_PARTIAL = "org.apache.cxf.transport.process202Response";
+    
+    /**
+     * Boolean property specifying if 202 response is partial/oneway response, should it be
+     * propagated down to message observers or not.
+     * Default value is false.
+     */
+    String PROPAGATE_202_RESPONSE_ONEWAY_OR_PARTIAL = "org.apache.cxf.transport.propagate202Response"; 
 
     /**
      * Boolean property specifying if the thread which runs a request is

--- a/rt/rs/client/src/main/java/org/apache/cxf/jaxrs/client/AbstractClient.java
+++ b/rt/rs/client/src/main/java/org/apache/cxf/jaxrs/client/AbstractClient.java
@@ -955,6 +955,8 @@ public abstract class AbstractClient implements Client {
     }
 
     protected void setSupportOnewayResponseProperty(Message outMessage) {
+        // Do propagate the response down to observer chain
+        outMessage.put(Message.PROPAGATE_202_RESPONSE_ONEWAY_OR_PARTIAL, true);
         if (!outMessage.getExchange().isOneWay()) {
             outMessage.put(Message.PROCESS_ONEWAY_RESPONSE, true);
         }

--- a/rt/transports/http/src/main/java/org/apache/cxf/transport/http/HTTPConduit.java
+++ b/rt/transports/http/src/main/java/org/apache/cxf/transport/http/HTTPConduit.java
@@ -1660,8 +1660,13 @@ public abstract class HTTPConduit
                         }
                     }
                     exchange.put("IN_CHAIN_COMPLETE", Boolean.TRUE);
-                    
+
                     exchange.setInMessage(inMessage);
+                    if (MessageUtils.getContextualBoolean(outMessage, 
+                            Message.PROPAGATE_202_RESPONSE_ONEWAY_OR_PARTIAL, false)) {
+                        incomingObserver.onMessage(inMessage);
+                    }
+
                     return;
                 }
             } else {

--- a/systests/jaxrs/src/test/java/org/apache/cxf/systest/jaxrs/BookStore.java
+++ b/systests/jaxrs/src/test/java/org/apache/cxf/systest/jaxrs/BookStore.java
@@ -1544,6 +1544,11 @@ public class BookStore {
     }
 
     @POST
+    @Path("/no-content")
+    public void noContent() {
+    }
+
+    @POST
     @Path("/books/customstatus")
     @Produces("application/xml")
     @Consumes("text/xml")


### PR DESCRIPTION
It turns out that when async client is used with oneway methods (in CXF context, oneway is the method that returns 202), the response hangs indefinitely due to the fact that the client callback is never called / propagated. Additionally, it turned out, for sync / async flows, the response filters are also not called for oneway methods.

- Introduced new contextual property `PROPAGATE_202_RESPONSE_ONEWAY_OR_PARTIAL`
- It is set to `false` by default but JAX-RS clients override it with `true` 
