### PR TITLE
CXF-8617: The org.apache.cxf.transport.http.asyncclient.hc5.AsyncHTTPConduitTest hangs intermittently

### DIFF
--- a/rt/transports/http-hc5/src/main/java/org/apache/cxf/transport/http/asyncclient/hc5/SharedOutputBuffer.java
+++ b/rt/transports/http-hc5/src/main/java/org/apache/cxf/transport/http/asyncclient/hc5/SharedOutputBuffer.java
@@ -119,10 +119,9 @@ public class SharedOutputBuffer extends ExpandableBuffer {
                     bytesWritten = channel.write(buffer());
                 }
             }
-            if ((largeWrapper == null || !largeWrapper.hasRemaining()) && !super.hasData()) {
+            if ((largeWrapper == null || !largeWrapper.hasRemaining()) && !super.hasData() && this.endOfStream) {
                 // No more buffered content
                 // If at the end of the stream, terminate
-                this.endOfStream = true;
                 channel.endStream();
             }
             // no need to signal if the large wrapper is present and has data remaining

--- a/rt/transports/http-hc5/src/test/java/org/apache/cxf/transport/http/asyncclient/hc5/AsyncHTTPConduitTest.java
+++ b/rt/transports/http-hc5/src/test/java/org/apache/cxf/transport/http/asyncclient/hc5/AsyncHTTPConduitTest.java
@@ -24,6 +24,7 @@ import java.util.Collections;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import javax.xml.ws.AsyncHandler;
@@ -320,7 +321,10 @@ public class AsyncHTTPConduitTest extends AbstractBusClientServerTestBase {
                     } else {
                         Thread.sleep(50);
                     }
-                    initialThreadsLatch.await();
+                    if (!initialThreadsLatch.await(30, TimeUnit.SECONDS)) {
+                        throw new TimeoutException("The initial threads latch timeout exceeded,"
+                            + " exception in JaxwsClientCallback?");
+                    }
                     doneLatch.countDown();
                 } catch (Exception e) {
                     throw new RuntimeException(e);


### PR DESCRIPTION
Caused by the exception in `SharedOutputBuffer` which signaled the end of the stream prematurely.