### PR TITLE
cxf-rt-transports-http: allow to use service list endpoint as lightweight healthcheck endpoint using HTTP HEAD method

### DIFF
--- a/rt/transports/http/src/main/java/org/apache/cxf/transport/servlet/servicelist/ServiceListGeneratorServlet.java
+++ b/rt/transports/http/src/main/java/org/apache/cxf/transport/servlet/servicelist/ServiceListGeneratorServlet.java
@@ -22,6 +22,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 import javax.servlet.ServletConfig;
@@ -33,6 +34,7 @@ import javax.servlet.http.HttpServletResponse;
 import org.apache.cxf.Bus;
 import org.apache.cxf.BusFactory;
 import org.apache.cxf.common.util.StringUtils;
+import org.apache.cxf.helpers.CastUtils;
 import org.apache.cxf.helpers.IOUtils;
 import org.apache.cxf.message.Message;
 import org.apache.cxf.service.model.EndpointInfo;
@@ -45,17 +47,12 @@ public class ServiceListGeneratorServlet extends HttpServlet {
     private DestinationRegistry destinationRegistry;
     private Bus bus;
     private String serviceListStyleSheet;
-    private String title;
+    private String title = "CXF - Service list";
     private boolean showForeignContexts = true;
 
     public ServiceListGeneratorServlet(DestinationRegistry destinationRegistry, Bus bus) {
         this.destinationRegistry = destinationRegistry;
-        this.bus = bus;
-        if (this.bus == null) {
-            this.bus = BusFactory.getDefaultBus(false);
-        }
-
-        this.title = "CXF - Service list";
+        this.bus = bus != null ? bus : BusFactory.getDefaultBus(false);
     }
 
     public void setServiceListStyleSheet(String serviceListStyleSheet) {
@@ -66,17 +63,11 @@ public class ServiceListGeneratorServlet extends HttpServlet {
         this.title = title;
     }
 
-
-    @SuppressWarnings("unchecked")
     @Override
     public void service(HttpServletRequest request,
                         HttpServletResponse response) throws ServletException, IOException {
-        Object obj = request.getAttribute(ServletController.AUTH_SERVICE_LIST);
-        boolean isAuthServiceList = false;
-        if (obj != null) {
-            isAuthServiceList = Boolean.valueOf(obj.toString());
-        }
-        if (isAuthServiceList) {
+        final Object isAuthServiceList = request.getAttribute(ServletController.AUTH_SERVICE_LIST);
+        if (isAuthServiceList != null && Boolean.valueOf(isAuthServiceList.toString())) {
             String authServiceListRealm = (String)request.getAttribute(ServletController.AUTH_SERVICE_LIST_REALM);
             ServiceListJAASAuthenticator authenticator = new ServiceListJAASAuthenticator();
             authenticator.setRealm(authServiceListRealm);
@@ -86,24 +77,18 @@ public class ServiceListGeneratorServlet extends HttpServlet {
             request.removeAttribute(ServletController.AUTH_SERVICE_LIST);
             request.removeAttribute(ServletController.AUTH_SERVICE_LIST_REALM);
         }
-        AbstractDestination[] destinations = destinationRegistry.getSortedDestinations();
         if (request.getParameter("stylesheet") != null) {
             renderStyleSheet(request, response);
             return;
         }
-        List<String> privateEndpoints;
+
+        if ("HEAD".equals(request.getMethod())) {
+            return;
+        }
         if (bus == null) {
             bus = BusFactory.getDefaultBus(false);
         }
-        if (bus != null) {
-            privateEndpoints = (List<String>)bus.getProperty("org.apache.cxf.private.endpoints");
-        } else {
-            privateEndpoints = new ArrayList<>();
-        }
-
-        AbstractDestination[] soapEndpoints = getSOAPEndpoints(destinations, privateEndpoints);
-        AbstractDestination[] restEndpoints = getRestEndpoints(destinations, privateEndpoints);
-        ServiceListWriter serviceListWriter;
+        final ServiceListWriter serviceListWriter;
         if ("false".equals(request.getParameter("formatted"))) {
             boolean renderWsdlList = "true".equals(request.getParameter("wsdlList"));
             serviceListWriter = new UnformattedServiceListWriter(renderWsdlList, bus);
@@ -136,14 +121,19 @@ public class ServiceListGeneratorServlet extends HttpServlet {
 
         }
         response.setContentType(serviceListWriter.getContentType());
-        Object basePath = request.getAttribute(Message.BASE_PATH);
+        final Object basePath = request.getAttribute(Message.BASE_PATH);
+        final AbstractDestination[] destinations = destinationRegistry.getSortedDestinations();
+        final List<String> privateEndpoints = bus != null
+            ? CastUtils.cast((List<?>) bus.getProperty("org.apache.cxf.private.endpoints"))
+            : Collections.emptyList();
         serviceListWriter.writeServiceList(response.getWriter(),
                                            basePath == null ? null : basePath.toString(),
-                                           soapEndpoints, restEndpoints);
+                                           getSOAPEndpoints(destinations, privateEndpoints),
+                                           getRestEndpoints(destinations, privateEndpoints));
     }
 
 
-    private boolean isPrivate(EndpointInfo ei, List<String> privateEndpoints) {
+    private static boolean isPrivate(EndpointInfo ei, List<String> privateEndpoints) {
         if (privateEndpoints != null) {
             for (String s : privateEndpoints) {
                 if (ei.getAddress().endsWith(s)) {
@@ -154,7 +144,7 @@ public class ServiceListGeneratorServlet extends HttpServlet {
         return false;
     }
 
-    private AbstractDestination[] getSOAPEndpoints(AbstractDestination[] destinations,
+    private static AbstractDestination[] getSOAPEndpoints(AbstractDestination[] destinations,
                                                    List<String> privateEndpoints) {
         List<AbstractDestination> soapEndpoints = new ArrayList<>();
         for (AbstractDestination sd : destinations) {
@@ -166,7 +156,7 @@ public class ServiceListGeneratorServlet extends HttpServlet {
         return soapEndpoints.toArray(new AbstractDestination[0]);
     }
 
-    private AbstractDestination[] getRestEndpoints(AbstractDestination[] destinations,
+    private static AbstractDestination[] getRestEndpoints(AbstractDestination[] destinations,
                                                    List<String> privateEndpoints) {
         List<AbstractDestination> restfulDests = new ArrayList<>();
         for (AbstractDestination sd : destinations) {

--- a/rt/transports/http/src/test/java/org/apache/cxf/transport/servlet/ServletControllerTest.java
+++ b/rt/transports/http/src/test/java/org/apache/cxf/transport/servlet/ServletControllerTest.java
@@ -30,9 +30,9 @@ import org.apache.cxf.message.Message;
 import org.apache.cxf.transport.MessageObserver;
 import org.apache.cxf.transport.http.AbstractHTTPDestination;
 import org.apache.cxf.transport.http.DestinationRegistry;
+import org.apache.cxf.transport.servlet.servicelist.ServiceListGeneratorServlet;
 
 import org.easymock.EasyMock;
-import org.junit.Before;
 import org.junit.Test;
 
 import static org.junit.Assert.assertFalse;
@@ -40,40 +40,23 @@ import static org.junit.Assert.assertTrue;
 
 public class ServletControllerTest {
 
-    private HttpServletRequest req;
-    private HttpServletResponse res;
-    private DestinationRegistry registry;
-    private HttpServlet serviceListGenerator;
-
-    @Before
-    public void setUp() {
-        req = EasyMock.createMock(HttpServletRequest.class);
-        res = EasyMock.createMock(HttpServletResponse.class);
-        registry = EasyMock.createMock(DestinationRegistry.class);
-        serviceListGenerator = EasyMock.createMock(HttpServlet.class);
-    }
+    private HttpServletRequest req = EasyMock.createMock(HttpServletRequest.class);
+    private HttpServletResponse res = EasyMock.createMock(HttpServletResponse.class);
+    private DestinationRegistry registry = EasyMock.createMock(DestinationRegistry.class);
+    private HttpServlet serviceListGenerator = EasyMock.createMock(HttpServlet.class);
 
     private void setReq(String pathInfo, String requestUri, String styleSheet, String formatted) {
-        req.getPathInfo();
-        EasyMock.expectLastCall().andReturn(pathInfo).anyTimes();
-        req.getContextPath();
-        EasyMock.expectLastCall().andReturn("").anyTimes();
-        req.getServletPath();
-        EasyMock.expectLastCall().andReturn("").anyTimes();
+        EasyMock.expect(req.getPathInfo()).andReturn(pathInfo).anyTimes();
+        EasyMock.expect(req.getContextPath()).andReturn("").anyTimes();
+        EasyMock.expect(req.getServletPath()).andReturn("").anyTimes();
         req.setAttribute(Message.BASE_PATH, "http://localhost:8080");
         EasyMock.expectLastCall().anyTimes();
-        req.getRequestURI();
-        EasyMock.expectLastCall().andReturn(requestUri).times(2);
-        req.getParameter("stylesheet");
-        EasyMock.expectLastCall().andReturn(styleSheet);
-        req.getParameter("formatted");
-        EasyMock.expectLastCall().andReturn(formatted);
-        req.getRequestURL();
-        EasyMock.expectLastCall().andReturn(new StringBuffer("http://localhost:8080" + requestUri)); //NOPMD
-        registry.getDestinationsPaths();
-        EasyMock.expectLastCall().andReturn(Collections.emptySet()).atLeastOnce();
-        registry.getDestinationForPath("", true);
-        EasyMock.expectLastCall().andReturn(null).anyTimes();
+        EasyMock.expect(req.getRequestURI()).andReturn(requestUri).times(2);
+        EasyMock.expect(req.getParameter("stylesheet")).andReturn(styleSheet);
+        EasyMock.expect(req.getParameter("formatted")).andReturn(formatted);
+        EasyMock.expect(req.getRequestURL()).andReturn(new StringBuffer("http://localhost:8080").append(requestUri));
+        EasyMock.expect(registry.getDestinationsPaths()).andReturn(Collections.emptySet()).atLeastOnce();
+        EasyMock.expect(registry.getDestinationForPath("", true)).andReturn(null).anyTimes();
     }
 
     private void expectServiceListGeneratorCalled() throws ServletException, IOException {
@@ -161,6 +144,19 @@ public class ServletControllerTest {
         sc.invoke(req, res);
         assertFalse(sc.invokeDestinationCalled());
     }
+
+    @Test
+    public void testHealthcheck() throws Exception {
+        setReq(null, "/services", null, "true");
+        EasyMock.expect(req.getAttribute(ServletController.AUTH_SERVICE_LIST)).andReturn(null);
+        EasyMock.expect(req.getMethod()).andReturn("HEAD");
+
+        EasyMock.replay(req, registry);
+        TestServletController sc = new TestServletController(registry, new ServiceListGeneratorServlet(registry, null));
+        sc.invoke(req, res);
+        assertFalse(sc.invokeDestinationCalled());
+    }
+
 
     public static class TestServletController extends ServletController {
         private boolean invokeDestinationCalled;


### PR DESCRIPTION
lightweight healthcheck endpoint using HTTP HEAD method