### PR TITLE
Fix/CXF-8698.2 Unxepected URLEncode in MTOM Content-Id

### DIFF
--- a/core/src/main/java/org/apache/cxf/attachment/AttachmentSerializer.java
+++ b/core/src/main/java/org/apache/cxf/attachment/AttachmentSerializer.java
@@ -237,7 +237,14 @@ public class AttachmentSerializer {
                 //
                 String[] address = attachmentId.split("@", 2);
                 if (address.length == 2) {
-                    writer.write(attachmentId);
+                    // See please AttachmentUtil::createContentID, the domain part is URL encoded
+                    final String decoded = tryDecode(address[1], StandardCharsets.UTF_8);
+                    // If the domain part is encoded, decode it 
+                    if (!decoded.equalsIgnoreCase(address[1])) {
+                        writer.write(address[0] + "@" + decoded);
+                    } else {
+                        writer.write(attachmentId);
+                    }
                 } else {
                     writer.write(URLEncoder.encode(attachmentId, StandardCharsets.UTF_8.name()));
                 }
@@ -372,5 +379,15 @@ public class AttachmentSerializer {
     // only the % encoded character to their equivalent US-ASCII characters. 
     private static String decode(String s, Charset charset) {
         return URLDecoder.decode(s.replaceAll("([^%])[+]", "$1%2B"), charset);
+    }
+
+    // Try to decode the string assuming the decoding may fail, the original string is going to
+    // be returned in this case.
+    private static String tryDecode(String s, Charset charset) {
+        try { 
+            return decode(s, charset);
+        } catch (IllegalArgumentException ex) {
+            return s;
+        }
     }
 }

--- a/core/src/main/java/org/apache/cxf/attachment/AttachmentUtil.java
+++ b/core/src/main/java/org/apache/cxf/attachment/AttachmentUtil.java
@@ -45,7 +45,6 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.logging.Logger;
-import java.util.regex.Pattern;
 
 import jakarta.activation.CommandInfo;
 import jakarta.activation.CommandMap;
@@ -77,15 +76,8 @@ public final class AttachmentUtil {
     private static final Random BOUND_RANDOM = new Random();
     private static final CommandMap DEFAULT_COMMAND_MAP = CommandMap.getDefaultCommandMap();
     private static final MailcapCommandMap COMMAND_MAP = new EnhancedMailcapCommandMap();
-
-    /**
-     * Yet <a href="https://datatracker.ietf.org/doc/html/rfc822#appendix-D">RFC-822 Appendix D (ALPHABETICAL LISTING OF SYNTAX RULES)</a>
-     * allows more characters in domain-literal,
-     * this regex is valid to check that the parsed domain is compliant,
-     * although it is stricter
-     */
-    private static final Pattern ALPHA_NUMERIC_DOMAIN_PATTERN = Pattern.compile("^\\w+(\\.\\w+)*$");
-
+    
+    
     static final class EnhancedMailcapCommandMap extends MailcapCommandMap {
         @Override
         public synchronized DataContentHandler createDataContentHandler(
@@ -235,49 +227,24 @@ public final class AttachmentUtil {
         }
     }
 
-    /**
-     * Creates Content ID from {@link #ATT_UUID} and given namespace
-     * <p>
-     * Example:
-     * <pre>6976d00d-740c-48ed-b63d-8c56707544f7-1@example.com</pre>
-     * <p>
-     * <a href="https://datatracker.ietf.org/doc/html/rfc2392#section-2">RFC-2392 Section 2 (The MID and CID URL Schemes)</a>
-     * specifies Content ID as:
-     * <pre>
-     *   content-id = url-addr-spec
-     *   url-addr-spec = addr-spec ; URL encoding of RFC 822 addr-spec
-     * </pre>
-     * <a href="https://datatracker.ietf.org/doc/html/rfc822#appendix-D">RFC-822 Appendix D (ALPHABETICAL LISTING OF SYNTAX RULES)</a>:
-     * <pre>
-     *   addr-spec = local-part "@" domain ; global address
-     * </pre>
-     *
-     * @param ns namespace. If null, falls back to "cxf.apache.org"
-     * @return Content ID
-     */
-    public static String createContentID(String ns) {
+    public static String createContentID(String ns) throws UnsupportedEncodingException {
         // tend to change
         String cid = "cxf.apache.org";
         if (ns != null && !ns.isEmpty()) {
-            if (isAlphaNumericDomain(ns)) {
-                cid = ns;
-            }
             try {
                 URI uri = new URI(ns);
                 String host = uri.getHost();
-                if (host != null && isAlphaNumericDomain(host)) {
+                if (host != null) {
                     cid = host;
+                } else {
+                    cid = ns;
                 }
             } catch (Exception e) {
-                // Could not parse domain => use fallback value
+                cid = ns;
             }
         }
         return ATT_UUID + '-' + Integer.toString(COUNTER.incrementAndGet()) + '@'
-            + URLEncoder.encode(cid, StandardCharsets.UTF_8);
-    }
-
-    private static boolean isAlphaNumericDomain(String string) {
-        return ALPHA_NUMERIC_DOMAIN_PATTERN.matcher(string).matches();
+            + URLEncoder.encode(cid, StandardCharsets.UTF_8.name());
     }
 
     public static String getUniqueBoundaryValue() {
@@ -517,7 +484,12 @@ public final class AttachmentUtil {
         source.setContentType(mimeType);
         DataHandler handler = new DataHandler(source);
 
-        String id = AttachmentUtil.createContentID(elementNS);
+        String id;
+        try {
+            id = AttachmentUtil.createContentID(elementNS);
+        } catch (UnsupportedEncodingException e) {
+            throw new Fault(e);
+        }
         AttachmentImpl att = new AttachmentImpl(id, handler);
         att.setXOP(isXop);
         return att;
@@ -552,7 +524,12 @@ public final class AttachmentUtil {
         //      ignore, just do the normal attachment thing
         }
 
-        String id = AttachmentUtil.createContentID(elementNS);
+        String id;
+        try {
+            id = AttachmentUtil.createContentID(elementNS);
+        } catch (UnsupportedEncodingException e) {
+            throw new Fault(e);
+        }
         AttachmentImpl att = new AttachmentImpl(id, handler);
         if (!StringUtils.isEmpty(handler.getName())) {
             //set Content-Disposition attachment header if filename isn't null

--- a/core/src/test/java/org/apache/cxf/attachment/AttachmentSerializerTest.java
+++ b/core/src/test/java/org/apache/cxf/attachment/AttachmentSerializerTest.java
@@ -183,6 +183,12 @@ public class AttachmentSerializerTest {
     }
 
     @Test
+    public void testMessageMTOMCidEncoded() throws Exception {
+        doTestMessageMTOM("cid:cxf@[2001%3A0db8%3A11a3%3A09d7%3A1f34%3A8a2e%3A07a0%3A765d]",
+            "<cxf@[2001:0db8:11a3:09d7:1f34:8a2e:07a0:765d]>");
+    }
+
+    @Test
     public void testMessageMTOMUrlDecoded() throws Exception {
         doTestMessageMTOM("test+me.xml", "<test%2Bme.xml>");
     }


### PR DESCRIPTION
Related to https://github.com/apache/cxf/pull/950 and https://github.com/apache/cxf/pull/993

## Problem
The cxf version `3.5.3` introduced bug which results in invalid MTOM requests.
More precisely, the version highlighted an older bug, I'll elaborate on it :)

## Investigation

Commit https://github.com/apache/cxf/commit/ffba34eed2d5b4af22a93c100e4687e234d53b28#diff-e3efb80d0a98bbbd7f6eddd3c021c5fb5ab05ea2ee8d97dc68026f6345e5a509 by @reta had changed how `Content-Id` is being dumped to headers.
First of all, thank you for the bold point of doing this, referring to the RFCs. 
Let's have a look at the line 243 in particular

Provided that `attachmentId` is of format `uuid@domain` it works as exepected, however, `attachmentId` is being generated by CXF in routine https://github.com/apache/cxf/blob/2ad9d0b2eef17c0d57d3cb96f3b2cecd1e704869/core/src/main/java/org/apache/cxf/attachment/AttachmentUtil.java#L230 which results in `uuid@urn:xml:namespace` on some inputs.
This input leads to the Header being URL encoded.

Issues with this header are known for a while https://issues.apache.org/jira/browse/CXF-2669 
What's important is how do the SOAP servers treat URL-encoded `Content-Id`.
In my experience, IRS.gov does not match 
```
Content-ID: <3315f978-0190-4bc2-8a97-f766a78a7946-1@urn%3Aus%3Agov%3Atreasury%3Airs%3Acommon>
```
with previously defined reference
```
<xop:Include xmlns:xop="http://www.w3.org/2004/08/xop/include" href="cid:3315f978-0190-4bc2-8a97-f766a78a7946-1@urn%3Aus%3Agov%3Atreasury%3Airs%3Acommon"/>
```
which is basically the same and _should_ match.

That said, it's well-known issue in the wild
1. https://access.redhat.com/solutions/2062163
2. https://access.redhat.com/solutions/4076871

The latter points to the fact that there should be no URL-encoded symbols in `Content-Id`, which is met by @reta's commit.

## The Fix

The problem is in `AttachmentUtil::createContentID`, so I've fixed the `Content-Id` generation to be more strict and use safe fallback value in cases of unmet domain pattern.
The buggy method uses `new URI(...).getHost()` to extract domain, which is not the domain we expect to put in Content ID. 
Namely, `URI::getHost` javadoc indicates:
```
An IPv6 address enclosed in square brackets ('[' and ']') and consisting of hexadecimal digits, colon characters (':'), and possibly an embedded IPv4 address. The full syntax of IPv6 addresses is specified in RFC 2373: IPv6 Addressing Architecture.
```

Thus, I've also added few tests, which include IPv6 (just in case :) ), and looking at those you may ensure the implications of the fix

## Prolog

I'm new to Apache, and I'm not sure that this is the proper way to post the bug report.
I wasn't able to log in to Apache's JIRA, so I decided to go with fix to speed things up.
You may force-push / rebranch / rewrite / throw my commits away, but I'd be happy so long as the fix would be accepted

As of now, I've rolled back cxf version to `3.5.3` and it works as expected. Provided that the upgrade has followed Java 17 migration, the same could happen to all the projects willing to use Java 17 along with CXF & MTOM functionality