### PR TITLE
CXF-8809: Migrate LDAP systest cases from ApacheDS to UnboundID LDAP

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -60,7 +60,6 @@
         <!-- please maintain alphabetical order here -->
         <cxf.activemq.artemis.version>2.26.0</cxf.activemq.artemis.version>
         <cxf.ahc.version>2.12.3</cxf.ahc.version>
-        <cxf.apacheds.version>2.0.0.AM26</cxf.apacheds.version>
         <cxf.arquillian.version>1.7.0.Alpha13</cxf.arquillian.version>
         <cxf.arquillian.weld.container.version>3.0.0.Final</cxf.arquillian.weld.container.version>
         <cxf.aspectj.version>1.9.1</cxf.aspectj.version>
@@ -147,6 +146,7 @@
         <cxf.junit.version>4.13.2</cxf.junit.version>
         <cxf.junit5.version>5.9.1</cxf.junit5.version>
         <cxf.kerby.version>2.0.2</cxf.kerby.version>
+        <cxf.ldapsdk.version>6.0.7</cxf.ldapsdk.version>
         <cxf.littleproxy.version>1.1.2</cxf.littleproxy.version>
         <cxf.logback.classic.version>1.4.5</cxf.logback.classic.version>
         <cxf.lucene.version>9.4.2</cxf.lucene.version>
@@ -2171,7 +2171,7 @@
             <properties>
                 <!-- EasyMock stills uses JDK Internal APIs: see please https://bugs.openjdk.java.net/browse/JDK-8255363 -->
                 <!-- JAXB: see please https://github.com/javaee/jaxb-v2/issues/1184 -->
-                <cxf.surefire.fork.vmargs>-ea --add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/sun.security.x509=ALL-UNNAMED --add-opens java.base/sun.security.util=ALL-UNNAMED --add-opens java.xml/com.sun.org.apache.xerces.internal.dom=ALL-UNNAMED --add-opens java.base/java.net=ALL-UNNAMED  --add-opens java.base/sun.net.www.protocol.https=ALL-UNNAMED</cxf.surefire.fork.vmargs>
+                <cxf.surefire.fork.vmargs>-ea --add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.xml/com.sun.org.apache.xerces.internal.dom=ALL-UNNAMED --add-opens java.base/java.net=ALL-UNNAMED  --add-opens java.base/sun.net.www.protocol.https=ALL-UNNAMED</cxf.surefire.fork.vmargs>
             </properties>
         </profile>
     </profiles>

--- a/systests/ldap/pom.xml
+++ b/systests/ldap/pom.xml
@@ -197,40 +197,16 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.apache.directory.server</groupId>
-            <artifactId>apacheds-core-annotations</artifactId>
-            <version>${cxf.apacheds.version}</version>
+            <groupId>com.unboundid</groupId>
+            <artifactId>unboundid-ldapsdk</artifactId>
+            <version>${cxf.ldapsdk.version}</version>
             <scope>test</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>bouncycastle</groupId>
-                    <artifactId>bcprov-jdk15</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
-            <groupId>org.apache.directory.server</groupId>
-            <artifactId>apacheds-core-integ</artifactId>
-            <version>${cxf.apacheds.version}</version>
+            <groupId>org.zapodot</groupId>
+            <artifactId>embedded-ldap-junit</artifactId>
+            <version>0.9.0</version>
             <scope>test</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>bouncycastle</groupId>
-                    <artifactId>bcprov-jdk15</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.directory.server</groupId>
-            <artifactId>apacheds-protocol-shared</artifactId>
-            <version>${cxf.apacheds.version}</version>
-            <scope>test</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>bouncycastle</groupId>
-                    <artifactId>bcprov-jdk15</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.springframework.ldap</groupId>

--- a/systests/ldap/src/test/java/org/apache/cxf/systest/ldap/jaxrs/JAXRSLDAPUserTest.java
+++ b/systests/ldap/src/test/java/org/apache/cxf/systest/ldap/jaxrs/JAXRSLDAPUserTest.java
@@ -28,56 +28,33 @@ import java.nio.file.Path;
 import jakarta.ws.rs.InternalServerErrorException;
 import org.apache.cxf.jaxrs.client.WebClient;
 import org.apache.cxf.testutil.common.AbstractClientServerTestBase;
-import org.apache.directory.server.annotations.CreateLdapServer;
-import org.apache.directory.server.annotations.CreateTransport;
-import org.apache.directory.server.core.annotations.ApplyLdifFiles;
-import org.apache.directory.server.core.annotations.CreateDS;
-import org.apache.directory.server.core.annotations.CreateIndex;
-import org.apache.directory.server.core.annotations.CreatePartition;
-import org.apache.directory.server.core.integ.AbstractLdapTestUnit;
-import org.apache.directory.server.core.integ.FrameworkRunner;
+import org.zapodot.junit.ldap.EmbeddedLdapRule;
+import org.zapodot.junit.ldap.EmbeddedLdapRuleBuilder;
 
