### PR TITLE
[CXF-8648] Make ClaimsAuthorizingInterceptor configurable in ClaimsAu…

### DIFF
--- a/rt/frontend/jaxrs/src/main/java/org/apache/cxf/jaxrs/security/ClaimsAuthorizingFilter.java
+++ b/rt/frontend/jaxrs/src/main/java/org/apache/cxf/jaxrs/security/ClaimsAuthorizingFilter.java
@@ -33,7 +33,15 @@ import org.apache.cxf.rt.security.claims.interceptor.ClaimsAuthorizingIntercepto
 
 public class ClaimsAuthorizingFilter implements ContainerRequestFilter {
 
-    private ClaimsAuthorizingInterceptor interceptor = new ClaimsAuthorizingInterceptor();
+    private ClaimsAuthorizingInterceptor interceptor;
+
+    public ClaimsAuthorizingFilter() {
+        this.interceptor = new ClaimsAuthorizingInterceptor();
+    }
+
+    public ClaimsAuthorizingFilter(ClaimsAuthorizingInterceptor interceptor) {
+        this.interceptor = interceptor;
+    }
 
     @Override
     public void filter(ContainerRequestContext context) {
@@ -45,13 +53,14 @@ public class ClaimsAuthorizingFilter implements ContainerRequestFilter {
         }
     }
 
+    @Deprecated()
     public void setClaims(Map<String, List<ClaimBean>> claimsMap) {
         interceptor.setClaims(claimsMap);
     }
 
+    @Deprecated()
     public void setSecuredObject(Object securedObject) {
         interceptor.setSecuredObject(securedObject);
     }
-
 
 }

--- a/systests/rs-security/src/test/resources/org/apache/cxf/systest/jaxrs/security/jose/jwt/authn-authz-server.xml
+++ b/systests/rs-security/src/test/resources/org/apache/cxf/systest/jaxrs/security/jose/jwt/authn-authz-server.xml
@@ -77,9 +77,13 @@ under the License.
            </map>
        </property> 
     </bean>
-    
-    <bean id="claimsHandler" class="org.apache.cxf.jaxrs.security.ClaimsAuthorizingFilter">
+
+    <bean id="claimsInterceptor" class="org.apache.cxf.rt.security.claims.interceptor.ClaimsAuthorizingInterceptor">
         <property name="securedObject" ref="serviceBean"/>
+    </bean>
+
+    <bean id="claimsHandler" class="org.apache.cxf.jaxrs.security.ClaimsAuthorizingFilter">
+        <constructor-arg ref="claimsInterceptor"/>
     </bean>
     
     <jaxrs:server address="https://localhost:${testutil.ports.jaxrs-jwt-authn-authz}/signedjwtauthz">

--- a/systests/rs-security/src/test/resources/org/apache/cxf/systest/jaxrs/security/saml/secureServer.xml
+++ b/systests/rs-security/src/test/resources/org/apache/cxf/systest/jaxrs/security/saml/secureServer.xml
@@ -48,8 +48,11 @@ under the License.
     <bean id="serviceBean" class="org.apache.cxf.systest.jaxrs.security.saml.SecureBookStore"/>
     <bean id="serviceBeanClaims" class="org.apache.cxf.systest.jaxrs.security.saml.SecureClaimBookStore"/>
     <bean id="samlEnvHandler" class="org.apache.cxf.rs.security.saml.SamlEnvelopedInHandler"/>
-    <bean id="claimsHandler" class="org.apache.cxf.jaxrs.security.ClaimsAuthorizingFilter">
+    <bean id="claimsInterceptor" class="org.apache.cxf.rt.security.claims.interceptor.ClaimsAuthorizingInterceptor">
         <property name="securedObject" ref="serviceBeanClaims"/>
+    </bean>
+    <bean id="claimsHandler" class="org.apache.cxf.jaxrs.security.ClaimsAuthorizingFilter">
+        <constructor-arg ref="claimsInterceptor"/>
     </bean>
     <bean id="authorizationInterceptor" class="org.apache.cxf.interceptor.security.SecureAnnotationsInterceptor">
         <property name="securedObject" ref="serviceBean"/>


### PR DESCRIPTION
…thorizingFilter

I've deprecated the setters on ClaimsAuthorizingFilter which are a wrapper on the inner bean only. Instead, the inner bean can now be configured on its own and assigned to the ClaimsAuthorizingFilter