### PR TITLE
CXF-8642: ResponseImpl#hasEntity return 'false' when entity is buffered but entity stream is fully consumed with processing exception

### DIFF
--- a/rt/frontend/jaxrs/src/main/java/org/apache/cxf/jaxrs/impl/ResponseImpl.java
+++ b/rt/frontend/jaxrs/src/main/java/org/apache/cxf/jaxrs/impl/ResponseImpl.java
@@ -152,6 +152,9 @@ public final class ResponseImpl extends Response {
         Object actualEntity = getActualEntity();
         if (actualEntity == null) {
             return false;
+        } else if (entityBufferred) {
+            // if actualEntity is not null and entity was buffered, the response definitely has entity
+            return true;
         } else if (actualEntity instanceof InputStream) {
             final InputStream is = (InputStream) actualEntity;
             try {


### PR DESCRIPTION
`ResponseImpl#hasEntity` returns 'false' when entity is buffered but entity stream is fully consumed with processing exception. 

No new TCK test cases are failing:
```
Test results: passed: 2,631; failed: 32
```