### PR TITLE
CXF-8911: Allow wrapping AsyncHTTPConduit response processing (using new AsyncHttpResponseWrapperFactory bus extension)

### DIFF
--- a/rt/transports/http-hc/src/main/java/org/apache/cxf/transport/http/asyncclient/AsyncHttpResponseWrapperFactory.java
+++ b/rt/transports/http-hc/src/main/java/org/apache/cxf/transport/http/asyncclient/AsyncHttpResponseWrapperFactory.java
@@ -1,0 +1,55 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.cxf.transport.http.asyncclient;
+
+import java.util.function.Consumer;
+
+import org.apache.cxf.Bus;
+import org.apache.http.HttpResponse;
+
+/**
+ * The {@link Bus} extension to allow wrapping up the response processing of 
+ * the {@link AsyncHTTPConduit} instance.
+ */
+@FunctionalInterface
+public interface AsyncHttpResponseWrapperFactory {
+    /** 
+     * Creates new instance of the {@link AsyncHttpResponseWrapper} 
+     * @return new instance of the {@link AsyncHttpResponseWrapper} (or null)
+     */
+    AsyncHttpResponseWrapper create();
+
+    /**
+     * The wrapper around the response that will be called by the {@link AsyncHTTPConduit} 
+     * instance once the response is received. 
+     */
+    interface AsyncHttpResponseWrapper {
+        /**
+         * The callback which is called by the {@link AsyncHTTPConduit} instance once 
+         * the response is received. The delegating response handler is passed as the
+         * an argument and has to be called.
+         * @param response the response received
+         * @param delegate delegating response handler
+         */
+        default void responseReceived(HttpResponse response, Consumer<HttpResponse> delegate) {
+            delegate.accept(response);
+        }
+    }
+}

--- a/rt/transports/http-hc5/src/main/java/org/apache/cxf/transport/http/asyncclient/hc5/AsyncHTTPConduit.java
+++ b/rt/transports/http-hc5/src/main/java/org/apache/cxf/transport/http/asyncclient/hc5/AsyncHTTPConduit.java
@@ -66,6 +66,7 @@ import org.apache.cxf.transport.http.Address;
 import org.apache.cxf.transport.http.Headers;
 import org.apache.cxf.transport.http.HttpClientHTTPConduit;
 import org.apache.cxf.transport.http.asyncclient.hc5.AsyncHTTPConduitFactory.UseAsyncPolicy;
+import org.apache.cxf.transport.http.asyncclient.hc5.AsyncHttpResponseWrapperFactory.AsyncHttpResponseWrapper;
 import org.apache.cxf.transport.https.HttpsURLConnectionInfo;
 import org.apache.cxf.transports.http.configuration.HTTPClientPolicy;
 import org.apache.cxf.version.Version;
