### PR TITLE
Bump tycho-packaging-plugin from 0.26.0 to 2.7.5 (#1126)

### DIFF
--- a/services/xkms/xkms-x509-handlers/pom.xml
+++ b/services/xkms/xkms-x509-handlers/pom.xml
@@ -77,8 +77,14 @@
         <plugins>
             <plugin>
                 <groupId>org.eclipse.tycho</groupId>
+                <artifactId>tycho-maven-plugin</artifactId>
+                <version>2.7.5</version>
+                <extensions>true</extensions>
+            </plugin>
+            <plugin>
+                <groupId>org.eclipse.tycho</groupId>
                 <artifactId>tycho-packaging-plugin</artifactId>
-                <version>0.26.0</version>
+                <version>2.7.5</version>
                 <executions>
                     <execution>
                         <id>timestamp</id>


### PR DESCRIPTION
* Bump tycho-packaging-plugin from 0.26.0 to 2.7.5

Bumps [tycho-packaging-plugin](https://github.com/eclipse/tycho) from 0.26.0 to 2.7.5.
- [Release notes](https://github.com/eclipse/tycho/releases)
- [Changelog](https://github.com/eclipse-tycho/tycho/blob/master/RELEASE_NOTES.md)
- [Commits](https://github.com/eclipse/tycho/compare/tycho-0.26.0...tycho-2.7.5)

---
updated-dependencies:
- dependency-name: org.eclipse.tycho:tycho-packaging-plugin dependency-type: direct:production update-type: version-update:semver-major ...

Signed-off-by: dependabot[bot] <support@github.com>

* Add tycho-maven-plugin (needed by tycho-packaging-plugin)

---------

Signed-off-by: dependabot[bot] <support@github.com>
Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>
Co-authored-by: Andriy Redko <drreta@gmail.com>