### PR TITLE
CXF-8730: Fix org.apache.cxf.osgi.itests.jaxrs.JaxRsServiceTest

### DIFF
--- a/osgi/itests/src/test/java/org/apache/cxf/osgi/itests/BundlesAndNamespacesTest.java
+++ b/osgi/itests/src/test/java/org/apache/cxf/osgi/itests/BundlesAndNamespacesTest.java
@@ -54,6 +54,7 @@ public class BundlesAndNamespacesTest extends CXFOSGiTestSupport {
     public Option[] config() {
         return OptionUtils.combine(
             cxfBaseConfig(),
+            testUtils(),
             features(cxfUrl, "aries-blueprint", "cxf-core", "cxf-jaxws"),
             logLevel(LogLevel.INFO)
         );

--- a/osgi/itests/src/test/java/org/apache/cxf/osgi/itests/CXFOSGiTestSupport.java
+++ b/osgi/itests/src/test/java/org/apache/cxf/osgi/itests/CXFOSGiTestSupport.java
@@ -24,6 +24,7 @@ import java.io.File;
 
 import javax.inject.Inject;
 
+import org.apache.cxf.testutil.common.TestUtil;
 import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.InvalidSyntaxException;
@@ -48,11 +49,13 @@ import static org.ops4j.pax.exam.karaf.options.KarafDistributionOption.karafDist
 /**
  *
  */
-public class CXFOSGiTestSupport {
+public abstract class CXFOSGiTestSupport {
 
     // Adding apache snapshots as cxf trunk may contain snapshot dependencies
 //    private static final String REPOS = "https://repo1.maven.org/maven2@id=central,"
 //        + "https://repository.apache.org/content/groups/snapshots-group@id=apache@snapshots@noreleases";
+
+    protected static final String PORT = TestUtil.getPortNumber("osgi-itests");
 
     @Inject
     protected BundleContext bundleContext;
@@ -69,7 +72,6 @@ public class CXFOSGiTestSupport {
             .type("xml").classifier("features");
 
         String localRepo = System.getProperty("localRepository");
-        Object urp = System.getProperty("cxf.useRandomFirstPort");
 
         final Option[] basicOptions = new Option[] {
             karafDistributionConfiguration()
@@ -90,7 +92,8 @@ public class CXFOSGiTestSupport {
                 .useOptions(editConfigurationFilePut("etc/org.ops4j.pax.url.mvn.cfg",
                                                      "org.ops4j.pax.url.mvn.localRepository",
                                                      localRepo)),
-            when(urp != null).useOptions(systemProperty("cxf.useRandomFirstPort").value("true"))
+            systemProperty("testutil.ports.osgi-itests").value(PORT),
+            editConfigurationFilePut("etc/org.ops4j.pax.web.cfg", "org.osgi.service.http.port", PORT)
         };
         if (JavaVersionUtil.getMajorVersion() >= 9) {
             final String karafVersion = MavenUtils.getArtifactVersion("org.apache.karaf", "apache-karaf-minimal");

--- a/osgi/itests/src/test/java/org/apache/cxf/osgi/itests/jaxrs/JaxRsServiceTest.java
+++ b/osgi/itests/src/test/java/org/apache/cxf/osgi/itests/jaxrs/JaxRsServiceTest.java
@@ -53,7 +53,7 @@ import static org.ops4j.pax.exam.karaf.options.KarafDistributionOption.logLevel;
 @ExamReactorStrategy(PerClass.class)
 public class JaxRsServiceTest extends CXFOSGiTestSupport {
 
-    private static final String BASE_URL = "http://localhost:8181/cxf/jaxrs/bookstore";
+    private static final String BASE_URL = "http://localhost:" + PORT + "/cxf/jaxrs/bookstore";
 
     private final WebTarget wt = ClientBuilder.newClient().target(BASE_URL);
 
@@ -109,6 +109,7 @@ public class JaxRsServiceTest extends CXFOSGiTestSupport {
             cxfBaseConfig(),
             features(cxfUrl, "cxf-core", "cxf-wsdl", "cxf-jaxrs", "cxf-bean-validation-core", "cxf-bean-validation"),
             logLevel(LogLevel.INFO),
+            testUtils(),
             provision(serviceBundle())
         );
     }
@@ -133,5 +134,4 @@ public class JaxRsServiceTest extends CXFOSGiTestSupport {
                 .build(TinyBundles.withBnd());
         }
     }
-
 }

--- a/osgi/itests/src/test/java/org/apache/cxf/osgi/itests/soap/HttpServiceTest.java
+++ b/osgi/itests/src/test/java/org/apache/cxf/osgi/itests/soap/HttpServiceTest.java
@@ -48,7 +48,7 @@ public class HttpServiceTest extends CXFOSGiTestSupport {
 
     @Test
     public void testHttpEndpoint() throws Exception {
-        Greeter greeter = greeterHttpProxy("8181");
+        Greeter greeter = greeterHttpProxy(PORT);
         String res = greeter.greetMe("Chris");
         assertEquals("Hi Chris", res);
     }

--- a/osgi/itests/src/test/java/org/apache/cxf/osgi/itests/soap/JmsServiceTest.java
+++ b/osgi/itests/src/test/java/org/apache/cxf/osgi/itests/soap/JmsServiceTest.java
@@ -77,6 +77,7 @@ public class JmsServiceTest extends CXFOSGiTestSupport {
     public Option[] config() {
         return OptionUtils.combine(
             cxfBaseConfig(),
+            testUtils(),
             features(cxfUrl, "cxf-jaxws", "cxf-transports-jms"),
             features(maven().groupId("org.apache.activemq").artifactId("activemq-karaf").versionAsInProject()
                 .type("xml").classifier("features-core"),


### PR DESCRIPTION
When running pipeline, it is very likely that more than 1 build is run on the same runner, since OSGi tests use hardcoded port, the tests often conflict and fail the whole pipeline.
