### PR TITLE
Update Undertow to 2.3.5.Final

### DIFF
--- a/distribution/javadoc/pom.xml
+++ b/distribution/javadoc/pom.xml
@@ -416,7 +416,7 @@
         </dependency>
         <dependency>
              <groupId>io.undertow</groupId>
-             <artifactId>undertow-servlet-jakarta</artifactId>
+             <artifactId>undertow-servlet</artifactId>
         </dependency>
         <dependency>
             <groupId>org.eclipse.jetty</groupId>

--- a/distribution/src/main/release/samples/jax_rs/sse_client/pom.xml
+++ b/distribution/src/main/release/samples/jax_rs/sse_client/pom.xml
@@ -47,7 +47,7 @@
 
         <dependency>
             <groupId>io.undertow</groupId>
-            <artifactId>undertow-servlet-jakarta</artifactId>
+            <artifactId>undertow-servlet</artifactId>
         </dependency>
     </dependencies>
     

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -193,7 +193,7 @@
         <cxf.tika.version>2.7.0</cxf.tika.version>
         <cxf.tomcat.version>10.1.7</cxf.tomcat.version>
         <cxf.tomitribe.http.signature.version>1.8</cxf.tomitribe.http.signature.version>
-        <cxf.undertow.version>2.2.20.Final</cxf.undertow.version>
+        <cxf.undertow.version>2.3.5.Final</cxf.undertow.version>
         <!-- the Export-Package is the same as the Maven artifact
              version (with the Final), but we don't want an import package with a version
              with a qualifier. We do want a range. -->
@@ -1163,7 +1163,7 @@
             </dependency>
             <dependency>
                  <groupId>io.undertow</groupId>
-                 <artifactId>undertow-servlet-jakarta</artifactId>
+                 <artifactId>undertow-servlet</artifactId>
                  <version>${cxf.undertow.version}</version>
             </dependency>
             <dependency>

--- a/rt/transports/http-undertow/pom.xml
+++ b/rt/transports/http-undertow/pom.xml
@@ -50,7 +50,7 @@
         </dependency>
         <dependency>
             <groupId>io.undertow</groupId>
-            <artifactId>undertow-servlet-jakarta</artifactId>
+            <artifactId>undertow-servlet</artifactId>
         </dependency>
         <dependency>
             <groupId>${cxf.servlet-api.group}</groupId>

--- a/systests/rs-sse/rs-sse-undertow/pom.xml
+++ b/systests/rs-sse/rs-sse-undertow/pom.xml
@@ -42,7 +42,7 @@
         </dependency>
         <dependency>
             <groupId>io.undertow</groupId>
-            <artifactId>undertow-servlet-jakarta</artifactId>
+            <artifactId>undertow-servlet</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
Update Undertow to 2.3.5.Final. The Undertow dropped Jakarta support from 2.2.x line (after 2.2.20.Final release).