### PR TITLE
CXF-8822: AsyncHTTPConduit removes query-parameters when path is empty

### DIFF
--- a/rt/transports/http-hc/src/main/java/org/apache/cxf/transport/http/asyncclient/AsyncHTTPConduit.java
+++ b/rt/transports/http-hc/src/main/java/org/apache/cxf/transport/http/asyncclient/AsyncHTTPConduit.java
@@ -190,9 +190,17 @@ public class AsyncHTTPConduit extends URLConnectionHTTPConduit {
             super.setupConnection(message, addressChanged ? new Address(uriString, uri) : address, csPolicy);
             return;
         }
+
         if (StringUtils.isEmpty(uri.getPath())) {
-            //hc needs to have the path be "/"
-            uri = uri.resolve("/");
+            try {
+                //hc needs to have the path be "/"
+                uri = new URI(uri.getScheme(),
+                    uri.getUserInfo(), uri.getHost(), uri.getPort(),
+                    uri.resolve("/").getPath(), uri.getQuery(),
+                    uri.getFragment());
+            } catch (final URISyntaxException ex) {
+                throw new IOException(ex);
+            }
         }
 
         message.put(USE_ASYNC, Boolean.TRUE);

--- a/rt/transports/http-hc/src/test/java/org/apache/cxf/transport/http/asyncclient/AsyncHTTPConduitTest.java
+++ b/rt/transports/http-hc/src/test/java/org/apache/cxf/transport/http/asyncclient/AsyncHTTPConduitTest.java
@@ -19,6 +19,7 @@
 
 package org.apache.cxf.transport.http.asyncclient;
 
+import java.io.IOException;
 import java.net.URL;
 import java.util.Collections;
 import java.util.concurrent.CountDownLatch;
@@ -36,6 +37,9 @@ import org.apache.cxf.continuations.ContinuationProvider;
 import org.apache.cxf.endpoint.Client;
 import org.apache.cxf.frontend.ClientProxy;
 import org.apache.cxf.jaxws.JaxWsProxyFactoryBean;
+import org.apache.cxf.message.Exchange;
+import org.apache.cxf.message.ExchangeImpl;
+import org.apache.cxf.message.MessageImpl;
 import org.apache.cxf.testutil.common.AbstractBusClientServerTestBase;
 import org.apache.cxf.transport.http.HTTPConduit;
 import org.apache.cxf.transport.http.HTTPConduitFactory;
@@ -473,4 +477,39 @@ public class AsyncHTTPConduitTest extends AbstractBusClientServerTestBase {
         System.out.println("Total: " + (end - start) + " " + rlatch.getCount());
     }
 
+    @Test
+    public void testPathWithQueryParams() throws IOException {
+        final String address = "http://localhost:" + PORT + "/SoapContext/SoapPort?param1=value1&param2=value2";
+        final Greeter greeter = new SOAPService().getSoapPort();
+        setAddress(greeter, address);
+
+        final HTTPConduit c = (HTTPConduit)ClientProxy.getClient(greeter).getConduit();
+        final MessageImpl message = new MessageImpl();
+        message.put(AsyncHTTPConduit.USE_ASYNC, AsyncHTTPConduitFactory.UseAsyncPolicy.ALWAYS);
+
+        final Exchange exchange = new ExchangeImpl();
+        message.setExchange(exchange);
+        c.prepare(message);
+
+        final CXFHttpRequest e = message.get(CXFHttpRequest.class);
+        assertEquals(address, e.getURI().toString());
+    }
+
+    @Test
+    public void testEmptyPathWithQueryParams() throws IOException {
+        final String address = "http://localhost:" + PORT + "?param1=value1&param2=value2";
+        final Greeter greeter = new SOAPService().getSoapPort();
+        setAddress(greeter, address);
+
+        final HTTPConduit c = (HTTPConduit)ClientProxy.getClient(greeter).getConduit();
+        final MessageImpl message = new MessageImpl();
+        message.put(AsyncHTTPConduit.USE_ASYNC, AsyncHTTPConduitFactory.UseAsyncPolicy.ALWAYS);
+
+        final Exchange exchange = new ExchangeImpl();
+        message.setExchange(exchange);
+        c.prepare(message);
+
+        final CXFHttpRequest e = message.get(CXFHttpRequest.class);
+        assertEquals("http://localhost:" + PORT + "/?param1=value1&param2=value2", e.getURI().toString());
+    }
 }

