### PR TITLE
Update UDPDestination.java

### DIFF
--- a/rt/transports/udp/src/main/java/org/apache/cxf/transport/udp/UDPDestination.java
+++ b/rt/transports/udp/src/main/java/org/apache/cxf/transport/udp/UDPDestination.java
@@ -202,7 +202,9 @@ public class UDPDestination extends AbstractDestination {
                     NetworkInterface ni = ifcs.nextElement();
                     if (ni.supportsMulticast() && ni.isUp()) {
                         for (InterfaceAddress ia : ni.getInterfaceAddresses()) {
-                            if (ia.getAddress() instanceof java.net.Inet4Address && !ia.getAddress().isLoopbackAddress()
+                            // Ignore any virtual interfaces created by/for a VPN connection.
+                            if (ia != null && ia.getAddress() instanceof java.net.Inet4Address
+                                    && !ia.getAddress().isLoopbackAddress()
                                     && !ni.getDisplayName().startsWith("vnic")) {
                                 possibles.add(ni);
                             }


### PR DESCRIPTION
- Protect against a null pointer when running on a Windows 11 PC on a corporate VPN
- Null pointer caused by interface "TAP-Windows Adaptor V9"