### PR TITLE
CXF-8522: Fixing jaxrs.spec.resource.requestmatching consumesOnResourceLocatorTest & other subresource test cases

### DIFF
--- a/rt/frontend/jaxrs/src/main/java/org/apache/cxf/jaxrs/utils/JAXRSUtils.java
+++ b/rt/frontend/jaxrs/src/main/java/org/apache/cxf/jaxrs/utils/JAXRSUtils.java
@@ -510,7 +510,7 @@ public final class JAXRSUtils {
         int pathMatched = 0;
         int methodMatched = 0;
         int consumeMatched = 0;
-
+        
         List<OperationResourceInfo> finalPathSubresources = null;
         for (Map.Entry<ClassResourceInfo, MultivaluedMap<String, String>> rEntry : matchedResources.entrySet()) {
             ClassResourceInfo resource = rEntry.getKey();
@@ -561,7 +561,12 @@ public final class JAXRSUtils {
                 LOG.fine(matchMessageLogSupplier(ori, path, httpMethod, requestType, acceptContentTypes, added));
             }
         }
-        if (finalPathSubresources != null && pathMatched > 0
+        
+        // We may get several matching candidates with different HTTP methods which match subresources
+        // and resources. Before excluding subresources, let us make sure we have at least one matching
+        // HTTP method candidate.
+        boolean isOptions = HttpMethod.OPTIONS.equalsIgnoreCase(httpMethod);
+        if (finalPathSubresources != null && (methodMatched > 0 || isOptions)
             && !MessageUtils.getContextualBoolean(message, KEEP_SUBRESOURCE_CANDIDATES, false)) {
             for (OperationResourceInfo key : finalPathSubresources) {
                 candidateList.remove(key);

--- a/systests/jaxrs/src/test/java/org/apache/cxf/systest/jaxrs/BookResourceLocator.java
+++ b/systests/jaxrs/src/test/java/org/apache/cxf/systest/jaxrs/BookResourceLocator.java
@@ -19,28 +19,22 @@
 
 package org.apache.cxf.systest.jaxrs;
 
-
+import javax.ws.rs.Consumes;
 import javax.ws.rs.GET;
-import javax.ws.rs.Path;
-import javax.ws.rs.PathParam;
+import javax.ws.rs.POST;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
 
-@Path("/bookstore")
-public class BookStoreSubObject {
-    @Path("/booksubresourceobject")
-    public Object getBookSubResourceObject() throws BookNotFoundFault {
+public class BookResourceLocator {
+    @GET
+    public Book get() {
         return new Book();
     }
-    
-    @Path("consumeslocator")
-    public BookResourceLocator consumeslocator() {
-        return new BookResourceLocator();
-    }
-    
-    @GET
-    @Path("{id}")
-    public Book book(@PathParam("id") Long id) {
-        return new Book("Book", id);
+
+    @POST
+    @Consumes(MediaType.TEXT_PLAIN)
+    @Produces(MediaType.TEXT_PLAIN)
+    public Book post() {
+        return get();
     }
 }
-
-

--- a/systests/jaxrs/src/test/java/org/apache/cxf/systest/jaxrs/JAXRSClientServerSubBookTest.java
+++ b/systests/jaxrs/src/test/java/org/apache/cxf/systest/jaxrs/JAXRSClientServerSubBookTest.java
@@ -19,6 +19,12 @@
 
 package org.apache.cxf.systest.jaxrs;
 
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.ClientBuilder;
+import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
 import org.apache.cxf.jaxrs.client.WebClient;
 import org.apache.cxf.jaxrs.model.AbstractResourceInfo;
 import org.apache.cxf.testutil.common.AbstractBusClientServerTestBase;
@@ -26,7 +32,9 @@ import org.apache.cxf.testutil.common.AbstractBusClientServerTestBase;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
+import static org.hamcrest.CoreMatchers.equalTo;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 public class JAXRSClientServerSubBookTest extends AbstractBusClientServerTestBase {
@@ -44,9 +52,23 @@ public class JAXRSClientServerSubBookTest extends AbstractBusClientServerTestBas
     public void testGetChapterFromBookSubObject() throws Exception {
         WebClient wc =
             WebClient.create("http://localhost:" + PORT + "/bookstore/booksubresourceobject/chaptersobject/sub/1");
-        WebClient.getConfig(wc).getHttpConduit().getClient().setReceiveTimeout(100000000L);
         Chapter c = wc.accept("application/xml").get(Chapter.class);
         assertNotNull(c);
     }
 
+    @Test
+    public void testSubresourceLocatorFromBookSubObject() throws Exception {
+        final Client c = ClientBuilder.newClient();
+
+        // There are two matching endpoints with different HTTP methods:
+        //  - POST for BookSubObject /consumeslocator"
+        //  - GET for BookStore /{id}
+        // The test verifies that in this case for the POST method the correct subresource
+        // locator is picked.
+        final WebTarget wc = c.target("http://localhost:" + PORT + "/bookstore/consumeslocator");
+        try (Response r = wc.request().header("Content-Type", MediaType.APPLICATION_ATOM_XML).post(null)) {
+            assertThat(r.getStatus(), equalTo(Response.Status.UNSUPPORTED_MEDIA_TYPE.getStatusCode()));
+            assertThat(Integer.toString(r.getStatus()), equalTo(r.readEntity(String.class)));
+        }
+    }
 }


### PR DESCRIPTION
Before:

| Tests that passed  |  2637| 
|  -- |  -- | 
|  Tests that failed | 12   |  
| Total  | 2663  | 

After:

| Tests that passed  |  2638 | 
|  -- |  -- | 
|  Tests that failed | 25   |  
| Total  | 2663  | 

Only 12 test cases left:

```
JT Harness : Tests that failed
Tests are grouped by their final status message.
Test case throws exception: No exception has been thrown for link <http://:@>

    [com/sun/ts/tests/jaxrs/api/rs/core/linkbuilder/JAXRSClient.java#buildNoArgsThrowsUriBuilderExceptionTest_from_standalone](file:///tmp/JTwork/com/sun/ts/tests/jaxrs/api/rs/core/linkbuilder/JAXRSClient_buildNoArgsThrowsUriBuilderExceptionTest_from_standalone.jtr): JAXRSClient_buildNoArgsThrowsUriBuilderExceptionTest_from_standalone
    [com/sun/ts/tests/jaxrs/api/rs/core/linkbuilder/JAXRSClient.java#buildObjectsThrowsUriBuilderExceptionTest_from_standalone](file:///tmp/JTwork/com/sun/ts/tests/jaxrs/api/rs/core/linkbuilder/JAXRSClient_buildObjectsThrowsUriBuilderExceptionTest_from_standalone.jtr): JAXRSClient_buildObjectsThrowsUriBuilderExceptionTest_from_standalone 

Test case throws exception: UriBuilderException has not been thrown, link= <http://@>

    [com/sun/ts/tests/jaxrs/api/rs/core/linkbuilder/JAXRSClient.java#buildRelativizedThrowsUriBuilderExceptionTest_from_standalone](file:///tmp/JTwork/com/sun/ts/tests/jaxrs/api/rs/core/linkbuilder/JAXRSClient_buildRelativizedThrowsUriBuilderExceptionTest_from_standalone.jtr): JAXRSClient_buildRelativizedThrowsUriBuilderExceptionTest_from_standalone 

Test case throws exception: [JAXRSCommonClient] null failed! Check output for cause of failure.

    [com/sun/ts/tests/jaxrs/ee/rs/container/requestcontext/JAXRSClient.java#setRequestUriTwoUrisTest_from_standalone](file:///tmp/JTwork/com/sun/ts/tests/jaxrs/ee/rs/container/requestcontext/JAXRSClient_setRequestUriTwoUrisTest_from_standalone.jtr): JAXRSClient_setRequestUriTwoUrisTest_from_standalone
    [com/sun/ts/tests/jaxrs/ee/rs/container/responsecontext/JAXRSClient.java#getEntityAnnotationsTest_from_standalone](file:///tmp/JTwork/com/sun/ts/tests/jaxrs/ee/rs/container/responsecontext/JAXRSClient_getEntityAnnotationsTest_from_standalone.jtr): JAXRSClient_getEntityAnnotationsTest_from_standalone
    [com/sun/ts/tests/jaxrs/ee/rs/core/uriinfo/JAXRSClient.java#getMatchedURIsTest1_from_standalone](file:///tmp/JTwork/com/sun/ts/tests/jaxrs/ee/rs/core/uriinfo/JAXRSClient_getMatchedURIsTest1_from_standalone.jtr): JAXRSClient_getMatchedURIsTest1_from_standalone
    [com/sun/ts/tests/jaxrs/ee/rs/core/uriinfo/JAXRSClient.java#getMatchedURIsTest2_from_standalone](file:///tmp/JTwork/com/sun/ts/tests/jaxrs/ee/rs/core/uriinfo/JAXRSClient_getMatchedURIsTest2_from_standalone.jtr): JAXRSClient_getMatchedURIsTest2_from_standalone
    [com/sun/ts/tests/jaxrs/ee/rs/core/uriinfo/JAXRSClient.java#getMatchedURIsTest_from_standalone](file:///tmp/JTwork/com/sun/ts/tests/jaxrs/ee/rs/core/uriinfo/JAXRSClient_getMatchedURIsTest_from_standalone.jtr): JAXRSClient_getMatchedURIsTest_from_standalone
    [com/sun/ts/tests/jaxrs/ee/rs/ext/interceptor/containerwriter/interceptorcontext/JAXRSClient.java#getAnnotationsTest_from_standalone](file:///tmp/JTwork/com/sun/ts/tests/jaxrs/ee/rs/ext/interceptor/containerwriter/interceptorcontext/JAXRSClient_getAnnotationsTest_from_standalone.jtr): JAXRSClient_getAnnotationsTest_from_standalone
    [com/sun/ts/tests/jaxrs/ee/rs/ext/paramconverter/JAXRSClient.java#atomicIntegerIsLazyDeployableAndThrowsErrorTest_from_standalone](file:///tmp/JTwork/com/sun/ts/tests/jaxrs/ee/rs/ext/paramconverter/JAXRSClient_atomicIntegerIsLazyDeployableAndThrowsErrorTest_from_standalone.jtr): JAXRSClient_atomicIntegerIsLazyDeployableAndThrowsErrorTest_from_standalone
    [com/sun/ts/tests/jaxrs/ee/rs/get/JAXRSClient.java#optionSubTest_from_standalone](file:///tmp/JTwork/com/sun/ts/tests/jaxrs/ee/rs/get/JAXRSClient_optionSubTest_from_standalone.jtr): JAXRSClient_optionSubTest_from_standalone 

Test case throws exception: javax.ws.rs.POST, javax.ws.rs.Path, does not contain javax.ws.rs.ext.Provider , annotations not passed to MessageBodyWriter?

    [com/sun/ts/tests/jaxrs/ee/rs/core/responsebuilder/JAXRSClient.java#entityObjectTest_from_standalone](file:///tmp/JTwork/com/sun/ts/tests/jaxrs/ee/rs/core/responsebuilder/JAXRSClient_entityObjectTest_from_standalone.jtr): JAXRSClient_entityObjectTest_from_standalone
```