### PR TITLE
Temporary exclude modules which still depend on 'javax.*' by displacing them to separate 'javax' profile

### DIFF
--- a/maven-plugins/pom.xml
+++ b/maven-plugins/pom.xml
@@ -34,10 +34,20 @@
         <module>codegen-plugin</module>
         <module>java2ws-plugin</module>
         <module>java2wadl-plugin</module>
-        <module>java2swagger-plugin</module>
         <module>wsdl-validator-plugin</module>
-        <module>wadl2java-plugin</module>
         <module>corba</module>
         <module>archetypes</module>
     </modules>
+    
+    <profiles>
+        <!-- TODO: This profile includes modules which are still on 'javax.*' namespace and
+        are not migrated to Jakarta -->
+        <profile>
+            <id>javax</id>
+            <modules>
+                <module>wadl2java-plugin</module>
+                <module>java2swagger-plugin</module>
+            </modules>
+        </profile>
+    </profiles>
 </project>

--- a/osgi/karaf/features/pom.xml
+++ b/osgi/karaf/features/pom.xml
@@ -42,8 +42,8 @@
                     <artifactId>jakarta.activation</artifactId>
                 </exclusion>
                 <exclusion>
-                    <groupId>jakarta.annotation</groupId>
-                    <artifactId>jakarta.annotation-api</artifactId>
+                    <groupId>javax.annotation</groupId>
+                    <artifactId>javax.annotation-api</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>

--- a/osgi/karaf/features/src/main/resources/features.xml
+++ b/osgi/karaf/features/src/main/resources/features.xml
@@ -23,7 +23,7 @@
     <feature name="cxf-specs" version="${project.version}">
         <bundle start-level="9">mvn:org.apache.geronimo.specs/geronimo-osgi-registry/1.1</bundle>
         <bundle start-level="10" dependency="true">mvn:com.sun.activation/jakarta.activation/${cxf.jakarta.activation.version}</bundle>
-        <bundle start-level="10" dependency="true">mvn:jakarta.annotation/jakarta.annotation-api/${cxf.javax.annotation-api.version}</bundle>
+        <bundle start-level="10" dependency="true">mvn:jakarta.annotation/jakarta.annotation-api/${cxf.jakarta.annotation-api.version}</bundle>
         <bundle start-level="10" dependency="true">mvn:org.apache.servicemix.specs/org.apache.servicemix.specs.stax-api-1.2/${cxf.servicemix.specs.version}</bundle>
         <bundle start-level="10" dependency="true">mvn:org.apache.servicemix.specs/org.apache.servicemix.specs.jaxb-api-2.3/${cxf.servicemix.specs.jaxb.version}</bundle>
         <bundle start-level="10" dependency="true">mvn:org.apache.servicemix.specs/org.apache.servicemix.specs.jaxws-api-2.3/${cxf.specs.jaxws.api.version}</bundle>
@@ -265,7 +265,7 @@
     <feature name="cxf-jackson" version="${project.version}">
         <!-- Required by jackson-dataformat-yaml -->
         <bundle start-level="10" dependency="true">mvn:org.apache.servicemix.specs/org.apache.servicemix.specs.jaxrs-api-2.1/${cxf.servicemix.jaxrs.specs.version}</bundle>
-        <bundle start-level="10" dependency="true">mvn:jakarta.annotation/jakarta.annotation-api/${cxf.javax.annotation-api.version}</bundle>
+        <bundle start-level="10" dependency="true">mvn:jakarta.annotation/jakarta.annotation-api/${cxf.jakarta.annotation-api.version}</bundle>
         <bundle start-level="35">mvn:org.yaml/snakeyaml/${cxf.snakeyaml.version}</bundle>
         <bundle start-level="35">mvn:com.fasterxml.jackson.core/jackson-core/${cxf.jackson.version}</bundle>
         <bundle start-level="35">mvn:com.fasterxml.jackson.core/jackson-annotations/${cxf.jackson.version}</bundle>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -229,7 +229,7 @@
         <cxf.woodstox.core.version>6.2.7</cxf.woodstox.core.version>
         <cxf.woodstox.stax2-api.version>4.2.1</cxf.woodstox.stax2-api.version>
         <cxf.wsdl4j.version>1.6.3</cxf.wsdl4j.version>
-        <cxf.jakarta.wss4j.version>3.0.0-SNAPSHOT</cxf.jakarta.wss4j.version>
+        <cxf.jakarta.wss4j.version>2.4.1</cxf.jakarta.wss4j.version>
         <cxf.xalan.version>2.7.2</cxf.xalan.version>
         <cxf.xerces.version>2.12.2</cxf.xerces.version>
         <cxf.xmlschema.version>2.3.0</cxf.xmlschema.version>
@@ -273,7 +273,6 @@
         <cxf.xalan.bundle.version>2.7.2_3</cxf.xalan.bundle.version>
         <cxf.xerces.bundle.version>2.12.0_1</cxf.xerces.bundle.version>
         <cxf.xmlresolver.bundle.version>1.2_5</cxf.xmlresolver.bundle.version>
