### PR TITLE
[CXF-8959] Fixed order dependent flakiness in AttachmentUtilTest.java in core module

### DIFF
--- a/core/src/main/java/org/apache/cxf/io/CachedOutputStream.java
+++ b/core/src/main/java/org/apache/cxf/io/CachedOutputStream.java
@@ -576,6 +576,10 @@ public class CachedOutputStream extends OutputStream {
         this.cipherTransformation = cipherTransformation;
     }
 
+    public void resetDefaultThreshold() {
+        thresholdSysPropSet = false;
+    }
+
     public static void setDefaultMaxSize(long l) {
         if (l == -1) {
             String s = SystemPropertyAction.getProperty(CachedConstants.MAX_SIZE_SYS_PROP, "-1");

--- a/core/src/main/java/org/apache/cxf/io/CachedOutputStream.java
+++ b/core/src/main/java/org/apache/cxf/io/CachedOutputStream.java
@@ -576,10 +576,6 @@ public class CachedOutputStream extends OutputStream {
         this.cipherTransformation = cipherTransformation;
     }
 
-    public void resetDefaultThreshold() {
-        thresholdSysPropSet = false;
-    }
-
     public static void setDefaultMaxSize(long l) {
         if (l == -1) {
             String s = SystemPropertyAction.getProperty(CachedConstants.MAX_SIZE_SYS_PROP, "-1");
@@ -593,9 +589,12 @@ public class CachedOutputStream extends OutputStream {
             i = SystemPropertyAction.getInteger(CachedConstants.THRESHOLD_SYS_PROP, -1);
             if (i <= 0) {
                 i = 128 * 1024;
+                thresholdSysPropSet = false; /* we not using system property value */
             } else {
                 thresholdSysPropSet = true;
             }
+        } else {
+            thresholdSysPropSet = false; /* we not consulting system properties at all */
         }
         defaultThreshold = i;
     }

--- a/core/src/test/java/org/apache/cxf/attachment/AttachmentUtilTest.java
+++ b/core/src/test/java/org/apache/cxf/attachment/AttachmentUtilTest.java
@@ -269,6 +269,7 @@ public class AttachmentUtilTest {
     @Test
     public void bigIntAsAttachmentMaxSize() throws IOException {
         CachedOutputStream cos = spy(CachedOutputStream.class);
+        cos.resetDefaultThreshold();
         BigInteger bigInteger = new BigInteger(String.valueOf(Long.MAX_VALUE));
         cos = testSetStreamedAttachmentProperties(AttachmentDeserializer.ATTACHMENT_MAX_SIZE, bigInteger, cos);
         verify(cos).setMaxSize(bigInteger.longValue());
@@ -277,6 +278,7 @@ public class AttachmentUtilTest {
         // Overflow long value
         bigInteger = bigInteger.add(BigInteger.ONE);
         cos = spy(CachedOutputStream.class);
+        cos.resetDefaultThreshold();
         cos = testSetStreamedAttachmentProperties(AttachmentDeserializer.ATTACHMENT_MAX_SIZE, bigInteger, cos);
         verify(cos).setThreshold(102400L);
     }
@@ -284,6 +286,7 @@ public class AttachmentUtilTest {
     @Test
     public void longAsAttachmentMaxSize() throws IOException {
         CachedOutputStream cos = spy(CachedOutputStream.class);
+        cos.resetDefaultThreshold();
         cos = testSetStreamedAttachmentProperties(AttachmentDeserializer.ATTACHMENT_MAX_SIZE, Long.MAX_VALUE, cos);
         verify(cos).setMaxSize(Long.MAX_VALUE);
         verify(cos).setThreshold(102400L);
@@ -292,6 +295,7 @@ public class AttachmentUtilTest {
     @Test
     public void integerAsAttachmentMaxSize() throws IOException {
         CachedOutputStream cos = spy(CachedOutputStream.class);
+        cos.resetDefaultThreshold();
         cos = testSetStreamedAttachmentProperties(AttachmentDeserializer.ATTACHMENT_MAX_SIZE, Integer.MAX_VALUE, cos);
         verify(cos).setMaxSize(Integer.MAX_VALUE);
         verify(cos).setThreshold(102400L);
@@ -300,6 +304,7 @@ public class AttachmentUtilTest {
     @Test
     public void shortAsAttachmentMaxSize() throws IOException {
         CachedOutputStream cos = spy(CachedOutputStream.class);
+        cos.resetDefaultThreshold();
         cos = testSetStreamedAttachmentProperties(AttachmentDeserializer.ATTACHMENT_MAX_SIZE, Short.MAX_VALUE, cos);
         verify(cos).setMaxSize(Short.MAX_VALUE);
         verify(cos).setThreshold(102400L);
@@ -308,6 +313,7 @@ public class AttachmentUtilTest {
     @Test
     public void byteAsAttachmentMaxSize() throws IOException {
         CachedOutputStream cos = spy(CachedOutputStream.class);
+        cos.resetDefaultThreshold();
         cos = testSetStreamedAttachmentProperties(AttachmentDeserializer.ATTACHMENT_MAX_SIZE, Byte.MAX_VALUE, cos);
         verify(cos).setMaxSize(Byte.MAX_VALUE);
         verify(cos).setThreshold(102400L);
@@ -316,6 +322,7 @@ public class AttachmentUtilTest {
     @Test
     public void numberStringAsAttachmentMaxSize() throws IOException {
         CachedOutputStream cos = spy(CachedOutputStream.class);
+        cos.resetDefaultThreshold();
         cos = testSetStreamedAttachmentProperties(AttachmentDeserializer.ATTACHMENT_MAX_SIZE, "12345", cos);
         verify(cos).setMaxSize(12345);
         verify(cos).setThreshold(102400L);
@@ -341,6 +348,7 @@ public class AttachmentUtilTest {
     public void fileAsAttachmentDirectory() throws IOException {
         File attachmentDirectory = new File("/dev/null");
         CachedOutputStream cos = spy(CachedOutputStream.class);
+        cos.resetDefaultThreshold();
         cos = testSetStreamedAttachmentProperties(AttachmentDeserializer.ATTACHMENT_DIRECTORY, attachmentDirectory,
                 cos);
         verify(cos).setOutputDir(attachmentDirectory);
@@ -351,6 +359,7 @@ public class AttachmentUtilTest {
     public void stringAsAttachmentDirectory() throws IOException {
         String attachmentDirectory = "/dev/null";
         CachedOutputStream cos = spy(CachedOutputStream.class);
+        cos.resetDefaultThreshold();
         cos = testSetStreamedAttachmentProperties(AttachmentDeserializer.ATTACHMENT_DIRECTORY, attachmentDirectory,
                 cos);
         verify(cos).setOutputDir(new File(attachmentDirectory));

--- a/core/src/test/java/org/apache/cxf/attachment/AttachmentUtilTest.java
+++ b/core/src/test/java/org/apache/cxf/attachment/AttachmentUtilTest.java
@@ -269,7 +269,6 @@ public class AttachmentUtilTest {
     @Test
     public void bigIntAsAttachmentMaxSize() throws IOException {
         CachedOutputStream cos = spy(CachedOutputStream.class);
-        cos.resetDefaultThreshold();
         BigInteger bigInteger = new BigInteger(String.valueOf(Long.MAX_VALUE));
         cos = testSetStreamedAttachmentProperties(AttachmentDeserializer.ATTACHMENT_MAX_SIZE, bigInteger, cos);
         verify(cos).setMaxSize(bigInteger.longValue());
@@ -278,7 +277,6 @@ public class AttachmentUtilTest {
         // Overflow long value
         bigInteger = bigInteger.add(BigInteger.ONE);
         cos = spy(CachedOutputStream.class);
-        cos.resetDefaultThreshold();
         cos = testSetStreamedAttachmentProperties(AttachmentDeserializer.ATTACHMENT_MAX_SIZE, bigInteger, cos);
         verify(cos).setThreshold(102400L);
     }
@@ -286,7 +284,6 @@ public class AttachmentUtilTest {
     @Test
     public void longAsAttachmentMaxSize() throws IOException {
         CachedOutputStream cos = spy(CachedOutputStream.class);
-        cos.resetDefaultThreshold();
         cos = testSetStreamedAttachmentProperties(AttachmentDeserializer.ATTACHMENT_MAX_SIZE, Long.MAX_VALUE, cos);
         verify(cos).setMaxSize(Long.MAX_VALUE);
         verify(cos).setThreshold(102400L);
@@ -295,7 +292,6 @@ public class AttachmentUtilTest {
     @Test
     public void integerAsAttachmentMaxSize() throws IOException {
         CachedOutputStream cos = spy(CachedOutputStream.class);
-        cos.resetDefaultThreshold();
         cos = testSetStreamedAttachmentProperties(AttachmentDeserializer.ATTACHMENT_MAX_SIZE, Integer.MAX_VALUE, cos);
         verify(cos).setMaxSize(Integer.MAX_VALUE);
         verify(cos).setThreshold(102400L);
@@ -304,7 +300,6 @@ public class AttachmentUtilTest {
     @Test
     public void shortAsAttachmentMaxSize() throws IOException {
         CachedOutputStream cos = spy(CachedOutputStream.class);
-        cos.resetDefaultThreshold();
         cos = testSetStreamedAttachmentProperties(AttachmentDeserializer.ATTACHMENT_MAX_SIZE, Short.MAX_VALUE, cos);
         verify(cos).setMaxSize(Short.MAX_VALUE);
         verify(cos).setThreshold(102400L);
@@ -313,7 +308,6 @@ public class AttachmentUtilTest {
     @Test
     public void byteAsAttachmentMaxSize() throws IOException {
         CachedOutputStream cos = spy(CachedOutputStream.class);
-        cos.resetDefaultThreshold();
         cos = testSetStreamedAttachmentProperties(AttachmentDeserializer.ATTACHMENT_MAX_SIZE, Byte.MAX_VALUE, cos);
         verify(cos).setMaxSize(Byte.MAX_VALUE);
         verify(cos).setThreshold(102400L);
@@ -322,7 +316,6 @@ public class AttachmentUtilTest {
     @Test
     public void numberStringAsAttachmentMaxSize() throws IOException {
         CachedOutputStream cos = spy(CachedOutputStream.class);
-        cos.resetDefaultThreshold();
         cos = testSetStreamedAttachmentProperties(AttachmentDeserializer.ATTACHMENT_MAX_SIZE, "12345", cos);
         verify(cos).setMaxSize(12345);
         verify(cos).setThreshold(102400L);
@@ -348,7 +341,6 @@ public class AttachmentUtilTest {
     public void fileAsAttachmentDirectory() throws IOException {
         File attachmentDirectory = new File("/dev/null");
         CachedOutputStream cos = spy(CachedOutputStream.class);
-        cos.resetDefaultThreshold();
         cos = testSetStreamedAttachmentProperties(AttachmentDeserializer.ATTACHMENT_DIRECTORY, attachmentDirectory,
                 cos);
         verify(cos).setOutputDir(attachmentDirectory);
@@ -359,7 +351,6 @@ public class AttachmentUtilTest {
     public void stringAsAttachmentDirectory() throws IOException {
         String attachmentDirectory = "/dev/null";
         CachedOutputStream cos = spy(CachedOutputStream.class);
-        cos.resetDefaultThreshold();
         cos = testSetStreamedAttachmentProperties(AttachmentDeserializer.ATTACHMENT_DIRECTORY, attachmentDirectory,
                 cos);
         verify(cos).setOutputDir(new File(attachmentDirectory));

--- a/core/src/test/java/org/apache/cxf/io/CachedOutputStreamTest.java
+++ b/core/src/test/java/org/apache/cxf/io/CachedOutputStreamTest.java
@@ -125,6 +125,8 @@ public class CachedOutputStreamTest extends CachedStreamTestBase {
             if (old != null) {
                 System.setProperty(CachedConstants.THRESHOLD_SYS_PROP, old);
             }
+            // Always restore the default properties
+            reloadDefaultProperties();
         }
     }
 }

--- a/core/src/test/java/org/apache/cxf/io/CachedStreamTestBase.java
+++ b/core/src/test/java/org/apache/cxf/io/CachedStreamTestBase.java
@@ -219,6 +219,8 @@ public abstract class CachedStreamTestBase {
             if (old != null) {
                 System.setProperty(CachedConstants.THRESHOLD_SYS_PROP, old);
             }
+            // Always restore the default properties
+            reloadDefaultProperties();
         }
     }
 


### PR DESCRIPTION
**Description**

Fixed the order dependent flaky test in AttachmentUtilTest.java in core module.

**Root Cause**

The polluter that caused the flakiness in `AttachmentUtilTest.java` was the test class `CachedOutputStreamTest.java`. In `AttachmentUtilTest`, there were multiple tests that used Mockito.spy() to verify the behavior of `CachedOutputStream` object. In those tests, the spy `CachedOutputStream` object "cos" was generated (`CachedOutputStream cos = spy(CachedOutputStream.class`). Then after this, there was a line `verify(cos).setThreshold(102400L)`. Therefore, after the cos being initialized, we need to make sure the setThreshold has been called once. However, it doesn't execute as expected, and the root cause is that 
1. the threshold is not provided when calling `testSetStreamedAttachmentProperties()` method -> so the setThreshold() won't be called in line 198 in AttachmentUtil.java and 
2. the `thresholdSysPropSet` (the boolean that indicated whether the default threshold has been set or not) has been set to true when we run the `CachedOutputStreamTest.java`. Inside the `CachedOutputStreamTest.java`, the unit test `testUseSysPropsWithAttachmentDeserializer()` called the `AttachmentUtil.setStreamedAttachmentProperties(message, cache`), so the `thresholdSysPropSet`has been set to true then. -> so the etThreshold(AttachmentDeserializer.THRESHOLD) won't be called in  line 215 in  AttachmentUtil.java.

Since none of them being called, the verify(cos).setThreshold(102400L) will complained that setThreshold() was not invoked.

 Therefore, if we run `CachedOutputStreamTest.java` before running the `AttachmentUtilTest.java`, the `verify(cos).setThreshold(102400L)` statement will lead to the error message 
```
Wanted but not invoked:
cachedOutputStream.setThreshold(102400L);
-> at org.apache.cxf.attachment.AttachmentUtilTest.bigIntAsAttachmentMaxSize(AttachmentUtilTest.java:279)
```

**Fix log**

After debugging the code, it is clear that the `thresholdSysPropSet` should be `False` every time the CachedOutputStream object was initialized. Therefore, I add the method `resetDefaultThreshold()` in the `CachedOutputStream.java`. In the test class `AttachmentUtilTest`, I called this reset method after initializing the new CachedOutputStream(). After this fix, the failure has been solved. 

**How this has been tested**

Java: openjdk version "17.0.8.1"
Maven: Apache Maven 3.9.5

**How to reproduce the failure**
`mvn install -pl core -am -DskipTests`
(must setup iDFlakies on a Maven project - https://github.com/UT-SE-Research/iDFlakies)
`mvn -pl core idflakies:detect -Ddetector.detector_type=random-class-method -Ddt.randomize.rounds=10 -Ddt.detector.original_order.all_must_pass=false`

