### PR TITLE
CXF-8698: Content-ID of attachments for outgoing requests are URL-decoded instead of URL-encoded (limiting decoding only to % encoded characters)

### DIFF
--- a/core/src/main/java/org/apache/cxf/attachment/AttachmentSerializer.java
+++ b/core/src/main/java/org/apache/cxf/attachment/AttachmentSerializer.java
@@ -26,6 +26,7 @@ import java.io.StringWriter;
 import java.io.Writer;
 import java.net.URLDecoder;
 import java.net.URLEncoder;
+import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.Iterator;
@@ -225,8 +226,8 @@ public class AttachmentSerializer {
             // remaining parts with an angle bracket pair, "<" and ">".  
             //
             if (attachmentId.startsWith("cid:")) {
-                writer.write(URLDecoder.decode(attachmentId.substring(4),
-                    StandardCharsets.UTF_8.name()));
+                writer.write(decode(attachmentId.substring(4),
+                    StandardCharsets.UTF_8));
             } else { 
                 //
                 // RFC-2392 (https://datatracker.ietf.org/doc/html/rfc2392) says:
@@ -371,4 +372,9 @@ public class AttachmentSerializer {
         this.xop = xop;
     }
 
+    // URL decoder would also decode '+' but according to  RFC-2392 we need to convert
+    // only the % encoded character to their equivalent US-ASCII characters. 
+    private static String decode(String s, Charset charset) {
+        return URLDecoder.decode(s.replaceAll("([^%])[+]", "$1%2B"), charset);
+    }
 }

--- a/core/src/test/java/org/apache/cxf/attachment/AttachmentSerializerTest.java
+++ b/core/src/test/java/org/apache/cxf/attachment/AttachmentSerializerTest.java
@@ -187,6 +187,11 @@ public class AttachmentSerializerTest {
     public void testMessageMTOMUrlDecoded() throws Exception {
         doTestMessageMTOM("test+me.xml", "<test%2Bme.xml>");
     }
+    
+    @Test
+    public void testMessageMTOMUrlDecodedCid() throws Exception {
+        doTestMessageMTOM("cid:test+me.xml", "<test+me.xml>");
+    }
 
     private void doTestMessageMTOM(String contentId, String expectedContentId) throws Exception {
         MessageImpl msg = new MessageImpl();


### PR DESCRIPTION
Limiting decoding only to % encoded characters (as per  RFC-2392).

// A "cid" URL is converted to the corresponding Content-ID message
// header [MIME] by removing the "cid:" prefix, converting the % encoded
// character to their equivalent US-ASCII characters