### PR TITLE
Allow building with maven 4

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -568,7 +568,7 @@
             </plugin>
             <plugin>
                 <artifactId>maven-remote-resources-plugin</artifactId>
-                <version>1.7.0</version>
+                <version>3.0.0</version>
                 <dependencies>
                     <dependency>
                         <groupId>org.apache.cxf.build-utils</groupId>

--- a/systests/wsdl_maven/codegen/src/it/settings.xml
+++ b/systests/wsdl_maven/codegen/src/it/settings.xml
@@ -30,9 +30,11 @@ under the License.
                     <url>@localRepositoryUrl@</url>
                     <releases>
                         <enabled>true</enabled>
+                        <checksumPolicy>ignore</checksumPolicy>
                     </releases>
                     <snapshots>
                         <enabled>true</enabled>
+                        <checksumPolicy>ignore</checksumPolicy>
                     </snapshots>
                 </repository>
             </repositories>
@@ -42,9 +44,11 @@ under the License.
                     <url>@localRepositoryUrl@</url>
                     <releases>
                         <enabled>true</enabled>
+                        <checksumPolicy>ignore</checksumPolicy>
                     </releases>
                     <snapshots>
                         <enabled>true</enabled>
+                        <checksumPolicy>ignore</checksumPolicy>
                     </snapshots>
                 </pluginRepository>
             </pluginRepositories>


### PR DESCRIPTION
This upgrade is important in order to be able to build CXF with maven 4.x.