### PR TITLE
CXF-8824: CDI beans produced by @Produces methods are generated twice

### DIFF
--- a/integration/cdi/src/main/java/org/apache/cxf/cdi/JAXRSCdiResourceExtension.java
+++ b/integration/cdi/src/main/java/org/apache/cxf/cdi/JAXRSCdiResourceExtension.java
@@ -472,7 +472,8 @@ public class JAXRSCdiResourceExtension implements Extension {
      */
     private List< Object > loadBeans(final BeanManager beanManager, Collection<Class<?>> limitedClasses,
                                      Collection<Bean<?>> beans) {
-        final List< Object > instances = new ArrayList<>();
+        // Use set to account for singletons and application scoped beans
+        final Set< Object > instances = new LinkedHashSet<>();
 
         for (final Bean< ? > bean: beans) {
             if (limitedClasses.isEmpty() || limitedClasses.contains(bean.getBeanClass())) {
@@ -486,7 +487,7 @@ public class JAXRSCdiResourceExtension implements Extension {
             }
         }
 
-        return instances;
+        return new ArrayList<>(instances);
     }
 
     /**
@@ -495,7 +496,8 @@ public class JAXRSCdiResourceExtension implements Extension {
      * @return the references for all discovered CXF-specific features
      */
     private List< Feature > loadFeatures(final BeanManager beanManager, Collection<Class<?>> limitedClasses) {
-        final List< Feature > features = new ArrayList<>();
+        // Use set to account for singletons and application scoped beans
+        final Set< Feature > features = new LinkedHashSet<>();
 
         for (final Bean< ? extends Feature > bean: featureBeans) {
             if (limitedClasses.isEmpty() || limitedClasses.contains(bean.getBeanClass())) {
@@ -509,7 +511,7 @@ public class JAXRSCdiResourceExtension implements Extension {
             }
         }
 
-        return features;
+        return new ArrayList<>(features);
     }
 
     /**

--- a/systests/cdi/cdi-owb/cdi-producers-owb/src/test/java/org/apache/cxf/systest/jaxrs/cdi/BookStoreFeed.java
+++ b/systests/cdi/cdi-owb/cdi-producers-owb/src/test/java/org/apache/cxf/systest/jaxrs/cdi/BookStoreFeed.java
@@ -31,9 +31,11 @@ import org.apache.cxf.systests.cdi.base.BookStoreService;
 @Path("/bookstore/")
 public class BookStoreFeed {
     private final BookStoreService service;
-    
-    public BookStoreFeed(BookStoreService service) {
+    private final ServerFactoryDebugExtension debugExtension;
+
+    public BookStoreFeed(BookStoreService service, ServerFactoryDebugExtension debugExtension) {
         this.service = service;
+        this.debugExtension = debugExtension;
     }
     
     @GET
@@ -50,5 +52,11 @@ public class BookStoreFeed {
         }
         
         return feed;
+    }
+
+    @GET
+    @Path("providers")
+    public String providers() {
+        return debugExtension.providers();
     }
 }

--- a/systests/cdi/cdi-owb/cdi-producers-owb/src/test/java/org/apache/cxf/systest/jaxrs/cdi/BookStoreProducerApplication.java
+++ b/systests/cdi/cdi-owb/cdi-producers-owb/src/test/java/org/apache/cxf/systest/jaxrs/cdi/BookStoreProducerApplication.java
@@ -20,6 +20,7 @@ package org.apache.cxf.systest.jaxrs.cdi;
 
 import jakarta.enterprise.inject.Produces;
 import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
 import jakarta.ws.rs.ApplicationPath;
 import jakarta.ws.rs.core.Application;
 import jakarta.ws.rs.core.Feature;
@@ -31,8 +32,8 @@ import org.apache.cxf.systests.cdi.base.BookStoreService;
 public class BookStoreProducerApplication extends Application {
     @Produces protected BookStoreValidatingFeed bookStoreValidatingFeed = new BookStoreValidatingFeed();
     @Inject private BookStoreService service;
-    
-    @Produces
+
+    @Produces @Singleton
     public ValidationExceptionMapper validationExceptionMapper() {
         return new ValidationExceptionMapper();
     }
@@ -43,8 +44,8 @@ public class BookStoreProducerApplication extends Application {
     }
 
     @Produces
-    public BookStoreFeed bookStoreFeed() {
-        return new BookStoreFeed(service);
+    public BookStoreFeed bookStoreFeed(ServerFactoryDebugExtension debugExtension) {
+        return new BookStoreFeed(service, debugExtension);
     }
 
     @Produces

--- a/systests/cdi/cdi-owb/cdi-producers-owb/src/test/java/org/apache/cxf/systest/jaxrs/cdi/ServerFactoryDebugExtension.java
+++ b/systests/cdi/cdi-owb/cdi-producers-owb/src/test/java/org/apache/cxf/systest/jaxrs/cdi/ServerFactoryDebugExtension.java
@@ -1,0 +1,44 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.cxf.systest.jaxrs.cdi;
+
+import java.util.stream.Collectors;
+
+import jakarta.inject.Singleton;
+import org.apache.cxf.jaxrs.JAXRSServerFactoryBean;
+import org.apache.cxf.jaxrs.ext.JAXRSServerFactoryCustomizationExtension;
+
+@Singleton
+public class ServerFactoryDebugExtension implements JAXRSServerFactoryCustomizationExtension {
+    private String providers; 
+
+    @Override
+    public void customize(JAXRSServerFactoryBean bean) {
+        providers = bean.getProviders()
+            .stream()
+            .map(t -> t.getClass().getSimpleName())
+            .sorted()
+            .collect(Collectors.joining(","));
+    }
+
+    String providers() {
+        return providers;
+    }
+}

--- a/systests/cdi/cdi-owb/cdi-producers-owb/src/test/java/org/apache/cxf/systest/jaxrs/cdi/jetty/JettyEmbeddedTest.java
+++ b/systests/cdi/cdi-owb/cdi-producers-owb/src/test/java/org/apache/cxf/systest/jaxrs/cdi/jetty/JettyEmbeddedTest.java
@@ -21,6 +21,7 @@ package org.apache.cxf.systest.jaxrs.cdi.jetty;
 import java.util.UUID;
 
 import jakarta.ws.rs.core.Form;
+import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 import org.apache.cxf.jaxrs.model.AbstractResourceInfo;
 import org.apache.cxf.systests.cdi.base.AbstractCdiSingleAppTest;
@@ -83,6 +84,18 @@ public class JettyEmbeddedTest extends AbstractCdiSingleAppTest {
                         .param("name", "Book 1234"));
 
         assertEquals(Response.Status.CREATED.getStatusCode(), r.getStatus());
+    }
+
+    @Test
+    public void testConfiguredProviders() {
+        assertEquals("AtomFeedProvider,"
+                + "CustomContextFeature,"
+                + "JacksonJsonProvider,"
+                + "JacksonJsonProvider,"
+                + "SampleFeature,"
+                + "SampleNestedFeature,"
+                + "ValidationExceptionMapper",
+            createWebClient(getBasePath() + "/providers", MediaType.TEXT_PLAIN).get(String.class).trim());
     }
 
     @Override

--- a/systests/cdi/cdi-owb/cdi-producers-owb/src/test/java/org/apache/cxf/systest/jaxrs/cdi/jetty/JettyWarTest.java
+++ b/systests/cdi/cdi-owb/cdi-producers-owb/src/test/java/org/apache/cxf/systest/jaxrs/cdi/jetty/JettyWarTest.java
@@ -21,6 +21,7 @@ package org.apache.cxf.systest.jaxrs.cdi.jetty;
 import java.util.UUID;
 
 import jakarta.ws.rs.core.Form;
+import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 import org.apache.cxf.jaxrs.model.AbstractResourceInfo;
 import org.apache.cxf.systests.cdi.base.AbstractCdiSingleAppTest;
@@ -85,6 +86,18 @@ public class JettyWarTest extends AbstractCdiSingleAppTest {
                         .param("name", "Book 1234"));
 
         assertEquals(Response.Status.CREATED.getStatusCode(), r.getStatus());
+    }
+
+    @Test
+    public void testConfiguredProviders() {
+        assertEquals("AtomFeedProvider,"
+                + "CustomContextFeature,"
+                + "JacksonJsonProvider,"
+                + "JacksonJsonProvider,"
+                + "SampleFeature,"
+                + "SampleNestedFeature,"
+                + "ValidationExceptionMapper",
+            createWebClient(getBasePath() + "/providers", MediaType.TEXT_PLAIN).get(String.class).trim());
     }
 
     @Override

--- a/systests/cdi/cdi-owb/cdi-producers-owb/src/test/java/org/apache/cxf/systest/jaxrs/cdi/tomcat/TomcatWarTest.java
+++ b/systests/cdi/cdi-owb/cdi-producers-owb/src/test/java/org/apache/cxf/systest/jaxrs/cdi/tomcat/TomcatWarTest.java
@@ -21,6 +21,7 @@ package org.apache.cxf.systest.jaxrs.cdi.tomcat;
 import java.util.UUID;
 
 import jakarta.ws.rs.core.Form;
+import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 import org.apache.cxf.jaxrs.model.AbstractResourceInfo;
 import org.apache.cxf.systests.cdi.base.AbstractCdiSingleAppTest;
@@ -82,6 +83,18 @@ public class TomcatWarTest extends AbstractCdiSingleAppTest {
                         .param("name", "Book 1234"));
 
         assertEquals(Response.Status.CREATED.getStatusCode(), r.getStatus());
+    }
+
+    @Test
+    public void testConfiguredProviders() {
+        assertEquals("AtomFeedProvider,"
+                + "CustomContextFeature,"
+                + "JacksonJsonProvider,"
+                + "JacksonJsonProvider,"
+                + "SampleFeature,"
+                + "SampleNestedFeature,"
+                + "ValidationExceptionMapper",
+            createWebClient(getBasePath() + "/providers", MediaType.TEXT_PLAIN).get(String.class).trim());
     }
 
     @Override


### PR DESCRIPTION
CDI beans produced by @Produces methods are generated twice