### PR TITLE
CXF-8859: Get rid of EasyMock in cxf-rt-ws-security

### DIFF
--- a/rt/ws/security/pom.xml
+++ b/rt/ws/security/pom.xml
@@ -174,8 +174,9 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.easymock</groupId>
-            <artifactId>easymock</artifactId>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>${cxf.mockito.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/rt/ws/security/src/test/java/org/apache/cxf/ws/security/wss4j/AttachmentCallbackHandlerTest.java
+++ b/rt/ws/security/src/test/java/org/apache/cxf/ws/security/wss4j/AttachmentCallbackHandlerTest.java
@@ -32,12 +32,14 @@ import org.apache.wss4j.common.ext.AttachmentRequestCallback;
 import org.apache.wss4j.common.util.AttachmentUtils;
 import org.apache.wss4j.dom.engine.WSSConfig;
 
-import org.easymock.EasyMock;
 import org.junit.Test;
 
-import static org.easymock.EasyMock.anyObject;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doCallRealMethod;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class AttachmentCallbackHandlerTest {
 
@@ -61,12 +63,10 @@ public class AttachmentCallbackHandlerTest {
         Attachment attachment = new AttachmentImpl(attachmentId);
 
         // Mock up a DataHandler for the Attachment
-        DataHandler dataHandler = EasyMock.mock(DataHandler.class);
-        dataHandler.setCommandMap(anyObject(CommandMap.class));
-        EasyMock.expectLastCall();
-        EasyMock.expect(dataHandler.getInputStream()).andReturn(null);
-        EasyMock.expect(dataHandler.getContentType()).andReturn(null);
-        EasyMock.replay(dataHandler);
+        DataHandler dataHandler = mock(DataHandler.class);
+        doCallRealMethod().when(dataHandler).setCommandMap(any(CommandMap.class));
+        when(dataHandler.getInputStream()).thenReturn(null);
+        when(dataHandler.getContentType()).thenReturn(null);
 
         ((AttachmentImpl)attachment).setDataHandler(dataHandler);
         AttachmentCallbackHandler callbackHandler =
@@ -81,7 +81,6 @@ public class AttachmentCallbackHandlerTest {
         List<org.apache.wss4j.common.ext.Attachment> attachments = attachmentRequestCallback.getAttachments();
         assertNotNull(attachments);
         assertEquals(1, attachments.size());
-        EasyMock.verify(dataHandler);
     }
 
 }

--- a/rt/ws/security/src/test/java/org/apache/cxf/ws/security/wss4j/SecurityVerificationOutTest.java
+++ b/rt/ws/security/src/test/java/org/apache/cxf/ws/security/wss4j/SecurityVerificationOutTest.java
@@ -31,59 +31,43 @@ import org.apache.cxf.ws.policy.PolicyException;
 import org.apache.cxf.ws.security.policy.interceptors.SecurityVerificationOutInterceptor;
 import org.apache.neethi.Policy;
 
-import org.easymock.EasyMock;
-import org.easymock.IMocksControl;
-import org.junit.Before;
 import org.junit.Test;
 
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
 public class SecurityVerificationOutTest extends AbstractPolicySecurityTest {
-    private IMocksControl control;
-
-
-    @Before
-    public void setUp() {
-        control = EasyMock.createNiceControl();
-    }
-
     @Test(expected = PolicyException.class)
     public void testEncryptedPartsNoBinding() throws Exception {
         SoapMessage message = coachMessage("encrypted_parts_missing_binding.xml");
-        control.replay();
         SecurityVerificationOutInterceptor.INSTANCE.handleMessage(message);
-        control.verify();
     }
 
     @Test(expected = PolicyException.class)
     public void testSignedPartsNoBinding() throws Exception {
         SoapMessage message = coachMessage("signed_parts_missing_binding.xml");
-        control.replay();
         SecurityVerificationOutInterceptor.INSTANCE.handleMessage(message);
-        control.verify();
     }
 
     @Test
     public void testEncryptedPartsOK() throws Exception {
         SoapMessage message = coachMessage("encrypted_parts_policy_body.xml");
-        control.replay();
         SecurityVerificationOutInterceptor.INSTANCE.handleMessage(message);
-        control.verify();
     }
 
     @Test
     public void testSignedPartsOK() throws Exception {
         SoapMessage message = coachMessage("signed_parts_policy_body.xml");
-        control.replay();
         SecurityVerificationOutInterceptor.INSTANCE.handleMessage(message);
-        control.verify();
     }
 
     private SoapMessage coachMessage(String policyName)
         throws IOException, ParserConfigurationException, SAXException {
         Policy policy = policyBuilder.getPolicy(this.getResourceAsStream(policyName));
         AssertionInfoMap aim = new AssertionInfoMap(policy);
-        SoapMessage message = control.createMock(SoapMessage.class);
-        EasyMock.expect(message.get(Message.REQUESTOR_ROLE)).andReturn(Boolean.TRUE);
-        EasyMock.expect(message.get(AssertionInfoMap.class)).andReturn(aim);
+        SoapMessage message = mock(SoapMessage.class);
+        when(message.get(Message.REQUESTOR_ROLE)).thenReturn(Boolean.TRUE);
+        when(message.get(AssertionInfoMap.class)).thenReturn(aim);
         return message;
     }
 }


### PR DESCRIPTION
Get rid of EasyMock in cxf-rt-ws-security