### PR TITLE
Fixing jaxrs.spec.provider.standardnotnull clientDataSourceProviderTest

### DIFF
--- a/rt/frontend/jaxrs/src/main/java/org/apache/cxf/jaxrs/utils/JAXRSUtils.java
+++ b/rt/frontend/jaxrs/src/main/java/org/apache/cxf/jaxrs/utils/JAXRSUtils.java
@@ -48,6 +48,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
+import javax.activation.DataSource;
 import javax.ws.rs.ClientErrorException;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.HttpMethod;
@@ -239,7 +240,8 @@ public final class JAXRSUtils {
     public static boolean isStreamingOutType(Class<?> type) {
         return STREAMING_OUT_TYPES.contains(type) 
             || Closeable.class.isAssignableFrom(type)
-            || Source.class.isAssignableFrom(type);
+            || Source.class.isAssignableFrom(type)
+            || DataSource.class.isAssignableFrom(type);
     }
 
     public static List<PathSegment> getPathSegments(String thePath, boolean decode) {


### PR DESCRIPTION
Fixing jaxrs.spec.provider.standardnotnull clientDataSourceProviderTest

Before:

```
Tests that passed: 2630
Tests that failed: 33 
Total: 2663
```

| keyword                                                                                                       | passed | failed | Total |
|---|---|---|---|
| all clientDataSourceProviderTest forward javaee jaxrs standalone_vehicle |  |  1  | 1  |

After:
```
Tests that passed: 2631
Tests that failed: 32 
Total: 2663
```

| keyword                                                                                                       | passed | failed | Total |
|---|---|---|---|
| all clientDataSourceProviderTest forward javaee jaxrs standalone_vehicle | 1 |   | 1 |
