### PR TITLE
Cxf dev2

### DIFF
--- a/core/src/test/java/org/apache/cxf/helpers/FileUtilsTest.java
+++ b/core/src/test/java/org/apache/cxf/helpers/FileUtilsTest.java
@@ -24,7 +24,6 @@ import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
@@ -78,8 +77,6 @@ public class FileUtilsTest {
 
         List<File> foundFiles2 = FileUtils.getFiles(directory, ".*\\.class$");
 
-        Collections.sort(foundFiles);
-        Collections.sort(foundFiles2);
         assertEquals(foundFiles, foundFiles2);
     }
 }

--- a/core/src/test/java/org/apache/cxf/helpers/FileUtilsTest.java
+++ b/core/src/test/java/org/apache/cxf/helpers/FileUtilsTest.java
@@ -24,6 +24,7 @@ import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
@@ -77,6 +78,8 @@ public class FileUtilsTest {
 
         List<File> foundFiles2 = FileUtils.getFiles(directory, ".*\\.class$");
 
+        Collections.sort(foundFiles);
+        Collections.sort(foundFiles2);
         assertEquals(foundFiles, foundFiles2);
     }
 }

--- a/rt/javascript/javascript-tests/src/test/java/org/apache/cxf/javascript/fortest/AttributeTestBean.java
+++ b/rt/javascript/javascript-tests/src/test/java/org/apache/cxf/javascript/fortest/AttributeTestBean.java
@@ -28,7 +28,13 @@ import jakarta.xml.bind.annotation.XmlType;
  *
  */
 @XmlRootElement(namespace = "uri:org.apache.cxf.javascript.testns")
-@XmlType(namespace = "uri:org.apache.cxf.javascript.testns")
+@XmlType(namespace = "uri:org.apache.cxf.javascript.testns",
+        propOrder = {
+        "element1",
+        "attribute1",
+        "element2",
+        "attribute2"
+        })
 public class AttributeTestBean {
 
     //CHECKSTYLE:OFF

--- a/rt/javascript/javascript-tests/src/test/java/org/apache/cxf/javascript/fortest/TestBean1.java
+++ b/rt/javascript/javascript-tests/src/test/java/org/apache/cxf/javascript/fortest/TestBean1.java
@@ -29,7 +29,21 @@ import jakarta.xml.bind.annotation.XmlType;
  * Bean with a selection of elements suitable for testing the JavaScript client.
  */
 @XmlRootElement(namespace = "uri:org.apache.cxf.javascript.testns")
-@XmlType(namespace = "uri:org.apache.cxf.javascript.testns")
+@XmlType(namespace = "uri:org.apache.cxf.javascript.testns",
+        propOrder = {
+        "stringItem",
+        "intItem",
+        "longItem",
+        "base64Item",
+        "optionalIntItem",
+        "optionalStringItem",
+        "optionalIntArrayItem",
+        "doubleItem",
+        "beanTwoItem",
+        "beanTwoNotRequiredItem",
+        "enumeration",
+        "enum2"
+        })
 public class TestBean1 {
 
     public TestBean1() {


### PR DESCRIPTION
### Description
Fixed the flaky tests named `testDeserialization` inside `SerializationTest.java` and `AttributeTest.java` classes. 

https://github.com/apache/cxf/blob/3048785bf03baf76750f448777dfb003b5b1c98e/rt/javascript/javascript-tests/src/test/java/org/apache/cxf/javascript/types/SerializationTest.java#L91

https://github.com/apache/cxf/blob/3048785bf03baf76750f448777dfb003b5b1c98e/rt/javascript/javascript-tests/src/test/java/org/apache/cxf/javascript/types/AttributeTest.java#L73

#### Root Cause
The test `testDeserialization` has been reported as flaky when run with the [NonDex](https://github.com/TestingResearchIllinois/NonDex) tool. The tests failed because of the serialization of Testbean and AttributeTestBean classes, where the order of elements in the serialized XML changes between runs. The contents of the serialized strings do not remain constant and hence the tests are failing.  

#### Fix
To define a specific order for the XML elements when the classes TestBean1 and AttributeTestBean are serialized, we need to add the propOrder attribute to the @XmlType annotation. This attribute explicitly specifies the order in which fields should be serialized.

### How this has been tested?

**Java:** openjdk version "11.0.20.1"
**Maven:** Apache Maven 3.6.3

1) **Module build** - Successful
Command used - 
```
mvn install -pl core -am -DskipTests
```

2) **Regular test**  - Successful
Command used - 
```
mvn -pl rt/javascript/javascript-tests test -Dtest=org.apache.cxf.javascript.types.SerializationTest#testDeserialization
```

```
mvn -pl rt/javascript/javascript-tests test -Dtest=org.apache.cxf.javascript.types.AttributeTest#testDeserialization
```

3) **NonDex test**  - Failed
Command used - 
```
mvn -pl rt/javascript/javascript-tests edu.illinois:nondex-maven-plugin:2.1.7-SNAPSHOT:nondex -Dtest=org.apache.cxf.javascript.types.SerializationTest#testDeserialization
```

```

mvn -pl rt/javascript/javascript-tests edu.illinois:nondex-maven-plugin:2.1.7-SNAPSHOT:nondex -Dtest=org.apache.cxf.javascript.types.AttributeTest#testDeserialization -DnondexRuns=10
```

NonDex test passed after the fix.