### PR TITLE
CXF-8703: PAX Maven URL does not take local Maven repository into account

### DIFF
--- a/services/sts/systests/sts-itests/src/test/java/org/apache/cxf/systest/sts/itests/BasicSTSIntegrationTest.java
+++ b/services/sts/systests/sts-itests/src/test/java/org/apache/cxf/systest/sts/itests/BasicSTSIntegrationTest.java
@@ -59,8 +59,8 @@ public class BasicSTSIntegrationTest {
             systemProperty("BasicSTSIntegrationTest.PORT").value(port),
             editConfigurationFilePut("etc/org.ops4j.pax.web.cfg",
                                     "org.osgi.service.http.port", port),
-            when(!localRepository.isEmpty())
-                .useOptions(systemProperty("org.ops4j.pax.url.mvn.localRepository").value(localRepository)),
+            when(!localRepository.isEmpty()).useOptions(editConfigurationFilePut("etc/org.ops4j.pax.url.mvn.cfg",
+                    "org.ops4j.pax.url.mvn.localRepository", localRepository)),
             //DO NOT COMMIT WITH THIS LINE ENABLED!!!
             //KarafDistributionOption.keepRuntimeFolder(),
             //KarafDistributionOption.debugConfiguration(), // nor this


### PR DESCRIPTION
PAX Maven URL does not take local Maven repository into account, see please [1]. It seems like the system property is not taken into account.

[1] https://github.com/apache/cxf/pull/946/files
