### PR TITLE
CXF-8890: Get rid of EasyMock in cxf-rt-transports-http

### DIFF
--- a/rt/transports/http/pom.xml
+++ b/rt/transports/http/pom.xml
@@ -62,11 +62,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.easymock</groupId>
-            <artifactId>easymock</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
             <version>${cxf.mockito.version}</version>

--- a/rt/transports/http/src/test/java/org/apache/cxf/transport/http/DestinationRegistryImplTest.java
+++ b/rt/transports/http/src/test/java/org/apache/cxf/transport/http/DestinationRegistryImplTest.java
@@ -26,8 +26,6 @@ import javax.xml.namespace.QName;
 import org.apache.cxf.service.model.EndpointInfo;
 import org.apache.cxf.transport.MessageObserver;
 
-import org.easymock.EasyMock;
-import org.easymock.IMocksControl;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -36,6 +34,8 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 /**
  *
@@ -52,20 +52,17 @@ public class DestinationRegistryImplTest {
     private static final int[] MATCHED_PATH_INDEXES = {0, 0, 1, -1,
                                                        3, 0, 0, 4,
                                                        -1, 5, 5, 5};
-    private IMocksControl control;
     private DestinationRegistry registry;
     private MessageObserver observer;
 
     @Before
     public void setUp() {
-        control = EasyMock.createNiceControl();
         registry = new DestinationRegistryImpl();
-        observer = control.createMock(MessageObserver.class);
+        observer = mock(MessageObserver.class);
     }
 
     @After
     public void tearDown() {
-        control = null;
         registry = null;
     }
 
@@ -93,19 +90,17 @@ public class DestinationRegistryImplTest {
             for (int j = 0; j < REGISTERED_PATHS.length; j++) {
                 AbstractHTTPDestination target = registry.getDestinationForPath(REGISTERED_PATHS[j]);
                 if (mi == j) {
-                    EasyMock.expect(target.getMessageObserver()).andReturn(observer);
+                    when(target.getMessageObserver()).thenReturn(observer);
                     EndpointInfo endpoint = new EndpointInfo();
                     endpoint.setAddress(REGISTERED_PATHS[mi]);
                     endpoint.setName(QNAME);
-                    EasyMock.expect(target.getEndpointInfo()).andReturn(endpoint);
+                    when(target.getEndpointInfo()).thenReturn(endpoint);
 
                 } else {
-                    EasyMock.expect(target.getMessageObserver()).andReturn(observer).anyTimes();
+                    when(target.getMessageObserver()).thenReturn(observer);
                 }
 
             }
-
-            control.replay();
 
             AbstractHTTPDestination destination = registry.checkRestfulRequest(REQUEST_PATHS[i]);
 
@@ -117,25 +112,19 @@ public class DestinationRegistryImplTest {
             } else {
                 assertNull(destination);
             }
-
-            control.verify();
-
-            control.reset();
         }
 
     }
 
     private void setUpDestinations() {
         for (int i = 0; i < REGISTERED_PATHS.length; i++) {
-            AbstractHTTPDestination destination = control.createMock(AbstractHTTPDestination.class);
+            AbstractHTTPDestination destination = mock(AbstractHTTPDestination.class);
             EndpointInfo endpoint = new EndpointInfo();
             endpoint.setAddress(REGISTERED_PATHS[i]);
             endpoint.setName(QNAME);
-            EasyMock.expect(destination.getEndpointInfo()).andReturn(endpoint);
+            when(destination.getEndpointInfo()).thenReturn(endpoint);
 
-            control.replay();
             registry.addDestination(destination);
-            control.reset();
         }
 
     }

--- a/rt/transports/http/src/test/java/org/apache/cxf/transport/http/HTTPConduitURLEasyMockTest.java
+++ b/rt/transports/http/src/test/java/org/apache/cxf/transport/http/HTTPConduitURLEasyMockTest.java
@@ -49,8 +49,6 @@ import org.apache.cxf.transport.MessageObserver;
 import org.apache.cxf.transport.https.HttpsURLConnectionFactory;
 import org.apache.cxf.ws.addressing.EndpointReferenceType;
 
-import org.easymock.EasyMock;
-import org.easymock.IMocksControl;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
@@ -62,6 +60,11 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.nullable;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 /**
  */
