### PR TITLE
CXF-8936 Fix h2 protocol negotiation in Jetty Transport

### DIFF
--- a/rt/transports/http-jetty/src/main/java/org/apache/cxf/transport/http_jetty/JettyHTTPServerEngine.java
+++ b/rt/transports/http-jetty/src/main/java/org/apache/cxf/transport/http_jetty/JettyHTTPServerEngine.java
@@ -684,7 +684,6 @@ public class JettyHTTPServerEngine implements ServerEngine, HttpServerEngineSupp
             result = new org.eclipse.jetty.server.ServerConnector(server);
 
             if (tlsServerParameters != null) {
-                connectionFactories.add(httpFactory);
                 httpConfig.addCustomizer(new SecureRequestCustomizer(tlsServerParameters.isSniHostCheck()));
 
                 if (isHttp2Enabled(bus)) {
@@ -704,10 +703,14 @@ public class JettyHTTPServerEngine implements ServerEngine, HttpServerEngineSupp
                         }
                     }
                 }
-                if (connectionFactories.size() == 1) {
+                
+                if (connectionFactories.isEmpty()) {
                     final SslConnectionFactory scf = new SslConnectionFactory(sslcf, httpFactory.getProtocol());
                     connectionFactories.add(scf);
                 }
+                
+                // Ensure http/1.1 is last in the list so it is the lowest priority in ALPN
+                connectionFactories.add(httpFactory);
 
                 // Has to be set before the default protocol change
                 result.setConnectionFactories(connectionFactories);


### PR DESCRIPTION
# Summary 

I have been trying to update one of our apps using the Jetty backend to use http2. While doing this I've noticed that the protocol negotiation is in the wrong order which results in http/1.1 always being preferred where the client includes this in the ALPN handshake. This means that both browsers and cURL will never successfully negotiate h2/http2.

https://issues.apache.org/jira/browse/CXF-8936

[output-jetty-original.txt](https://github.com/apache/cxf/files/12729574/output-jetty-original.txt)
[output-netty.txt](https://github.com/apache/cxf/files/12729575/output-netty.txt)