### PR TITLE
CXF-8877: Get rid of EasyMock in cxf-rt-transports-http-netty-client

### DIFF
--- a/rt/transports/http-netty/netty-client/pom.xml
+++ b/rt/transports/http-netty/netty-client/pom.xml
@@ -75,11 +75,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.easymock</groupId>
-            <artifactId>easymock</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-testutils</artifactId>
             <version>${project.version}</version>


### PR DESCRIPTION
Get rid of EasyMock in cxf-rt-transports-http-netty-client