--- a/rt/transports/http-hc5/src/main/java/org/apache/cxf/transport/http/asyncclient/hc5/AsyncHTTPConduit.java
+++ b/rt/transports/http-hc5/src/main/java/org/apache/cxf/transport/http/asyncclient/hc5/AsyncHTTPConduit.java
@@ -201,10 +201,17 @@ public class AsyncHTTPConduit extends URLConnectionHTTPConduit {
             super.setupConnection(message, addressChanged ? new Address(uriString, uri) : address, csPolicy);
             return;
         }
-        
+
         if (StringUtils.isEmpty(uri.getPath())) {
-            //hc needs to have the path be "/"
-            uri = uri.resolve("/");
+            try {
+                //hc needs to have the path be "/"
+                uri = new URI(uri.getScheme(),
+                    uri.getUserInfo(), uri.getHost(), uri.getPort(),
+                    uri.resolve("/").getPath(), uri.getQuery(),
+                    uri.getFragment());
+            } catch (final URISyntaxException ex) {
+                throw new IOException(ex);
+            }
         }
 
         message.put(USE_ASYNC, Boolean.TRUE);

--- a/rt/transports/http-hc5/src/test/java/org/apache/cxf/transport/http/asyncclient/hc5/AsyncHTTPConduitTest.java
+++ b/rt/transports/http-hc5/src/test/java/org/apache/cxf/transport/http/asyncclient/hc5/AsyncHTTPConduitTest.java
@@ -19,6 +19,7 @@
 
 package org.apache.cxf.transport.http.asyncclient.hc5;
 
+import java.io.IOException;
 import java.net.URL;
 import java.util.Collections;
 import java.util.concurrent.CountDownLatch;
@@ -37,6 +38,9 @@ import org.apache.cxf.continuations.ContinuationProvider;
 import org.apache.cxf.endpoint.Client;
 import org.apache.cxf.frontend.ClientProxy;
 import org.apache.cxf.jaxws.JaxWsProxyFactoryBean;
+import org.apache.cxf.message.Exchange;
+import org.apache.cxf.message.ExchangeImpl;
+import org.apache.cxf.message.MessageImpl;
 import org.apache.cxf.testutil.common.AbstractBusClientServerTestBase;
 import org.apache.cxf.transport.http.HTTPConduit;
 import org.apache.cxf.transport.http.HTTPConduitFactory;
@@ -333,5 +337,41 @@ public class AsyncHTTPConduitTest extends AbstractBusClientServerTestBase {
         doneLatch.await(30, TimeUnit.SECONDS);
 
         assertEquals("All responses should be handled eventually", 0, doneLatch.getCount());
+    }
+
+    @Test
+    public void testPathWithQueryParams() throws IOException {
+        final String address = "http://localhost:" + PORT + "/SoapContext/SoapPort?param1=value1&param2=value2";
+        final Greeter greeter = new SOAPService().getSoapPort();
+        setAddress(greeter, address);
+
+        final HTTPConduit c = (HTTPConduit)ClientProxy.getClient(greeter).getConduit();
+        final MessageImpl message = new MessageImpl();
+        message.put(AsyncHTTPConduit.USE_ASYNC, AsyncHTTPConduitFactory.UseAsyncPolicy.ALWAYS);
+
+        final Exchange exchange = new ExchangeImpl();
+        message.setExchange(exchange);
+        c.prepare(message);
+
+        final CXFHttpRequest e = message.get(CXFHttpRequest.class);
+        assertEquals(address, e.getUri().toString());
+    }
+
+    @Test
+    public void testEmptyPathWithQueryParams() throws IOException {
+        final String address = "http://localhost:" + PORT + "?param1=value1&param2=value2";
+        final Greeter greeter = new SOAPService().getSoapPort();
+        setAddress(greeter, address);
+
+        final HTTPConduit c = (HTTPConduit)ClientProxy.getClient(greeter).getConduit();
+        final MessageImpl message = new MessageImpl();
+        message.put(AsyncHTTPConduit.USE_ASYNC, AsyncHTTPConduitFactory.UseAsyncPolicy.ALWAYS);
+
+        final Exchange exchange = new ExchangeImpl();
+        message.setExchange(exchange);
+        c.prepare(message);
+
+        final CXFHttpRequest e = message.get(CXFHttpRequest.class);
+        assertEquals("http://localhost:" + PORT + "/?param1=value1&param2=value2", e.getUri().toString());
     }
 }


### PR DESCRIPTION
AsyncHTTPConduit removes query-parameters when path is empty