### PR TITLE
CXF-8682: x-forwarded-proto header causes cxf to not match request to java method

### DIFF
--- a/rt/frontend/jaxrs/src/main/java/org/apache/cxf/jaxrs/utils/HttpUtils.java
+++ b/rt/frontend/jaxrs/src/main/java/org/apache/cxf/jaxrs/utils/HttpUtils.java
@@ -471,7 +471,9 @@ public final class HttpUtils {
             URI uri = new URI(endpointAddress);
             String path = uri.getRawPath();
             String scheme = uri.getScheme();
-            if (scheme != null && !scheme.startsWith(HttpUtils.HTTP_SCHEME)
+            // RFC-3986: the scheme and host are case-insensitive and therefore should 
+            // be normalized to lowercase. 
+            if (scheme != null && !scheme.toLowerCase().startsWith(HttpUtils.HTTP_SCHEME)
                 && HttpUtils.isHttpRequest(m)) {
                 path = HttpUtils.toAbsoluteUri(path, m).getRawPath();
             }

--- a/rt/frontend/jaxrs/src/test/java/org/apache/cxf/jaxrs/utils/HttpUtilsTest.java
+++ b/rt/frontend/jaxrs/src/test/java/org/apache/cxf/jaxrs/utils/HttpUtilsTest.java
@@ -222,6 +222,33 @@ public class HttpUtilsTest {
     }
 
     @Test
+    public void testGetBaseAddressHttpUriMixedCase() {
+        final String baseURI = "HTTP://LoCALHoST:8080/STORE";
+        
+        Message m = new MessageImpl();
+        HttpServletRequest req = EasyMock.createMock(HttpServletRequest.class);
+        m.put(AbstractHTTPDestination.HTTP_REQUEST, req);
+        Exchange exchange = new ExchangeImpl();
+        
+        req.getRequestURL();
+        EasyMock.expectLastCall().andReturn(new StringBuffer(baseURI));
+        req.getPathInfo();
+        EasyMock.expectLastCall().andReturn("/STORE");
+        req.getContextPath();
+        EasyMock.expectLastCall().andReturn("/");
+        req.getServletPath();
+        EasyMock.expectLastCall().andReturn("/");
+        EasyMock.replay(req);
+
+        m.setExchange(exchange);
+        Destination dest = EasyMock.createMock(Destination.class);
+        exchange.setDestination(dest);
+        m.put(Message.BASE_PATH, baseURI);
+        String address = HttpUtils.getBaseAddress(m);
+        assertEquals("/STORE", address);
+    }
+
+    @Test
     public void testReplaceAnyIPAddress() {
         Message m = new MessageImpl();
         HttpServletRequest req = EasyMock.createMock(HttpServletRequest.class);


### PR DESCRIPTION
CXF-8682: x-forwarded-proto header causes cxf to not match request to java method