### PR TITLE
CXF-8876: Get rid of EasyMock in cxf-rt-transports-http-jetty

### DIFF
--- a/rt/transports/http-jetty/pom.xml
+++ b/rt/transports/http-jetty/pom.xml
@@ -120,8 +120,9 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.easymock</groupId>
-            <artifactId>easymock</artifactId>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>${cxf.mockito.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/rt/transports/http-jetty/src/test/java/org/apache/cxf/transport/http_jetty/JettyHTTPServerEngineTest.java
+++ b/rt/transports/http-jetty/src/test/java/org/apache/cxf/transport/http_jetty/JettyHTTPServerEngineTest.java
@@ -54,8 +54,6 @@ import org.eclipse.jetty.server.handler.ContextHandler;
 import org.eclipse.jetty.util.thread.QueuedThreadPool;
 import org.eclipse.jetty.util.thread.ThreadPool;
 
-import org.easymock.EasyMock;
-import org.easymock.IMocksControl;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -64,6 +62,8 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class JettyHTTPServerEngineTest {
     private static final int PORT1
@@ -77,26 +77,19 @@ public class JettyHTTPServerEngineTest {
 
 
     private Bus bus;
-    private IMocksControl control;
     private JettyHTTPServerEngineFactory factory;
 
     @Before
     public void setUp() throws Exception {
-        control = EasyMock.createNiceControl();
-        bus = control.createMock(Bus.class);
+        bus = mock(Bus.class);
 
         Configurer configurer = new ConfigurerImpl();
-        bus.getExtension(Configurer.class);
-        EasyMock.expectLastCall().andReturn(configurer).anyTimes();
+        when(bus.getExtension(Configurer.class)).thenReturn(configurer);
 
-        InstrumentationManager iManager = control.createMock(InstrumentationManager.class);
-        iManager.getMBeanServer();
-        EasyMock.expectLastCall().andReturn(ManagementFactory.getPlatformMBeanServer()).anyTimes();
+        InstrumentationManager iManager = mock(InstrumentationManager.class);
+        when(iManager.getMBeanServer()).thenReturn(ManagementFactory.getPlatformMBeanServer());
 
-        bus.getExtension(InstrumentationManager.class);
-        EasyMock.expectLastCall().andReturn(iManager).anyTimes();
-
-        control.replay();
+        when(bus.getExtension(InstrumentationManager.class)).thenReturn(iManager);
 
         factory = new JettyHTTPServerEngineFactory();
         factory.setBus(bus);


### PR DESCRIPTION
Get rid of EasyMock in cxf-rt-transports-http-jetty