### PR TITLE
Bringing back RetryAnalyzer to mitigate flaky Microprofile Rest Client TCK tests

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -61,7 +61,7 @@
         <cxf.activemq.artemis.version>2.26.0</cxf.activemq.artemis.version>
         <cxf.ahc.version>2.12.3</cxf.ahc.version>
         <cxf.apacheds.version>2.0.0.AM26</cxf.apacheds.version>
-        <cxf.arquillian.version>1.7.0.Alpha9</cxf.arquillian.version>
+        <cxf.arquillian.version>1.7.0.Alpha13</cxf.arquillian.version>
         <cxf.arquillian.weld.container.version>3.0.0.Final</cxf.arquillian.weld.container.version>
         <cxf.aspectj.version>1.9.1</cxf.aspectj.version>
         <cxf.assertj.version>3.22.0</cxf.assertj.version>

--- a/systests/microprofile/client/weld/pom.xml
+++ b/systests/microprofile/client/weld/pom.xml
@@ -32,7 +32,7 @@
     
     <properties>
         <cxf.module.name>org.apache.cxf.systests.microprofile.weld</cxf.module.name>
-        <cxf.jetty.version>9.2.28.v20190418</cxf.jetty.version>
+        <cxf.jetty.version>9.4.49.v20220914</cxf.jetty.version>
     </properties>
 
     <dependencies>
@@ -213,7 +213,12 @@
                         <wiremock.server.port>${wiremock.server.port}</wiremock.server.port>
                         <sse.server.port>${sse.server.port}</sse.server.port>
                     </systemPropertyVariables>
-                    <forkCount>1</forkCount>
+                    <properties>
+                        <property>
+                            <name>listener</name>
+                            <value>org.apache.cxf.microprofile.AnnotationTransformer</value>
+                        </property>
+                    </properties>
                     <reuseForks>false</reuseForks>
                 </configuration>
             </plugin>

--- a/systests/microprofile/client/weld/src/test/java/org/apache/cxf/microprofile/AnnotationTransformer.java
+++ b/systests/microprofile/client/weld/src/test/java/org/apache/cxf/microprofile/AnnotationTransformer.java
@@ -1,0 +1,33 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.cxf.microprofile;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Method;
+
+import org.testng.IAnnotationTransformer;
+import org.testng.annotations.ITestAnnotation;
+
+public class AnnotationTransformer implements IAnnotationTransformer {
+    @Override
+    public void transform(ITestAnnotation annotation, Class test, Constructor constructor, Method method) {
+        annotation.setRetryAnalyzer(RetryAnalyzer.class);
+    }
+}

--- a/systests/microprofile/client/weld/src/test/java/org/apache/cxf/microprofile/RetryAnalyzer.java
+++ b/systests/microprofile/client/weld/src/test/java/org/apache/cxf/microprofile/RetryAnalyzer.java
@@ -1,0 +1,39 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.cxf.microprofile;
+
+import org.testng.IRetryAnalyzer;
+import org.testng.ITestResult;
+import org.testng.Reporter;
+
+public class RetryAnalyzer implements IRetryAnalyzer {
+    private static final int RETRIES = 3;
+    private int counter;
+
+    @Override
+    public boolean retry(ITestResult result) {
+        if (++counter < RETRIES) {
+            Reporter.log("Retrying test case '" + result.getName() + "', attempt " + counter);
+            return true;
+        } else {
+            return false;
+        }
+    }
+}


### PR DESCRIPTION
Bringing back RetryAnalyzer to mitigate flaky Microprofile Rest Client TCK tests, mostly every build is failing:
 - https://ci-builds.apache.org/job/CXF/job/CXF-JDK20/157/ 
 - https://ci-builds.apache.org/job/CXF/job/CXF-JDK19/362/
 - https://ci-builds.apache.org/job/CXF/job/CXF-JDK17/856/
 - https://ci-builds.apache.org/job/CXF/job/CXF-JDK17-PR/129/
 - ...