@@ -75,7 +78,6 @@ public class HTTPConduitURLEasyMockTest {
 
     private static final String NOWHERE = "http://nada.nothing.nowhere.null/";
     private static final String PAYLOAD = "message payload";
-    private IMocksControl control;
     private EndpointInfo endpointInfo;
     private HttpsURLConnectionFactory connectionFactory;
     private HttpURLConnection connection;
@@ -145,19 +147,16 @@ public class HTTPConduitURLEasyMockTest {
 
     @Test
     public void testSend() throws Exception {
-        control = EasyMock.createNiceControl();
         HTTPConduit conduit = setUpConduit(true, false, "POST");
         Message message = createMessage();
         message.put(HTTPConduit.SET_HTTP_RESPONSE_MESSAGE, Boolean.FALSE);
         conduit.prepare(message);
         verifySentMessage(conduit, message, "POST");
         assertNull(inMessage.get(HTTPConduit.HTTP_RESPONSE_MESSAGE));
-        finalVerify();
     }
 
     @Test
     public void testSendWithHeaders() throws Exception {
-        control = EasyMock.createNiceControl();
         HTTPConduit conduit = setUpConduit(true, false, "POST");
         Message message = createMessage();
         message.put(HTTPConduit.SET_HTTP_RESPONSE_MESSAGE, Boolean.TRUE);
@@ -165,7 +164,6 @@ public class HTTPConduitURLEasyMockTest {
         conduit.prepare(message);
         verifySentMessage(conduit, message, true, "POST", false);
         assertEquals(HTTP_RESPONSE_MESSAGE, inMessage.get(HTTPConduit.HTTP_RESPONSE_MESSAGE));
-        finalVerify();
     }
 
     private Message createMessage() {
@@ -178,7 +176,6 @@ public class HTTPConduitURLEasyMockTest {
     @Test
     @org.junit.Ignore
     public void testSendWithHeadersCheckErrorStream() throws Exception {
-        control = EasyMock.createNiceControl();
         HTTPConduit conduit = setUpConduit(true, false, "POST");
         Message message = new MessageImpl();
         message.put(HTTPConduit.SET_HTTP_RESPONSE_MESSAGE, Boolean.TRUE);
@@ -187,36 +184,30 @@ public class HTTPConduitURLEasyMockTest {
         conduit.prepare(message);
         verifySentMessage(conduit, message, true, "POST", true);
         assertEquals(HTTP_RESPONSE_MESSAGE, inMessage.get(HTTPConduit.HTTP_RESPONSE_MESSAGE));
-        finalVerify();
     }
 
     @Test
     public void testSendHttpConnection() throws Exception {
-        control = EasyMock.createNiceControl();
         HTTPConduit conduit = setUpConduit(true, false, "POST");
         Message message = createMessage();
         message.put(HTTPConduit.SET_HTTP_RESPONSE_MESSAGE, Boolean.TRUE);
         conduit.prepare(message);
         verifySentMessage(conduit, message, "POST");
         assertEquals(HTTP_RESPONSE_MESSAGE, inMessage.get(HTTPConduit.HTTP_RESPONSE_MESSAGE));
-        finalVerify();
     }
 
     @Test
     public void testSendHttpConnectionAutoRedirect() throws Exception {
-        control = EasyMock.createNiceControl();
         HTTPConduit conduit = setUpConduit(true, true, "POST");
         Message message = createMessage();
         message.put(HTTPConduit.SET_HTTP_RESPONSE_MESSAGE, Boolean.TRUE);
         conduit.prepare(message);
         verifySentMessage(conduit, message, "POST");
         assertEquals(HTTP_RESPONSE_MESSAGE, inMessage.get(HTTPConduit.HTTP_RESPONSE_MESSAGE));
-        finalVerify();
     }
 
     @Test
     public void testSendHttpGetConnectionAutoRedirect() throws Exception {
-        control = EasyMock.createNiceControl();
         HTTPConduit conduit = setUpConduit(true, true, "GET");
         Message message = new MessageImpl();
         message.put(HTTPConduit.SET_HTTP_RESPONSE_MESSAGE, Boolean.TRUE);
@@ -225,12 +216,10 @@ public class HTTPConduitURLEasyMockTest {
         verifySentMessage(conduit, message, "GET");
         assertEquals(HTTP_RESPONSE_MESSAGE, inMessage.get(HTTPConduit.HTTP_RESPONSE_MESSAGE));
         conduit.close(message);
-        finalVerify();
     }
 
     @Test
     public void testSendHttpGetConnection() throws Exception {
-        control = EasyMock.createNiceControl();
         HTTPConduit conduit = setUpConduit(true, false, "GET");
         Message message = new MessageImpl();
         message.put(Message.HTTP_REQUEST_METHOD, "GET");
@@ -239,13 +228,11 @@ public class HTTPConduitURLEasyMockTest {
         verifySentMessage(conduit, message, "GET");
         assertEquals(HTTP_RESPONSE_MESSAGE, inMessage.get(HTTPConduit.HTTP_RESPONSE_MESSAGE));
         conduit.close(message);
-        finalVerify();
     }
 
     @Test
     public void testSendOnewayChunkedEmptyPartialResponseProcessResponse()
         throws Exception {
-        control = EasyMock.createNiceControl();
         HTTPConduit conduit = setUpConduit(true, false, "POST");
         Message message = createMessage();
         conduit.prepare(message);
@@ -256,13 +243,11 @@ public class HTTPConduitURLEasyMockTest {
                           ResponseDelimiter.CHUNKED,
                           true,  // empty response
                           "POST");
-        finalVerify();
     }
 
     @Test
     public void testSendOnewayDoNotProcessResponse()
         throws Exception {
-        control = EasyMock.createNiceControl();
         HTTPConduit conduit = setUpConduit(true, false, "POST");
         Message message = createMessage();
         conduit.prepare(message);
@@ -272,13 +257,11 @@ public class HTTPConduitURLEasyMockTest {
                           ResponseDelimiter.CHUNKED,
                           true,  // empty response
                           "POST");
-        finalVerify();
     }
 
     @Test
     public void testSendTwowayDecoupledEmptyPartialResponse()
         throws Exception {
-        control = EasyMock.createNiceControl();
         HTTPConduit conduit = setUpConduit(true, false, "POST");
         Message message = createMessage();
         conduit.prepare(message);
@@ -288,12 +271,10 @@ public class HTTPConduitURLEasyMockTest {
                           ResponseDelimiter.EOF,
                           true,  // empty response
                           "POST");
-        finalVerify();
     }
 
     @Test
     public void testSendHttpConnectionAllowedRedirectVerbs() throws Exception {
-        control = EasyMock.createNiceControl();
         HTTPConduit conduit = setUpConduit(true, false, "POST");
         Message message = createMessage();
         message.put("http.redirect.allowed.verbs", "POST");
@@ -302,7 +283,6 @@ public class HTTPConduitURLEasyMockTest {
         conduit.getClient().setAutoRedirect(true);
         verifySentMessage(conduit, message, "POST");
         assertEquals(HTTP_RESPONSE_MESSAGE, inMessage.get(HTTPConduit.HTTP_RESPONSE_MESSAGE));
-        finalVerify();
     }
 
     private void setUpHeaders(Message message) {
@@ -325,14 +305,11 @@ public class HTTPConduitURLEasyMockTest {
     }
 
     private void setUpExchange(Message message, boolean oneway) {
-        Exchange exchange = control.createMock(Exchange.class);
+        Exchange exchange = mock(Exchange.class);
         message.setExchange(exchange);
-        exchange.isOneWay();
-        EasyMock.expectLastCall().andReturn(oneway).anyTimes();
-        exchange.isSynchronous();
-        EasyMock.expectLastCall().andReturn(true).anyTimes();
-        exchange.isEmpty();
-        EasyMock.expectLastCall().andReturn(true).anyTimes();
+        when(exchange.isOneWay()).thenReturn(oneway);
+        when(exchange.isSynchronous()).thenReturn(true);
+        when(exchange.isEmpty()).thenReturn(true);
     }
 
     private HTTPConduit setUpConduit(
@@ -342,49 +319,36 @@ public class HTTPConduitURLEasyMockTest {
         endpointInfo = new EndpointInfo();
         endpointInfo.setAddress(NOWHERE + "bar/foo");
         connectionFactory =
-            control.createMock(HttpsURLConnectionFactory.class);
+            mock(HttpsURLConnectionFactory.class);
 
         if (send) {
-            //proxy = control.createMock(Proxy.class);
+            //proxy = mock(Proxy.class);
             proxy = Proxy.NO_PROXY;
             connection =
-                control.createMock(HttpURLConnection.class);
-            connection.getURL();
-            EasyMock.expectLastCall().andReturn(new URL(NOWHERE + "bar/foo")).anyTimes();
+                mock(HttpURLConnection.class);
+            when(connection.getURL()).thenReturn(new URL(NOWHERE + "bar/foo"));
 
-            connectionFactory.createConnection((TLSClientParameters)EasyMock.isNull(),
-                                      EasyMock.eq(proxy),
-                                      EasyMock.eq(new URL(NOWHERE + "bar/foo")));
-            EasyMock.expectLastCall().andReturn(connection);
+            when(connectionFactory.createConnection(nullable(TLSClientParameters.class),
+                                      eq(proxy),
+                                      eq(new URL(NOWHERE + "bar/foo")))).thenReturn(connection);
 
-            connection.setDoOutput(true);
-            EasyMock.expectLastCall();
-
-            connection.setRequestMethod(method);
-            EasyMock.expectLastCall();
+            doNothing().when(connection).setDoOutput(true);
+            doNothing().when(connection).setRequestMethod(method);
 
             if (!autoRedirect && "POST".equals(method)) {
-                connection.setChunkedStreamingMode(-1);
-                EasyMock.expectLastCall();
+                doNothing().when(connection).setChunkedStreamingMode(-1);
             }
-            connection.getRequestMethod();
-            EasyMock.expectLastCall().andReturn(method).anyTimes();
+            when(connection.getRequestMethod()).thenReturn(method);
 
-            connection.setInstanceFollowRedirects(false);
-            EasyMock.expectLastCall().times(1);
+            doNothing().when(connection).setInstanceFollowRedirects(false);
 
-            connection.setConnectTimeout(303030);
-            EasyMock.expectLastCall();
-            connection.setReadTimeout(404040);
-            EasyMock.expectLastCall();
-            connection.setUseCaches(false);
-            EasyMock.expectLastCall();
+            doNothing().when(connection).setConnectTimeout(303030);
+            doNothing().when(connection).setReadTimeout(404040);
+            doNothing().when(connection).setUseCaches(false);
 
         }
 
         ExtensionManagerBus bus = new ExtensionManagerBus();
-
-        control.replay();
 
         HTTPConduit conduit = new HTTPTestConduit(bus,
                                               endpointInfo,
@@ -468,30 +432,21 @@ public class HTTPConduitURLEasyMockTest {
                                    boolean emptyResponse,
                                    String method)
         throws IOException {
-        control.verify();
-        control.reset();
 
         OutputStream wrappedOS = verifyRequestHeaders(message, expectHeaders, method);
 
         if (!"GET".equals(method)) {
-            os.write(PAYLOAD.getBytes(), 0, PAYLOAD.length());
-            EasyMock.expectLastCall();
+            doNothing().when(os).write(PAYLOAD.getBytes(), 0, PAYLOAD.length());
 
-            os.flush();
-            EasyMock.expectLastCall();
-            os.flush();
-            EasyMock.expectLastCall();
-            os.close();
-            EasyMock.expectLastCall();
+            doNothing().when(os).flush();
+            doNothing().when(os).flush();
+            doNothing().when(os).close();
         }
 
         setUpExchange(message, style == ResponseStyle.NONE || style == ResponseStyle.ONEWAY_NONE);
 
-        connection.getRequestMethod();
-        EasyMock.expectLastCall().andReturn(method).anyTimes();
+        when(connection.getRequestMethod()).thenReturn(method);
         verifyHandleResponse(style, delimiter, emptyResponse, conduit);
-
-        control.replay();
 
         wrappedOS.flush();
         wrappedOS.flush();
@@ -516,8 +471,6 @@ public class HTTPConduitURLEasyMockTest {
                 }
             }
         }
-
-        finalVerify();
     }
 
     private OutputStream verifyRequestHeaders(Message message, boolean expectHeaders, String method)
@@ -528,31 +481,23 @@ public class HTTPConduitURLEasyMockTest {
         assertTrue("expected output stream format",
                    message.getContentFormats().contains(OutputStream.class));
 
-        connection.getRequestMethod();
-        EasyMock.expectLastCall().andReturn(method).anyTimes();
+        when(connection.getRequestMethod()).thenReturn(method);
 
         if (!"GET".equals(method)) {
-            os = EasyMock.createMock(OutputStream.class);
-            connection.getOutputStream();
-            EasyMock.expectLastCall().andReturn(os);
+            os = mock(OutputStream.class);
+            when(connection.getOutputStream()).thenReturn(os);
         }
 
         message.put(HTTPConduit.KEY_HTTP_CONNECTION, connection);
         if (expectHeaders) {
-            connection.setRequestProperty(EasyMock.eq("Authorization"),
-                                          EasyMock.eq("Basic Qko6dmFsdWU="));
-            EasyMock.expectLastCall();
-            connection.setRequestProperty(EasyMock.eq("Content-Type"),
-                                          EasyMock.eq("text/xml;charset=utf8"));
-            EasyMock.expectLastCall();
-            connection.setRequestProperty(EasyMock.eq("Accept"),
-                                          EasyMock.eq("text/xml;charset=utf8,text/plain"));
-            EasyMock.expectLastCall();
+            doNothing().when(connection).setRequestProperty(eq("Authorization"),
+                                          eq("Basic Qko6dmFsdWU="));
+            doNothing().when(connection).setRequestProperty(eq("Content-Type"),
+                                          eq("text/xml;charset=utf8"));
+            doNothing().when(connection).setRequestProperty(eq("Accept"),
+                                          eq("text/xml;charset=utf8,text/plain"));
         }
-        connection.getRequestProperties();
-        EasyMock.expectLastCall().andReturn(new HashMap<String, List<String>>()).anyTimes();
-
-        control.replay();
+        when(connection.getRequestProperties()).thenReturn(new HashMap<String, List<String>>());
 
         AbstractThresholdOutputStream wrappedOS
             = (AbstractThresholdOutputStream) message.getContent(OutputStream.class);
@@ -561,93 +506,70 @@ public class HTTPConduitURLEasyMockTest {
         wrappedOS.write(PAYLOAD.getBytes());
         wrappedOS.unBuffer();
 
-        control.verify();
-        control.reset();
-
         return wrappedOS;
     }
 
+    @SuppressWarnings("unchecked")
     private void verifyHandleResponse(ResponseStyle style,
                                       ResponseDelimiter delimiter,
                                       boolean emptyResponse,
                                       HTTPConduit conduit) throws IOException {
-        connection.getHeaderFields();
-        EasyMock.expectLastCall().andReturn(Collections.EMPTY_MAP).anyTimes();
+        when(connection.getHeaderFields()).thenReturn(Collections.EMPTY_MAP);
         
-        connection.getResponseMessage();
-        EasyMock.expectLastCall().andReturn(HTTP_RESPONSE_MESSAGE).anyTimes();
+        when(connection.getResponseMessage()).thenReturn(HTTP_RESPONSE_MESSAGE);
         
         int responseCode = getResponseCode(style);
         if (conduit.getClient().isAutoRedirect()) {
-            connection.getResponseCode();
-            EasyMock.expectLastCall().andReturn(301).once().andReturn(responseCode).anyTimes();
-            connection.getURL();
-            EasyMock.expectLastCall().andReturn(new URL(NOWHERE + "bar/foo/redirect")).anyTimes();
+            when(connection.getResponseCode()).thenReturn(301).thenReturn(responseCode);
+            when(connection.getURL()).thenReturn(new URL(NOWHERE + "bar/foo/redirect"));
         } else {
-            connection.getResponseCode();
-            EasyMock.expectLastCall().andReturn(responseCode).anyTimes();
+            when(connection.getResponseCode()).thenReturn(responseCode);
         }
 
         switch (style) {
         case NONE:
         case DECOUPLED:
-            is = control.createMock(InputStream.class);
-            connection.getInputStream();
-            EasyMock.expectLastCall().andReturn(is).anyTimes();
+            is = mock(InputStream.class);
+            when(connection.getInputStream()).thenReturn(is);
             connection.getContentLength();
             if (delimiter == ResponseDelimiter.CHUNKED
                 || delimiter == ResponseDelimiter.EOF) {
-                EasyMock.expectLastCall().andReturn(-1).anyTimes();
+                when(connection.getContentLength()).thenReturn(-1);
                 if (delimiter == ResponseDelimiter.CHUNKED) {
-                    connection.getHeaderField("Transfer-Encoding");
-                    EasyMock.expectLastCall().andReturn("chunked");
+                    when(connection.getHeaderField("Transfer-Encoding")).thenReturn("chunked");
                 } else if (delimiter == ResponseDelimiter.EOF) {
-                    connection.getHeaderField("Connection");
-                    EasyMock.expectLastCall().andReturn("close");
+                    when(connection.getHeaderField("Connection")).thenReturn("close");
                 }
-                is.read();
                 if (emptyResponse) {
-                    EasyMock.expectLastCall().andReturn(-1).anyTimes();
+                    when(is.read()).thenReturn(-1);
                 } else {
-                    EasyMock.expectLastCall().andReturn((int)'<');
+                    when(is.read()).thenReturn((int)'<');
                 }
             } else {
-                EasyMock.expectLastCall().andReturn(123).anyTimes();
+                when(connection.getContentLength()).thenReturn(123);
             }
             if (emptyResponse) {
-                is.close();
-                EasyMock.expectLastCall();
+                doNothing().when(is).close();
             }
             break;
 
         case BACK_CHANNEL:
-            is = EasyMock.createMock(InputStream.class);
-            connection.getInputStream();
-            EasyMock.expectLastCall().andReturn(is).anyTimes();
+            is = mock(InputStream.class);
+            when(connection.getInputStream()).thenReturn(is);
             break;
 
         case BACK_CHANNEL_ERROR:
-            is = EasyMock.createMock(InputStream.class);
-            connection.getInputStream();
-            EasyMock.expectLastCall().andReturn(is).anyTimes();
-            connection.getErrorStream();
-            EasyMock.expectLastCall().andReturn(null);
+            is = mock(InputStream.class);
+            when(connection.getInputStream()).thenReturn(is);
+            when(connection.getErrorStream()).thenReturn(null);
             break;
 
         case ONEWAY_NONE:
-            connection.getInputStream();
-            EasyMock.expectLastCall().andReturn(new ByteArrayInputStream(new byte[0])).anyTimes();
+            when(connection.getInputStream()).thenReturn(new ByteArrayInputStream(new byte[0]));
             break;
 
         default:
             break;
-        }
-    }
-
-    private void finalVerify() {
-        if (control != null) {
-            control.verify();
-            control = null;
         }
     }
 

--- a/rt/transports/http/src/test/java/org/apache/cxf/transport/http/policy/PolicyUtilsTest.java
+++ b/rt/transports/http/src/test/java/org/apache/cxf/transport/http/policy/PolicyUtilsTest.java
@@ -37,26 +37,16 @@ import org.apache.cxf.ws.policy.PolicyAssertion;
 import org.apache.cxf.ws.policy.PolicyDataEngineImpl;
 import org.apache.cxf.ws.policy.builder.jaxb.JaxbAssertion;
 
-import org.easymock.EasyMock;
-import org.easymock.IMocksControl;
-import org.junit.Before;
 import org.junit.Test;
 
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 /**
  *
  */
 public class PolicyUtilsTest {
-
-    private IMocksControl control;
-
-    @Before
-    public void setUp() {
-        control = EasyMock.createNiceControl();
-    }
-
-
     @Test
     public void testAssertClientPolicyNoop() {
         testAssertPolicyNoop(true);
@@ -69,24 +59,20 @@ public class PolicyUtilsTest {
 
     void testAssertPolicyNoop(boolean isRequestor) {
         PolicyDataEngine pde = new PolicyDataEngineImpl(null);
-        Message message = control.createMock(Message.class);
-        EasyMock.expect(message.get(AssertionInfoMap.class)).andReturn(null);
-        control.replay();
+        Message message = mock(Message.class);
+        when(message.get(AssertionInfoMap.class)).thenReturn(null);
 
         pde.assertMessage(message, null, new ClientPolicyCalculator());
-        control.verify();
 
-        control.reset();
         Collection<PolicyAssertion> as = new ArrayList<>();
         AssertionInfoMap aim = new AssertionInfoMap(as);
-        EasyMock.expect(message.get(AssertionInfoMap.class)).andReturn(aim);
-        control.replay();
+        when(message.get(AssertionInfoMap.class)).thenReturn(aim);
+
         if (isRequestor) {
             pde.assertMessage(message, null, new ClientPolicyCalculator());
         } else {
             pde.assertMessage(message, null, new ServerPolicyCalculator());
         }
-        control.verify();
     }
 
 
@@ -108,7 +94,7 @@ public class PolicyUtilsTest {
     }
 
     void testAssertClientPolicy(boolean outbound) {
-        Message message = control.createMock(Message.class);
+        Message message = mock(Message.class);
         HTTPClientPolicy ep = new HTTPClientPolicy();
         HTTPClientPolicy cmp = new HTTPClientPolicy();
 
@@ -127,21 +113,19 @@ public class PolicyUtilsTest {
         ais.add(cmai);
         ais.add(icmai);
         aim.put(new ClientPolicyCalculator().getDataClassName(), ais);
-        EasyMock.expect(message.get(AssertionInfoMap.class)).andReturn(aim);
-        Exchange ex = control.createMock(Exchange.class);
-        EasyMock.expect(message.getExchange()).andReturn(ex).atLeastOnce();
-        EasyMock.expect(ex.getOutMessage()).andReturn(outbound ? message : null).atLeastOnce();
+        when(message.get(AssertionInfoMap.class)).thenReturn(aim);
+        Exchange ex = mock(Exchange.class);
+        when(message.getExchange()).thenReturn(ex);
+        when(ex.getOutMessage()).thenReturn(outbound ? message : null);
         if (!outbound) {
-            EasyMock.expect(ex.getOutFaultMessage()).andReturn(null).atLeastOnce();
+            when(ex.getOutFaultMessage()).thenReturn(null);
         }
 
-        control.replay();
         PolicyDataEngine pde = new PolicyDataEngineImpl(null);
         pde.assertMessage(message, ep, new ClientPolicyCalculator());
         assertTrue(eai.isAsserted());
         assertTrue(cmai.isAsserted());
         assertTrue(icmai.isAsserted());
-        control.verify();
     }
 
     @Test
@@ -162,7 +146,7 @@ public class PolicyUtilsTest {
     }
 
     void testAssertServerPolicy(boolean outbound) {
-        Message message = control.createMock(Message.class);
+        Message message = mock(Message.class);
         HTTPServerPolicy ep = new HTTPServerPolicy();
         HTTPServerPolicy mp = new HTTPServerPolicy();
         HTTPServerPolicy cmp = new HTTPServerPolicy();
@@ -183,21 +167,19 @@ public class PolicyUtilsTest {
         AssertionInfoMap aim = new AssertionInfoMap(CastUtils.cast(Collections.EMPTY_LIST,
                                                                    PolicyAssertion.class));
         aim.put(new ServerPolicyCalculator().getDataClassName(), ais);
-        EasyMock.expect(message.get(AssertionInfoMap.class)).andReturn(aim).atLeastOnce();
-        Exchange ex = control.createMock(Exchange.class);
-        EasyMock.expect(message.getExchange()).andReturn(ex).atLeastOnce();
-        EasyMock.expect(ex.getOutMessage()).andReturn(outbound ? message : null).atLeastOnce();
+        when(message.get(AssertionInfoMap.class)).thenReturn(aim);
+        Exchange ex = mock(Exchange.class);
+        when(message.getExchange()).thenReturn(ex);
+        when(ex.getOutMessage()).thenReturn(outbound ? message : null);
         if (!outbound) {
-            EasyMock.expect(ex.getOutFaultMessage()).andReturn(null).atLeastOnce();
+            when(ex.getOutFaultMessage()).thenReturn(null);
         }
 
-        control.replay();
         new PolicyDataEngineImpl(null).assertMessage(message, ep,
                                                      new ServerPolicyCalculator());
         assertTrue(eai.isAsserted());
         assertTrue(mai.isAsserted());
         assertTrue(outbound ? cmai.isAsserted() : !cmai.isAsserted());
         assertTrue(outbound ? icmai.isAsserted() : !icmai.isAsserted());
-        control.verify();
     }
 }

--- a/rt/transports/http/src/test/java/org/apache/cxf/transport/servlet/BaseUrlHelperTest.java
+++ b/rt/transports/http/src/test/java/org/apache/cxf/transport/servlet/BaseUrlHelperTest.java
@@ -20,32 +20,28 @@ package org.apache.cxf.transport.servlet;
 
 import jakarta.servlet.http.HttpServletRequest;
 
-import org.easymock.EasyMock;
 import org.junit.Assert;
 import org.junit.Test;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class BaseUrlHelperTest {
     private String testGetBaseURL(String requestUrl, String contextPath,
                                   String servletPath, String pathInfo) {
-        HttpServletRequest req = EasyMock.createMock(HttpServletRequest.class);
-        req.getRequestURL();
-        EasyMock.expectLastCall().andReturn(new StringBuffer(requestUrl));
+        HttpServletRequest req = mock(HttpServletRequest.class);
+        when(req.getRequestURL()).thenReturn(new StringBuffer(requestUrl));
 
-        req.getContextPath();
-        EasyMock.expectLastCall().andReturn(contextPath).anyTimes();
-        req.getServletPath();
-        EasyMock.expectLastCall().andReturn(servletPath).anyTimes();
+        when(req.getContextPath()).thenReturn(contextPath);
+        when(req.getServletPath()).thenReturn(servletPath);
 
-        req.getPathInfo();
-        EasyMock.expectLastCall().andReturn(pathInfo).times(2);
+        when(req.getPathInfo()).thenReturn(pathInfo);
 
         String basePath = contextPath + servletPath;
         if (basePath.length() == 0) {
-            req.getRequestURI();
-            EasyMock.expectLastCall().andReturn(pathInfo);
+            when(req.getRequestURI()).thenReturn(pathInfo);
         }
 
-        EasyMock.replay(req);
         return BaseUrlHelper.getBaseURL(req);
     }
 


### PR DESCRIPTION
Get rid of EasyMock in cxf-rt-transports-http