### PR TITLE
[CXF-8837] key must not be an instanceof RSAPrivateKey

### DIFF
--- a/rt/rs/security/jose-parent/jose/src/main/java/org/apache/cxf/rs/security/jose/jws/JwsUtils.java
+++ b/rt/rs/security/jose-parent/jose/src/main/java/org/apache/cxf/rs/security/jose/jws/JwsUtils.java
@@ -116,11 +116,9 @@ public final class JwsUtils {
         }
         if (key instanceof ECPrivateKey) {
             return new EcDsaJwsSignatureProvider((ECPrivateKey)key, algo);
-        } else if (key instanceof RSAPrivateKey) {
-            return new PrivateKeyJwsSignatureProvider(key, algo);
         }
-
-        return null;
+        
+        return new PrivateKeyJwsSignatureProvider(key, algo);
     }
     public static JwsSignatureProvider getHmacSignatureProvider(String encodedKey, SignatureAlgorithm algo) {
         return getHmacSignatureProvider(JoseUtils.decode(encodedKey), algo);
@@ -178,13 +176,11 @@ public final class JwsUtils {
             throw new JwsException(JwsException.Error.ALGORITHM_NOT_SET);
         }
 
-        if (key instanceof RSAPublicKey) {
-            return new PublicKeyJwsSignatureVerifier(key, algo);
-        } else if (key instanceof ECPublicKey) {
+        if (key instanceof ECPublicKey) {
             return new EcDsaJwsSignatureVerifier(key, algo);
         }
 
-        return null;
+        return new PublicKeyJwsSignatureVerifier(key, algo);
     }
     public static JwsSignatureVerifier getHmacSignatureVerifier(String encodedKey, SignatureAlgorithm algo) {
         return getHmacSignatureVerifier(JoseUtils.decode(encodedKey), algo);


### PR DESCRIPTION
It would be great if this patch can also be backported to previous versions of CXF, down to 3.4.x. 