### PR TITLE
CXF-8796: Replace REMOVED_MARKER with null

### DIFF
--- a/core/src/main/java/org/apache/cxf/message/MessageContentsList.java
+++ b/core/src/main/java/org/apache/cxf/message/MessageContentsList.java
@@ -27,6 +27,15 @@ import org.apache.cxf.helpers.CastUtils;
 import org.apache.cxf.service.model.MessagePartInfo;
 
 public class MessageContentsList extends ArrayList<Object> {
+
+    /**
+     * Indicates that the element of the underlying list is absent.
+     * This is necessary for the elements to keep their original
+     * indexes within this list when some preceding elements
+     * are not populated or deleted.
+     * 
+     * @see {@link #get(MessagePartInfo)}, {@link #remove(MessagePartInfo)}
+     */
     public static final Object REMOVED_MARKER = new Object();
     private static final long serialVersionUID = -5780720048950696258L;
 
@@ -53,6 +62,7 @@ public class MessageContentsList extends ArrayList<Object> {
         return (MessageContentsList)o;
     }
 
+    @Override
     public Object set(int idx, Object value) {
         ensureSize(idx);
         return super.set(idx, value);
@@ -76,11 +86,46 @@ public class MessageContentsList extends ArrayList<Object> {
         return super.get(key.getIndex()) != REMOVED_MARKER;
     }
 
+    /**
+     * @param key the key whose associated element is to be returned.
+     * @return the element to which the index property of the specified key
+     * is mapped, or {@code null} if mapped element is marked as removed.
+     */
     public Object get(MessagePartInfo key) {
         Object o = super.get(key.getIndex());
         return o == REMOVED_MARKER ? null : o;
     }
+
+    /**
+     * Marks corresponding element as removed, indicating absent value,
+     * so subsequent {@code get(MessagePartInfo)} for the same key return null.
+     * @param key the key whose associated element is to be marked as removed.
+     */
     public void remove(MessagePartInfo key) {
         put(key, REMOVED_MARKER);
     }
+
+    /**
+     * Allocates a new array containing the elements of the underlying list.
+     *
+     * @return an array containing all the elements of this list which are not
+     * marked as removed and {@code null} instead of those elements which are
+     * marked as removed, producing the same sequence of the elements as when
+     * sequentially iterating through underlying list using {@code get(int)}.
+     *                                                                              
+     * @see {@link #get(MessagePartInfo)}
+     */
+    @Override
+    public Object[] toArray() {
+        final int size = size();
+        Object[] array = new Object[size];
+        for (int idx = 0; idx < size; ++idx) {
+            Object o = super.get(idx);
+            if (o != REMOVED_MARKER) {
+                array[idx] = o;
+            }
+        }
+        return array;
+    }
+
 }


### PR DESCRIPTION

The reason of java.lang.IllegalArgumentException: argument type mismatch exception with code first RPC is that inherited ArrayList.toArray is used to prepare arguments for DelegatingMethodAccessorImpl.invoke passing MessageContentsList.REMOVED_MARKER java.lang.Object instance directly to parameter of Web service method (see stack below).

MessageContentsList.REMOVED_MARKER instance acts as an indicator of absent value and appears if the value of parameter is not provided in SOAP request (see added comments in the source code). In the fix, REMOVED_MARKER is replaced with "null" value in overriden MessageContentsList.toArray. This change prevents java.lang.IllegalArgumentException: argument type mismatch exception and works with bean validation for both hibernate-validator and Apache bval bean validation providers.

CXF 3.5.2 stack and values when ArrayList.toArray is used to prepare arguments for DelegatingMethodAccessorImpl.invoke, where java.lang.Object@12d4589f is MessageContentsList.REMOVED_MARKER:

```
@WebService(targetNamespace = "http://test.apache.org/")
@SOAPBinding(style = javax.jws.soap.SOAPBinding.Style.RPC, use = javax.jws.soap.SOAPBinding.Use.LITERAL)
public class SoapBindingArgumentTypeMismatch {
    public boolean allocate(Integer projectId,
            Integer[] targetIds,
            Integer[] parameterIds) {
        return targetIds == null;
    }
}
```

```
MessageContentsList.toArray() line: 124	
JAXWSMethodInvoker(AbstractInvoker).invoke(Exchange, Object, Method, List<Object>) line: 93	
JAXWSMethodInvoker(AbstractJAXWSMethodInvoker).invoke(Exchange, Object, Method, List<Object>) line: 232	
JAXWSMethodInvoker.invoke(Exchange, Object, Method, List<Object>) line: 85	
JAXWSMethodInvoker(AbstractInvoker).invoke(Exchange, Object) line: 74	
ServiceInvokerInterceptor$1.run() line: 59	
Executors$RunnableAdapter<T>.call() line: 515	
ServiceInvokerInterceptor$2(FutureTask<V>).run() line: 264	
ServiceInvokerInterceptor$2.run() line: 126	
SynchronousExecutor.execute(Runnable) line: 37	
ServiceInvokerInterceptor.handleMessage(Message) line: 131	
PhaseInterceptorChain.doIntercept(Message) line: 307	
ChainInitiationObserver.onMessage(Message) line: 121	
ServletDestination(AbstractHTTPDestination).invoke(ServletConfig, ServletContext, HttpServletRequest, HttpServletResponse) line: 265	
ServletController.invokeDestination(HttpServletRequest, HttpServletResponse, AbstractHTTPDestination) line: 234	
ServletController.invoke(HttpServletRequest, HttpServletResponse, boolean) line: 208	
ServletController.invoke(HttpServletRequest, HttpServletResponse) line: 160	
CXFServlet(CXFNonSpringServlet).invoke(HttpServletRequest, HttpServletResponse) line: 225	
CXFServlet(AbstractHTTPServlet).handleRequest(HttpServletRequest, HttpServletResponse) line: 304	
CXFServlet(AbstractHTTPServlet).doPost(HttpServletRequest, HttpServletResponse) line: 217	
CXFServlet(HttpServlet).service(HttpServletRequest, HttpServletResponse) line: 681	
CXFServlet(AbstractHTTPServlet).service(ServletRequest, ServletResponse) line: 279	
ApplicationFilterChain.internalDoFilter(ServletRequest, ServletResponse) line: 227	
ApplicationFilterChain.doFilter(ServletRequest, ServletResponse) line: 162	
WsFilter.doFilter(ServletRequest, ServletResponse, FilterChain) line: 53	
ApplicationFilterChain.internalDoFilter(ServletRequest, ServletResponse) line: 189	
ApplicationFilterChain.doFilter(ServletRequest, ServletResponse) line: 162	
StandardWrapperValve.invoke(Request, Response) line: 197	
StandardContextValve.invoke(Request, Response) line: 97	
NonLoginAuthenticator(AuthenticatorBase).invoke(Request, Response) line: 540	
StandardHostValve.invoke(Request, Response) line: 135	
RewriteValve.invoke(Request, Response) line: 289	
ErrorReportValve.invoke(Request, Response) line: 92	
StandardEngineValve.invoke(Request, Response) line: 78	
CoyoteAdapter.service(Request, Response) line: 359	
Http11Processor.service(SocketWrapperBase<?>) line: 399	
Http11Processor(AbstractProcessorLight).process(SocketWrapperBase<?>, SocketEvent) line: 65	
AbstractProtocol$ConnectionHandler<S>.process(SocketWrapperBase<S>, SocketEvent) line: 889	
NioEndpoint$SocketProcessor.doRun() line: 1735	
NioEndpoint$SocketProcessor(SocketProcessorBase<S>).run() line: 49	
ThreadPoolExecutor.runWorker(ThreadPoolExecutor$Worker) line: 1191	
ThreadPoolExecutor$Worker.run() line: 659	
TaskThread$WrappingRunnable.run() line: 61	
TaskThread(Thread).run() line: 829	
```

```
this	MessageContentsList  (id=72)	           [1, java.lang.Object@12d4589f, [Ljava.lang.Integer;@16ebce1d]
	elementData	Object[6]  (id=133)	               [1, java.lang.Object@12d4589f, [222], null, null, null]      
		[0]	Integer  (id=134)	                   1                                                            
			value	1	                           1                                                            
		[1]	Object  (id=138)	                   java.lang.Object@12d4589f                                    
		[2]	Integer[1]  (id=139)	               [222]                                                        
			[0]	Integer  (id=142)	               222                                                          
		[3]	null	                               null                                                         
		[4]	null	                               null                                                         
		[5]	null	                               null                                                         
	modCount	3	                               3                                                            
	size	3	                                   3                                                            
idx	0	                                           0                                                            
size	3	                                       3                                                            
array	Object[3]  (id=82)	                       [null, null, null]                                           
	[0]	null	                                   null                                                         
	[1]	null	                                   null                                                         
	[2]	null	                                   null

```
