### PR TITLE
OpenTelemetry: OneWay client calls not closing the span

### DIFF
--- a/integration/tracing/tracing-opentelemetry/src/main/java/org/apache/cxf/tracing/opentelemetry/AbstractOpenTelemetryClientProvider.java
+++ b/integration/tracing/tracing-opentelemetry/src/main/java/org/apache/cxf/tracing/opentelemetry/AbstractOpenTelemetryClientProvider.java
@@ -58,11 +58,11 @@ public abstract class AbstractOpenTelemetryClientProvider extends AbstractTracin
                                                           URI uri, String method) {
         Context parentContext = Context.current();
         Span activeSpan = tracer.spanBuilder(buildSpanDescription(uri.toString(), method))
-                .setParent(parentContext).setSpanKind(SpanKind.CLIENT)
-                .setAttribute(SemanticAttributes.HTTP_METHOD, method)
-                .setAttribute(SemanticAttributes.HTTP_URL, uri.toString())
-                // TODO: Enhance with semantics from request
-                .startSpan();
+            .setParent(parentContext).setSpanKind(SpanKind.CLIENT)  
+            .setAttribute(SemanticAttributes.HTTP_METHOD, method)
+            .setAttribute(SemanticAttributes.HTTP_URL, uri.toString())
+            // TODO: Enhance with semantics from request
+            .startSpan();
         Scope scope = activeSpan.makeCurrent();
 
         openTelemetry.getPropagators().getTextMapPropagator().inject(Context.current(), requestHeaders,
@@ -77,7 +77,7 @@ public abstract class AbstractOpenTelemetryClientProvider extends AbstractTracin
         }
 
         return new TraceScopeHolder<TraceScope>(new TraceScope(activeSpan, scope, null),
-                span != null /* detached */);
+                                             span != null /* detached */);
     }
 
     private boolean isAsyncInvocation() {

--- a/integration/tracing/tracing-opentelemetry/src/main/java/org/apache/cxf/tracing/opentelemetry/AbstractOpenTelemetryClientProvider.java
+++ b/integration/tracing/tracing-opentelemetry/src/main/java/org/apache/cxf/tracing/opentelemetry/AbstractOpenTelemetryClientProvider.java
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License. You may obtain a copy of the License at
- * <p>
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * <p>
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -17,6 +17,16 @@
  * under the License.
  */
 package org.apache.cxf.tracing.opentelemetry;
+
+import java.net.URI;
+import java.util.List;
+import java.util.Map;
+import java.util.logging.Logger;
+
+import org.apache.cxf.common.logging.LogUtils;
+import org.apache.cxf.phase.PhaseInterceptorChain;
+import org.apache.cxf.tracing.AbstractTracingProvider;
+import org.apache.cxf.tracing.opentelemetry.internal.TextMapInjectAdapter;
 
 import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.common.Attributes;
@@ -27,15 +37,6 @@ import io.opentelemetry.api.trace.Tracer;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.context.Scope;
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
-import org.apache.cxf.common.logging.LogUtils;
-import org.apache.cxf.phase.PhaseInterceptorChain;
-import org.apache.cxf.tracing.AbstractTracingProvider;
-import org.apache.cxf.tracing.opentelemetry.internal.TextMapInjectAdapter;
-
-import java.net.URI;
-import java.util.List;
-import java.util.Map;
-import java.util.logging.Logger;
 
 public abstract class AbstractOpenTelemetryClientProvider extends AbstractTracingProvider {
     protected static final Logger LOG = LogUtils.getL7dLogger(AbstractOpenTelemetryClientProvider.class);

--- a/integration/tracing/tracing-opentelemetry/src/main/java/org/apache/cxf/tracing/opentelemetry/OpenTelemetryClientStartInterceptor.java
+++ b/integration/tracing/tracing-opentelemetry/src/main/java/org/apache/cxf/tracing/opentelemetry/OpenTelemetryClientStartInterceptor.java
@@ -38,23 +38,23 @@ public class OpenTelemetryClientStartInterceptor extends AbstractOpenTelemetryCl
         this(Phase.PRE_STREAM, openTelemetry, tracer);
     }
 
-    public OpenTelemetryClientStartInterceptor(final String phase, final OpenTelemetry openTelemetry,
-                                               final String instrumentationName) {
+    public OpenTelemetryClientStartInterceptor(final String phase, final OpenTelemetry openTelemetry, 
+            final String instrumentationName) {
         super(phase, openTelemetry, instrumentationName);
     }
 
-    public OpenTelemetryClientStartInterceptor(final String phase, final OpenTelemetry openTelemetry,
-                                               final Tracer tracer) {
+    public OpenTelemetryClientStartInterceptor(final String phase, final OpenTelemetry openTelemetry, 
+            final Tracer tracer) {
         super(phase, openTelemetry, tracer);
     }
 
     @Override
     public void handleMessage(Message message) throws Fault {
         final Map<String, List<String>> headers = CastUtils
-                .cast((Map<?, ?>)message.get(Message.PROTOCOL_HEADERS));
+            .cast((Map<?, ?>)message.get(Message.PROTOCOL_HEADERS));
         final TraceScopeHolder<TraceScope> holder = super.startTraceSpan(headers, getUri(message),
-                (String)message
-                        .get(Message.HTTP_REQUEST_METHOD));
+                                                                         (String)message
+                                                                             .get(Message.HTTP_REQUEST_METHOD));
 
         if (holder != null) {
             message.getExchange().put(TRACE_SPAN, holder);
@@ -70,7 +70,7 @@ public class OpenTelemetryClientStartInterceptor extends AbstractOpenTelemetryCl
     public void handleFault(Message message) {
         @SuppressWarnings("unchecked")
         final TraceScopeHolder<TraceScope> holder = (TraceScopeHolder<TraceScope>)message.getExchange()
-                .get(TRACE_SPAN);
+            .get(TRACE_SPAN);
 
         final Exception ex = message.getContent(Exception.class);
         super.stopTraceSpan(holder, ex);

--- a/integration/tracing/tracing-opentelemetry/src/main/java/org/apache/cxf/tracing/opentelemetry/OpenTelemetryClientStartInterceptor.java
+++ b/integration/tracing/tracing-opentelemetry/src/main/java/org/apache/cxf/tracing/opentelemetry/OpenTelemetryClientStartInterceptor.java
@@ -61,8 +61,7 @@ public class OpenTelemetryClientStartInterceptor extends AbstractOpenTelemetryCl
 
         // STOP interceptor is not going to be invoked for oneWay calls. Need to close the span.
         if (message.getExchange().isOneWay()) {
-            // set response status = 200 as default since the actual one will never come to this interceptor
-            super.stopTraceSpan(holder, 200);
+            super.stopTraceSpan(holder);
         }
     }
 

--- a/integration/tracing/tracing-opentelemetry/src/main/java/org/apache/cxf/tracing/opentelemetry/OpenTelemetryClientStartInterceptor.java
+++ b/integration/tracing/tracing-opentelemetry/src/main/java/org/apache/cxf/tracing/opentelemetry/OpenTelemetryClientStartInterceptor.java
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License. You may obtain a copy of the License at
- * <p>
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * <p>
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -18,15 +18,16 @@
  */
 package org.apache.cxf.tracing.opentelemetry;
 
-import io.opentelemetry.api.OpenTelemetry;
-import io.opentelemetry.api.trace.Tracer;
+import java.util.List;
+import java.util.Map;
+
 import org.apache.cxf.helpers.CastUtils;
 import org.apache.cxf.interceptor.Fault;
 import org.apache.cxf.message.Message;
 import org.apache.cxf.phase.Phase;
 
-import java.util.List;
-import java.util.Map;
+import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.api.trace.Tracer;
 
 public class OpenTelemetryClientStartInterceptor extends AbstractOpenTelemetryClientInterceptor {
     public OpenTelemetryClientStartInterceptor(final OpenTelemetry openTelemetry, final String instrumentationName) {
@@ -50,9 +51,9 @@ public class OpenTelemetryClientStartInterceptor extends AbstractOpenTelemetryCl
     @Override
     public void handleMessage(Message message) throws Fault {
         final Map<String, List<String>> headers = CastUtils
-                .cast((Map<?, ?>) message.get(Message.PROTOCOL_HEADERS));
+                .cast((Map<?, ?>)message.get(Message.PROTOCOL_HEADERS));
         final TraceScopeHolder<TraceScope> holder = super.startTraceSpan(headers, getUri(message),
-                (String) message
+                (String)message
                         .get(Message.HTTP_REQUEST_METHOD));
 
         if (holder != null) {
@@ -67,7 +68,8 @@ public class OpenTelemetryClientStartInterceptor extends AbstractOpenTelemetryCl
 
     @Override
     public void handleFault(Message message) {
-        @SuppressWarnings("unchecked") final TraceScopeHolder<TraceScope> holder = (TraceScopeHolder<TraceScope>) message.getExchange()
+        @SuppressWarnings("unchecked")
+        final TraceScopeHolder<TraceScope> holder = (TraceScopeHolder<TraceScope>)message.getExchange()
                 .get(TRACE_SPAN);
 
         final Exception ex = message.getContent(Exception.class);

--- a/integration/tracing/tracing-opentelemetry/src/main/java/org/apache/cxf/tracing/opentelemetry/OpenTelemetryClientStartInterceptor.java
+++ b/integration/tracing/tracing-opentelemetry/src/main/java/org/apache/cxf/tracing/opentelemetry/OpenTelemetryClientStartInterceptor.java
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License. You may obtain a copy of the License at
- *
+ * <p>
  * http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -18,16 +18,15 @@
  */
 package org.apache.cxf.tracing.opentelemetry;
 
-import java.util.List;
-import java.util.Map;
-
+import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.api.trace.Tracer;
 import org.apache.cxf.helpers.CastUtils;
 import org.apache.cxf.interceptor.Fault;
 import org.apache.cxf.message.Message;
 import org.apache.cxf.phase.Phase;
 
-import io.opentelemetry.api.OpenTelemetry;
-import io.opentelemetry.api.trace.Tracer;
+import java.util.List;
+import java.util.Map;
 
 public class OpenTelemetryClientStartInterceptor extends AbstractOpenTelemetryClientInterceptor {
     public OpenTelemetryClientStartInterceptor(final OpenTelemetry openTelemetry, final String instrumentationName) {
@@ -38,34 +37,39 @@ public class OpenTelemetryClientStartInterceptor extends AbstractOpenTelemetryCl
         this(Phase.PRE_STREAM, openTelemetry, tracer);
     }
 
-    public OpenTelemetryClientStartInterceptor(final String phase, final OpenTelemetry openTelemetry, 
-            final String instrumentationName) {
+    public OpenTelemetryClientStartInterceptor(final String phase, final OpenTelemetry openTelemetry,
+                                               final String instrumentationName) {
         super(phase, openTelemetry, instrumentationName);
     }
 
-    public OpenTelemetryClientStartInterceptor(final String phase, final OpenTelemetry openTelemetry, 
-            final Tracer tracer) {
+    public OpenTelemetryClientStartInterceptor(final String phase, final OpenTelemetry openTelemetry,
+                                               final Tracer tracer) {
         super(phase, openTelemetry, tracer);
     }
 
     @Override
     public void handleMessage(Message message) throws Fault {
         final Map<String, List<String>> headers = CastUtils
-            .cast((Map<?, ?>)message.get(Message.PROTOCOL_HEADERS));
+                .cast((Map<?, ?>) message.get(Message.PROTOCOL_HEADERS));
         final TraceScopeHolder<TraceScope> holder = super.startTraceSpan(headers, getUri(message),
-                                                                         (String)message
-                                                                             .get(Message.HTTP_REQUEST_METHOD));
+                (String) message
+                        .get(Message.HTTP_REQUEST_METHOD));
 
         if (holder != null) {
             message.getExchange().put(TRACE_SPAN, holder);
+        }
+
+        // STOP interceptor is not going to be invoked for oneWay calls. Need to close the span.
+        if (message.getExchange().isOneWay()) {
+            // set response status = 200 as default since the actual one will never come to this interceptor
+            super.stopTraceSpan(holder, 200);
         }
     }
 
     @Override
     public void handleFault(Message message) {
-        @SuppressWarnings("unchecked")
-        final TraceScopeHolder<TraceScope> holder = (TraceScopeHolder<TraceScope>)message.getExchange()
-            .get(TRACE_SPAN);
+        @SuppressWarnings("unchecked") final TraceScopeHolder<TraceScope> holder = (TraceScopeHolder<TraceScope>) message.getExchange()
+                .get(TRACE_SPAN);
 
         final Exception ex = message.getContent(Exception.class);
         super.stopTraceSpan(holder, ex);


### PR DESCRIPTION
With OTel, it is required for every span must be closed by the one who started it. Not closing it causes issues in the e2e traces.

Added a condition in the OutInterceptor to close the span immediately if it is a one-way call since InInterceptor will never be invoked.