### PR TITLE
CXF-8954: Always create MBeanServer instance per Jetty Server instance and destroy server properly at shutdown

### DIFF
--- a/rt/transports/http-jetty/src/main/java/org/apache/cxf/transport/http_jetty/JettyHTTPServerEngine.java
+++ b/rt/transports/http-jetty/src/main/java/org/apache/cxf/transport/http_jetty/JettyHTTPServerEngine.java
@@ -1108,9 +1108,10 @@ public class JettyHTTPServerEngine implements ServerEngine, HttpServerEngineSupp
                 if (mBeanContainer != null) {
                     removeServerMBean();
                 }
-                //After upgrade Jetty to 11.0.8, server.destroy() will clear all MBeans from container
-                //The old version doesn't behavior like this and this w
-                //server.destroy();
+                // After upgrade Jetty to 11.0.8, server.destroy() will clear all MBeans from container
+                // The old version doesn't behave like this because MBeanContainer was shareable but
+                // is not anymore (the factory should create new a container for each server engine).
+                server.destroy();
                 server = null;
             }
         }

--- a/rt/transports/http-jetty/src/main/java/org/apache/cxf/transport/http_jetty/JettyHTTPServerEngineFactory.java
+++ b/rt/transports/http-jetty/src/main/java/org/apache/cxf/transport/http_jetty/JettyHTTPServerEngineFactory.java
@@ -87,11 +87,6 @@ public class JettyHTTPServerEngineFactory {
      */
     private Bus bus;
 
-    /**
-     * The Jetty {@link MBeanContainer} to use when enabling JMX in Jetty.
-     */
-    private Container.Listener mBeanContainer;
-
     public JettyHTTPServerEngineFactory() {
         // Empty
     }
@@ -331,9 +326,7 @@ public class JettyHTTPServerEngineFactory {
     }
 
     public synchronized Container.Listener getMBeanContainer() {
-        if (this.mBeanContainer != null) {
-            return mBeanContainer;
-        }
+        Container.Listener mBeanContainer = null;
 
         MBeanServer mbs = getMBeanServer();
         if (mbs != null) {
@@ -374,7 +367,6 @@ public class JettyHTTPServerEngineFactory {
         // clean up the collections
         threadingParametersMap.clear();
         tlsParametersMap.clear();
-        mBeanContainer = null;
     }
 
     public void preShutdown() {


### PR DESCRIPTION
Always create MBeanServer instance per Jetty Server instance and destroy server properly at shutdown