### PR TITLE
[CXF-8686] JWT role claim incorrectly parsed if not tokenized as string

### DIFF
--- a/rt/rs/security/jose-parent/jose-jaxrs/src/main/java/org/apache/cxf/rs/security/jose/jaxrs/JwtTokenSecurityContext.java
+++ b/rt/rs/security/jose-parent/jose-jaxrs/src/main/java/org/apache/cxf/rs/security/jose/jaxrs/JwtTokenSecurityContext.java
@@ -44,10 +44,21 @@ public class JwtTokenSecurityContext implements ClaimsSecurityContext {
         principal = new SimplePrincipal(jwt.getClaims().getSubject());
         this.token = jwt;
         if (roleClaim != null && jwt.getClaims().containsProperty(roleClaim)) {
-            roles = new HashSet<>();
-            String role = jwt.getClaims().getStringProperty(roleClaim).trim();
-            for (String r : role.split(",")) {
-                roles.add(new SimpleGroup(r));
+            Object roleClaimValue = jwt.getClaims().getClaim(roleClaim);
+            if (!(roleClaimValue instanceof List)) {
+                roles = new HashSet<>();
+                String role = jwt.getClaims().getStringProperty(roleClaim).trim();
+                for (String r : role.split(",")) {
+                    roles.add(new SimpleGroup(r));
+                }
+            } else if (roleClaimValue instanceof List && ((List) roleClaimValue).stream()
+                        .noneMatch(o -> !(o instanceof String))) {
+                roles = new HashSet<>();
+                ((List)roleClaimValue).stream().forEach(val -> {
+                    roles.add(new SimpleGroup(val.toString()));
+                });
+            } else {
+                roles = Collections.emptySet();
             }
         } else {
             roles = Collections.emptySet();

--- a/systests/rs-security/src/test/java/org/apache/cxf/systest/jaxrs/security/jose/jwt/JWTAuthnAuthzTest.java
+++ b/systests/rs-security/src/test/java/org/apache/cxf/systest/jaxrs/security/jose/jwt/JWTAuthnAuthzTest.java
@@ -22,6 +22,7 @@ package org.apache.cxf.systest.jaxrs.security.jose.jwt;
 import java.net.URL;
 import java.time.Instant;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -90,11 +91,11 @@ public class JWTAuthnAuthzTest extends AbstractBusClientServerTestBase {
         WebClient.getConfig(client).getRequestContext().putAll(properties);
 
         Response response = client.post(new Book("book", 123L));
-        assertEquals(response.getStatus(), 200);
+        assertEquals(200, response.getStatus());
 
         Book returnedBook = response.readEntity(Book.class);
-        assertEquals(returnedBook.getName(), "book");
-        assertEquals(returnedBook.getId(), 123L);
+        assertEquals("book", returnedBook.getName());
+        assertEquals(123L, returnedBook.getId());
     }
 
     @org.junit.Test
@@ -131,7 +132,7 @@ public class JWTAuthnAuthzTest extends AbstractBusClientServerTestBase {
         WebClient.getConfig(client).getRequestContext().putAll(properties);
 
         Response response = client.post(new Book("book", 123L));
-        assertNotEquals(response.getStatus(), 200);
+        assertNotEquals(200, response.getStatus());
     }
 
     @org.junit.Test
@@ -169,11 +170,95 @@ public class JWTAuthnAuthzTest extends AbstractBusClientServerTestBase {
         WebClient.getConfig(client).getRequestContext().putAll(properties);
 
         Response response = client.post(new Book("book", 123L));
-        assertEquals(response.getStatus(), 200);
+        assertEquals(200, response.getStatus());
 
         Book returnedBook = response.readEntity(Book.class);
-        assertEquals(returnedBook.getName(), "book");
-        assertEquals(returnedBook.getId(), 123L);
+        assertEquals("book", returnedBook.getName());
+        assertEquals(123L, returnedBook.getId());
+    }
+
+    @org.junit.Test
+    public void testAuthorizationWithTwoRolesAsList() throws Exception {
+
+        URL busFile = JWTAuthnAuthzTest.class.getResource("client.xml");
+
+        List<Object> providers = new ArrayList<>();
+        providers.add(new JacksonJsonProvider());
+        providers.add(new JwtAuthenticationClientFilter());
+
+        String address = "https://localhost:" + PORT + "/signedjwtauthz/bookstore/books";
+        WebClient client =
+                WebClient.create(address, providers, busFile.toString());
+        client.type("application/json").accept("application/json");
+
+        // Create the JWT Token
+        JwtClaims claims = new JwtClaims();
+        claims.setSubject("alice");
+        claims.setIssuer("DoubleItSTSIssuer");
+        claims.setIssuedAt(Instant.now().getEpochSecond());
+        claims.setAudiences(toList(address));
+        // The endpoint requires a role of "boss"
+        claims.setProperty("role", Arrays.asList("otherrole", "boss"));
+
+        JwtToken token = new JwtToken(claims);
+
+        Map<String, Object> properties = new HashMap<>();
+        properties.put("rs.security.keystore.type", "jwk");
+        properties.put("rs.security.keystore.alias", "2011-04-29");
+        properties.put("rs.security.keystore.file",
+                "org/apache/cxf/systest/jaxrs/security/certs/jwkPrivateSet.txt");
+        properties.put("rs.security.signature.algorithm", "RS256");
+        properties.put(JwtConstants.JWT_TOKEN, token);
+        WebClient.getConfig(client).getRequestContext().putAll(properties);
+
+        Response response = client.post(new Book("book", 123L));
+        assertEquals(200, response.getStatus());
+
+        Book returnedBook = response.readEntity(Book.class);
+        assertEquals("book", returnedBook.getName());
+        assertEquals(123L, returnedBook.getId());
+    }
+
+    @org.junit.Test
+    public void testAuthorizationWithTwoRolesAsString() throws Exception {
+
+        URL busFile = JWTAuthnAuthzTest.class.getResource("client.xml");
+
+        List<Object> providers = new ArrayList<>();
+        providers.add(new JacksonJsonProvider());
+        providers.add(new JwtAuthenticationClientFilter());
+
+        String address = "https://localhost:" + PORT + "/signedjwtauthz/bookstore/books";
+        WebClient client =
+                WebClient.create(address, providers, busFile.toString());
+        client.type("application/json").accept("application/json");
+
+        // Create the JWT Token
+        JwtClaims claims = new JwtClaims();
+        claims.setSubject("alice");
+        claims.setIssuer("DoubleItSTSIssuer");
+        claims.setIssuedAt(Instant.now().getEpochSecond());
+        claims.setAudiences(toList(address));
+        // The endpoint requires a role of "boss"
+        claims.setProperty("role", "otherrole,boss");
+
+        JwtToken token = new JwtToken(claims);
+
+        Map<String, Object> properties = new HashMap<>();
+        properties.put("rs.security.keystore.type", "jwk");
+        properties.put("rs.security.keystore.alias", "2011-04-29");
+        properties.put("rs.security.keystore.file",
+                "org/apache/cxf/systest/jaxrs/security/certs/jwkPrivateSet.txt");
+        properties.put("rs.security.signature.algorithm", "RS256");
+        properties.put(JwtConstants.JWT_TOKEN, token);
+        WebClient.getConfig(client).getRequestContext().putAll(properties);
+
+        Response response = client.post(new Book("book", 123L));
+        assertEquals(200, response.getStatus());
+
+        Book returnedBook = response.readEntity(Book.class);
+        assertEquals("book", returnedBook.getName());
+        assertEquals(123L, returnedBook.getId());
     }
 
     @org.junit.Test
@@ -209,7 +294,7 @@ public class JWTAuthnAuthzTest extends AbstractBusClientServerTestBase {
         WebClient.getConfig(client).getRequestContext().putAll(properties);
 
         Response response = client.post(new Book("book", 123L));
-        assertNotEquals(response.getStatus(), 200);
+        assertNotEquals(200, response.getStatus());
     }
 
     @org.junit.Test
@@ -246,7 +331,7 @@ public class JWTAuthnAuthzTest extends AbstractBusClientServerTestBase {
         WebClient.getConfig(client).getRequestContext().putAll(properties);
 
         Response response = client.post(new Book("book", 123L));
-        assertNotEquals(response.getStatus(), 200);
+        assertNotEquals(200, response.getStatus());
     }
 
     @org.junit.Test
@@ -284,11 +369,11 @@ public class JWTAuthnAuthzTest extends AbstractBusClientServerTestBase {
         WebClient.getConfig(client).getRequestContext().putAll(properties);
 
         Response response = client.post(new Book("book", 123L));
-        assertEquals(response.getStatus(), 200);
+        assertEquals(200, response.getStatus());
 
         Book returnedBook = response.readEntity(Book.class);
-        assertEquals(returnedBook.getName(), "book");
-        assertEquals(returnedBook.getId(), 123L);
+        assertEquals("book", returnedBook.getName());
+        assertEquals(123L, returnedBook.getId());
     }
 
     @org.junit.Test
@@ -326,11 +411,11 @@ public class JWTAuthnAuthzTest extends AbstractBusClientServerTestBase {
         WebClient.getConfig(client).getRequestContext().putAll(properties);
 
         Response response = client.get();
-        assertEquals(response.getStatus(), 200);
+        assertEquals(200, response.getStatus());
 
         Book returnedBook = response.readEntity(Book.class);
-        assertEquals(returnedBook.getName(), "book");
-        assertEquals(returnedBook.getId(), 123L);
+        assertEquals("book", returnedBook.getName());
+        assertEquals(123L, returnedBook.getId());
     }
 
     @org.junit.Test
@@ -368,7 +453,7 @@ public class JWTAuthnAuthzTest extends AbstractBusClientServerTestBase {
         WebClient.getConfig(client).getRequestContext().putAll(properties);
 
         Response response = client.head();
-        assertEquals(response.getStatus(), 200);
+        assertEquals(200, response.getStatus());
     }
 
     @org.junit.Test
@@ -406,7 +491,7 @@ public class JWTAuthnAuthzTest extends AbstractBusClientServerTestBase {
         WebClient.getConfig(client).getRequestContext().putAll(properties);
 
         Response response = client.post(new Book("book", 123L));
-        assertNotEquals(response.getStatus(), 200);
+        assertNotEquals(200, response.getStatus());
     }
 
     @org.junit.Test
@@ -444,7 +529,7 @@ public class JWTAuthnAuthzTest extends AbstractBusClientServerTestBase {
         WebClient.getConfig(client).getRequestContext().putAll(properties);
 
         Response response = client.get();
-        assertNotEquals(response.getStatus(), 200);
+        assertNotEquals(200, response.getStatus());
     }
 
     @org.junit.Test
@@ -482,7 +567,7 @@ public class JWTAuthnAuthzTest extends AbstractBusClientServerTestBase {
         WebClient.getConfig(client).getRequestContext().putAll(properties);
 
         Response response = client.head();
-        assertNotEquals(response.getStatus(), 200);
+        assertNotEquals(200, response.getStatus());
     }
 
     @org.junit.Test
@@ -522,11 +607,11 @@ public class JWTAuthnAuthzTest extends AbstractBusClientServerTestBase {
         WebClient.getConfig(client).getRequestContext().putAll(properties);
 
         Response response = client.post(new Book("book", 123L));
-        assertEquals(response.getStatus(), 200);
+        assertEquals(200, response.getStatus());
 
         Book returnedBook = response.readEntity(Book.class);
-        assertEquals(returnedBook.getName(), "book");
-        assertEquals(returnedBook.getId(), 123L);
+        assertEquals("book", returnedBook.getName());
+        assertEquals(123L, returnedBook.getId());
     }
 
     @org.junit.Test
@@ -565,7 +650,7 @@ public class JWTAuthnAuthzTest extends AbstractBusClientServerTestBase {
         WebClient.getConfig(client).getRequestContext().putAll(properties);
 
         Response response = client.post(new Book("book", 123L));
-        assertEquals(response.getStatus(), 403);
+        assertEquals(403, response.getStatus());
     }
 
     @org.junit.Test
@@ -603,7 +688,7 @@ public class JWTAuthnAuthzTest extends AbstractBusClientServerTestBase {
         WebClient.getConfig(client).getRequestContext().putAll(properties);
 
         Response response = client.post(new Book("book", 123L));
-        assertEquals(response.getStatus(), 403);
+        assertEquals(403, response.getStatus());
     }
 
     private List<String> toList(String address) {


### PR DESCRIPTION
BTW, I noticed that the assertion statements were not correct.