### PR TITLE
CXF-8746: Support force GET on redirections

### DIFF
--- a/rt/transports/http-hc5/src/main/java/org/apache/cxf/transport/http/asyncclient/hc5/AsyncHTTPConduit.java
+++ b/rt/transports/http-hc5/src/main/java/org/apache/cxf/transport/http/asyncclient/hc5/AsyncHTTPConduit.java
@@ -131,10 +131,11 @@ public class AsyncHTTPConduit extends URLConnectionHTTPConduit {
     }
 
     @Override
-    protected void setupConnection(Message message, Address address, HTTPClientPolicy csPolicy) throws IOException {
+    protected void setupConnection(Message message, Address address, HTTPClientPolicy csPolicy,
+                                    boolean forceGET) throws IOException {
         if (factory.isShutdown()) {
             message.put(USE_ASYNC, Boolean.FALSE);
-            super.setupConnection(message, address, csPolicy);
+            super.setupConnection(message, address, csPolicy, forceGET);
             return;
         }
         propagateJaxwsSpecTimeoutSettings(message, csPolicy);
@@ -198,7 +199,7 @@ public class AsyncHTTPConduit extends URLConnectionHTTPConduit {
         
         if (!PropertyUtils.isTrue(o)) {
             message.put(USE_ASYNC, Boolean.FALSE);
-            super.setupConnection(message, addressChanged ? new Address(uriString, uri) : address, csPolicy);
+            super.setupConnection(message, addressChanged ? new Address(uriString, uri) : address, csPolicy, forceGET);
             return;
         }
         
@@ -214,7 +215,11 @@ public class AsyncHTTPConduit extends URLConnectionHTTPConduit {
         message.put("http.scheme", uri.getScheme());
         String httpRequestMethod =
             (String)message.get(Message.HTTP_REQUEST_METHOD);
-        if (httpRequestMethod == null) {
+
+        if (forceGET) {
+            httpRequestMethod = "GET";
+            message.put(Message.HTTP_REQUEST_METHOD, httpRequestMethod);
+        } else if (httpRequestMethod == null) {
             httpRequestMethod = "POST";
             message.put(Message.HTTP_REQUEST_METHOD, httpRequestMethod);
         }
@@ -834,7 +839,7 @@ public class AsyncHTTPConduit extends URLConnectionHTTPConduit {
                     //ignore
                 }
                 cookies.writeToMessageHeaders(outMessage);
-                retransmit(url.toString());
+                retransmit(url.toString(), false);
                 return true;
             }
             return b;
@@ -848,7 +853,7 @@ public class AsyncHTTPConduit extends URLConnectionHTTPConduit {
             wrappedStream.close();
         }
 
-        protected void setupNewConnection(String newURL) throws IOException {
+        protected void setupNewConnection(String newURL, boolean forceGET) throws IOException {
             httpResponse = null;
             isAsync = outMessage != null && outMessage.getExchange() != null
                 && !outMessage.getExchange().isSynchronous();
@@ -864,11 +869,11 @@ public class AsyncHTTPConduit extends URLConnectionHTTPConduit {
             outbuf = new SharedOutputBuffer(bufSize);
             try {
                 if (defaultAddress.getString().equals(newURL)) {
-                    setupConnection(outMessage, defaultAddress, csPolicy);
+                    setupConnection(outMessage, defaultAddress, csPolicy, forceGET);
                 } else {
                     Address address = new Address(newURL);
                     this.url = address.getURI();
-                    setupConnection(outMessage, address, csPolicy);
+                    setupConnection(outMessage, address, csPolicy, forceGET);
                 }
                 entity = outMessage.get(CXFHttpRequest.class);
                 basicEntity = (MutableHttpEntity)entity.getEntity();

--- a/rt/transports/http/src/main/java/org/apache/cxf/transport/http/HTTPConduit.java
+++ b/rt/transports/http/src/main/java/org/apache/cxf/transport/http/HTTPConduit.java
@@ -197,6 +197,8 @@ public abstract class HTTPConduit
     private static final String AUTO_REDIRECT_ALLOWED_URI = "http.redirect.allowed.uri";
     private static final String AUTO_REDIRECT_MAX_SAME_URI_COUNT = "http.redirect.max.same.uri.count";
 
+    private static final String AUTO_REDIRECT_FORCE_GET_ON_301_302 = "http.redirect.force.GET";
+
     private static final String HTTP_POST_METHOD = "POST";
     private static final String HTTP_GET_METHOD = "GET";
     private static final Set<String> KNOWN_HTTP_VERBS_WITH_NO_CONTENT =
@@ -478,7 +480,8 @@ public abstract class HTTPConduit
     }
 
 
-    protected abstract void setupConnection(Message message, Address address, HTTPClientPolicy csPolicy)
+    protected abstract void setupConnection(Message message, Address address, HTTPClientPolicy csPolicy,
+                                            boolean forceGET)
         throws IOException;
 
     /**
@@ -517,7 +520,7 @@ public abstract class HTTPConduit
         boolean needToCacheRequest = false;
 
         HTTPClientPolicy csPolicy = getClient(message);
-        setupConnection(message, currentAddress, csPolicy);
+        setupConnection(message, currentAddress, csPolicy, false);
 
         // If the HTTP_REQUEST_METHOD is not set, the default is "POST".
         String httpRequestMethod =
@@ -1188,7 +1191,7 @@ public abstract class HTTPConduit
         protected abstract InputStream getPartialResponse() throws IOException;
 
         //methods to support retransmission for auth or redirects
-        protected abstract void setupNewConnection(String newURL) throws IOException;
+        protected abstract void setupNewConnection(String newURL, boolean forceGET) throws IOException;
         protected abstract void retransmitStream() throws IOException;
         protected abstract void updateCookiesBeforeRetransmit() throws IOException;
 
@@ -1272,8 +1275,8 @@ public abstract class HTTPConduit
         }
 
 
-        protected void retransmit(String newURL) throws IOException {
-            setupNewConnection(newURL);
+        protected void retransmit(String newURL, boolean forceGET) throws IOException {
+            setupNewConnection(newURL, forceGET);
             if (cachedStream != null && cachedStream.size() < Integer.MAX_VALUE) {
                 setFixedLengthStreamingMode((int)cachedStream.size());
             }
@@ -1470,7 +1473,7 @@ public abstract class HTTPConduit
             case HttpURLConnection.HTTP_SEE_OTHER:
             case 307:
             case 308:
-                return redirectRetransmit();
+                return redirectRetransmit(responseCode);
             case HttpURLConnection.HTTP_UNAUTHORIZED:
             case HttpURLConnection.HTTP_PROXY_AUTH:
                 return authorizationRetransmit();
@@ -1479,7 +1482,7 @@ public abstract class HTTPConduit
             }
             return false;
         }
-        protected boolean redirectRetransmit() throws IOException {
+        protected boolean redirectRetransmit(int responseCode) throws IOException {
             // If we are not redirecting by policy, then we don't.
             if (!getClient(outMessage).isAutoRedirect()) {
                 return false;
@@ -1490,10 +1493,13 @@ public abstract class HTTPConduit
             String newURL = extractLocation(Headers.getSetProtocolHeaders(m));
             String urlString = url.toString();
 
+            boolean forceGET = false;
+
             try {
                 newURL = convertToAbsoluteUrlIfNeeded(conduitName, urlString, newURL, outMessage);
                 detectRedirectLoop(conduitName, urlString, newURL, outMessage);
                 checkAllowedRedirectUri(conduitName, urlString, newURL, outMessage);
+                forceGET = forceGET(responseCode, outMessage);
             } catch (IOException ex) {
                 // Consider introducing ClientRedirectException instead - it will require
                 // those client runtimes which want to check for it have a direct link to it
@@ -1515,7 +1521,7 @@ public abstract class HTTPConduit
                 }
                 cookies.writeToMessageHeaders(outMessage);
                 outMessage.put("transport.retransmit.url", newURL);
-                retransmit(newURL);
+                retransmit(newURL, forceGET);
                 return true;
             }
             return false;
@@ -1555,7 +1561,7 @@ public abstract class HTTPConduit
             }
             new Headers(outMessage).setAuthorization(authorizationToken);
             cookies.writeToMessageHeaders(outMessage);
-            retransmit(url.toString());
+            retransmit(url.toString(), false);
             return true;
         }
 
@@ -1843,6 +1849,12 @@ public abstract class HTTPConduit
                 }
             }
         }
+    }
+
+    private static boolean forceGET(int responseCode, Message message) {
+        return MessageUtils.getContextualBoolean(message, AUTO_REDIRECT_FORCE_GET_ON_301_302)
+                && (responseCode == HttpURLConnection.HTTP_MOVED_PERM
+                    || responseCode == HttpURLConnection.HTTP_MOVED_TEMP);
     }
 
     private static void checkAllowedRedirectUri(String conduitName,

--- a/rt/transports/http/src/test/java/org/apache/cxf/transport/http/MockHTTPConduit.java
+++ b/rt/transports/http/src/test/java/org/apache/cxf/transport/http/MockHTTPConduit.java
@@ -38,7 +38,7 @@ public class MockHTTPConduit extends HTTPConduit {
     }
 
     @Override
-    protected void setupConnection(Message message, Address address, HTTPClientPolicy csPolicy)
+    protected void setupConnection(Message message, Address address, HTTPClientPolicy csPolicy, boolean forceGET)
         throws IOException {
         // TODO Auto-generated method stub
 
@@ -136,7 +136,7 @@ public class MockHTTPConduit extends HTTPConduit {
         }
 
         @Override
-        protected void setupNewConnection(String newURL) throws IOException {
+        protected void setupNewConnection(String newURL, boolean forceGet) throws IOException {
             // TODO Auto-generated method stub
             
         }

--- a/rt/transports/websocket/src/main/java/org/apache/cxf/transport/websocket/ahc/AhcWebSocketConduit.java
+++ b/rt/transports/websocket/src/main/java/org/apache/cxf/transport/websocket/ahc/AhcWebSocketConduit.java
@@ -77,8 +77,10 @@ public class AhcWebSocketConduit extends URLConnectionHTTPConduit {
     }
 
     @Override
-    protected void setupConnection(Message message, Address address, HTTPClientPolicy csPolicy)
+    protected void setupConnection(Message message, Address address, HTTPClientPolicy csPolicy, boolean forceGET)
         throws IOException {
+
+        forceGET = false; // this option is not enabled in this AhcWebSocket context
 
         URI currentURL = address.getURI();
         String s = currentURL.getScheme();
@@ -272,7 +274,7 @@ public class AhcWebSocketConduit extends URLConnectionHTTPConduit {
         }
 
         @Override
-        protected void setupNewConnection(String newURL) throws IOException {
+        protected void setupNewConnection(String newURL, boolean forceGET) throws IOException {
             // TODO
             throw new IOException("not supported");
         }


### PR DESCRIPTION
CXF-8746: Support force GET on 301 & 302 redirections for historical reasons as explained in https://www.rfc-editor.org/rfc/rfc7231.html section 6.4.2 & 6.4.3.