### PR TITLE
Refactor assertFalse(equals()) using assertNotEquals & Refactor assertTrue(equals()) using assertEquals

### DIFF
--- a/core/src/test/java/org/apache/cxf/helpers/NameSpaceTest.java
+++ b/core/src/test/java/org/apache/cxf/helpers/NameSpaceTest.java
@@ -22,7 +22,7 @@ package org.apache.cxf.helpers;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNull;
 
 public class NameSpaceTest {
@@ -64,7 +64,7 @@ public class NameSpaceTest {
         NSDecl nsDecl2 = new NSDecl("ns2", MY_URL2);
         NSDecl nsDecl3 = new NSDecl(MY_OWN_PREFIX, MY_CUSTOM_URL);
 
-        assertFalse(nsDecl2.equals(nsDecl1));
+        assertNotEquals(nsDecl1, nsDecl2);
         assertEquals(nsDecl3, nsDecl1);
 
     }

--- a/core/src/test/java/org/apache/cxf/io/CachedStreamTestBase.java
+++ b/core/src/test/java/org/apache/cxf/io/CachedStreamTestBase.java
@@ -38,6 +38,7 @@ import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
@@ -115,7 +116,7 @@ public abstract class CachedStreamTestBase {
         assertNotNull(tmpfile);
 
         final String enctext = readFromStream(new FileInputStream(tmpfile));
-        assertFalse("text is not encoded", text.equals(enctext));
+        assertNotEquals("text is not encoded", enctext, text);
 
         Object fin = getInputStreamObject(cache);
 
@@ -145,7 +146,7 @@ public abstract class CachedStreamTestBase {
         assertNotNull(tmpfile);
 
         final String enctext = readFromStream(new FileInputStream(tmpfile));
-        assertFalse("text is not encoded", text.equals(enctext));
+        assertNotEquals("text is not encoded", enctext, text);
 
         Object fin = getInputStreamObject(cache);
 

--- a/core/src/test/java/org/apache/cxf/version/VersionTest.java
+++ b/core/src/test/java/org/apache/cxf/version/VersionTest.java
@@ -21,7 +21,7 @@ package org.apache.cxf.version;
 
 import org.junit.Test;
 
-import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
 
 public class VersionTest {
@@ -30,7 +30,7 @@ public class VersionTest {
     public void testLoadProperties() {
         String version = Version.getCurrentVersion();
         String token = "${product.version}";
-        assertFalse(token.equals(version));
+        assertNotEquals(version, token);
     }
 
     @Test

--- a/integration/jca/src/test/java/org/apache/cxf/jca/cxf/handlers/ObjectMethodInvocationHandlerTest.java
+++ b/integration/jca/src/test/java/org/apache/cxf/jca/cxf/handlers/ObjectMethodInvocationHandlerTest.java
@@ -29,6 +29,7 @@ import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
 
 
@@ -115,7 +116,7 @@ public class ObjectMethodInvocationHandlerTest extends AbstractInvocationHandler
             (TestInterface)Proxy.newProxyInstance(TestInterface.class.getClassLoader(), interfaces, handler2);
 
         assertEquals(proxy1, proxy1);
-        assertFalse(proxy1.equals(proxy2));
+        assertNotEquals(proxy1, proxy2);
     }
 
 

--- a/integration/jca/src/test/java/org/apache/cxf/jca/outbound/ManagedConnectionImplTest.java
+++ b/integration/jca/src/test/java/org/apache/cxf/jca/outbound/ManagedConnectionImplTest.java
@@ -27,7 +27,7 @@ import org.apache.hello_world_soap_http.Greeter;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
 import static org.mockito.Mockito.mock;
 
 /**
@@ -60,7 +60,7 @@ public class ManagedConnectionImplTest {
 
         assertEquals(handle1, handle1);
         assertEquals(handle2, handle2);
-        assertFalse(handle1.equals(handle2));
+        assertNotEquals(handle1, handle2);
 
     }
 

--- a/rt/ws/rm/src/test/java/org/apache/cxf/ws/rm/DestinationSequenceTest.java
+++ b/rt/ws/rm/src/test/java/org/apache/cxf/ws/rm/DestinationSequenceTest.java
@@ -129,14 +129,14 @@ public class DestinationSequenceTest {
         DestinationSequence seq = new DestinationSequence(id, ref, destination,
             ProtocolVariation.RM10WSA200408);
         DestinationSequence otherSeq = null;
-        assertFalse(seq.equals(otherSeq));
+        assertNotEquals(seq, otherSeq);
         otherSeq = new DestinationSequence(id, ref, destination, ProtocolVariation.RM10WSA200408);
         assertEquals(seq, otherSeq);
         assertEquals(seq.hashCode(), otherSeq.hashCode());
         Identifier otherId = factory.createIdentifier();
         otherId.setValue("otherSeq");
         otherSeq = new DestinationSequence(otherId, ref, destination, ProtocolVariation.RM10WSA200408);
-        assertFalse(seq.equals(otherSeq));
+        assertNotEquals(seq, otherSeq);
         assertNotEquals(seq.hashCode(), otherSeq.hashCode());
     }
 

--- a/rt/ws/rm/src/test/java/org/apache/cxf/ws/rm/RMManagerTest.java
+++ b/rt/ws/rm/src/test/java/org/apache/cxf/ws/rm/RMManagerTest.java
@@ -68,6 +68,7 @@ import org.mockito.ArgumentCaptor;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
@@ -698,7 +699,7 @@ public class RMManagerTest {
         assertNotNull(id1.getValue());
         Identifier id2 = generator.generateSequenceIdentifier();
         assertTrue(id1 != id2);
-        assertFalse(id1.getValue().equals(id2.getValue()));
+        assertNotEquals(id1.getValue(), id2.getValue());
     }
 
     // just read the begining of the input and compare it against the specified string

--- a/rt/ws/rm/src/test/java/org/apache/cxf/ws/rm/SourceSequenceTest.java
+++ b/rt/ws/rm/src/test/java/org/apache/cxf/ws/rm/SourceSequenceTest.java
@@ -37,6 +37,7 @@ import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
@@ -157,14 +158,14 @@ public class SourceSequenceTest {
     public void testEqualsAndHashCode() {
         SourceSequence seq = new SourceSequence(id, ProtocolVariation.RM10WSA200408);
         SourceSequence otherSeq = null;
-        assertFalse(seq.equals(otherSeq));
+        assertNotEquals(seq, otherSeq);
         otherSeq = new SourceSequence(id, ProtocolVariation.RM10WSA200408);
         assertEquals(seq, otherSeq);
         assertEquals(seq.hashCode(), otherSeq.hashCode());
         Identifier otherId = factory.createIdentifier();
         otherId.setValue("otherSeq");
         otherSeq = new SourceSequence(otherId, ProtocolVariation.RM10WSA200408);
-        assertFalse(seq.equals(otherSeq));
+        assertNotEquals(seq, otherSeq);
         assertTrue(seq.hashCode() != otherSeq.hashCode());
     }
 

--- a/services/sts/sts-core/src/test/java/org/apache/cxf/sts/token/renewer/SAMLTokenRenewerTest.java
+++ b/services/sts/sts-core/src/test/java/org/apache/cxf/sts/token/renewer/SAMLTokenRenewerTest.java
@@ -61,7 +61,7 @@ import org.apache.wss4j.common.util.DateUtil;
 
 import org.junit.BeforeClass;
 
-import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -131,7 +131,7 @@ public class SAMLTokenRenewerTest {
 
         String oldId = new SamlAssertionWrapper(samlToken).getId();
         String newId = new SamlAssertionWrapper(renewerResponse.getToken()).getId();
-        assertFalse(oldId.equals(newId));
+        assertNotEquals(oldId, newId);
 
         // Now validate it again
         validateTarget = new ReceivedToken(renewerResponse.getToken());
@@ -272,7 +272,7 @@ public class SAMLTokenRenewerTest {
 
         String oldId = new SamlAssertionWrapper(samlToken).getId();
         String newId = new SamlAssertionWrapper(renewerResponse.getToken()).getId();
-        assertFalse(oldId.equals(newId));
+        assertNotEquals(oldId, newId);
 
         // Now validate it again
         validateTarget = new ReceivedToken(renewerResponse.getToken());
@@ -348,7 +348,7 @@ public class SAMLTokenRenewerTest {
 
         String oldId = new SamlAssertionWrapper(samlToken).getId();
         String newId = new SamlAssertionWrapper(renewerResponse.getToken()).getId();
-        assertFalse(oldId.equals(newId));
+        assertNotEquals(oldId, newId);
 
         // Now validate it again
         validateTarget = new ReceivedToken(renewerResponse.getToken());

--- a/services/sts/systests/advanced/src/test/java/org/apache/cxf/systest/sts/renew/SAMLRenewUnitTest.java
+++ b/services/sts/systests/advanced/src/test/java/org/apache/cxf/systest/sts/renew/SAMLRenewUnitTest.java
@@ -38,6 +38,7 @@ import org.junit.runners.Parameterized.Parameters;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -87,7 +88,7 @@ public class SAMLRenewUnitTest extends AbstractBusClientServerTestBase {
 
         // Renew the token
         SecurityToken renewedToken = renewSecurityToken(bus, wsdlLocation, token, false);
-        assertFalse(token.equals(renewedToken));
+        assertNotEquals(token, renewedToken);
 
         // Try to validate old token -> fail.
         try {
@@ -117,7 +118,7 @@ public class SAMLRenewUnitTest extends AbstractBusClientServerTestBase {
 
         // Renew the token
         SecurityToken renewedToken = renewSecurityToken(bus, wsdlLocation, token, false);
-        assertFalse(token.equals(renewedToken));
+        assertNotEquals(token, renewedToken);
 
         // Try to validate old token -> fail.
         try {
@@ -173,7 +174,7 @@ public class SAMLRenewUnitTest extends AbstractBusClientServerTestBase {
 
         // Renew the token
         SecurityToken renewedToken = renewSecurityToken(bus, wsdlLocation, token, false);
-        assertFalse(token.equals(renewedToken));
+        assertNotEquals(token, renewedToken);
 
         // Validate the renewed token
         validateSecurityToken(bus, wsdlLocation, renewedToken);
@@ -222,7 +223,7 @@ public class SAMLRenewUnitTest extends AbstractBusClientServerTestBase {
 
         // Renew the token
         SecurityToken renewedToken = renewSecurityToken(bus, wsdlLocation, token, false);
-        assertFalse(token.equals(renewedToken));
+        assertNotEquals(token, renewedToken);
 
         // Validate the renewed token
         validateSecurityToken(bus, wsdlLocation, renewedToken);

--- a/systests/jaxrs/src/test/java/org/apache/cxf/systest/jaxrs/failover/AbstractFailoverTest.java
+++ b/systests/jaxrs/src/test/java/org/apache/cxf/systest/jaxrs/failover/AbstractFailoverTest.java
@@ -43,7 +43,7 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -255,7 +255,7 @@ public abstract class AbstractFailoverTest extends AbstractBusClientServerTestBa
                 ex = error;
             }
             String currEndpoint = getCurrentEndpointAddress(bookStore);
-            assertFalse(currEndpoint.equals(inactiveReplica));
+            assertNotEquals(currEndpoint, inactiveReplica);
             if (expectRandom) {
                 assertTrue(currEndpoint.equals(activeReplica1) || currEndpoint.equals(activeReplica2));
             } else {
@@ -306,7 +306,7 @@ public abstract class AbstractFailoverTest extends AbstractBusClientServerTestBa
                 ex = error;
             }
             String currEndpoint = getCurrentEndpointAddress(bookStore);
-            assertFalse(currEndpoint.equals(inactiveReplica));
+            assertNotEquals(currEndpoint, inactiveReplica);
             if (expectRandom) {
                 assertTrue(currEndpoint.equals(activeReplica1) || currEndpoint.equals(activeReplica2));
             } else {

--- a/systests/jaxws/src/test/java/org/apache/cxf/systest/jaxws/CXF7990Test.java
+++ b/systests/jaxws/src/test/java/org/apache/cxf/systest/jaxws/CXF7990Test.java
@@ -33,6 +33,7 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
 public class CXF7990Test extends AbstractClientServerTestBase {
@@ -78,7 +79,7 @@ public class CXF7990Test extends AbstractClientServerTestBase {
             echoService.echoException("test");
             fail("SOAPException is expected");
         } catch (SOAPFaultException e) {
-            assertTrue(e.getMessage().equals("TestSOAPFaultException"));
+            assertEquals(e.getMessage(), "TestSOAPFaultException");
         }
     }
 
@@ -95,7 +96,7 @@ public class CXF7990Test extends AbstractClientServerTestBase {
             echoService.echoProxy("http://localhost:" + PORT + "/echo/service?wsdl");
             fail("SOAPException is expected");
         } catch (SOAPFaultException e) {
-            assertTrue(e.getMessage(), e.getMessage().equals("SOAPFaultString"));
+            assertEquals(e.getMessage(), e.getMessage(), "SOAPFaultString");
         }
     }
 

--- a/systests/jaxws/src/test/java/org/apache/cxf/systest/jaxws/JaxWsClientThreadTest.java
+++ b/systests/jaxws/src/test/java/org/apache/cxf/systest/jaxws/JaxWsClientThreadTest.java
@@ -120,8 +120,8 @@ public class JaxWsClientThreadTest extends AbstractCXFTest {
         }
 
         // main thread contextValues are un changed
-        assertTrue("address from existing context has not changed", address.equals(requestContext
-            .get(BindingProvider.ENDPOINT_ADDRESS_PROPERTY)));
+        assertEquals("address from existing context has not changed", address, requestContext
+            .get(BindingProvider.ENDPOINT_ADDRESS_PROPERTY));
 
         // get the latest values
 
@@ -207,8 +207,8 @@ public class JaxWsClientThreadTest extends AbstractCXFTest {
         }
 
         // main thread contextValues are un changed
-        assertTrue("address from existing context has not changed", address.equals(requestContext
-            .get(BindingProvider.ENDPOINT_ADDRESS_PROPERTY)));
+        assertEquals("address from existing context has not changed", address, requestContext
+            .get(BindingProvider.ENDPOINT_ADDRESS_PROPERTY));
 
         // get the latest values
 

--- a/systests/uncategorized/src/test/java/org/apache/cxf/systest/type_test/AbstractTypeTestClient3.java
+++ b/systests/uncategorized/src/test/java/org/apache/cxf/systest/type_test/AbstractTypeTestClient3.java
@@ -2237,9 +2237,9 @@ public abstract class AbstractTypeTestClient3 extends AbstractTypeTestClient2 {
             List<Short> ret = testDocLiteral ? docClient.testAnonEnumList(x, y, z) : xmlClient
                 .testAnonEnumList(x, y, z);
             if (!perfTestOnly) {
-                assertEquals("testAnonEnumList(): Incorrect value for inout param", x, y.value);
-                assertEquals("testAnonEnumList(): Incorrect value for out param", yOrig, z.value);
-                assertEquals("testAnonEnumList(): Incorrect return value", x, ret);
+                Assert.assertEquals("testAnonEnumList(): Incorrect value for inout param", x, y.value);
+                Assert.assertEquals("testAnonEnumList(): Incorrect value for out param", yOrig, z.value);
+                Assert.assertEquals("testAnonEnumList(): Incorrect return value", x, ret);                
             }
         } else {
             Short[] x = {(short)10, (short)100};

--- a/systests/uncategorized/src/test/java/org/apache/cxf/systest/type_test/AbstractTypeTestClient3.java
+++ b/systests/uncategorized/src/test/java/org/apache/cxf/systest/type_test/AbstractTypeTestClient3.java
@@ -2237,9 +2237,9 @@ public abstract class AbstractTypeTestClient3 extends AbstractTypeTestClient2 {
             List<Short> ret = testDocLiteral ? docClient.testAnonEnumList(x, y, z) : xmlClient
                 .testAnonEnumList(x, y, z);
             if (!perfTestOnly) {
-                assertTrue("testAnonEnumList(): Incorrect value for inout param", x.equals(y.value));
-                assertTrue("testAnonEnumList(): Incorrect value for out param", yOrig.equals(z.value));
-                assertTrue("testAnonEnumList(): Incorrect return value", x.equals(ret));
+                assertEquals("testAnonEnumList(): Incorrect value for inout param", x, y.value);
+                assertEquals("testAnonEnumList(): Incorrect value for out param", yOrig, z.value);
+                assertEquals("testAnonEnumList(): Incorrect return value", x, ret);
             }
         } else {
             Short[] x = {(short)10, (short)100};

--- a/tools/wsdlto/test/src/test/java/org/apache/cxf/tools/wsdlto/jaxws/CodeGenTest.java
+++ b/tools/wsdlto/test/src/test/java/org/apache/cxf/tools/wsdlto/jaxws/CodeGenTest.java
@@ -56,6 +56,7 @@ import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -1428,7 +1429,7 @@ public class CodeGenTest extends AbstractCodeGenTest {
         processor.execute();
         Class<?> sei = classLoader.loadClass("org.apache.cxf.cxf1404.hello_world_soap_http.Greeter");
         assertEquals(1, sei.getMethods().length);
-        assertFalse(Void.TYPE.equals(sei.getMethods()[0].getReturnType()));
+        assertNotEquals(Void.TYPE, sei.getMethods()[0].getReturnType());
     }
     @Test
     public void testCXF1950()  throws Exception {


### PR DESCRIPTION
I am working on research that investigates test smell refactoring in which we identify alternative implementations of test cases, study how commonly used these refactorings are, and assess how acceptable they are in practice. 

For example, the smell in [NameSpaceTest.java](https://github.com/apache/cxf/pull/1395/files#diff-222a3706aae4f8dd30c4e5e1953ed3d6fca3d04085e56e4bce43466369ed282c) occurs when inappropriate assertions, such as `assertFalse(nsDecl2.equals(nsDecl1));` are used, while there exist better alternatives, such as `assertNotEquals(nsDecl1, nsDecl2);`.


We would like to get your feedback on these particular test smells and their refactorings. Thanks in advance for your input.
