### PR TITLE
NPE fix in addClaims() method

### DIFF
--- a/rt/ws/security/src/main/java/org/apache/cxf/ws/security/trust/AbstractSTSClient.java
+++ b/rt/ws/security/src/main/java/org/apache/cxf/ws/security/trust/AbstractSTSClient.java
@@ -1453,7 +1453,7 @@ public abstract class AbstractSTSClient implements Configurable, InterceptorProv
         if (claimsToSerialize instanceof Element) {
             StaxUtils.copy((Element)claimsToSerialize, writer);
         } else if (claimsToSerialize instanceof ClaimCollection) {
-            ClaimCollection claimCollection = (ClaimCollection)claims;
+            ClaimCollection claimCollection = (ClaimCollection)claimsToSerialize;
             claimCollection.serialize(writer, "wst", namespace);
         }
     }


### PR DESCRIPTION
In AbstractSTSClient NPE is thrown when instance claims is null, and claimsCallbackHandler returns claims as ClaimCollection.
In the original code the wrong variable was cast on the claimCollection local variable, was claims and should be claimsToSerialize.