### PR TITLE
fix flaky test

### DIFF
--- a/rt/transports/http-netty/netty-server/src/test/java/org/apache/cxf/transport/http/netty/server/integration/NettyServerTest.java
+++ b/rt/transports/http-netty/netty-server/src/test/java/org/apache/cxf/transport/http/netty/server/integration/NettyServerTest.java
@@ -90,7 +90,8 @@ public class NettyServerTest extends AbstractBusClientServerTestBase {
         ByteArrayOutputStream bos = new ByteArrayOutputStream();
         IOUtils.copyAndCloseInput(in, bos);
         String result = bos.toString();
-        assertTrue("Expect the SOAPService", result.indexOf("<service name=\"SOAPService\">") > 0);
+        assertTrue("Expect the SOAPService", result.indexOf("<service name=\"SOAPService\">") > 0
+                || result.indexOf("<wsdl:service name=\"SOAPService\">") > 0);
     }
 
 }


### PR DESCRIPTION
### Description
Fixed the flaky test `testGetWsdl` inside `NettyServerTest.java` class. 

https://github.com/apache/cxf/blob/3048785bf03baf76750f448777dfb003b5b1c98e/rt/transports/http-netty/netty-server/src/test/java/org/apache/cxf/transport/http/netty/server/integration/NettyServerTest.java#L86

#### Root Cause
The test `testGetWsdl` has been reported as flaky when run with the [NonDex](https://github.com/TestingResearchIllinois/NonDex) tool. The test failed because it is trying to find if a certain element(`<service name"SOAPService">`) is present inside the XML file which is returned by calling WSDL service. But there is slight change in the content of XML returned by the service. For example, in some cases the XML returned contained elements with `:wsdl` prefix. So instead of `<service name"SOAPService">` , the XML content contained `<wsdl:service name"SOAPService">`. As a result the test is failed.

#### Fix
After debugging the code, it is clear that XML content with `wsdl:` prefix, means that the elements are qualified by the namespace, and when you see the same tags without the prefix, the XML is still using the WSDL namespace, but it's defined as the default namespace, so the prefix is not necessary. So, the test is fixed by adding a condition to check if the element with `wsdl:` is present.


### How this has been tested?

**Java:** openjdk version "11.0.20.1"
**Maven:** Apache Maven 3.6.3

1) **Module build** - Successful
Command used - 
```
mvn install -pl core -am -DskipTests
```

2) **Regular test**  - Successful
Command used - 
```
mvn -pl core test -Dtest=org.apache.cxf.transport.http.netty.server.integration.NettyServerTest#testGetWsdl
```

3) **NonDex test**  - Failed
Command used - 
```
mvn -pl rt/transports/http-netty/netty-server edu.illinois:nondex-maven-plugin:2.1.7-SNAPSHOT:nondex -Dtest=org.apache.cxf.transport.http.netty.server.integration.NettyServerTest#testGetWsdl
```

NonDex test passed after the fix.


