### PR TITLE
CXF-8928: Reduce code quality warnings in generated code

### DIFF
--- a/tools/wsdlto/frontend/jaxws/src/main/java/org/apache/cxf/tools/wsdlto/frontend/jaxws/template/service.vm
+++ b/tools/wsdlto/frontend/jaxws/src/main/java/org/apache/cxf/tools/wsdlto/frontend/jaxws/template/service.vm
@@ -68,17 +68,17 @@ public class ${service.Name} extends ${serviceSuperclass} {
 #if ($markGenerated == "true")
     @Generated(value = "org.apache.cxf.tools.wsdlto.WSDLToJava", date = "$currentdate")
 #end
-    public final static URL WSDL_LOCATION;
+    public static final URL WSDL_LOCATION;
 
 #if ($markGenerated == "true")
     @Generated(value = "org.apache.cxf.tools.wsdlto.WSDLToJava", date = "$currentdate")
 #end
-    public final static QName SERVICE = new QName("$service.Namespace", "$service.ServiceName");
+    public static final QName SERVICE = new QName("$service.Namespace", "$service.ServiceName");
 #foreach ($port in ${service.Ports})
 #if ($markGenerated == "true")
     @Generated(value = "org.apache.cxf.tools.wsdlto.WSDLToJava", date = "$currentdate")
 #end
-    public final static QName $port.Name = new QName("$service.Namespace", "$port.PortName");
+    public static final QName $port.Name = new QName("$service.Namespace", "$port.PortName");
 #end
     static {
 #if ($wsdlLocation == "")


### PR DESCRIPTION
The cxf-codegen-plugin converts a WSDL into java classes, among them the class for the Jax-WS Service.

In the template some class members have the modifiers "public final static". The java standard recommends them to be in the order "public static final"

> If two or more (distinct) field modifiers appear in a field
declaration, it is customary, though not required, that they appear in the order consistent with that shown above in the production for FieldModifier. –
https://docs.oracle.com/javase/specs/jls/se20/html/jls-8.html#jls-8.3.1

If the generated source code is checked in to source control it is common that it will be analyzed using checkstyle, Teamscale and other linters. To reduce linter complaints the order should be changed.