### PR TITLE
Use Collection.Sort and compare the contents of the list to fix the flaky test

### DIFF
--- a/core/src/test/java/org/apache/cxf/helpers/FileUtilsTest.java
+++ b/core/src/test/java/org/apache/cxf/helpers/FileUtilsTest.java
@@ -24,6 +24,7 @@ import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
@@ -77,6 +78,8 @@ public class FileUtilsTest {
 
         List<File> foundFiles2 = FileUtils.getFiles(directory, ".*\\.class$");
 
+        Collections.sort(foundFiles);
+        Collections.sort(foundFiles2);
         assertEquals(foundFiles, foundFiles2);
     }
 }


### PR DESCRIPTION
### Description
Fixed the flaky test `testGetFiles` inside `FileUtilsTest.java` class. 

https://github.com/apache/cxf/blob/8b205c8086aeb1f5514472f0802c1fb7d510a50e/core/src/test/java/org/apache/cxf/helpers/FileUtilsTest.java#L70

#### Root Cause
The test `testGetFiles` has been reported as flaky when run with the [NonDex](https://github.com/TestingResearchIllinois/NonDex) tool. The test failed because it is trying to compare contents in two lists, but since the order is not maintained in lists the assert is failing. The List in Java is implemented in such a way that it does not store the order in which the values are inserted. As a result, when both the lists are compared, it caused the failure. 

#### Fix
This test is fixed by first sorting the two lists and then comparing both lists.

### How this has been tested?

**Java:** openjdk version "11.0.20.1"
**Maven:** Apache Maven 3.6.3

1) **Module build** - Successful
Command used - 
```
mvn install -pl core -am -DskipTests
```

2) **Regular test**  - Successful
Command used - 
```
mvn -pl core test -Dtest=org.apache.cxf.helpers.FileUtilsTest#testGetFiles
```

3) **NonDex test**  - Failed
Command used - 
```
mvn -pl core edu.illinois:nondex-maven-plugin:2.1.7-SNAPSHOT:nondex -Dtest=org.apache.cxf.helpers.FileUtilsTest#testGetFiles
```

NonDex test passed after the fix.