### PR TITLE
CXF-8920: use the same approach with Temporal.class.isAssignableFrom …

### DIFF
--- a/rt/rs/extensions/search/src/main/java/org/apache/cxf/jaxrs/ext/search/AbstractSearchConditionParser.java
+++ b/rt/rs/extensions/search/src/main/java/org/apache/cxf/jaxrs/ext/search/AbstractSearchConditionParser.java
@@ -194,6 +194,7 @@ public abstract class AbstractSearchConditionParser<T> implements SearchConditio
                 && (isPrimitive
                     ||
                     Date.class.isAssignableFrom(returnType)
+                    || Temporal.class.isAssignableFrom(returnType)
                     || returnCollection
                     || paramConverterAvailable(returnType));
 
@@ -207,8 +208,13 @@ public abstract class AbstractSearchConditionParser<T> implements SearchConditio
 
             if (lastTry) {
                 if (!returnCollection) {
-                    nextObject = isPrimitive ? InjectionUtils.convertStringToPrimitive(value, returnType)
-                        : convertToDate(returnType, value);
+                    if (isPrimitive) {
+                        nextObject = InjectionUtils.convertStringToPrimitive(value, returnType);
+                    } else if (Temporal.class.isAssignableFrom(returnType)) {
+                        nextObject = convertToTemporal((Class<? extends Temporal>)returnType, value);
+                    } else {
+                        nextObject = convertToDate(returnType, value);
+                    }
                 } else {
                     CollectionCheck collCheck = getCollectionCheck(originalPropName, true, actualReturnType);
                     if (collCheck == null) {

--- a/rt/rs/extensions/search/src/test/java/org/apache/cxf/jaxrs/ext/search/fiql/FiqlCollectionsTest.java
+++ b/rt/rs/extensions/search/src/test/java/org/apache/cxf/jaxrs/ext/search/fiql/FiqlCollectionsTest.java
@@ -18,6 +18,7 @@
  */
 package org.apache.cxf.jaxrs.ext.search.fiql;
 
+import java.time.LocalDate;
 import java.util.Set;
 
 import org.apache.cxf.jaxrs.ext.search.SearchCondition;
@@ -42,6 +43,14 @@ public class FiqlCollectionsTest {
         FiqlParser<Room> roomParser = new FiqlParser<>(Room.class);
         SearchCondition<Room> roomCondition = roomParser
                 .parse("furniture.spec.features.description==description");
+        Room room = roomCondition.getCondition();
+        assertNotNull(room);
+    }
+
+    @Test
+    public void testTemporalUsedOnCollection() throws SearchParseException {
+        FiqlParser<Room> roomParser = new FiqlParser<>(Room.class);
+        SearchCondition<Room> roomCondition = roomParser.parse("furniture.spec.features.localDate==2023-08-24");
         Room room = roomCondition.getCondition();
         assertNotNull(room);
     }
@@ -88,11 +97,20 @@ public class FiqlCollectionsTest {
 
     public static class Feature {
         String description;
+        LocalDate localDate;
         public String getDescription() {
             return description;
         }
         public void setDescription(String description) {
             this.description = description;
+        }
+
+        public LocalDate getLocalDate() {
+            return localDate;
+        }
+
+        public void setLocalDate(LocalDate localDate) {
+            this.localDate = localDate;
         }
     }
 }


### PR DESCRIPTION
…check as used for non-collection fields to recognize and convert temporal values