### PR TITLE
Revert maven-remote-resources-plugin due to issues with the build

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -568,7 +568,7 @@
             </plugin>
             <plugin>
                 <artifactId>maven-remote-resources-plugin</artifactId>
-                <version>3.0.0</version>
+                <version>1.7.0</version>
                 <dependencies>
                     <dependency>
                         <groupId>org.apache.cxf.build-utils</groupId>


### PR DESCRIPTION
Reverting the update due to https://issues.apache.org/jira/browse/MRRESOURCES-121, the build is flooded with:

```
[WARNING] Failed to build parent project for io.netty:netty-buffer:jar:4.1.85.Final
[WARNING] Invalid project model for artifact [netty-buffer:io.netty:4.1.85.Final]. It will be ignored by the remote resources Mojo.
[WARNING] Failed to build parent project for io.netty:netty-transport:jar:4.1.85.Final
[WARNING] Invalid project model for artifact [netty-transport:io.netty:4.1.85.Final]. It will be ignored by the remote resources Mojo.
[WARNING] Failed to build parent project for io.netty:netty-resolver:jar:4.1.85.Final
[WARNING] Invalid project model for artifact [netty-resolver:io.netty:4.1.85.Final]. It will be ignored by the remote resources Mojo.
[WARNING] Failed to build parent project for io.netty:netty-codec:jar:4.1.85.Final
[WARNING] Invalid project model for artifact [netty-codec:io.netty:4.1.85.Final]. It will be ignored by the remote resources Mojo.
[WARNING] Failed to build parent project for io.netty:netty-handler:jar:4.1.85.Final
[WARNING] Invalid project model for artifact [netty-handler:io.netty:4.1.85.Final]. It will be ignored by the remote resources Mojo.
[WARNING] Failed to build parent project for io.netty:netty-transport-native-unix-common:jar:4.1.85.Final
[WARNING] Invalid project model for artifact [netty-transport-native-unix-common:io.netty:4.1.85.Final]. It will be ignored by the remote resources Mojo.
```

The 3.1.0 indeed fixes the issue (tested with SNAPSHOT), but the 3.0.0 has to be reverted, created https://issues.apache.org/jira/browse/CXF-8802 to update CXF once 3.1.0 becomes available.

@gnodet fyi (sadly, we need 3.1.0)