### PR TITLE
[CXF-8697] Fix order-dependent flaky tests

### DIFF
--- a/core/src/test/java/org/apache/cxf/io/CachedStreamTestBase.java
+++ b/core/src/test/java/org/apache/cxf/io/CachedStreamTestBase.java
@@ -69,16 +69,27 @@ public abstract class CachedStreamTestBase {
 
     @Test
     public void testDeleteTmpFile() throws IOException {
-        Object cache = createCache();
-        //ensure output data size larger then 64k which will generate tmp file
-        String result = initTestData(65);
-        File tempFile = getTmpFile(result, cache);
-        assertNotNull(tempFile);
-        //assert tmp file is generated
-        assertTrue(tempFile.exists());
-        close(cache);
-        //assert tmp file is deleted after close the CachedOutputStream
-        assertFalse(tempFile.exists());
+        String old = System.getProperty(CachedConstants.THRESHOLD_SYS_PROP);
+        try {
+            System.setProperty(CachedConstants.THRESHOLD_SYS_PROP, "4");
+            reloadDefaultProperties();
+            Object cache = createCache();
+            //ensure output data size larger then 64k which will generate tmp file
+            String result = initTestData(65);
+            File tempFile = getTmpFile(result, cache);
+            assertNotNull(tempFile);
+            //assert tmp file is generated
+            assertTrue(tempFile.exists());
+            close(cache);
+            //assert tmp file is deleted after close the CachedOutputStream
+            assertFalse(tempFile.exists());
+        } finally {
+            System.clearProperty(CachedConstants.THRESHOLD_SYS_PROP);
+            if (old != null) {
+                System.setProperty(CachedConstants.THRESHOLD_SYS_PROP, old);
+            }
+            reloadDefaultProperties();
+        }
     }
 
     @Test

--- a/core/src/test/java/org/apache/cxf/io/CachedStreamTestBase.java
+++ b/core/src/test/java/org/apache/cxf/io/CachedStreamTestBase.java
@@ -69,27 +69,16 @@ public abstract class CachedStreamTestBase {
 
     @Test
     public void testDeleteTmpFile() throws IOException {
-        String old = System.getProperty(CachedConstants.THRESHOLD_SYS_PROP);
-        try {
-            System.setProperty(CachedConstants.THRESHOLD_SYS_PROP, "4");
-            reloadDefaultProperties();
-            Object cache = createCache();
-            //ensure output data size larger then 64k which will generate tmp file
-            String result = initTestData(65);
-            File tempFile = getTmpFile(result, cache);
-            assertNotNull(tempFile);
-            //assert tmp file is generated
-            assertTrue(tempFile.exists());
-            close(cache);
-            //assert tmp file is deleted after close the CachedOutputStream
-            assertFalse(tempFile.exists());
-        } finally {
-            System.clearProperty(CachedConstants.THRESHOLD_SYS_PROP);
-            if (old != null) {
-                System.setProperty(CachedConstants.THRESHOLD_SYS_PROP, old);
-            }
-            reloadDefaultProperties();
-        }
+        Object cache = createCache(64 * 1024);
+        //ensure output data size larger then 64k which will generate tmp file
+        String result = initTestData(65);
+        File tempFile = getTmpFile(result, cache);
+        assertNotNull(tempFile);
+        //assert tmp file is generated
+        assertTrue(tempFile.exists());
+        close(cache);
+        //assert tmp file is deleted after close the CachedOutputStream
+        assertFalse(tempFile.exists());
     }
 
     @Test


### PR DESCRIPTION
**Issue**
[Jira Issue](https://issues.apache.org/jira/browse/CXF-8697?jql=project%20%3D%20CXF%20AND%20resolution%20%3D%20Unresolved%20AND%20text%20~%20%22CachedOutputStream%22%20ORDER%20BY%20priority%20DESC%2C%20updated%20DESC)

The tests `org.apache.cxf.io.CacheAndWriteOutputStreamTest.testDeleteTmpFile` and `org.apache.cxf.io.CachedOutputStreamTest.testDeleteTmpFile` fail when run by themselves with the command `mvn test` because the temporary file is null. The reason is because the method `createFileOutPutStream` is never called in the method `enforceLimits` in `CachedOutputStream` since the threshold instance variable is not greater than the totalLength variable. The threshold variable depends on the static variable defaultThreshold. The defaultThreshold also depends on the system property. Therefore, these tests pass when the whole test suite is run because a different test, such as `testUseSysProps`, changes the static variable along with the system property before `testDeleteTmpFile` is run.

**Solution**
In order to allow these two tests to pass on their own, the system property must first be set to "4". Next, the static variables need to be updated with a call to `reloadDefaultProperties`. Since the previous version of these tests do not change system properties and static variables, the test should then reset the system property to the original state once finished executing. Please let me know if you would like me to reset the state differently.
