### PR TITLE
CXF-8620: AbstractHTTPServlet should support HTTP TRACE method dispatching if it is allowed by underlying container

### DIFF
--- a/rt/frontend/jaxrs/src/main/java/org/apache/cxf/jaxrs/ext/TRACE.java
+++ b/rt/frontend/jaxrs/src/main/java/org/apache/cxf/jaxrs/ext/TRACE.java
@@ -1,0 +1,33 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.cxf.jaxrs.ext;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import javax.ws.rs.HttpMethod;
+
+@HttpMethod("TRACE")
+@Target(value = ElementType.METHOD)
+@Retention(value = RetentionPolicy.RUNTIME)
+public @interface TRACE {
+}

--- a/rt/transports/http/src/main/java/org/apache/cxf/transport/servlet/AbstractHTTPServlet.java
+++ b/rt/transports/http/src/main/java/org/apache/cxf/transport/servlet/AbstractHTTPServlet.java
@@ -245,6 +245,12 @@ public abstract class AbstractHTTPServlet extends HttpServlet implements Filter 
         throws ServletException, IOException {
         handleRequest(request, response);
     }
+    
+    @Override
+    protected void doTrace(HttpServletRequest request, HttpServletResponse response)
+        throws ServletException, IOException {
+        handleRequest(request, response);
+    }
 
     /**
      * {@inheritDoc}

--- a/systests/spring-boot/src/test/java/org/apache/cxf/systest/jaxrs/resources/Library.java
+++ b/systests/spring-boot/src/test/java/org/apache/cxf/systest/jaxrs/resources/Library.java
@@ -63,4 +63,9 @@ public class Library implements LibraryApi {
     public Catalog catalog() {
         return new Catalog();
     }
+    
+    @Override
+    public Response traceBooks() {
+        return Response.status(Status.NOT_ACCEPTABLE).build();
+    }
 }

--- a/systests/spring-boot/src/test/java/org/apache/cxf/systest/jaxrs/resources/LibraryApi.java
+++ b/systests/spring-boot/src/test/java/org/apache/cxf/systest/jaxrs/resources/LibraryApi.java
@@ -29,6 +29,8 @@ import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
+import org.apache.cxf.jaxrs.ext.TRACE;
+
 public interface LibraryApi {
     @Produces({ MediaType.APPLICATION_JSON })
     @GET
@@ -44,4 +46,8 @@ public interface LibraryApi {
     
     @Path("/catalog")
     Catalog catalog(); 
+    
+    @TRACE
+    @Produces({ MediaType.APPLICATION_JSON })
+    Response traceBooks();
 }

--- a/systests/spring-boot/src/test/java/org/apache/cxf/systest/jaxrs/spring/boot/SpringJaxrsTest.java
+++ b/systests/spring-boot/src/test/java/org/apache/cxf/systest/jaxrs/spring/boot/SpringJaxrsTest.java
@@ -29,6 +29,7 @@ import javax.ws.rs.ProcessingException;
 import javax.ws.rs.client.ClientBuilder;
 import javax.ws.rs.client.WebTarget;
 import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.Status;
 
 import com.fasterxml.jackson.jaxrs.json.JacksonJsonProvider;
 
@@ -44,7 +45,9 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.boot.web.embedded.tomcat.TomcatServletWebServerFactory;
 import org.springframework.boot.web.server.LocalServerPort;
+import org.springframework.boot.web.server.WebServerFactoryCustomizer;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.test.context.ActiveProfiles;
@@ -93,6 +96,13 @@ public class SpringJaxrsTest {
         @Bean
         public JacksonJsonProvider jacksonJsonProvider() {
             return new JacksonJsonProvider();
+        }
+        
+        @Bean
+        public WebServerFactoryCustomizer<TomcatServletWebServerFactory> tomcatCustomizer() {
+            return customizer -> customizer.addConnectorCustomizers(connector -> {
+                connector.setAllowTrace(true);
+            });
         }
     }
 
@@ -413,6 +423,47 @@ public class SpringJaxrsTest {
                 entry("status", "UNKNOWN"));
     }
     
+    @Test
+    public void testJaxrsCustomHttpMethodMetric() {
+        final WebTarget target = createWebTarget();
+        
+        try (Response r = target.request().trace()) {
+            assertThat(r.getStatus()).isEqualTo(Status.NOT_ACCEPTABLE.getStatusCode());
+        }
+        
+        await()
+            .atMost(Duration.ofSeconds(1))
+            .ignoreException(MeterNotFoundException.class)
+            .until(() -> registry.get("cxf.server.requests").timers(), not(empty()));
+        RequiredSearch serverRequestMetrics = registry.get("cxf.server.requests");
+
+        Map<Object, Object> serverTags = serverRequestMetrics.timer().getId().getTags().stream()
+            .collect(toMap(Tag::getKey, Tag::getValue));
+
+        assertThat(serverTags)
+            .containsOnly(
+                entry("exception", "None"),
+                entry("method", "TRACE"),
+                entry("operation", "traceBooks"),
+                entry("uri", "/api/library"),
+                entry("outcome", "CLIENT_ERROR"),
+                entry("status", "406"));
+        
+        RequiredSearch clientRequestMetrics = registry.get("cxf.client.requests");
+
+        Map<Object, Object> clientTags = clientRequestMetrics.timer().getId().getTags().stream()
+                .collect(toMap(Tag::getKey, Tag::getValue));
+
+        assertThat(clientTags)
+            .containsOnly(
+                entry("exception", "None"),
+                entry("method", "TRACE"),
+                entry("operation", "UNKNOWN"),
+                entry("uri", "http://localhost:" + port + "/api/library"),
+                entry("outcome", "CLIENT_ERROR"),
+                entry("status", "406"));
+    }
+
     private LibraryApi createApi(int portToUse) {
         final JAXRSClientFactoryBean factory = new JAXRSClientFactoryBean();
         factory.setAddress("http://localhost:" + portToUse + "/api/library");

--- a/systests/transport-netty/src/test/java/org/apache/cxf/systest/http2/netty/BookStore.java
+++ b/systests/transport-netty/src/test/java/org/apache/cxf/systest/http2/netty/BookStore.java
@@ -23,11 +23,15 @@ import java.io.IOException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
+import javax.ws.rs.Consumes;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.Status;
 
 import org.apache.cxf.jaxrs.ext.StreamingResponse;
+import org.apache.cxf.jaxrs.ext.TRACE;
 
 @Path("/web/bookstore")
 public class BookStore {
@@ -62,6 +66,14 @@ public class BookStore {
                 });
             }
         };
+    }
+    
+    @TRACE
+    @Produces("application/xml")
+    @Consumes("application/xml")
+    @Path("/trace")
+    public Response traceBook() {
+        return Response.status(Status.NOT_ACCEPTABLE).build();
     }
 }
 

--- a/systests/transport-netty/src/test/java/org/apache/cxf/systest/http2/netty/Http2TestClient.java
+++ b/systests/transport-netty/src/test/java/org/apache/cxf/systest/http2/netty/Http2TestClient.java
@@ -163,6 +163,10 @@ public class Http2TestClient implements AutoCloseable {
         public ClientResponse get() throws Exception {
             return request(address, path, version, HttpMethod.GET, accept);
         }
+        
+        public ClientResponse trace() throws Exception {
+            return request(address, path, version, HttpMethod.TRACE, accept);
+        }
     }
     
     public RequestBuilder request(final String address) throws IOException {


### PR DESCRIPTION
A number of JAX-RS TCK of tests use HTTP TRACE to verify the client / server behavior, but TRACE HTTP method dispatching is not supported by AbstractHTTPServlet, causing tests do not fail.
