### PR TITLE
CXF-8952: HttpClientHTTPConduit in CXF doesn't support TLSv1.3 along …

### DIFF
--- a/rt/transports/http/src/main/java/org/apache/cxf/transport/http/HttpClientHTTPConduit.java
+++ b/rt/transports/http/src/main/java/org/apache/cxf/transport/http/HttpClientHTTPConduit.java
@@ -251,7 +251,7 @@ public class HttpClientHTTPConduit extends URLConnectionHTTPConduit {
                             cb.sslParameters(params);
                         } else {
                             SSLParameters params = new SSLParameters(cipherSuites, 
-                                                                     new String[] {"TLSv1", "TLSv1.1", "TLSv1.2"});
+                                                             new String[] {"TLSv1", "TLSv1.1", "TLSv1.2", "TLSv1.3"});
                             cb.sslParameters(params);
                         }
                     }


### PR DESCRIPTION
…with other protocols

CXF HttpClientHTTPConduit doesn't work with endpoints that have disabled lower versions of TLSv1