### PR TITLE
CXF-8630: Remove mockwebserver dependency, use wiremock instead

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -170,7 +170,6 @@
         <cxf.microprofile.openapi.version>2.0</cxf.microprofile.openapi.version>
         <cxf.mina.version>2.1.5</cxf.mina.version>
         <cxf.mockito.version>4.2.0</cxf.mockito.version>
-        <cxf.mockwebserver.version>4.9.3</cxf.mockwebserver.version>
         <cxf.msv.version>2013.6.1</cxf.msv.version>
         <cxf.neethi.version>3.2.0</cxf.neethi.version>
         <cxf.netty.version.range>[4,5)</cxf.netty.version.range>

--- a/rt/rs/microprofile-client/pom.xml
+++ b/rt/rs/microprofile-client/pom.xml
@@ -182,16 +182,22 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-          <groupId>org.apache.commons</groupId>
-          <artifactId>commons-jcs-jcache</artifactId>
-          <version>${cxf.commons-jcs-jcache.version}</version>
-          <scope>test</scope>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-jcs-jcache</artifactId>
+            <version>${cxf.commons-jcs-jcache.version}</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
-          <groupId>com.squareup.okhttp3</groupId>
-          <artifactId>mockwebserver</artifactId>
-          <version>${cxf.mockwebserver.version}</version>
-          <scope>test</scope>
+            <groupId>com.github.tomakehurst</groupId>
+            <artifactId>wiremock</artifactId>
+            <version>${cxf.wiremock.version}</version>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.xmlunit</groupId>
+                    <artifactId>xmlunit-core</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
     </dependencies>
 

--- a/rt/rs/microprofile-client/src/test/java/org/apache/cxf/microprofile/client/AsyncTest.java
+++ b/rt/rs/microprofile-client/src/test/java/org/apache/cxf/microprofile/client/AsyncTest.java
@@ -19,27 +19,69 @@
 package org.apache.cxf.microprofile.client;
 
 import java.net.URI;
+import java.util.Queue;
+import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.TimeUnit;
 
-import okhttp3.mockwebserver.MockResponse;
-import okhttp3.mockwebserver.MockWebServer;
+import com.github.tomakehurst.wiremock.common.FileSource;
+import com.github.tomakehurst.wiremock.extension.Parameters;
+import com.github.tomakehurst.wiremock.extension.ResponseTransformer;
+import com.github.tomakehurst.wiremock.http.Request;
+import com.github.tomakehurst.wiremock.http.Response;
+import com.github.tomakehurst.wiremock.junit.WireMockRule;
+
 import org.apache.cxf.microprofile.client.mock.AsyncClient;
 import org.apache.cxf.microprofile.client.mock.NotFoundExceptionMapper;
 import org.eclipse.microprofile.rest.client.RestClientBuilder;
 
+import org.junit.Rule;
 import org.junit.Test;
 
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.notFound;
+import static com.github.tomakehurst.wiremock.client.WireMock.ok;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 public class AsyncTest {
+    @SuppressWarnings("unchecked")
+    @Rule
+    public WireMockRule wireMockRule = new WireMockRule(wireMockConfig()
+        .extensions(SimpleTransformer.class));
+    
+    public static class SimpleTransformer extends ResponseTransformer {
+        private final Queue<String> queue = new ArrayBlockingQueue<>(2);
+        
+        public SimpleTransformer() {
+            queue.add("Hello");
+            queue.add("World");
+        }
+        
+        @Override
+        public Response transform(Request request, Response response, FileSource fileSource, Parameters parameters) {
+            return Response.Builder
+                .like(response)
+                .but().body(queue.poll())
+                .build();
+        }
 
+        @Override
+        public boolean applyGlobally() {
+            return false;
+        }
+
+        @Override
+        public String getName() {
+            return "enqueue-transformer";
+        }
+    }
+    
     @Test
     public void testAsyncClient() throws Exception {
-        MockWebServer mockWebServer = new MockWebServer();
-        URI uri = mockWebServer.url("/").uri();
+        URI uri = URI.create(wireMockRule.baseUrl());
         AsyncClient client = RestClientBuilder.newBuilder()
                                               .baseUri(uri)
                                               .connectTimeout(5, TimeUnit.SECONDS)
@@ -47,8 +89,7 @@ public class AsyncTest {
                                               .build(AsyncClient.class);
         assertNotNull(client);
 
-        mockWebServer.enqueue(new MockResponse().setBody("Hello"));
-        mockWebServer.enqueue(new MockResponse().setBody("World"));
+        wireMockRule.stubFor(get("/").willReturn(ok().withTransformers("enqueue-transformer")));
 
         String combined = client.get().thenCombine(client.get(), (a, b) -> {
             return a + " " + b;
@@ -59,18 +100,16 @@ public class AsyncTest {
 
     @Test
     public void testAsyncClientCanMapExceptionResponses() throws Exception {
-        MockWebServer mockWebServer = new MockWebServer();
-        URI uri = mockWebServer.url("/").uri();
-
+        URI uri = URI.create(wireMockRule.baseUrl());
         AsyncClient client = RestClientBuilder.newBuilder()
                                               .baseUri(uri)
                                               .connectTimeout(5, TimeUnit.SECONDS)
                                               .readTimeout(5, TimeUnit.SECONDS)
                                               .register(NotFoundExceptionMapper.class)
                                               .build(AsyncClient.class);
-        mockWebServer.enqueue(new MockResponse().setResponseCode(404));
+        wireMockRule.stubFor(get("/").willReturn(notFound()));
 
-        CompletionStage cs = client.get().exceptionally(t -> {
+        CompletionStage<?> cs = client.get().exceptionally(t -> {
             Throwable t2 = t.getCause();
             return t.getClass().getSimpleName() + ":" + (t2 == null ? "null" : t2.getClass().getSimpleName());
         });


### PR DESCRIPTION
Right now there is one module which uses `mockwebserver` for test scaffolding, this is not really necessary since we already have `wiremock` dependency in place. One or another should be used, although `wiremock`  is used in most places.