### PR TITLE
CXF-8788: Remove the 'jakarta' profile (which enables the Spring milestone repositories)

### DIFF
--- a/distribution/src/main/release/samples/pom.xml
+++ b/distribution/src/main/release/samples/pom.xml
@@ -32,7 +32,7 @@
         <maven.deploy.skip>true</maven.deploy.skip>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <spring.boot.version>3.0.0</spring.boot.version>
-        <spring.cloud.eureka.version>4.0.0-RC3</spring.cloud.eureka.version>
+        <spring.cloud.eureka.version>4.0.0</spring.cloud.eureka.version>
         <cxf.jetty11.version>11.0.13</cxf.jetty11.version>
         <cxf.netty.version>4.1.86.Final</cxf.netty.version>
         <cxf.httpcomponents.client.version>4.5.13</cxf.httpcomponents.client.version>
@@ -263,37 +263,6 @@
                     <snapshots>
                         <enabled>true</enabled>
                     </snapshots>
-                </pluginRepository>
-            </pluginRepositories>
-        </profile>
-        <!--
-            TODO: Please remove, temporary repository settings in order to enable snapshots for
-            Spring Boot 3.0.0
-        -->
-        <profile>
-            <id>jakarta</id>
-            <activation>
-                <activeByDefault>true</activeByDefault>
-            </activation>
-            <repositories>
-                <repository>
-                    <id>spring.milestone</id>
-                    <url>https://repo.spring.io/milestone/</url>
-                    <name>Spring Milestone Repo</name>
-                </repository>
-                <repository>
-                    <id>netflix.candidates</id>
-                    <url>https://artifactory-oss.prod.netflix.net/artifactory/maven-oss-candidates</url>
-                    <snapshots>
-                        <enabled>false</enabled>
-                    </snapshots>
-                </repository>
-            </repositories>
-            <pluginRepositories>
-                <pluginRepository>
-                    <id>spring.milestone</id>
-                    <url>https://repo.spring.io/milestone/</url>
-                    <name>Spring Milestone Repo</name>
                 </pluginRepository>
             </pluginRepositories>
         </profile>

--- a/pom.xml
+++ b/pom.xml
@@ -417,30 +417,6 @@
                 </plugins>
             </build>
         </profile>
-        <!-- 
-            TODO: Please remove, temporary repository settings in order to enable snapshots for
-            Spring Boot 3.0.0
-        -->
-        <profile>
-            <id>jakarta</id>
-            <activation>
-                <activeByDefault>true</activeByDefault>
-            </activation>
-            <repositories>
-                <repository>
-                    <id>spring.milestone</id>
-                    <url>https://repo.spring.io/milestone/</url>
-                    <name>Spring Milestone Repo</name>
-                </repository>
-            </repositories>
-            <pluginRepositories>
-                <pluginRepository>
-                    <id>spring.milestone</id>
-                    <url>https://repo.spring.io/milestone/</url>
-                    <name>Spring Milestone Repo</name>
-                </pluginRepository>
-            </pluginRepositories>
-        </profile>
     </profiles>
     <build>
         <defaultGoal>install</defaultGoal>


### PR DESCRIPTION
The last blocker (Spring Cloud release train) is now resolved