### PR TITLE
CXF-8689: cxf-java2ws-plugin plugin running on non-modular JDK fails with NullPointerException

### DIFF
--- a/maven-plugins/java2ws-plugin/src/main/java/org/apache/cxf/maven_plugin/Java2WSMojo.java
+++ b/maven-plugins/java2ws-plugin/src/main/java/org/apache/cxf/maven_plugin/Java2WSMojo.java
@@ -293,9 +293,11 @@ public class Java2WSMojo extends AbstractMojo {
         List<String> args = new ArrayList<>();
 
         if (fork) {
-            String[] split = additionalJvmArgs.split("\\s+");
-            for (String each : split) {
-                args.add(each);
+            if (!StringUtils.isEmpty(additionalJvmArgs)) {
+                String[] split = additionalJvmArgs.split("\\s+");
+                for (String each : split) {
+                    args.add(each);
+                }
             }
             // @see JavaToWS#isExitOnFinish()
             args.add("-DexitOnFinish=true");


### PR DESCRIPTION
cxf-java2ws-plugin plugin running on non-modular JDK fails with NullPointerException