### PR TITLE
CXF-8650: Fix org.apache.cxf.systest.jaxrs.JAXRSContinuationsServlet3Test.testSuspendSetTimeout

### DIFF
--- a/systests/jaxrs/src/test/java/org/apache/cxf/systest/jaxrs/AsyncResource2.java
+++ b/systests/jaxrs/src/test/java/org/apache/cxf/systest/jaxrs/AsyncResource2.java
@@ -19,15 +19,17 @@
 package org.apache.cxf.systest.jaxrs;
 
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.LockSupport;
 
 import javax.ws.rs.GET;
+import javax.ws.rs.InternalServerErrorException;
 import javax.ws.rs.Path;
 import javax.ws.rs.container.AsyncResponse;
 import javax.ws.rs.container.Suspended;
 
 @Path("resource2")
 public class AsyncResource2 {
-    static AsyncResponse asyncResponse;
+    private volatile AsyncResponse asyncResponse;
 
     @GET
     @Path("/suspend")
@@ -38,7 +40,15 @@ public class AsyncResource2 {
     @GET
     @Path("/setTimeOut")
     public boolean setTimeOut() {
+        int i = 0;
+        while (asyncResponse == null && ++i < 20) {
+            LockSupport.parkNanos(TimeUnit.MILLISECONDS.toNanos(10));
+        }
+
+        if (asyncResponse == null) {
+            throw new InternalServerErrorException("Unable to retrieve the AsyncResponse, was it suspended?");
+        } 
+
         return asyncResponse.setTimeout(2L, TimeUnit.SECONDS);
     }
-
 }

--- a/systests/jaxrs/src/test/java/org/apache/cxf/systest/jaxrs/JAXRSContinuationsServlet3Test.java
+++ b/systests/jaxrs/src/test/java/org/apache/cxf/systest/jaxrs/JAXRSContinuationsServlet3Test.java
@@ -87,7 +87,6 @@ public class JAXRSContinuationsServlet3Test extends AbstractJAXRSContinuationsTe
     }
 
     @Test
-    // FIXME: standalone test run failed, eg -Dtest=JAXRSContinuationsServlet3Test#testSuspendSetTimeout
     public void testSuspendSetTimeout() throws Exception {
         final String base = "http://localhost:" + getPort() + "/async/resource2/";
         Future<Response> suspend = invokeRequest(base + "suspend");


### PR DESCRIPTION
Fix org.apache.cxf.systest.jaxrs.JAXRSContinuationsServlet3Test.testSuspendSetTimeout