### PR TITLE
CXF-8758: Migration path for Wiremock (Jetty 11/JakartaEE)

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -201,7 +201,7 @@
         <cxf.validation.api.version>3.0.2</cxf.validation.api.version>
         <cxf.velocity.version>2.3</cxf.velocity.version>
         <cxf.wildfly.common.version>1.6.0.Final</cxf.wildfly.common.version>
-        <cxf.wiremock.version>2.27.2</cxf.wiremock.version>
+        <cxf.wiremock.version>3.0.0-beta-2</cxf.wiremock.version>
         <cxf.woodstox.core.version>6.4.0</cxf.woodstox.core.version>
         <cxf.woodstox.stax2-api.version>4.2.1</cxf.woodstox.stax2-api.version>
         <cxf.wsdl4j.version>1.6.3</cxf.wsdl4j.version>

--- a/rt/rs/microprofile-client/pom.xml
+++ b/rt/rs/microprofile-client/pom.xml
@@ -166,10 +166,9 @@
             <version>${cxf.commons-jcs-jcache.version}</version>
             <scope>test</scope>
         </dependency>
-        <!--TODO: after wiremock jakarta version is ready change back to com.github.tomakehurst:wiremock -->
         <dependency>
             <groupId>com.github.tomakehurst</groupId>
-            <artifactId>wiremock-standalone</artifactId>
+            <artifactId>wiremock</artifactId>
             <version>${cxf.wiremock.version}</version>
             <scope>test</scope>
             <exclusions>

--- a/systests/microprofile/client/async/pom.xml
+++ b/systests/microprofile/client/async/pom.xml
@@ -32,7 +32,6 @@
     <url>https://cxf.apache.org</url>
     <properties>
         <cxf.module.name>org.apache.cxf.systests.microprofile.async</cxf.module.name>
-        <cxf.wiremock.params>--port=8765</cxf.wiremock.params>
     </properties>
         <dependencies>
             <dependency>
@@ -143,10 +142,9 @@
                     </exclusion>
                 </exclusions>
             </dependency>
-            <!--TODO: after wiremock jakarta version is ready change back to com.github.tomakehurst:wiremock -->
             <dependency>
                 <groupId>com.github.tomakehurst</groupId>
-                <artifactId>wiremock-standalone</artifactId>
+                <artifactId>wiremock</artifactId>
                 <version>${cxf.wiremock.version}</version>
                 <scope>test</scope>
                 <exclusions>

--- a/systests/microprofile/client/nocdi/pom.xml
+++ b/systests/microprofile/client/nocdi/pom.xml
@@ -32,7 +32,6 @@
     <url>https://cxf.apache.org</url>
     <properties>
         <cxf.module.name>org.apache.cxf.systests.microprofile.nocdi</cxf.module.name>
-        <cxf.wiremock.params>--port=8765</cxf.wiremock.params>
     </properties>
     <dependencies>
         <dependency>
@@ -139,10 +138,9 @@
                 </exclusion>
             </exclusions>
         </dependency>
-        <!--TODO: after wiremock jakarta version is ready change back to com.github.tomakehurst:wiremock -->
         <dependency>
             <groupId>com.github.tomakehurst</groupId>
-            <artifactId>wiremock-standalone</artifactId>
+            <artifactId>wiremock</artifactId>
             <version>${cxf.wiremock.version}</version>
             <scope>test</scope>
             <exclusions>

--- a/systests/microprofile/client/weld/pom.xml
+++ b/systests/microprofile/client/weld/pom.xml
@@ -103,36 +103,6 @@
             <artifactId>johnzon-mapper</artifactId>
             <classifier>jakarta</classifier>
         </dependency>
-        <dependency>
-            <groupId>org.eclipse.jetty</groupId>
-            <artifactId>jetty-server</artifactId>
-            <version>${cxf.jetty.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.eclipse.jetty</groupId>
-            <artifactId>jetty-servlet</artifactId>
-            <version>${cxf.jetty.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.eclipse.jetty</groupId>
-            <artifactId>jetty-servlets</artifactId>
-            <version>${cxf.jetty.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.eclipse.jetty</groupId>
-            <artifactId>jetty-webapp</artifactId>
-            <version>${cxf.jetty.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.eclipse.jetty</groupId>
-            <artifactId>jetty-proxy</artifactId>
-            <version>${cxf.jetty.version}</version>
-            <scope>test</scope>
-        </dependency>
 
         <dependency>
             <groupId>jakarta.enterprise</groupId>
@@ -187,8 +157,7 @@
             <plugin>
                 <groupId>uk.co.automatictester</groupId>
                 <artifactId>wiremock-maven-plugin</artifactId>
-                <!-- Note, updating to 4.4.1 causes a weird Xalan error when building the distribution -->
-                <version>4.4.0</version>
+                <version>7.3.0</version>
                 <executions>
                     <execution>
                         <phase>generate-test-sources</phase>
@@ -201,6 +170,17 @@
                         </configuration>
                     </execution>
                 </executions>
+                <dependencies>
+                    <!-- 
+                    The end goal is to use wiremock 3.0.0 but sadly microprofile-rest-client-tck 
+                    still depends on javax.servlet (MyEventSourceServlet.java). 
+                    -->
+                    <dependency>
+                        <groupId>com.github.tomakehurst</groupId>
+                        <artifactId>wiremock-jre8-standalone</artifactId>
+                        <version>2.35.0</version>
+                    </dependency>
+                </dependencies>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
Migration path for Wiremock (Jetty 11/JakartaEE)