-        <cxf.xmlsec.bundle.version>3.0.0-SNAPSHOT</cxf.xmlsec.bundle.version>
         <cxf.xpp3.bundle.version>1.1.4c_6</cxf.xpp3.bundle.version>
         <cxf.awaitility.version>4.1.1</cxf.awaitility.version>
     </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -172,10 +172,17 @@
         <module>integration</module>
         <module>maven-plugins</module>
         <module>services</module>
-        <module>osgi</module>
         <module>systests</module>
     </modules>
     <profiles>
+        <!-- TODO: This profile includes modules which are still on 'javax.*' namespace and
+        are not migrated to Jakarta -->
+        <profile>
+            <id>javax</id>
+            <modules>
+                <module>osgi</module>
+            </modules>
+        </profile>
         <profile>
             <!-- default profile enables checkstyle and Xlint stuff -->
             <id>everything</id>

--- a/rt/rs/pom.xml
+++ b/rt/rs/pom.xml
@@ -33,7 +33,6 @@
         <module>client</module>
         <module>http-sci</module>
         <module>description</module>
-        <module>description-swagger</module>
         <module>extensions/json-basic</module>
         <module>extensions/providers</module>
         <module>extensions/search</module>
@@ -45,9 +44,20 @@
         <module>security</module>
         <module>sse</module>
         <module>description-openapi-v3</module>
-        <module>description-microprofile-openapi</module>
         <module>description-swagger-ui</module>
         <module>microprofile-client</module>
         <module>description-common-openapi</module>
     </modules>
+    
+    <profiles>
+        <!-- TODO: This profile includes modules which are still on 'javax.*' namespace and
+        are not migrated to Jakarta -->
+        <profile>
+            <id>javax</id>
+            <modules>
+                <module>description-swagger</module>
+                <module>description-microprofile-openapi</module>
+            </modules>
+        </profile>
+    </profiles>
 </project>

--- a/rt/transports/pom.xml
+++ b/rt/transports/pom.xml
@@ -38,8 +38,18 @@
         <module>http-hc5</module>
         <module>http-netty/netty-server</module>
         <module>http-netty/netty-client</module>
-        <module>jms</module>
         <module>udp</module>
-        <module>websocket</module>
     </modules>
+    
+    <profiles>
+        <!-- TODO: This profile includes modules which are still on 'javax.*' namespace and
+        are not migrated to Jakarta -->
+        <profile>
+            <id>javax</id>
+            <modules>
+                <module>jms</module>
+                <module>websocket</module>
+            </modules>
+        </profile>
+    </profiles>
 </project>

--- a/services/wsn/pom.xml
+++ b/services/wsn/pom.xml
@@ -32,7 +32,17 @@
     </parent>
     <modules>
         <module>wsn-api</module>
-        <module>wsn-core</module>
         <module>wsn-osgi</module>
     </modules>
+    
+    <profiles>
+        <!-- TODO: This profile includes modules which are still on 'javax.*' namespace and
+        are not migrated to Jakarta -->
+        <profile>
+            <id>javax</id>
+            <modules>
+                <module>wsn-core</module>
+            </modules>
+        </profile>
+    </profiles>
 </project>

--- a/systests/container-integration/pom.xml
+++ b/systests/container-integration/pom.xml
@@ -33,6 +33,16 @@
     <url>https://cxf.apache.org</url>
     <modules>
         <module>webapp</module>
-        <module>grizzly</module>
     </modules>
+    
+    <profiles>
+        <!-- TODO: This profile includes modules which are still on 'javax.*' namespace and
+        are not migrated to Jakarta -->
+        <profile>
+            <id>javax</id>
+            <modules>
+                <module>grizzly</module>
+            </modules>
+        </profile>
+    </profiles>
 </project>

--- a/systests/jaxrs/pom.xml
+++ b/systests/jaxrs/pom.xml
@@ -92,6 +92,12 @@
         <dependency>
             <groupId>org.apache.olingo</groupId>
             <artifactId>olingo-odata2-core</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>javax.ws.rs</groupId>
+                    <artifactId>javax.ws.rs-api</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>xalan</groupId>
@@ -108,6 +114,12 @@
             <artifactId>cxf-rt-rs-service-description-swagger</artifactId>
             <version>${project.version}</version>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>javax.validation</groupId>
+                    <artifactId>validation-api</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.cxf</groupId>

--- a/systests/microprofile/client/jaxrs/pom.xml
+++ b/systests/microprofile/client/jaxrs/pom.xml
@@ -54,12 +54,6 @@
             </dependency>
         <dependency>
             <groupId>org.apache.cxf</groupId>
