### PR TITLE
CXF-8848: Get rid of EasyMock in cxf-rt-databinding-jaxb

### DIFF
--- a/rt/databinding/jaxb/pom.xml
+++ b/rt/databinding/jaxb/pom.xml
@@ -95,8 +95,9 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.easymock</groupId>
-            <artifactId>easymock</artifactId>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>${cxf.mockito.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/rt/databinding/jaxb/src/test/java/org/apache/cxf/jaxb/BareInInterceptorTest.java
+++ b/rt/databinding/jaxb/src/test/java/org/apache/cxf/jaxb/BareInInterceptorTest.java
@@ -55,15 +55,14 @@ import org.apache.hello_world_doc_lit_bare.types.TradePriceData;
 import org.apache.hello_world_soap_http.types.GreetMe;
 import org.apache.hello_world_soap_http.types.GreetMeResponse;
 
-import org.easymock.IMocksControl;
 import org.junit.Before;
 import org.junit.Test;
 
-import static org.easymock.EasyMock.createNiceControl;
-import static org.easymock.EasyMock.expect;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class BareInInterceptorTest {
 
@@ -83,14 +82,13 @@ public class BareInInterceptorTest {
 
         BindingFactoryManager bfm = bus.getExtension(BindingFactoryManager.class);
 
-        IMocksControl control = createNiceControl();
-        BindingFactory bf = control.createMock(BindingFactory.class);
-        Binding binding = control.createMock(Binding.class);
-        expect(bf.createBinding(null)).andStubReturn(binding);
-        expect(binding.getInFaultInterceptors())
-            .andStubReturn(new ArrayList<Interceptor<? extends Message>>());
-        expect(binding.getOutFaultInterceptors())
-            .andStubReturn(new ArrayList<Interceptor<? extends Message>>());
+        BindingFactory bf = mock(BindingFactory.class);
+        Binding binding = mock(Binding.class);
+        when(bf.createBinding(null)).thenReturn(binding);
+        when(binding.getInFaultInterceptors())
+            .thenReturn(new ArrayList<Interceptor<? extends Message>>());
+        when(binding.getOutFaultInterceptors())
+            .thenReturn(new ArrayList<Interceptor<? extends Message>>());
 
         bfm.registerBindingFactory("http://schemas.xmlsoap.org/wsdl/soap/", bf);
 

--- a/rt/databinding/jaxb/src/test/java/org/apache/cxf/jaxb/BareOutInterceptorTest.java
+++ b/rt/databinding/jaxb/src/test/java/org/apache/cxf/jaxb/BareOutInterceptorTest.java
@@ -37,15 +37,13 @@ import org.apache.cxf.wsdl.interceptors.BareOutInterceptor;
 import org.apache.hello_world_soap_http.types.GreetMe;
 import org.apache.hello_world_soap_http.types.GreetMeResponse;
 
-import org.easymock.EasyMock;
-import org.easymock.IMocksControl;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
-
+import static org.mockito.Mockito.mock;
 
 public class BareOutInterceptorTest extends TestBase {
 
@@ -63,10 +61,8 @@ public class BareOutInterceptorTest extends TestBase {
         writer = getXMLStreamWriter(baos);
         message.setContent(XMLStreamWriter.class, writer);
         message.getExchange().put(BindingOperationInfo.class, operation);
-        IMocksControl control = EasyMock.createNiceControl();
-        InterceptorChain ic = control.createMock(InterceptorChain.class);
+        InterceptorChain ic = mock(InterceptorChain.class);
         message.setInterceptorChain(ic);
-        control.replay();
     }
 
     @After

--- a/rt/databinding/jaxb/src/test/java/org/apache/cxf/jaxb/DocLiteralInInterceptorTest.java
+++ b/rt/databinding/jaxb/src/test/java/org/apache/cxf/jaxb/DocLiteralInInterceptorTest.java
@@ -54,15 +54,14 @@ import org.apache.hello_world_doc_lit_bare.types.TradePriceData;
 import org.apache.hello_world_soap_http.types.GreetMe;
 import org.apache.hello_world_soap_http.types.GreetMeResponse;
 
-import org.easymock.IMocksControl;
 import org.junit.Before;
 import org.junit.Test;
 
-import static org.easymock.EasyMock.createNiceControl;
-import static org.easymock.EasyMock.expect;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class DocLiteralInInterceptorTest {
     PhaseInterceptorChain chain;
@@ -80,14 +79,13 @@ public class DocLiteralInInterceptorTest {
 
         BindingFactoryManager bfm = bus.getExtension(BindingFactoryManager.class);
 
-        IMocksControl control = createNiceControl();
-        BindingFactory bf = control.createMock(BindingFactory.class);
-        Binding binding = control.createMock(Binding.class);
-        expect(bf.createBinding(null)).andStubReturn(binding);
-        expect(binding.getInFaultInterceptors())
-            .andStubReturn(new ArrayList<Interceptor<? extends Message>>());
-        expect(binding.getOutFaultInterceptors())
-            .andStubReturn(new ArrayList<Interceptor<? extends Message>>());
+        BindingFactory bf = mock(BindingFactory.class);
+        Binding binding = mock(Binding.class);
+        when(bf.createBinding(null)).thenReturn(binding);
+        when(binding.getInFaultInterceptors())
+            .thenReturn(new ArrayList<Interceptor<? extends Message>>());
+        when(binding.getOutFaultInterceptors())
+            .thenReturn(new ArrayList<Interceptor<? extends Message>>());
 
         bfm.registerBindingFactory("http://schemas.xmlsoap.org/wsdl/soap/", bf);
     }

--- a/rt/databinding/jaxb/src/test/java/org/apache/cxf/jaxb/JAXBDataBindingTest.java
+++ b/rt/databinding/jaxb/src/test/java/org/apache/cxf/jaxb/JAXBDataBindingTest.java
@@ -70,8 +70,6 @@ import org.apache.cxf.wsdl11.WSDLServiceBuilder;
 import org.apache.hello_world_soap_http.types.GreetMe;
 import org.apache.hello_world_soap_http.types.GreetMeOneWay;
 
-import org.easymock.EasyMock;
-import org.easymock.IMocksControl;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -81,6 +79,8 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class JAXBDataBindingTest {
 
@@ -89,7 +89,6 @@ public class JAXBDataBindingTest {
     private Definition def;
     private Service service;
 
-    private IMocksControl control;
     private Bus bus;
     private BindingFactoryManager bindingFactoryManager;
     private JAXBDataBinding jaxbDataBinding;
@@ -106,16 +105,13 @@ public class JAXBDataBindingTest {
         def = wsdlReader.readWSDL(wsdlUrl);
 
 
-        control = EasyMock.createNiceControl();
-        bus = control.createMock(Bus.class);
-        bindingFactoryManager = control.createMock(BindingFactoryManager.class);
-        destinationFactoryManager = control.createMock(DestinationFactoryManager.class);
+        bus = mock(Bus.class);
+        bindingFactoryManager = mock(BindingFactoryManager.class);
+        destinationFactoryManager = mock(DestinationFactoryManager.class);
 
-        EasyMock.expect(bus.getExtension(BindingFactoryManager.class)).andStubReturn(bindingFactoryManager);
-        EasyMock.expect(bus.getExtension(DestinationFactoryManager.class))
-            .andStubReturn(destinationFactoryManager);
-
-        control.replay();
+        when(bus.getExtension(BindingFactoryManager.class)).thenReturn(bindingFactoryManager);
+        when(bus.getExtension(DestinationFactoryManager.class))
+            .thenReturn(destinationFactoryManager);
 
         WSDLServiceBuilder wsdlServiceBuilder = new WSDLServiceBuilder(bus);
         for (Service serv : CastUtils.cast(def.getServices().values(), Service.class)) {

--- a/rt/databinding/jaxb/src/test/java/org/apache/cxf/jaxb/TestBase.java
+++ b/rt/databinding/jaxb/src/test/java/org/apache/cxf/jaxb/TestBase.java
@@ -52,12 +52,11 @@ import org.apache.cxf.wsdl11.WSDLServiceFactory;
 import org.apache.hello_world_soap_http.types.GreetMe;
 import org.apache.hello_world_soap_http.types.GreetMeResponse;
 
-import org.easymock.IMocksControl;
 import org.junit.After;
 import org.junit.Before;
 
-import static org.easymock.EasyMock.createNiceControl;
-import static org.easymock.EasyMock.expect;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class TestBase {
 
@@ -77,14 +76,13 @@ public class TestBase {
 
         BindingFactoryManager bfm = bus.getExtension(BindingFactoryManager.class);
 
-        IMocksControl control = createNiceControl();
-        BindingFactory bf = control.createMock(BindingFactory.class);
-        Binding binding = control.createMock(Binding.class);
-        expect(bf.createBinding(null)).andStubReturn(binding);
-        expect(binding.getInFaultInterceptors())
-            .andStubReturn(new ArrayList<Interceptor<? extends Message>>());
-        expect(binding.getOutFaultInterceptors())
-            .andStubReturn(new ArrayList<Interceptor<? extends Message>>());
+        BindingFactory bf = mock(BindingFactory.class);
+        Binding binding = mock(Binding.class);
+        when(bf.createBinding(null)).thenReturn(binding);
+        when(binding.getInFaultInterceptors())
+            .thenReturn(new ArrayList<Interceptor<? extends Message>>());
+        when(binding.getOutFaultInterceptors())
+            .thenReturn(new ArrayList<Interceptor<? extends Message>>());
 
         bfm.registerBindingFactory("http://schemas.xmlsoap.org/wsdl/soap/", bf);
 


### PR DESCRIPTION
Get rid of EasyMock in cxf-rt-databinding-jaxb