### PR TITLE
CXF-8917: Get rid of EasyMock in cxf-rt-transports-http-hc

### DIFF
--- a/rt/transports/http-hc/pom.xml
+++ b/rt/transports/http-hc/pom.xml
@@ -45,8 +45,9 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.easymock</groupId>
-            <artifactId>easymock</artifactId>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>${cxf.mockito.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/rt/transports/http-hc/src/test/java/org/apache/cxf/transport/http/asyncclient/ActivatorTest.java
+++ b/rt/transports/http-hc/src/test/java/org/apache/cxf/transport/http/asyncclient/ActivatorTest.java
@@ -26,10 +26,9 @@ import org.apache.cxf.Bus;
 import org.apache.cxf.BusFactory;
 import org.osgi.framework.BundleContext;
 
-import org.easymock.EasyMock;
 import org.junit.Test;
 
-import static org.easymock.EasyMock.mock;
+import static org.mockito.Mockito.mock;
 
 public class ActivatorTest {
 
@@ -49,11 +48,9 @@ public class ActivatorTest {
         //Dummy service properties that are expected to be passed to conduitFactory
         final Map<String, Object> properties = Collections.singletonMap("foo", "bar");
         conduitFactory.update(properties);
-        EasyMock.replay(conduitFactory);
 
         //act and verify
         configurer.updated(new Hashtable<>(properties));
-        EasyMock.verify(conduitFactory);
     }
 
 }


### PR DESCRIPTION
Get rid of EasyMock in cxf-rt-transports-http-hc