### PR TITLE
Fix SCM URL in POM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
     <scm>
         <connection>scm:git:https://gitbox.apache.org/repos/asf/cxf.git</connection>
         <developerConnection>scm:git:https://gitbox.apache.org/repos/asf/cxf.git</developerConnection>
-        <url>https://gitbox.apache.org/repos/asf/cxf.git</url>
+        <url>https://gitbox.apache.org/repos/asf?p=cxf.git</url>
         <tag>HEAD</tag>
     </scm>
     <issueManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
     <scm>
         <connection>scm:git:https://gitbox.apache.org/repos/asf/cxf.git</connection>
         <developerConnection>scm:git:https://gitbox.apache.org/repos/asf/cxf.git</developerConnection>
-        <url>https://gitbox.apache.org/repos/asf?p=cxf.git;a=summary</url>
+        <url>https://gitbox.apache.org/repos/asf/cxf.git</url>
         <tag>HEAD</tag>
     </scm>
     <issueManagement>


### PR DESCRIPTION
Discovered when looking at the merge request proposal generated by Renovate Bot:
<img width="700" alt="image" src="https://github.com/apache/cxf/assets/1470270/d67760e1-88a1-4457-bdc6-c405b0735790">
Where `(source)` points to https://gitbox.apache.org/repos/asf?p=cxf.git;a=summary (404).
<img width="506" alt="image" src="https://github.com/apache/cxf/assets/1470270/240ca698-64a6-4edc-8e6d-f5c8e9660022">

My suggested change is taken from the CXF item in the list of repos on https://gitbox.apache.org/repos/asf.
