### PR TITLE
CXF-8919 - JAXRSUtils references javax.activation.Datasource

### DIFF
--- a/rt/frontend/jaxrs/src/main/java/org/apache/cxf/jaxrs/utils/JAXRSUtils.java
+++ b/rt/frontend/jaxrs/src/main/java/org/apache/cxf/jaxrs/utils/JAXRSUtils.java
@@ -203,7 +203,7 @@ public final class JAXRSUtils {
             "java.util.concurrent.CompletableFuture",
             "java.util.concurrent.CompletionStage"
         ));
-    private static final LazyLoadedClass DATA_SOURCE_CLASS = new LazyLoadedClass("javax.activation.DataSource");
+    private static final LazyLoadedClass DATA_SOURCE_CLASS = new LazyLoadedClass("jakarta.activation.DataSource");
 
     // Class to lazily call the ClassLoaderUtil.loadClass, but do it once
     // and cache the result.  Then use the class to create instances as needed.


### PR DESCRIPTION
# What does this PR do?

JAXRSUtils has a LazyClass reference to `javax.activation.Datasource`. Since we are using jakarta namespace for cxf4, we need to fix it.

The wrong reference is a problem for

`com.sun.ts.tests.jaxrs.spec.provider.standardnotnull.JAXRSClient#java#clientDataSourceProviderTest_from_standalone`

if running the ee9.1 plattform tck for TomEE.
