### PR TITLE
#8932 : check JDK running to avoid using SpringBusFactory as default

### DIFF
--- a/core/src/main/java/org/apache/cxf/BusFactory.java
+++ b/core/src/main/java/org/apache/cxf/BusFactory.java
@@ -66,7 +66,7 @@ public abstract class BusFactory {
 
     public static final String BUS_FACTORY_PROPERTY_NAME = "org.apache.cxf.bus.factory";
     public static final String DEFAULT_BUS_FACTORY = "org.apache.cxf.bus.CXFBusFactory";
-
+    public static final String SPRING_BUS_FACTORY = "org.apache.cxf.bus.spring.SpringBusFactory";
     protected static Bus defaultBus;
 
     static class BusHolder {
@@ -379,6 +379,11 @@ public abstract class BusFactory {
                     busFactoryCondition = rd.readLine();
                 }
             }
+            if (SPRING_BUS_FACTORY.equalsIgnoreCase(busFactoryClass) && !isMinimalJdk17(Runtime.version().feature())) {
+                LogUtils.log(LOG, Level.WARNING, "BUS_FACTORY_DEFAULT_JDK");
+                busFactoryClass = DEFAULT_BUS_FACTORY;
+                busFactoryCondition = null;
+            }
             if (isValidBusFactoryClass(busFactoryClass)
                 && busFactoryCondition != null) {
                 try {
@@ -404,6 +409,11 @@ public abstract class BusFactory {
             LogUtils.log(LOG, Level.SEVERE, "FAILED_TO_DETERMINE_BUS_FACTORY_EXC", ex);
         }
         return busFactoryClass;
+    }
+
+    private static boolean isMinimalJdk17(Integer version) {
+        // this method checks that current running jdk version is 17+ (prerequisites for Spring usage)
+        return version != null && version.intValue() >= 17;
     }
 
     private static boolean isValidBusFactoryClass(String busFactoryClassName) {

--- a/core/src/main/java/org/apache/cxf/Messages.properties
+++ b/core/src/main/java/org/apache/cxf/Messages.properties
@@ -19,4 +19,5 @@
 #
 #
 FAILED_TO_DETERMINE_BUS_FACTORY_EXC = Failed to determine BusFactory implementation class name.
+BUS_FACTORY_DEFAULT_JDK = Failed to used SpringBusFactory with current JDK running, using default CXFBusFactory.
 BUS_FACTORY_INSTANTIATION_EXC = Failed to instantiate bus factory.


### PR DESCRIPTION
Tested OK against project sample in issue https://issues.apache.org/jira/browse/CXF-8932

Got the following output running JDK11
```
[INFO] --- cxf-codegen:4.0.4-SNAPSHOT:wsdl2java (generate-sources) @ issue-8932 ---
[INFO] Running code generation in fork mode...
[INFO] The java executable is /Library/Java/JavaVirtualMachines/jdk-11.0.13.jdk/Contents/Home/bin/java
[INFO] Building jar: /var/folders/m7/sbrqv5yd79z1slvj20s27wd80000gp/T/cxf-tmp-8102040999141811417/cxf-codegen15093912636962846588.jar
[WARNING] SLF4J: No SLF4J providers were found.
[WARNING] SLF4J: Defaulting to no-operation (NOP) logger implementation
[WARNING] SLF4J: See https://www.slf4j.org/codes.html#noProviders for further details.
[WARNING] sept. 21, 2023 10:44:07 AM org.apache.cxf.BusFactory getBusFactoryClass
**[WARNING] WARNING: Failed to used SpringBusFactory with current JDK running, using default CXFBusFactory.**
```