### PR TITLE
CXF-8635: Fix org.apache.cxf.jaxrs.client.logging.RESTLoggingTest.testSlf4

### DIFF
--- a/rt/rs/client/src/main/java/org/apache/cxf/jaxrs/client/AbstractClient.java
+++ b/rt/rs/client/src/main/java/org/apache/cxf/jaxrs/client/AbstractClient.java
@@ -440,8 +440,7 @@ public abstract class AbstractClient implements Client {
             return currentResponseBuilder;
         }
         
-        String reasonPhrase = (String)MessageUtils.getContextualProperty(
-                   responseMessage, HTTPConduit.HTTP_RESPONSE_MESSAGE, null);
+        final String reasonPhrase = (String)responseMessage.get(HTTPConduit.HTTP_RESPONSE_MESSAGE);
         if (reasonPhrase != null) {
             currentResponseBuilder.status(status, reasonPhrase);
         }

--- a/systests/transports/src/test/java/org/apache/cxf/systest/http/HTTPConduitTest.java
+++ b/systests/transports/src/test/java/org/apache/cxf/systest/http/HTTPConduitTest.java
@@ -38,6 +38,7 @@ import org.apache.cxf.bus.spring.SpringBusFactory;
 import org.apache.cxf.endpoint.Client;
 import org.apache.cxf.frontend.ClientProxy;
 import org.apache.cxf.testutil.common.AbstractBusClientServerTestBase;
+import org.apache.cxf.transport.http.HTTPConduit;
 import org.apache.hello_world.Greeter;
 import org.apache.hello_world.services.SOAPService;
 
@@ -45,7 +46,10 @@ import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.nullValue;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -170,9 +174,26 @@ public class HTTPConduitTest extends AbstractBusClientServerTestBase {
     }
 
     @Test
+    public void testResponseMessage() throws Exception {
+        startServer("Mortimer");
+        Greeter mortimer = getMortimerGreeter();
+        Client client = ClientProxy.getClient(mortimer);
+        client.getRequestContext().put(HTTPConduit.SET_HTTP_RESPONSE_MESSAGE, true);
+        
+        String answer = mortimer.sayHi();
+        answer = mortimer.sayHi();
+        answer = mortimer.sayHi();
+        assertTrue("Unexpected answer: " + answer,
+                "Bonjour from Mortimer".equals(answer));
+        assertProxyRequestCount(3);
+        assertThat(client.getResponseContext().get(HTTPConduit.HTTP_RESPONSE_MESSAGE), equalTo("OK"));
+    }
+    
+    @Test
     public void testBasicConnection() throws Exception {
         startServer("Mortimer");
         Greeter mortimer = getMortimerGreeter();
+        Client client = ClientProxy.getClient(mortimer);
 
         String answer = mortimer.sayHi();
         answer = mortimer.sayHi();
@@ -180,6 +201,7 @@ public class HTTPConduitTest extends AbstractBusClientServerTestBase {
         assertTrue("Unexpected answer: " + answer,
                 "Bonjour from Mortimer".equals(answer));
         assertProxyRequestCount(3);
+        assertThat(client.getResponseContext().get(HTTPConduit.HTTP_RESPONSE_MESSAGE), nullValue());
     }
 
     @Test


### PR DESCRIPTION
The regression introduced by [CXF-8633](https://issues.apache.org/jira/browse/CXF-8633) causes intermittent tests failures wirh `ConcurrentModificationException`: 

```
Caused by: java.util.ConcurrentModificationException
    	at java.base/java.util.HashMap$HashIterator.nextNode(HashMap.java:1511)
    	at java.base/java.util.HashMap$EntryIterator.next(HashMap.java:1544)
    	at java.base/java.util.HashMap$EntryIterator.next(HashMap.java:1542)
    	at java.base/java.util.HashMap.putMapEntries(HashMap.java:508)
    	at java.base/java.util.HashMap.putAll(HashMap.java:781)
    	at org.apache.cxf.message.MessageImpl.calcContextCache(MessageImpl.java:216)
    	at org.apache.cxf.message.MessageImpl.getContextualProperty(MessageImpl.java:179)
    	at org.apache.cxf.message.MessageUtils.getContextualProperty(MessageUtils.java:176)
    	at org.apache.cxf.jaxrs.client.AbstractClient.setResponseBuilder(AbstractClient.java:443)
    	at org.apache.cxf.jaxrs.client.WebClient.handleResponse(WebClient.java:1169)
    	... 35 more

```