### PR TITLE
CXF-8795: Fix org.apache.cxf.transport.jms.util.MessageListenerTest.testWithJTA

### DIFF
--- a/rt/transports/jms/src/test/java/org/apache/cxf/transport/jms/util/MessageListenerTest.java
+++ b/rt/transports/jms/src/test/java/org/apache/cxf/transport/jms/util/MessageListenerTest.java
@@ -291,9 +291,9 @@ public class MessageListenerTest {
             return new ConfigurationImpl()
                     .setSecurityEnabled(false)
                     .setPersistenceEnabled(false)
-                    .setAddressQueueScanPeriod(1)
+                    .setAddressQueueScanPeriod(0)
                     .addAcceptorConfiguration("#", "vm://0")
-                    .addAddressesSetting("#",
+                    .addAddressSetting("#",
                             new AddressSettings()
                                     .setMaxDeliveryAttempts(2)
                                     .setRedeliveryDelay(500L)


### PR DESCRIPTION
The `org.apache.cxf.transport.jms.util.MessageListenerTest.testWithJTA` fails intermittently [1] with:

```
jakarta.jms.InvalidDestinationException: AMQ229017: Queue test does not exist
	at org.apache.activemq.artemis.core.protocol.core.impl.ChannelImpl.sendBlocking(ChannelImpl.java:554)
	at org.apache.activemq.artemis.core.protocol.core.impl.ChannelImpl.sendBlocking(ChannelImpl.java:446)
``` 

[1] https://ci-builds.apache.org/job/CXF/job/pipeline/job/main/141/testReport/junit/org.apache.cxf.transport.jms.util/MessageListenerTest/Build___Matrix___JAVA_VERSION____jdk_17_latest____JDK_specific_build___Build___Test___testWithJTA/