@@ -105,6 +106,7 @@ public class AsyncHTTPConduit extends HttpClientHTTPConduit {
     public static final String USE_ASYNC = "use.async.http.conduit";
 
     private final AsyncHTTPConduitFactory factory;
+    private final AsyncHttpResponseWrapperFactory asyncHttpResponseWrapperFactory;
     private volatile int lastTlsHash = -1;
     private volatile Object sslState;
     private volatile URI sslURL;
@@ -116,6 +118,7 @@ public class AsyncHTTPConduit extends HttpClientHTTPConduit {
             throws IOException {
         super(b, ei, t);
         this.factory = factory;
+        this.asyncHttpResponseWrapperFactory = bus.getExtension(AsyncHttpResponseWrapperFactory.class);
     }
 
     public synchronized CloseableHttpAsyncClient getHttpAsyncClient(final TlsStrategy tlsStrategy)
@@ -491,14 +494,28 @@ public class AsyncHTTPConduit extends HttpClientHTTPConduit {
             if (connectionFuture != null) {
                 return;
             }
-
-            CXFResponseCallback responseCallback = new CXFResponseCallback() {
+            
+            final CXFResponseCallback delegate = new CXFResponseCallback() {
                 @Override
                 public void responseReceived(HttpResponse response) {
                     setHttpResponse(response);
                 }
 
             };
+
+            CXFResponseCallback responseCallback = delegate;
+            if (asyncHttpResponseWrapperFactory != null) {
+                final AsyncHttpResponseWrapper wrapper = asyncHttpResponseWrapperFactory.create();
+                if (wrapper != null) {
+                    responseCallback = new CXFResponseCallback() {
+                        @Override
+                        public void responseReceived(HttpResponse response) {
+                            wrapper.responseReceived(response, delegate::responseReceived);
+                        }
+                    };
+                }
+            }
+
 
             FutureCallback<Boolean> callback = new FutureCallback<Boolean>() {
 

--- a/rt/transports/http-hc5/src/main/java/org/apache/cxf/transport/http/asyncclient/hc5/AsyncHttpResponseWrapperFactory.java
+++ b/rt/transports/http-hc5/src/main/java/org/apache/cxf/transport/http/asyncclient/hc5/AsyncHttpResponseWrapperFactory.java
@@ -1,0 +1,55 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.cxf.transport.http.asyncclient.hc5;
+
+import java.util.function.Consumer;
+
+import org.apache.cxf.Bus;
+import org.apache.hc.core5.http.HttpResponse;
+
+/**
+ * The {@link Bus} extension to allow wrapping up the response processing of 
+ * the {@link AsyncHTTPConduit} instance.
+ */
+@FunctionalInterface
+public interface AsyncHttpResponseWrapperFactory {
+    /** 
+     * Creates new instance of the {@link AsyncHttpResponseWrapper} 
+     * @return new instance of the {@link AsyncHttpResponseWrapper} (or null)
+     */
+    AsyncHttpResponseWrapper create();
+
+    /**
+     * The wrapper around the response that will be called by the {@link AsyncHTTPConduit} 
+     * instance once the response is received. 
+     */
+    interface AsyncHttpResponseWrapper {
+        /**
+         * The callback which is called by the {@link AsyncHTTPConduit} instance once 
+         * the response is received. The delegating response handler is passed as the
+         * an argument and has to be called.
+         * @param response the response received
+         * @param delegate delegating response handler
+         */
+        default void responseReceived(HttpResponse response, Consumer<HttpResponse> delegate) {
+            delegate.accept(response);
+        }
+    }
+}

--- a/rt/transports/http-hc5/src/test/java/org/apache/cxf/transport/http/asyncclient/hc5/AsyncHTTPConduitTest.java
+++ b/rt/transports/http-hc5/src/test/java/org/apache/cxf/transport/http/asyncclient/hc5/AsyncHTTPConduitTest.java
@@ -27,6 +27,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Consumer;
 
 import jakarta.xml.ws.AsyncHandler;
 import jakarta.xml.ws.Endpoint;
@@ -44,9 +45,11 @@ import org.apache.cxf.message.MessageImpl;
 import org.apache.cxf.testutil.common.AbstractBusClientServerTestBase;
 import org.apache.cxf.transport.http.HTTPConduit;
 import org.apache.cxf.transport.http.HTTPConduitFactory;
+import org.apache.cxf.transport.http.asyncclient.hc5.AsyncHttpResponseWrapperFactory.AsyncHttpResponseWrapper;
 import org.apache.cxf.transports.http.configuration.HTTPClientPolicy;
 import org.apache.cxf.workqueue.AutomaticWorkQueueImpl;
 import org.apache.cxf.workqueue.WorkQueueManager;
+import org.apache.hc.core5.http.HttpResponse;
 import org.apache.hello_world_soap_http.Greeter;
 import org.apache.hello_world_soap_http.SOAPService;
 import org.apache.hello_world_soap_http.types.GreetMeLaterResponse;
@@ -56,6 +59,8 @@ import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.fail;
@@ -213,7 +218,7 @@ public class AsyncHTTPConduitTest extends AbstractBusClientServerTestBase {
     }
 
     @Test
-    public void testInovationWithHCAddress() throws Exception {
+    public void testInvocationWithHCAddress() throws Exception {
         String address = "hc://http://localhost:" + PORT + "/SoapContext/SoapPort";
         JaxWsProxyFactoryBean factory = new JaxWsProxyFactoryBean();
         factory.setServiceClass(Greeter.class);
@@ -234,6 +239,7 @@ public class AsyncHTTPConduitTest extends AbstractBusClientServerTestBase {
         String response = greeter.greetMe("test");
         assertEquals("Get a wrong response", "Hello test", response);
     }
+
     @Test
     public void testCall() throws Exception {
         updateAddressPort(g, PORT);
@@ -244,6 +250,7 @@ public class AsyncHTTPConduitTest extends AbstractBusClientServerTestBase {
         c.setClient(cp);
         assertEquals("Hello " + request, g.greetMe(request));
     }
+
     @Test
     public void testCallAsync() throws Exception {
         updateAddressPort(g, PORT);
@@ -262,6 +269,35 @@ public class AsyncHTTPConduitTest extends AbstractBusClientServerTestBase {
             public void handleResponse(Response<GreetMeLaterResponse> res) {
             }
         }).get();
+    }
+
+    @Test
+    public void testCallAsyncWithResponseWrapper() throws Exception {
+        try {
+            final CountDownLatch latch = new CountDownLatch(1);
+            final AsyncHttpResponseWrapper wrapper = new AsyncHttpResponseWrapper() {
+                @Override
+                public void responseReceived(HttpResponse response, Consumer<HttpResponse> delegate) {
+                    delegate.accept(response);
+                    latch.countDown();
+                }
+            };
+
+            getStaticBus().setExtension(() -> wrapper, AsyncHttpResponseWrapperFactory.class);
+
+            final String address = "hc://http://localhost:" + PORT + "/SoapContext/SoapPort";
+            final Greeter greeter = new SOAPService().getSoapPort();
+            setAddress(greeter, address);
+    
+            greeter.greetMeLaterAsync(1000, new AsyncHandler<GreetMeLaterResponse>() {
+                public void handleResponse(Response<GreetMeLaterResponse> res) {
+                }
+            }).get();
+
+            assertThat(latch.await(5, TimeUnit.SECONDS), is(true));
+        } finally {
+            getStaticBus().setExtension(null, AsyncHttpResponseWrapperFactory.class);
+        }
     }
 
     @Test


### PR DESCRIPTION
Allow wrapping AsyncHTTPConduit response processing (using new AsyncHttpResponseWrapperFactory bus extension)