### PR TITLE
Fixing Microprofile test suites (temporary adding javax.servlet dependency and downgrading to Jetty 9)

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -61,8 +61,8 @@
         <cxf.activemq.artemis.version>2.26.0</cxf.activemq.artemis.version>
         <cxf.ahc.version>2.12.3</cxf.ahc.version>
         <cxf.apacheds.version>2.0.0.AM26</cxf.apacheds.version>
-        <cxf.arquillian.version>1.1.14.Final</cxf.arquillian.version>
-        <cxf.arquillian.weld.container.version>2.0.1.Final</cxf.arquillian.weld.container.version>
+        <cxf.arquillian.version>1.7.0.Alpha10</cxf.arquillian.version>
+        <cxf.arquillian.weld.container.version>3.0.0.Final</cxf.arquillian.weld.container.version>
         <cxf.aspectj.version>1.9.1</cxf.aspectj.version>
         <cxf.assertj.version>3.22.0</cxf.assertj.version>
         <cxf.atmosphere.version.range>[3.0, 4.0)</cxf.atmosphere.version.range>
@@ -152,7 +152,7 @@
         <cxf.maven.core.version>3.6.3</cxf.maven.core.version>
         <cxf.micrometer.version>1.10.0-RC1</cxf.micrometer.version>
         <cxf.microprofile.config.version>3.0.1</cxf.microprofile.config.version>
-        <cxf.microprofile.rest.client.version>3.0</cxf.microprofile.rest.client.version>
+        <cxf.microprofile.rest.client.version>3.0.1</cxf.microprofile.rest.client.version>
         <cxf.microprofile.openapi.version>3.0</cxf.microprofile.openapi.version>
         <cxf.mina.version>2.1.5</cxf.mina.version>
         <cxf.mockito.version>4.8.1</cxf.mockito.version>

--- a/rt/rs/microprofile-client/pom.xml
+++ b/rt/rs/microprofile-client/pom.xml
@@ -162,19 +162,6 @@
             <version>${cxf.commons-jcs-jcache.version}</version>
             <scope>test</scope>
         </dependency>
-        <!--TODO: after wiremock jakarta version is ready change back to com.github.tomakehurst:wiremock -->
-        <dependency>
-            <groupId>com.github.tomakehurst</groupId>
-            <artifactId>wiremock-standalone</artifactId>
-            <version>${cxf.wiremock.version}</version>
-            <scope>test</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.xmlunit</groupId>
-                    <artifactId>xmlunit-core</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
     </dependencies>
 
     <profiles>

--- a/systests/microprofile/client/async/pom.xml
+++ b/systests/microprofile/client/async/pom.xml
@@ -33,6 +33,7 @@
     <properties>
         <cxf.module.name>org.apache.cxf.systests.microprofile.async</cxf.module.name>
         <cxf.wiremock.params>--port=8765</cxf.wiremock.params>
+        <cxf.jetty.version>9.4.49.v20220914</cxf.jetty.version>
     </properties>
         <dependencies>
             <dependency>
@@ -145,6 +146,12 @@
             <dependency>
                 <groupId>junit</groupId>
                 <artifactId>junit</artifactId>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>javax.servlet</groupId>
+                <artifactId>javax.servlet-api</artifactId>
+                <version>4.0.1</version>
                 <scope>test</scope>
             </dependency>
         </dependencies>

--- a/systests/microprofile/client/nocdi/pom.xml
+++ b/systests/microprofile/client/nocdi/pom.xml
@@ -33,6 +33,7 @@
     <properties>
         <cxf.module.name>org.apache.cxf.systests.microprofile.nocdi</cxf.module.name>
         <cxf.wiremock.params>--port=8765</cxf.wiremock.params>
+        <cxf.jetty.version>9.4.49.v20220914</cxf.jetty.version>
     </properties>
     <dependencies>
         <dependency>
@@ -141,6 +142,12 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>javax.servlet</groupId>
+            <artifactId>javax.servlet-api</artifactId>
+            <version>4.0.1</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/systests/microprofile/client/weld/pom.xml
+++ b/systests/microprofile/client/weld/pom.xml
@@ -32,6 +32,7 @@
     
     <properties>
         <cxf.module.name>org.apache.cxf.systests.microprofile.weld</cxf.module.name>
+        <cxf.jetty.version>9.4.49.v20220914</cxf.jetty.version>
     </properties>
     
     <dependencies>
@@ -93,6 +94,23 @@
                 <exclusion>
                     <groupId>com.github.tomakehurst</groupId>
                     <artifactId>wiremock</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.ejb</groupId>
+            <artifactId>jakarta.ejb-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.github.tomakehurst</groupId>
+            <artifactId>wiremock</artifactId>
+            <version>${cxf.wiremock.version}</version>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.xmlunit</groupId>
+                    <artifactId>xmlunit-core</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>


### PR DESCRIPTION
Fixing Microprofile test suites (temporary adding javax.servlet dependency and downgrading to Jetty 9), @jimma it may help you with https://issues.apache.org/jira/browse/CXF-8781