### PR TITLE
CXF-8853: Get rid of EasyMock in cxf-services-xkms-x509-handlers

### DIFF
--- a/services/xkms/xkms-x509-handlers/pom.xml
+++ b/services/xkms/xkms-x509-handlers/pom.xml
@@ -57,8 +57,9 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.easymock</groupId>
-            <artifactId>easymock</artifactId>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>${cxf.mockito.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/services/xkms/xkms-x509-handlers/src/test/java/org/apache/cxf/xkms/x509/handlers/X509LocatorTest.java
+++ b/services/xkms/xkms-x509-handlers/src/test/java/org/apache/cxf/xkms/x509/handlers/X509LocatorTest.java
@@ -33,10 +33,12 @@ import org.apache.cxf.xkms.model.xkms.UnverifiedKeyBindingType;
 import org.apache.cxf.xkms.model.xkms.UseKeyWithType;
 import org.apache.cxf.xkms.x509.repo.CertificateRepo;
 
-import org.easymock.EasyMock;
 import org.junit.Assert;
 import org.junit.Test;
 
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 /**
  * Test needs a real LDAP server.
  */
@@ -47,9 +49,8 @@ public class X509LocatorTest {
 
     @Test
     public void locate() throws CertificateException {
-        CertificateRepo certRepo = EasyMock.createMock(CertificateRepo.class);
-        EasyMock.expect(certRepo.findBySubjectDn(EasyMock.eq("alice"))).andReturn(getAliceCert());
-        EasyMock.replay(certRepo);
+        CertificateRepo certRepo = mock(CertificateRepo.class);
+        when(certRepo.findBySubjectDn(eq("alice"))).thenReturn(getAliceCert());
         X509Locator locator = new X509Locator(certRepo);
         LocateRequestType request = prepareLocateXKMSRequest();
         UnverifiedKeyBindingType result = locator.locate(request);


### PR DESCRIPTION
Get rid of EasyMock in cxf-services-xkms-x509-handlers