### PR TITLE
CXF-8698: Content-ID of attachments for outgoing requests are URL-decoded instead of URL-encoded

### DIFF
--- a/core/src/main/java/org/apache/cxf/attachment/AttachmentUtil.java
+++ b/core/src/main/java/org/apache/cxf/attachment/AttachmentUtil.java
@@ -355,13 +355,21 @@ public final class AttachmentUtil {
             }
             // strip cid:
             if (id.startsWith("cid:")) {
-                id = id.substring(4);
-            }
-            // urldecode. Is this bad even without cid:? What does decode do with malformed %-signs, anyhow?
-            try {
-                id = URLDecoder.decode(id, StandardCharsets.UTF_8.name());
-            } catch (UnsupportedEncodingException e) {
-                //ignore, keep id as is
+                //
+                // RFC-2392 (https://datatracker.ietf.org/doc/html/rfc2392) says:
+                //
+                // A "cid" URL is converted to the corresponding Content-ID message
+                // header [MIME] by removing the "cid:" prefix, converting the % encoded
+                // character to their equivalent US-ASCII characters, and enclosing the
+                // remaining parts with an angle bracket pair, "<" and ">".  
+                //
+                try {
+                    id = id.substring(4);
+                    // urldecode
+                    id = URLDecoder.decode(id, StandardCharsets.UTF_8.name());
+                } catch (UnsupportedEncodingException e) {
+                    //ignore, keep id as is
+                }
             }
         }
         if (id == null) {

--- a/core/src/test/java/org/apache/cxf/attachment/AttachmentSerializerTest.java
+++ b/core/src/test/java/org/apache/cxf/attachment/AttachmentSerializerTest.java
@@ -172,13 +172,27 @@ public class AttachmentSerializerTest {
         assertEquals("<test.xml>", part2.getHeader("Content-ID")[0]);
 
     }
-
+    
     @Test
     public void testMessageMTOM() throws Exception {
+        doTestMessageMTOM("test.xml", "<test.xml>");
+    }
+
+    @Test
+    public void testMessageMTOMCid() throws Exception {
+        doTestMessageMTOM("cid:http%3A%2F%2Fcxf.apache.org%2F", "<http://cxf.apache.org/>");
+    }
+
+    @Test
+    public void testMessageMTOMUrlDecoded() throws Exception {
+        doTestMessageMTOM("test+me.xml", "<test%2Bme.xml>");
+    }
+
+    private void doTestMessageMTOM(String contentId, String expectedContentId) throws Exception {
         MessageImpl msg = new MessageImpl();
 
         Collection<Attachment> atts = new ArrayList<>();
-        AttachmentImpl a = new AttachmentImpl("test.xml");
+        AttachmentImpl a = new AttachmentImpl(contentId);
 
         InputStream is = getClass().getResourceAsStream("my.wav");
         ByteArrayDataSource ds = new ByteArrayDataSource(is, "application/octet-stream");
@@ -235,7 +249,7 @@ public class AttachmentSerializerTest {
         MimeBodyPart part2 = (MimeBodyPart) multipart.getBodyPart(1);
         assertEquals("application/octet-stream", part2.getHeader("Content-Type")[0]);
         assertEquals("binary", part2.getHeader("Content-Transfer-Encoding")[0]);
-        assertEquals("<test.xml>", part2.getHeader("Content-ID")[0]);
+        assertEquals(expectedContentId, part2.getHeader("Content-ID")[0]);
 
     }
 


### PR DESCRIPTION
RFC-2392 (https://datatracker.ietf.org/doc/html/rfc2392) says:
```
  content-id = url-addr-spec
  url-addr-spec = addr-spec ; URL encoding of RFC 822 addr-spec
```

RFC-822 addr-spec (https://datatracker.ietf.org/doc/html/rfc822#appendix-D) says:
```
    addr-spec = local-part "@" domain ; global address
```

In the same vein, as RFC-2392 (https://datatracker.ietf.org/doc/html/rfc2392) says:
```
A "cid" URL is converted to the corresponding Content-ID message
header [MIME] by removing the "cid:" prefix, converting the % encoded
character to their equivalent US-ASCII characters, and enclosing the
remaining parts with an angle bracket pair, "<" and ">".  
```