### PR TITLE
[CXF-8761] DigestAuthSupplier: Must not decode URL encoded URI parts

### DIFF
--- a/rt/transports/http/src/main/java/org/apache/cxf/transport/http/auth/DigestAuthSupplier.java
+++ b/rt/transports/http/src/main/java/org/apache/cxf/transport/http/auth/DigestAuthSupplier.java
@@ -100,9 +100,9 @@ public class DigestAuthSupplier implements HttpAuthSupplier {
     }
 
     private static String getAuthURI(URI currentURI) {
-        String authURI = currentURI.getPath();
-        if (currentURI.getQuery() != null) {
-            authURI += '?' + currentURI.getQuery();
+        String authURI = currentURI.getRawPath();
+        if (currentURI.getRawQuery() != null) {
+            authURI += '?' + currentURI.getRawQuery();
         }
         return authURI;
     }

--- a/rt/transports/http/src/test/java/org/apache/cxf/transport/http/auth/DigestAuthSupplierTest.java
+++ b/rt/transports/http/src/test/java/org/apache/cxf/transport/http/auth/DigestAuthSupplierTest.java
@@ -91,4 +91,23 @@ public class DigestAuthSupplierTest {
         expectedParams.put("algorithm", "MD5");
         assertEquals(expectedParams, params);
     }
+
+    @Test
+    public void testUrlEncodedUri() throws Exception {
+        AuthorizationPolicy authPolicy = new AuthorizationPolicy();
+        authPolicy.setUserName("testUser");
+        authPolicy.setPassword("testPassword");
+
+        // uri with utf-8 url encoded path and query
+        URI uri = new URI("http://localhost.com/sch%C3%B6ne?gr%C3%BC%C3%9Fe");
+        assertEquals("/schöne", uri.getPath());
+        assertEquals("grüße", uri.getQuery());
+
+        DigestAuthSupplier authSupplier = new DigestAuthSupplier();
+        String authToken = authSupplier.getAuthorization(authPolicy, uri, new MessageImpl(), "Digest");
+        HttpAuthHeader authHeader = new HttpAuthHeader(authToken);
+        assertTrue(authHeader.authTypeIsDigest());
+        // uri parts must stay encoded
+        assertEquals("/sch%C3%B6ne?gr%C3%BC%C3%9Fe", authHeader.getParams().get("uri"));
+    }
 }


### PR DESCRIPTION
DigestAuthSupplier currently decodes URL encoded URI parts. This breaks digest auth because servers do digest auth based of the still encoded URI.