+import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.ClassRule;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-
-@RunWith(FrameworkRunner.class)
-
-//Define the DirectoryService
-@CreateDS(name = "JAXRSLDAPUserTest-class",
-    enableAccessControl = false,
-    allowAnonAccess = false,
-    enableChangeLog = true,
-    partitions = {
-        @CreatePartition(
-            name = "example",
-            suffix = "dc=example,dc=com",
-            indexes = {
-                @CreateIndex(attribute = "objectClass"),
-                @CreateIndex(attribute = "dc"),
-                @CreateIndex(attribute = "ou")
-            }
-        ) 
-    }
-)
-
-@CreateLdapServer(
-    transports = {
-        @CreateTransport(protocol = "LDAP", address = "localhost")
-    }
-)
-
-//Inject an file containing entries
-@ApplyLdifFiles("ldap.ldif")
 
 /**
  * Add a test for JAX-RS search using the LdapQueryVisitor.
  */
-public class JAXRSLDAPUserTest extends AbstractLdapTestUnit {
+public class JAXRSLDAPUserTest {
     public static final String PORT = UserLDAPServer.PORT;
     public static final String PORT2 = UserLDAPServer.PORT2;
+
+    @ClassRule
+    public static EmbeddedLdapRule embeddedLdapRule = EmbeddedLdapRuleBuilder
+        .newInstance()
+        .bindingToAddress("localhost")
+        .usingBindCredentials("ldap_su")
+        .usingBindDSN("UID=admin,DC=example,DC=com")
+        .usingDomainDsn("dc=example,dc=com")
+        .importingLdifs("ldap.ldif")
+        .build();
+
     private static boolean portUpdated;
 
     @BeforeClass
@@ -103,7 +80,7 @@ public class JAXRSLDAPUserTest extends AbstractLdapTestUnit {
             // Read in ldap.xml and substitute in the correct port
             Path path = FileSystems.getDefault().getPath(basedir, "/src/test/resources/ldap-jaxrs.xml");
             String content = new String(Files.readAllBytes(path), StandardCharsets.UTF_8);
-            content = content.replaceAll("portno", Integer.toString(super.getLdapServer().getPort()));
+            content = content.replaceAll("portno", Integer.toString(embeddedLdapRule.embeddedServerPort()));
 
             Path path2 = FileSystems.getDefault().getPath(basedir, "/target/test-classes/ldap-jaxrsport.xml");
             Files.write(path2, content.getBytes());
@@ -113,7 +90,7 @@ public class JAXRSLDAPUserTest extends AbstractLdapTestUnit {
 
     }
 
-    @org.junit.AfterClass
+    @AfterClass
     public static void cleanup() throws Exception {
         AbstractClientServerTestBase.stopAllServers();
     }

--- a/systests/ldap/src/test/resources/ldap.xml
+++ b/systests/ldap/src/test/resources/ldap.xml
@@ -36,7 +36,7 @@
         <entry key="http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname" value="sn"/>
         <entry key="http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress" value="mail"/>
         <entry key="http://schemas.xmlsoap.org/ws/2005/05/identity/claims/country" value="c"/>
-        <entry key="http://custom/x509" value="usercertificate"/>
+        <entry key="http://custom/x509" value="userCertificate"/>
     </util:map>
     <bean id="testClaimsHandler" class="org.apache.cxf.sts.claims.LdapClaimsHandler">
         <property name="ldapTemplate" ref="ldapTemplate" />


### PR DESCRIPTION
The ApacheDS project is effectively dead (no releases since 2020), moreover it is not compatible with latest JDK-20+:
```
java.lang.NoSuchMethodError: 'void sun.security.x509.X509CertInfo.set(java.lang.String, java.lang.Object)'
	at org.apache.directory.server.core.security.CertificateUtil.setInfo(CertificateUtil.java:96)
	at org.apache.directory.server.core.security.CertificateUtil.generateSelfSignedCertificate(CertificateUtil.java:194)
	at org.apache.directory.server.core.security.CertificateUtil.createTempKeyStore(CertificateUtil.java:337)
	at org.apache.directory.server.factory.ServerAnnotationProcessor.instantiateLdapServer(ServerAnnotationProcessor.java:158)
	at org.apache.directory.server.factory.ServerAnnotationProcessor.createLdapServer(ServerAnnotationProcessor.java:318)
	at org.apache.directory.server.factory.ServerAnnotationProcessor.createLdapServer(ServerAnnotationProcessor.java:351) 
```
The Apache CXF only uses ApacheDS in LDAP systests, we have to migrate to the supported option , for example UnboundID LDAP (https://github.com/pingidentity/ldapsdk)