### PR TITLE
CXF-8847: Get rid of EasyMock in cxf-rt-databinding-aegis

### DIFF
--- a/rt/databinding/aegis/pom.xml
+++ b/rt/databinding/aegis/pom.xml
@@ -128,8 +128,9 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.easymock</groupId>
-            <artifactId>easymock</artifactId>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>${cxf.mockito.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/rt/databinding/aegis/src/test/java/org/apache/cxf/aegis/type/mtom/DataSourceTypeTest.java
+++ b/rt/databinding/aegis/src/test/java/org/apache/cxf/aegis/type/mtom/DataSourceTypeTest.java
@@ -23,14 +23,11 @@ import java.io.InputStream;
 
 import jakarta.activation.DataSource;
 
-import org.easymock.MockType;
 import org.junit.Test;
 
-import static org.easymock.EasyMock.anyObject;
-import static org.easymock.EasyMock.expect;
-import static org.easymock.EasyMock.mock;
-import static org.easymock.EasyMock.replay;
-import static org.easymock.EasyMock.verify;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 /**
  * Unit test for DataSourceType class, which also tests any static helper functions invoked
@@ -41,39 +38,26 @@ public class DataSourceTypeTest {
 
     @Test
     public void inputStreamShouldBeClosedOnHappyPath() throws Exception {
-        DataSource ds = mock(MockType.STRICT, DataSource.class);
-        InputStream is = mock(MockType.STRICT, InputStream.class);
-        expect(ds.getInputStream()).andReturn(is);
-        replay(ds);
-        expect(is.available()).andReturn(1);
-        expect(is.read(anyObject(byte[].class))).andReturn(-1);
+        DataSource ds = mock(DataSource.class);
+        InputStream is = mock(InputStream.class);
+        when(ds.getInputStream()).thenReturn(is);
+        when(is.available()).thenReturn(1);
+        when(is.read(any(byte[].class))).thenReturn(-1);
         is.close();
-        replay(is);
 
         DataSourceType dst = new DataSourceType(false, null);
         dst.getBytes(ds);
-
-        verify(ds);
-        verify(is);
     }
 
     @Test(expected = RuntimeException.class)
     public void inputStreamShouldBeClosedOnReadingException() throws Exception {
-        DataSource ds = mock(MockType.STRICT, DataSource.class);
-        InputStream is = mock(MockType.STRICT, InputStream.class);
-        expect(ds.getInputStream()).andReturn(is);
-        replay(ds);
-        expect(is.available()).andThrow(new IOException());
+        DataSource ds = mock(DataSource.class);
+        InputStream is = mock(InputStream.class);
+        when(ds.getInputStream()).thenReturn(is);
+        when(is.available()).thenThrow(new IOException());
         is.close();
-        replay(is);
 
         DataSourceType dst = new DataSourceType(false, null);
-        try {
-            dst.getBytes(ds);
-        } finally {
-            verify(ds);
-            verify(is);
-        }
-
+        dst.getBytes(ds);
     }
 }


### PR DESCRIPTION
 Get rid of EasyMock in cxf-rt-databinding-aegis