### PR TITLE
CXF-8932: Plugins are not working on JDK11 and eagerly bring Spring dependencies

### DIFF
--- a/maven-plugins/codegen-plugin/pom.xml
+++ b/maven-plugins/codegen-plugin/pom.xml
@@ -108,16 +108,19 @@
             <groupId>org.springframework</groupId>
             <artifactId>spring-core</artifactId>
             <optional>true</optional>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-beans</artifactId>
             <optional>true</optional>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-context</artifactId>
             <optional>true</optional>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.sonatype.plexus</groupId>

--- a/maven-plugins/corba/pom.xml
+++ b/maven-plugins/corba/pom.xml
@@ -42,16 +42,19 @@
             <groupId>org.springframework</groupId>
             <artifactId>spring-core</artifactId>
             <optional>true</optional>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-beans</artifactId>
             <optional>true</optional>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-context</artifactId>
             <optional>true</optional>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.maven</groupId>

--- a/maven-plugins/java2wadl-plugin/pom.xml
+++ b/maven-plugins/java2wadl-plugin/pom.xml
@@ -89,16 +89,19 @@
             <groupId>org.springframework</groupId>
             <artifactId>spring-core</artifactId>
             <optional>true</optional>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-beans</artifactId>
             <optional>true</optional>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-context</artifactId>
             <optional>true</optional>
+            <scope>provided</scope>
         </dependency>
 
         <dependency>

--- a/maven-plugins/wadl2java-plugin/pom.xml
+++ b/maven-plugins/wadl2java-plugin/pom.xml
@@ -87,16 +87,19 @@
             <groupId>org.springframework</groupId>
             <artifactId>spring-core</artifactId>
             <optional>true</optional>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-beans</artifactId>
             <optional>true</optional>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-context</artifactId>
             <optional>true</optional>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.sonatype.plexus</groupId>


### PR DESCRIPTION
Plugins are not working on JDK11 and eagerly bring Spring dependencies

```
[INFO] Plugin Resolved: cxf-codegen-plugin-4.0.3.jar
[INFO]     Plugin Dependency Resolved: plexus-utils-3.5.1.jar
[INFO]     Plugin Dependency Resolved: plexus-archiver-4.8.0.jar
[INFO]     Plugin Dependency Resolved: cxf-core-4.0.3.jar
[INFO]     Plugin Dependency Resolved: cxf-tools-common-4.0.3.jar
[INFO]     Plugin Dependency Resolved: cxf-tools-wsdlto-core-4.0.3.jar
[INFO]     Plugin Dependency Resolved: cxf-tools-wsdlto-databinding-jaxb-4.0.3.jar
[INFO]     Plugin Dependency Resolved: cxf-tools-wsdlto-frontend-jaxws-4.0.3.jar
[INFO]     Plugin Dependency Resolved: cxf-tools-wsdlto-frontend-javascript-4.0.3.jar
[INFO]     Plugin Dependency Resolved: spring-core-6.0.11.jar
[INFO]     Plugin Dependency Resolved: spring-beans-6.0.11.jar
[INFO]     Plugin Dependency Resolved: spring-context-6.0.11.jar
[INFO]     Plugin Dependency Resolved: plexus-build-api-0.0.7.jar
```

After

```
[INFO] Plugin Resolved: cxf-codegen-plugin-4.0.4-SNAPSHOT.jar
[INFO]     Plugin Dependency Resolved: plexus-utils-3.5.1.jar
[INFO]     Plugin Dependency Resolved: plexus-archiver-4.8.0.jar
[INFO]     Plugin Dependency Resolved: cxf-core-4.0.4-SNAPSHOT.jar
[INFO]     Plugin Dependency Resolved: cxf-tools-common-4.0.4-SNAPSHOT.jar
[INFO]     Plugin Dependency Resolved: cxf-tools-wsdlto-core-4.0.4-SNAPSHOT.jar
[INFO]     Plugin Dependency Resolved: cxf-tools-wsdlto-databinding-jaxb-4.0.4-SNAPSHOT.jar
[INFO]     Plugin Dependency Resolved: cxf-tools-wsdlto-frontend-jaxws-4.0.4-SNAPSHOT.jar
[INFO]     Plugin Dependency Resolved: cxf-tools-wsdlto-frontend-javascript-4.0.4-SNAPSHOT.jar
[INFO]     Plugin Dependency Resolved: plexus-build-api-0.0.7.jar
```