### PR TITLE
Fix Jwe compression

### DIFF
--- a/core/src/main/java/org/apache/cxf/common/util/CompressionUtils.java
+++ b/core/src/main/java/org/apache/cxf/common/util/CompressionUtils.java
@@ -35,7 +35,7 @@ public final class CompressionUtils {
     }
     public static InputStream inflate(byte[] deflatedToken, boolean nowrap)
         throws DataFormatException {
-        Inflater inflater = new Inflater(true);
+        Inflater inflater = new Inflater(nowrap);
         inflater.setInput(deflatedToken);
 
         byte[] buffer = new byte[deflatedToken.length];

--- a/rt/security/src/main/java/org/apache/cxf/rt/security/crypto/CryptoUtils.java
+++ b/rt/security/src/main/java/org/apache/cxf/rt/security/crypto/CryptoUtils.java
@@ -546,7 +546,7 @@ public final class CryptoUtils {
                                       int mode)  throws SecurityException {
         boolean compressionSupported = keyProps != null && keyProps.isCompressionSupported();
         if (compressionSupported && mode == Cipher.ENCRYPT_MODE) {
-            bytes = CompressionUtils.deflate(bytes, false);
+            bytes = CompressionUtils.deflate(bytes, true);
         }
         try {
             Cipher c = initCipher(secretKey, keyProps, mode);
@@ -580,7 +580,7 @@ public final class CryptoUtils {
                 }
             }
             if (compressionSupported && mode == Cipher.DECRYPT_MODE) {
-                result = IOUtils.readBytesFromStream(CompressionUtils.inflate(result, false));
+                result = IOUtils.readBytesFromStream(CompressionUtils.inflate(result, true));
             }
             return result;
         } catch (Exception ex) {

--- a/rt/security/src/test/java/org/apache/cxf/rt/security/crypto/CryptoUtilsTest.java
+++ b/rt/security/src/test/java/org/apache/cxf/rt/security/crypto/CryptoUtilsTest.java
@@ -18,31 +18,39 @@
  */
 package org.apache.cxf.rt.security.crypto;
 
-import java.lang.SecurityException;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.Collection;
+
 import javax.crypto.SecretKey;
 
-import org.apache.cxf.rt.security.crypto.CryptoUtils;
-import org.apache.cxf.rt.security.crypto.KeyProperties;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 
 import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.fail;
 
+@RunWith(Parameterized.class)
 public class CryptoUtilsTest {
+    private final boolean compression;
+
+    public CryptoUtilsTest(boolean compression) {
+        this.compression = compression;
+    }
+
+    @Parameterized.Parameters
+    public static Collection<Object[]> compression() {
+        return Arrays.asList(new Object[][] {{true}, {false}});
+    }
 
     @Test
     public void testCompression() {
-        try {
-            byte[] bytes = "testString".getBytes("UTF-8");
-            KeyProperties keyProps = new KeyProperties("AES");
-            keyProps.setCompressionSupported(true);
-            SecretKey secretKey = CryptoUtils.getSecretKey(keyProps);
-            byte[] encryptedBytes = CryptoUtils.encryptBytes(bytes, secretKey, keyProps);
-            byte[] decryptedBytes = CryptoUtils.decryptBytes(encryptedBytes, secretKey, keyProps);
-            assertArrayEquals(bytes, decryptedBytes);
-        } catch (SecurityException ex) {
-            fail(ex.toString());
-        } catch (Exception ex) {
-        }
+        byte[] bytes = "testString".getBytes(StandardCharsets.UTF_8);
+        KeyProperties keyProps = new KeyProperties("AES");
+        keyProps.setCompressionSupported(compression);
+        SecretKey secretKey = CryptoUtils.getSecretKey(keyProps);
+        byte[] encryptedBytes = CryptoUtils.encryptBytes(bytes, secretKey, keyProps);
+        byte[] decryptedBytes = CryptoUtils.decryptBytes(encryptedBytes, secretKey, keyProps);
+        assertArrayEquals(bytes, decryptedBytes);
     }
 }

--- a/rt/security/src/test/java/org/apache/cxf/rt/security/crypto/CryptoUtilsTest.java
+++ b/rt/security/src/test/java/org/apache/cxf/rt/security/crypto/CryptoUtilsTest.java
@@ -1,0 +1,48 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.cxf.rt.security.crypto;
+
+import java.lang.SecurityException;
+import javax.crypto.SecretKey;
+
+import org.apache.cxf.rt.security.crypto.CryptoUtils;
+import org.apache.cxf.rt.security.crypto.KeyProperties;
+import org.junit.Test;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.fail;
+
+public class CryptoUtilsTest {
+
+    @Test
+    public void testCompression() {
+        try {
+            byte[] bytes = "testString".getBytes("UTF-8");
+            KeyProperties keyProps = new KeyProperties("AES");
+            keyProps.setCompressionSupported(true);
+            SecretKey secretKey = CryptoUtils.getSecretKey(keyProps);
+            byte[] encryptedBytes = CryptoUtils.encryptBytes(bytes, secretKey, keyProps);
+            byte[] decryptedBytes = CryptoUtils.decryptBytes(encryptedBytes, secretKey, keyProps);
+            assertArrayEquals(bytes, decryptedBytes);
+        } catch (SecurityException ex) {
+            fail(ex.toString());
+        } catch (Exception ex) {
+        }
+    }
+}


### PR DESCRIPTION
As for now Deflater and Inflater initialized with different 'nowrap' value. As result we are getting the folowing Exeption:
```
java.lang.SecurityException: java.util.zip.DataFormatException: invalid stored block lengths
        at org.apache.cxf.rt.security.crypto.CryptoUtils.processBytes(CryptoUtils.java:587)
        at org.apache.cxf.rt.security.crypto.CryptoUtils.decryptBytes(CryptoUtils.java:483)
        at org.apache.cxf.rs.security.jose.jwe.AbstractJweDecryption.doDecrypt(AbstractJweDecryption.java:72)
        at org.apache.cxf.rs.security.jose.jwe.AbstractJweDecryption.decrypt(AbstractJweDecryption.java:57)
        at org.apache.cxf.rs.security.jose.jwe.JweJsonConsumer.decryptWith(JweJsonConsumer.java:64)

```

This PR will fix the Jwe Compression by setting the 'nowrap' parameter for both Deflater and Inflater to 'true' (RAW DEF) as specified in the RFC1951.