### PR TITLE
CXF-8815: Fix org.apache.cxf.transport.http.asyncclient.hc5.AsyncHTTPConduitTest.testResponseSameBufferSize

### DIFF
--- a/rt/transports/http-hc5/src/main/java/org/apache/cxf/transport/http/asyncclient/hc5/CXFHttpAsyncResponseConsumer.java
+++ b/rt/transports/http-hc5/src/main/java/org/apache/cxf/transport/http/asyncclient/hc5/CXFHttpAsyncResponseConsumer.java
@@ -79,7 +79,7 @@ public class CXFHttpAsyncResponseConsumer implements AsyncResponseConsumer<Boole
         for (int i = 0; i < 5; i++) {
             // Only consume content when the work was accepted by the work queue
             if (outstream.retrySetHttpResponse(response)) {
-                buf.consumeContent(src);
+                buf.consumeContent(src, completed);
                 break;
             }
         }

--- a/rt/transports/http-hc5/src/main/java/org/apache/cxf/transport/http/asyncclient/hc5/SharedInputBuffer.java
+++ b/rt/transports/http-hc5/src/main/java/org/apache/cxf/transport/http/asyncclient/hc5/SharedInputBuffer.java
@@ -69,7 +69,7 @@ public class SharedInputBuffer extends ExpandableBuffer {
         }
     }
 
-    public int consumeContent(final ByteBuffer buffer) throws IOException {
+    public int consumeContent(final ByteBuffer buffer, boolean last) throws IOException {
         if (this.shutdown) {
             return -1;
         }
@@ -88,7 +88,7 @@ public class SharedInputBuffer extends ExpandableBuffer {
                 totalRead += bytesRead;
             }
             
-            if (bytesRead == -1) {
+            if (last) {
                 this.endOfStream = true;
             }
             


### PR DESCRIPTION
Fix org.apache.cxf.transport.http.asyncclient.hc5.AsyncHTTPConduitTest.testResponseSameBufferSize