-            <artifactId>cxf-rt-rs-service-description-swagger</artifactId>
-            <version>${project.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-rs-service-description-openapi-v3</artifactId>
             <version>${project.version}</version>
             <scope>test</scope>

--- a/systests/microprofile/client/weld/pom.xml
+++ b/systests/microprofile/client/weld/pom.xml
@@ -87,6 +87,12 @@
             <groupId>org.eclipse.microprofile.rest.client</groupId>
             <artifactId>microprofile-rest-client-tck</artifactId>
             <version>${cxf.microprofile.rest.client.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.github.tomakehurst</groupId>
+                    <artifactId>wiremock</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
     </dependencies>
     <build>

--- a/systests/pom.xml
+++ b/systests/pom.xml
@@ -35,11 +35,9 @@
         <module>uncategorized</module>
         <module>transports</module>
         <module>forked</module>
-        <module>transport-jms</module>
         <module>transport-undertow</module>
         <module>jaxws</module>
         <module>databinding</module>
-        <module>jaxrs</module>
         <module>ws-specs</module>
         <module>ws-rm</module>
         <module>ws-security</module>
@@ -58,4 +56,16 @@
         <module>transport-netty</module>
         <module>transport-hc5</module>
     </modules>
+    
+    <profiles>
+        <!-- TODO: This profile includes modules which are still on 'javax.*' namespace and
+        are not migrated to Jakarta -->
+        <profile>
+            <id>javax</id>
+            <modules>
+                <module>transport-jms</module>
+                <module>jaxrs</module>
+            </modules>
+        </profile>
+    </profiles>
 </project>

--- a/systests/rs-http-sci/src/test/java/org/apache/cxf/jaxrs/servlet/AbstractSciTest.java
+++ b/systests/rs-http-sci/src/test/java/org/apache/cxf/jaxrs/servlet/AbstractSciTest.java
@@ -21,7 +21,7 @@ package org.apache.cxf.jaxrs.servlet;
 import java.util.Arrays;
 import java.util.List;
 
-import com.fasterxml.jackson.jaxrs.json.JacksonJsonProvider;
+import com.fasterxml.jackson.jakarta.rs.json.JacksonJsonProvider;
 
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;

--- a/systests/rs-http-sci/src/test/java/org/apache/cxf/jaxrs/servlet/jetty/JettyEmptyApplicationTest.java
+++ b/systests/rs-http-sci/src/test/java/org/apache/cxf/jaxrs/servlet/jetty/JettyEmptyApplicationTest.java
@@ -19,7 +19,7 @@
 
 package org.apache.cxf.jaxrs.servlet.jetty;
 
-import com.fasterxml.jackson.jaxrs.json.JacksonJsonProvider;
+import com.fasterxml.jackson.jakarta.rs.json.JacksonJsonProvider;
 
 import org.apache.cxf.jaxrs.model.AbstractResourceInfo;
 import org.apache.cxf.jaxrs.servlet.AbstractSciTest;

--- a/systests/rs-http-sci/src/test/java/org/apache/cxf/jaxrs/servlet/jetty/JettyEmptyPathApplicationTest.java
+++ b/systests/rs-http-sci/src/test/java/org/apache/cxf/jaxrs/servlet/jetty/JettyEmptyPathApplicationTest.java
@@ -19,7 +19,7 @@
 
 package org.apache.cxf.jaxrs.servlet.jetty;
 
-import com.fasterxml.jackson.jaxrs.json.JacksonJsonProvider;
+import com.fasterxml.jackson.jakarta.rs.json.JacksonJsonProvider;
 
 import org.apache.cxf.jaxrs.model.AbstractResourceInfo;
 import org.apache.cxf.jaxrs.servlet.AbstractSciTest;

--- a/systests/rs-http-sci/src/test/java/org/apache/cxf/jaxrs/servlet/jetty/JettyNoApplicationTest.java
+++ b/systests/rs-http-sci/src/test/java/org/apache/cxf/jaxrs/servlet/jetty/JettyNoApplicationTest.java
@@ -19,7 +19,7 @@
 
 package org.apache.cxf.jaxrs.servlet.jetty;
 
-import com.fasterxml.jackson.jaxrs.json.JacksonJsonProvider;
+import com.fasterxml.jackson.jakarta.rs.json.JacksonJsonProvider;
 
 import org.apache.cxf.jaxrs.model.AbstractResourceInfo;
 import org.apache.cxf.jaxrs.servlet.AbstractSciTest;

--- a/systests/rs-http-sci/src/test/java/org/apache/demo/applications/classes/BookApplication.java
+++ b/systests/rs-http-sci/src/test/java/org/apache/demo/applications/classes/BookApplication.java
@@ -22,7 +22,7 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
 
-import com.fasterxml.jackson.jaxrs.json.JacksonJsonProvider;
+import com.fasterxml.jackson.jakarta.rs.json.JacksonJsonProvider;
 
 import jakarta.ws.rs.ApplicationPath;
 import jakarta.ws.rs.core.Application;

--- a/systests/rs-http-sci/src/test/java/org/apache/demo/applications/complete/BookApplication.java
+++ b/systests/rs-http-sci/src/test/java/org/apache/demo/applications/complete/BookApplication.java
@@ -22,7 +22,7 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
 
-import com.fasterxml.jackson.jaxrs.json.JacksonJsonProvider;
+import com.fasterxml.jackson.jakarta.rs.json.JacksonJsonProvider;
 
 import jakarta.ws.rs.ApplicationPath;
 import jakarta.ws.rs.core.Application;

--- a/systests/rs-http-sci/src/test/java/org/apache/demo/applications/singletons/BookApplication.java
+++ b/systests/rs-http-sci/src/test/java/org/apache/demo/applications/singletons/BookApplication.java
@@ -22,7 +22,7 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
 
-import com.fasterxml.jackson.jaxrs.json.JacksonJsonProvider;
+import com.fasterxml.jackson.jakarta.rs.json.JacksonJsonProvider;
 
 import jakarta.ws.rs.ApplicationPath;
 import jakarta.ws.rs.core.Application;

--- a/systests/rs-security/src/test/java/org/apache/cxf/systest/jaxrs/security/jose/jwejws/JAXRSJweJwsTest.java
+++ b/systests/rs-security/src/test/java/org/apache/cxf/systest/jaxrs/security/jose/jwejws/JAXRSJweJwsTest.java
@@ -26,7 +26,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Properties;
 
-import com.fasterxml.jackson.jaxrs.json.JacksonJsonProvider;
+import com.fasterxml.jackson.jakarta.rs.json.JacksonJsonProvider;
 
 import jakarta.annotation.Priority;
 import jakarta.ws.rs.BadRequestException;

--- a/systests/rs-security/src/test/java/org/apache/cxf/systest/jaxrs/security/jose/jwejws/JAXRSJwsJsonTest.java
+++ b/systests/rs-security/src/test/java/org/apache/cxf/systest/jaxrs/security/jose/jwejws/JAXRSJwsJsonTest.java
@@ -29,7 +29,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 
-import com.fasterxml.jackson.jaxrs.json.JacksonJsonProvider;
+import com.fasterxml.jackson.jakarta.rs.json.JacksonJsonProvider;
 
 import jakarta.ws.rs.BadRequestException;
 import org.apache.cxf.Bus;

--- a/systests/rs-security/src/test/java/org/apache/cxf/systest/jaxrs/security/jose/jwejws/JweJwsAlgorithmTest.java
+++ b/systests/rs-security/src/test/java/org/apache/cxf/systest/jaxrs/security/jose/jwejws/JweJwsAlgorithmTest.java
@@ -26,7 +26,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import com.fasterxml.jackson.jaxrs.json.JacksonJsonProvider;
+import com.fasterxml.jackson.jakarta.rs.json.JacksonJsonProvider;
 
 import jakarta.ws.rs.core.Response;
 import org.apache.cxf.jaxrs.client.WebClient;

--- a/systests/rs-security/src/test/java/org/apache/cxf/systest/jaxrs/security/jose/jwejws/JweJwsReferenceTest.java
+++ b/systests/rs-security/src/test/java/org/apache/cxf/systest/jaxrs/security/jose/jwejws/JweJwsReferenceTest.java
@@ -26,7 +26,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import com.fasterxml.jackson.jaxrs.json.JacksonJsonProvider;
+import com.fasterxml.jackson.jakarta.rs.json.JacksonJsonProvider;
 
 import jakarta.ws.rs.core.Response;
 import org.apache.cxf.jaxrs.client.WebClient;

--- a/systests/rs-security/src/test/java/org/apache/cxf/systest/jaxrs/security/jose/jwejws/JwsHTTPHeaderTest.java
+++ b/systests/rs-security/src/test/java/org/apache/cxf/systest/jaxrs/security/jose/jwejws/JwsHTTPHeaderTest.java
@@ -28,7 +28,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import com.fasterxml.jackson.jaxrs.json.JacksonJsonProvider;
+import com.fasterxml.jackson.jakarta.rs.json.JacksonJsonProvider;
 
 import jakarta.ws.rs.core.HttpHeaders;
 import jakarta.ws.rs.core.Response;

--- a/systests/rs-security/src/test/java/org/apache/cxf/systest/jaxrs/security/jose/jwt/JWTAlgorithmTest.java
+++ b/systests/rs-security/src/test/java/org/apache/cxf/systest/jaxrs/security/jose/jwt/JWTAlgorithmTest.java
@@ -28,7 +28,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import com.fasterxml.jackson.jaxrs.json.JacksonJsonProvider;
+import com.fasterxml.jackson.jakarta.rs.json.JacksonJsonProvider;
 
 import jakarta.ws.rs.core.Response;
 import org.apache.cxf.jaxrs.client.WebClient;

--- a/systests/rs-security/src/test/java/org/apache/cxf/systest/jaxrs/security/jose/jwt/JWTAuthnAuthzTest.java
+++ b/systests/rs-security/src/test/java/org/apache/cxf/systest/jaxrs/security/jose/jwt/JWTAuthnAuthzTest.java
@@ -27,7 +27,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import com.fasterxml.jackson.jaxrs.json.JacksonJsonProvider;
+import com.fasterxml.jackson.jakarta.rs.json.JacksonJsonProvider;
 
 import jakarta.ws.rs.core.Response;
 import org.apache.cxf.jaxrs.client.WebClient;

--- a/systests/rs-security/src/test/java/org/apache/cxf/systest/jaxrs/security/jose/jwt/JWTPropertiesTest.java
+++ b/systests/rs-security/src/test/java/org/apache/cxf/systest/jaxrs/security/jose/jwt/JWTPropertiesTest.java
@@ -28,7 +28,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import com.fasterxml.jackson.jaxrs.json.JacksonJsonProvider;
+import com.fasterxml.jackson.jakarta.rs.json.JacksonJsonProvider;
 
 import jakarta.ws.rs.core.Response;
 import org.apache.cxf.jaxrs.client.WebClient;

--- a/systests/rs-sse/rs-sse-base/src/main/java/org/apache/cxf/systest/jaxrs/sse/AbstractSseBaseTest.java
+++ b/systests/rs-sse/rs-sse-base/src/main/java/org/apache/cxf/systest/jaxrs/sse/AbstractSseBaseTest.java
@@ -24,7 +24,7 @@ import java.util.List;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.jaxrs.json.JacksonJsonProvider;
+import com.fasterxml.jackson.jakarta.rs.json.JacksonJsonProvider;
 
 import jakarta.ws.rs.client.ClientBuilder;
 import jakarta.ws.rs.client.WebTarget;

--- a/systests/rs-sse/rs-sse-base/src/main/java/org/apache/cxf/systest/jaxrs/sse/AbstractSseTest.java
+++ b/systests/rs-sse/rs-sse-base/src/main/java/org/apache/cxf/systest/jaxrs/sse/AbstractSseTest.java
@@ -34,7 +34,7 @@ import java.util.function.Consumer;
 
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.jaxrs.json.JacksonJsonProvider;
+import com.fasterxml.jackson.jakarta.rs.json.JacksonJsonProvider;
 
 import jakarta.ws.rs.client.Entity;
 import jakarta.ws.rs.client.WebTarget;

--- a/systests/rs-sse/rs-sse-base/src/main/java/org/apache/cxf/systest/jaxrs/sse/SseApplication.java
+++ b/systests/rs-sse/rs-sse-base/src/main/java/org/apache/cxf/systest/jaxrs/sse/SseApplication.java
@@ -23,7 +23,7 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 
-import com.fasterxml.jackson.jaxrs.json.JacksonJsonProvider;
+import com.fasterxml.jackson.jakarta.rs.json.JacksonJsonProvider;
 
 import jakarta.ws.rs.core.Application;
 

--- a/systests/rs-sse/rs-sse-jetty/src/test/java/org/apache/cxf/systest/jaxrs/sse/jetty/AbstractJettyServer.java
+++ b/systests/rs-sse/rs-sse-jetty/src/test/java/org/apache/cxf/systest/jaxrs/sse/jetty/AbstractJettyServer.java
@@ -19,7 +19,7 @@
 
 package org.apache.cxf.systest.jaxrs.sse.jetty;
 
-import com.fasterxml.jackson.jaxrs.json.JacksonJsonProvider;
+import com.fasterxml.jackson.jakarta.rs.json.JacksonJsonProvider;
 
 import org.apache.cxf.jaxrs.servlet.CXFNonSpringJaxrsServlet;
 import org.apache.cxf.systest.jaxrs.sse.BookStore;

--- a/systests/rs-sse/rs-sse-tomcat/src/test/java/org/apache/cxf/systest/jaxrs/sse/tomcat/AbstractTomcatServer.java
+++ b/systests/rs-sse/rs-sse-tomcat/src/test/java/org/apache/cxf/systest/jaxrs/sse/tomcat/AbstractTomcatServer.java
@@ -22,7 +22,7 @@ package org.apache.cxf.systest.jaxrs.sse.tomcat;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
-import com.fasterxml.jackson.jaxrs.json.JacksonJsonProvider;
+import com.fasterxml.jackson.jakarta.rs.json.JacksonJsonProvider;
 
 import org.apache.catalina.Context;
 import org.apache.catalina.Wrapper;

--- a/systests/rs-sse/rs-sse-undertow/src/test/java/org/apache/cxf/systest/jaxrs/sse/undertow/AbstractUndertowServer.java
+++ b/systests/rs-sse/rs-sse-undertow/src/test/java/org/apache/cxf/systest/jaxrs/sse/undertow/AbstractUndertowServer.java
@@ -19,7 +19,7 @@
 
 package org.apache.cxf.systest.jaxrs.sse.undertow;
 
-import com.fasterxml.jackson.jaxrs.json.JacksonJsonProvider;
+import com.fasterxml.jackson.jakarta.rs.json.JacksonJsonProvider;
 
 import org.apache.cxf.jaxrs.servlet.CXFNonSpringJaxrsServlet;
 import org.apache.cxf.systest.jaxrs.sse.BookStore;

--- a/systests/spring-boot/src/test/java/org/apache/cxf/systest/jaxrs/applications/LibraryApplication.java
+++ b/systests/spring-boot/src/test/java/org/apache/cxf/systest/jaxrs/applications/LibraryApplication.java
@@ -23,7 +23,7 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
 
-import com.fasterxml.jackson.jaxrs.json.JacksonJsonProvider;
+import com.fasterxml.jackson.jakarta.rs.json.JacksonJsonProvider;
 
 import jakarta.ws.rs.ApplicationPath;
 import jakarta.ws.rs.core.Application;

--- a/systests/spring-boot/src/test/java/org/apache/cxf/systest/jaxrs/spring/boot/SpringJaxrsApplicationTest.java
+++ b/systests/spring-boot/src/test/java/org/apache/cxf/systest/jaxrs/spring/boot/SpringJaxrsApplicationTest.java
@@ -40,6 +40,7 @@ import org.apache.cxf.metrics.MetricsProvider;
 import org.apache.cxf.systest.jaxrs.applications.LibraryApplication;
 import org.apache.cxf.systest.jaxrs.resources.Book;
 import org.apache.cxf.systest.jaxrs.resources.LibraryApi;
+import org.apache.cxf.testutil.common.TestUtil;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -48,7 +49,6 @@ import org.springframework.boot.web.server.LocalServerPort;
 import org.springframework.context.annotation.Bean;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
-import org.springframework.util.SocketUtils;
 
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Tag;
@@ -271,7 +271,7 @@ public class SpringJaxrsApplicationTest {
     
     @Test
     public void testJaxrsClientExceptionMetric() {
-        final int fakePort = SocketUtils.findAvailableTcpPort();
+        final int fakePort = Integer.parseInt(TestUtil.getPortNumber("client-exception"));
         
         final WebTarget target = ClientBuilder
             .newClient()
@@ -426,7 +426,7 @@ public class SpringJaxrsApplicationTest {
     
     @Test
     public void testJaxrsProxyClientExceptionMetric() {
-        final int fakePort = SocketUtils.findAvailableTcpPort();
+        final int fakePort = Integer.parseInt(TestUtil.getPortNumber("proxy-client-exception"));
         final LibraryApi api = createApi(fakePort);
 
         assertThatThrownBy(() -> api.deleteBooks())

--- a/systests/spring-boot/src/test/java/org/apache/cxf/systest/jaxrs/spring/boot/SpringJaxrsTest.java
+++ b/systests/spring-boot/src/test/java/org/apache/cxf/systest/jaxrs/spring/boot/SpringJaxrsTest.java
@@ -40,6 +40,7 @@ import org.apache.cxf.metrics.MetricsProvider;
 import org.apache.cxf.systest.jaxrs.resources.Book;
 import org.apache.cxf.systest.jaxrs.resources.Library;
 import org.apache.cxf.systest.jaxrs.resources.LibraryApi;
+import org.apache.cxf.testutil.common.TestUtil;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -51,7 +52,6 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
-import org.springframework.util.SocketUtils;
 
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Tag;
@@ -241,7 +241,7 @@ public class SpringJaxrsTest {
     
     @Test
     public void testJaxrsClientExceptionMetric() {
-        final int fakePort = SocketUtils.findAvailableTcpPort();
+        final int fakePort = Integer.parseInt(TestUtil.getPortNumber("client-exception"));
         
         final WebTarget target = ClientBuilder
             .newClient()
@@ -396,7 +396,7 @@ public class SpringJaxrsTest {
     
     @Test
     public void testJaxrsProxyClientExceptionMetric() {
-        final int fakePort = SocketUtils.findAvailableTcpPort();
+        final int fakePort = Integer.parseInt(TestUtil.getPortNumber("proxy-client-exception"));
         final LibraryApi api = createApi(fakePort);
 
         assertThatThrownBy(() -> api.deleteBooks())

--- a/systests/spring-boot/src/test/java/org/apache/cxf/systest/jaxws/spring/boot/SpringJaxwsTest.java
+++ b/systests/spring-boot/src/test/java/org/apache/cxf/systest/jaxws/spring/boot/SpringJaxwsTest.java
@@ -44,6 +44,7 @@ import org.apache.cxf.metrics.MetricsProvider;
 import org.apache.cxf.staxutils.StaxUtils;
 import org.apache.cxf.systest.jaxws.resources.HelloService;
 import org.apache.cxf.systest.jaxws.resources.HelloServiceImpl;
+import org.apache.cxf.testutil.common.TestUtil;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -54,7 +55,6 @@ import org.springframework.boot.web.server.LocalServerPort;
 import org.springframework.context.annotation.Bean;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
-import org.springframework.util.SocketUtils;
 
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Tag;
@@ -353,7 +353,7 @@ public class SpringJaxwsTest {
 
     @Test
     public void testJaxwsProxyClientExceptionMetric() throws MalformedURLException {
-        final int fakePort = SocketUtils.findAvailableTcpPort();
+        final int fakePort = Integer.parseInt(TestUtil.getPortNumber("proxy-client-exception"));
         final HelloService api = createApi(fakePort, HELLO_SERVICE_NAME_V1); 
         
         assertThatThrownBy(() -> api.sayHello("Elan"))

--- a/systests/tracing/src/test/java/org/apache/cxf/systest/jaxrs/tracing/brave/BraveTracingTest.java
+++ b/systests/tracing/src/test/java/org/apache/cxf/systest/jaxrs/tracing/brave/BraveTracingTest.java
@@ -29,7 +29,7 @@ import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.IntStream;
 
-import com.fasterxml.jackson.jaxrs.json.JacksonJsonProvider;
+import com.fasterxml.jackson.jakarta.rs.json.JacksonJsonProvider;
 
 import brave.Span;
 import brave.Tracer.SpanInScope;

--- a/systests/tracing/src/test/java/org/apache/cxf/systest/jaxrs/tracing/opentracing/OpenTracingTracingTest.java
+++ b/systests/tracing/src/test/java/org/apache/cxf/systest/jaxrs/tracing/opentracing/OpenTracingTracingTest.java
@@ -31,7 +31,7 @@ import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.IntStream;
 
-import com.fasterxml.jackson.jaxrs.json.JacksonJsonProvider;
+import com.fasterxml.jackson.jakarta.rs.json.JacksonJsonProvider;
 
 import jakarta.ws.rs.ProcessingException;
 import jakarta.ws.rs.core.MediaType;

--- a/systests/transport-hc5/src/test/java/org/apache/cxf/systest/hc5/GreeterImpl.java
+++ b/systests/transport-hc5/src/test/java/org/apache/cxf/systest/hc5/GreeterImpl.java
@@ -21,8 +21,7 @@ package org.apache.cxf.systest.hc5;
 
 import java.util.logging.Logger;
 
-import javax.jws.WebService;
-
+import jakarta.jws.WebService;
 import org.apache.cxf.common.logging.LogUtils;
 import org.apache.hello_world.Greeter;
 

--- a/systests/transport-hc5/src/test/java/org/apache/cxf/systest/hc5/https/clientauth/ClientAuthTest.java
+++ b/systests/transport-hc5/src/test/java/org/apache/cxf/systest/hc5/https/clientauth/ClientAuthTest.java
@@ -33,8 +33,8 @@ import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLSession;
 import javax.net.ssl.TrustManager;
 import javax.net.ssl.TrustManagerFactory;
-import javax.xml.ws.BindingProvider;
 
+import jakarta.xml.ws.BindingProvider;
 import org.apache.cxf.Bus;
 import org.apache.cxf.BusFactory;
 import org.apache.cxf.bus.spring.SpringBusFactory;

--- a/systests/transport-hc5/src/test/java/org/apache/cxf/systest/hc5/https/hostname/HostnameVerificationDeprecatedTest.java
+++ b/systests/transport-hc5/src/test/java/org/apache/cxf/systest/hc5/https/hostname/HostnameVerificationDeprecatedTest.java
@@ -25,8 +25,8 @@ import java.util.Collection;
 
 import javax.net.ssl.HostnameVerifier;
 import javax.net.ssl.HttpsURLConnection;
-import javax.xml.ws.BindingProvider;
 
+import jakarta.xml.ws.BindingProvider;
 import org.apache.cxf.Bus;
 import org.apache.cxf.BusFactory;
 import org.apache.cxf.bus.spring.SpringBusFactory;

--- a/systests/transport-hc5/src/test/java/org/apache/cxf/systest/hc5/https/hostname/HostnameVerificationTest.java
+++ b/systests/transport-hc5/src/test/java/org/apache/cxf/systest/hc5/https/hostname/HostnameVerificationTest.java
@@ -25,8 +25,8 @@ import java.util.Collection;
 
 import javax.net.ssl.HostnameVerifier;
 import javax.net.ssl.HttpsURLConnection;
-import javax.xml.ws.BindingProvider;
 
+import jakarta.xml.ws.BindingProvider;
 import org.apache.cxf.Bus;
 import org.apache.cxf.BusFactory;
 import org.apache.cxf.bus.spring.SpringBusFactory;

--- a/systests/transport-hc5/src/test/java/org/apache/cxf/systest/hc5/https/trust/TrustManagerTest.java
+++ b/systests/transport-hc5/src/test/java/org/apache/cxf/systest/hc5/https/trust/TrustManagerTest.java
@@ -34,8 +34,8 @@ import javax.net.ssl.CertPathTrustManagerParameters;
 import javax.net.ssl.TrustManager;
 import javax.net.ssl.TrustManagerFactory;
 import javax.net.ssl.X509TrustManager;
-import javax.xml.ws.BindingProvider;
 
+import jakarta.xml.ws.BindingProvider;
 import org.apache.cxf.Bus;
 import org.apache.cxf.BusFactory;
 import org.apache.cxf.bus.spring.SpringBusFactory;

--- a/systests/transport-hc5/src/test/java/org/apache/cxf/systest/hc5/https/trust/TrustServerNoSpring.java
+++ b/systests/transport-hc5/src/test/java/org/apache/cxf/systest/hc5/https/trust/TrustServerNoSpring.java
@@ -24,8 +24,8 @@ import java.util.HashMap;
 import java.util.Map;
 
 import javax.net.ssl.KeyManagerFactory;
-import javax.xml.ws.Endpoint;
 
+import jakarta.xml.ws.Endpoint;
 import org.apache.cxf.Bus;
 import org.apache.cxf.BusFactory;
 import org.apache.cxf.common.classloader.ClassLoaderUtils;

--- a/systests/transport-hc5/src/test/java/org/apache/cxf/systest/hc5/jaxrs/BookServerAsyncClient.java
+++ b/systests/transport-hc5/src/test/java/org/apache/cxf/systest/hc5/jaxrs/BookServerAsyncClient.java
@@ -25,7 +25,7 @@ import java.io.OutputStream;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
 
-import com.fasterxml.jackson.jaxrs.json.JacksonJsonProvider;
+import com.fasterxml.jackson.jakarta.rs.json.JacksonJsonProvider;
 
 import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.Produces;

--- a/systests/transports/pom.xml
+++ b/systests/transports/pom.xml
@@ -235,7 +235,7 @@
             <scope>test</scope>
             <exclusions>
                 <exclusion>
-                    <groupId>jakarta.servlet</groupId>
+                    <groupId>javax.servlet</groupId>
                     <artifactId>servlet-api</artifactId>
                 </exclusion>
                 <exclusion>

--- a/systests/transports/src/test/java/org/apache/cxf/systest/http2_jetty/Http2TestClient.java
+++ b/systests/transports/src/test/java/org/apache/cxf/systest/http2_jetty/Http2TestClient.java
@@ -138,11 +138,11 @@ public class Http2TestClient implements AutoCloseable {
             new ServerSessionListener.Adapter(), sessionPromise);
         final Session session = sessionPromise.get();
 
-        final HttpFields requestFields = new HttpFields();
+        final HttpFields.Mutable requestFields = HttpFields.build();
         requestFields.add(HttpHeader.ACCEPT, accept);
         requestFields.add(HttpHeader.HOST, "localhost");
 
-        final MetaData.Request request = new MetaData.Request(method, new HttpURI(address + path), 
+        final MetaData.Request request = new MetaData.Request(method, HttpURI.build(address + path), 
             version, requestFields);
 
         final CompletableFuture<ClientResponse> future = new CompletableFuture<>();
@@ -191,21 +191,15 @@ public class Http2TestClient implements AutoCloseable {
         }
         
         @Override
-        public void onTimeout(Stream stream, Throwable x) {
+        public boolean onIdleTimeout(Stream stream, Throwable x) {
             future.completeExceptionally(x);
-            super.onTimeout(stream, x);
+            return super.onIdleTimeout(stream, x);
         }
         
         @Override
         public void onFailure(Stream stream, int error, String reason, Throwable failure, Callback callback) {
-            future.completeExceptionally(failure);
-            super.onFailure(stream, error, reason, failure, callback);
-        }
-        
-        @Override
-        public void onFailure(Stream stream, int error, String reason, Callback callback) {
             future.completeExceptionally(new ClientErrorException(reason, error));
-            super.onFailure(stream, error, reason, callback);
+            super.onFailure(stream, error, reason, failure, callback);
         }
     }
 }

--- a/systests/uncategorized/src/test/java/org/apache/cxf/systest/jca/OutBoundConnectionTest.java
+++ b/systests/uncategorized/src/test/java/org/apache/cxf/systest/jca/OutBoundConnectionTest.java
@@ -21,11 +21,11 @@ package org.apache.cxf.systest.jca;
 
 import java.net.URL;
 
-import javax.resource.spi.ManagedConnection;
-import javax.resource.spi.ManagedConnectionFactory;
 import javax.security.auth.Subject;
 import javax.xml.namespace.QName;
 
+import jakarta.resource.spi.ManagedConnection;
+import jakarta.resource.spi.ManagedConnectionFactory;
 import jakarta.xml.ws.Endpoint;
 import jakarta.xml.ws.WebServiceException;
 import org.apache.cxf.BusFactory;

--- a/systests/wsdl_maven/codegen/src/it/cxf-4004/pom.xml
+++ b/systests/wsdl_maven/codegen/src/it/cxf-4004/pom.xml
@@ -43,7 +43,6 @@
                         <artifactId>jaxb-fluent-api</artifactId>
                         <version>2.1.8</version>
                     </dependency>
-                     
                 </dependencies>
                 <configuration>
                     <defaultOptions>

--- a/systests/wsdl_maven/pom.xml
+++ b/systests/wsdl_maven/pom.xml
@@ -30,7 +30,17 @@
         <version>4.0.0-SNAPSHOT</version>
     </parent>
     <modules>
-        <module>codegen</module>
         <module>java2ws</module>
     </modules>
+    
+    <profiles>
+        <!-- TODO: This profile includes modules which are still on 'javax.*' namespace and
+        are not migrated to Jakarta -->
+        <profile>
+            <id>javax</id>
+            <modules>
+                <module>codegen</module>
+            </modules>
+        </profile>
+    </profiles>
 </project>


### PR DESCRIPTION
Temporary exclude modules which still depend on 'javax.*' by displacing them to separate 'javax' profile