### PR TITLE
CXF-8478: fixing jaxrs.ee.rs.container.requestcontext setRequestUriTwoUrisTest

### DIFF
--- a/rt/frontend/jaxrs/src/main/java/org/apache/cxf/jaxrs/impl/UriInfoImpl.java
+++ b/rt/frontend/jaxrs/src/main/java/org/apache/cxf/jaxrs/impl/UriInfoImpl.java
@@ -219,7 +219,7 @@ public class UriInfoImpl implements UriInfo {
     }
 
     private String getAbsolutePathAsString() {
-        String address = getBaseUri().toString();
+        String address = URI.create(HttpUtils.getEndpointUri(message)).toString();
         if (MessageUtils.isRequestor(message)) {
             return address;
         }

--- a/rt/frontend/jaxrs/src/main/java/org/apache/cxf/jaxrs/utils/HttpUtils.java
+++ b/rt/frontend/jaxrs/src/main/java/org/apache/cxf/jaxrs/utils/HttpUtils.java
@@ -485,6 +485,20 @@ public final class HttpUtils {
         }
     }
 
+    public static String getEndpointUri(Message m) {
+        final Object servletRequest = m.get(AbstractHTTPDestination.HTTP_REQUEST);
+        
+        if (servletRequest != null) {
+            final Object property = ((javax.servlet.http.HttpServletRequest)servletRequest)
+                .getAttribute("org.apache.cxf.transport.endpoint.uri");
+            if (property != null) {
+                return property.toString();
+            }
+        }
+        
+        return getEndpointAddress(m);
+    }
+
     public static String getEndpointAddress(Message m) {
         String address;
         Destination d = m.getExchange().getDestination();

--- a/systests/jaxrs/src/test/java/org/apache/cxf/systest/jaxrs/BookServer20.java
+++ b/systests/jaxrs/src/test/java/org/apache/cxf/systest/jaxrs/BookServer20.java
@@ -147,6 +147,8 @@ public class BookServer20 extends AbstractServerTestServerBase {
 
             if ("wrongpath".equals(path)) {
                 context.setRequestUri(URI.create("/bookstore/bookheaders/simple"));
+            } else if ("absolutepath".equals(path)) {
+                context.setRequestUri(URI.create("http://xx.yy:888/bookstore/bookheaders/simple?q=1"));
             } else if ("throwException".equals(path)) {
                 context.setProperty("filterexception", "prematch");
                 throw new InternalServerErrorException(

--- a/systests/jaxrs/src/test/java/org/apache/cxf/systest/jaxrs/JAXRS20ClientServerBookTest.java
+++ b/systests/jaxrs/src/test/java/org/apache/cxf/systest/jaxrs/JAXRS20ClientServerBookTest.java
@@ -355,6 +355,12 @@ public class JAXRS20ClientServerBookTest extends AbstractBusClientServerTestBase
         String address = "http://localhost:" + PORT + "/wrongpath";
         doTestGetBookAsync(address, false);
     }
+    
+    @Test
+    public void testGetBookAbsolutePathAsync() throws Exception {
+        String address = "http://localhost:" + PORT + "/absolutepath";
+        doTestGetBookAsync(address, false);
+    }
 
     @Test
     public void testPostCollectionGenericEntity() throws Exception {


### PR DESCRIPTION
Fixing `jaxrs.ee.rs.container.requestcontext setRequestUriTwoUrisTest`. It turns out CXF does not distinguish between base URI and request URI but it should. Finally, we have a clean TCK run:

```
[javatest.batch] ********************************************************************************
[javatest.batch] Completed running 2663 tests.
[javatest.batch] Number of Tests Passed      = 2663
[javatest.batch] Number of Tests Failed      = 0
[javatest.batch] Number of Tests with Errors = 0
[javatest.batch] ********************************************************************************
```