### PR TITLE
fix flaky tests

### DIFF
--- a/rt/frontend/jaxrs/src/test/java/org/apache/cxf/jaxrs/utils/JAXBUtilsTest.java
+++ b/rt/frontend/jaxrs/src/test/java/org/apache/cxf/jaxrs/utils/JAXBUtilsTest.java
@@ -45,8 +45,8 @@ public class JAXBUtilsTest {
     }
 
     private void correctValueType(Class<?> clazz) {
-        Field[] fields = clazz.getDeclaredFields();
-        Annotation[] paramAnns = fields[0].getDeclaredAnnotations();
+        Field field = clazz.getDeclaredFields()[0];
+        Annotation[] paramAnns = field.getDeclaredAnnotations();
         Class<?> valueType = JAXBUtils.getValueTypeFromAdapter(LocalDate.class, LocalDate.class, paramAnns);
         Assert.assertEquals(String.class, valueType);
     }

--- a/rt/frontend/jaxrs/src/test/java/org/apache/cxf/jaxrs/utils/JAXBUtilsTest.java
+++ b/rt/frontend/jaxrs/src/test/java/org/apache/cxf/jaxrs/utils/JAXBUtilsTest.java
@@ -21,8 +21,11 @@ package org.apache.cxf.jaxrs.utils;
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
+import java.util.Arrays;
+import java.util.stream.Collectors;
 
 import jakarta.validation.constraints.NotNull;
 import jakarta.ws.rs.QueryParam;
@@ -45,7 +48,10 @@ public class JAXBUtilsTest {
     }
 
     private void correctValueType(Class<?> clazz) {
-        Field field = clazz.getDeclaredFields()[0];
+        Field[] fields = clazz.getDeclaredFields();
+        Field field = Arrays.stream(fields)
+                .filter(f -> !f.isSynthetic() && !Modifier.isFinal(f.getModifiers()))
+                .collect(Collectors.toList()).get(0);
         Annotation[] paramAnns = field.getDeclaredAnnotations();
         Class<?> valueType = JAXBUtils.getValueTypeFromAdapter(LocalDate.class, LocalDate.class, paramAnns);
         Assert.assertEquals(String.class, valueType);

--- a/rt/frontend/jaxrs/src/test/java/org/apache/cxf/jaxrs/utils/JAXBUtilsTest.java
+++ b/rt/frontend/jaxrs/src/test/java/org/apache/cxf/jaxrs/utils/JAXBUtilsTest.java
@@ -21,11 +21,8 @@ package org.apache.cxf.jaxrs.utils;
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Field;
-import java.lang.reflect.Modifier;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
-import java.util.Arrays;
-import java.util.stream.Collectors;
 
 import jakarta.validation.constraints.NotNull;
 import jakarta.ws.rs.QueryParam;
@@ -49,15 +46,12 @@ public class JAXBUtilsTest {
 
     private void correctValueType(Class<?> clazz) {
         Field[] fields = clazz.getDeclaredFields();
-        Field field = Arrays.stream(fields)
-                .filter(f -> !f.isSynthetic() && !Modifier.isFinal(f.getModifiers()))
-                .collect(Collectors.toList()).get(0);
-        Annotation[] paramAnns = field.getDeclaredAnnotations();
+        Annotation[] paramAnns = fields[0].getDeclaredAnnotations();
         Class<?> valueType = JAXBUtils.getValueTypeFromAdapter(LocalDate.class, LocalDate.class, paramAnns);
         Assert.assertEquals(String.class, valueType);
     }
 
-    public class CustomerDetailsWithExtendedAdapter {
+    public static class CustomerDetailsWithExtendedAdapter {
         @NotNull
         @QueryParam("birthDate")
         @XmlJavaTypeAdapter(LocalDateXmlAdapter.class)
@@ -72,7 +66,7 @@ public class JAXBUtilsTest {
         }
     }
 
-    public class CustomerDetailsWithSimpleAdapter {
+    public static class CustomerDetailsWithSimpleAdapter {
         @NotNull
         @QueryParam("birthDate")
         @XmlJavaTypeAdapter(LocalDateAdapter.class)


### PR DESCRIPTION
### Description
Fixed the flaky test `extendedXmlJavaTypeAdapter` and `simpleXmlJavaTypeAdapter`  inside `JAXBUtilsTest.java` class. 

https://github.com/apache/cxf/blob/b608027f5f352affd3d2228ae4733b47049f2590/rt/frontend/jaxrs/src/test/java/org/apache/cxf/jaxrs/utils/JAXBUtilsTest.java#L38

https://github.com/apache/cxf/blob/b608027f5f352affd3d2228ae4733b47049f2590/rt/frontend/jaxrs/src/test/java/org/apache/cxf/jaxrs/utils/JAXBUtilsTest.java#L43

#### Root Cause
The tests `extendedXmlJavaTypeAdapter` and `simpleXmlJavaTypeAdapter` have been reported flaky when run with the [NonDex](https://github.com/TestingResearchIllinois/NonDex) tool. The tests failed due to the non-deterministic ordering of fields returned by getDeclaredFields(). The getDeclaredFields() method returns an array of Field objects representing all the fields declared by a class or interface. In the above tests, it returned two values: one a private field named birthDate of type `java.time.LocalDate` and the other `org.apache.cxf.jaxrs.utils.JAXBUtilsTest$CustomerDetailsWithExtendedAdapter.this$0`. The second value represents a synthetic field generated by the Java compiler for the inner class CustomerDetailsWithExtendedAdapter. When an inner class accesses members of its enclosing class, Java creates a synthetic field (in this case, this$0) as a reference to the outer class (JAXBUtilsTest) which is not useful for the test.

#### Fix
To ensure the tests are not flaky due to the non-deterministic ordering of fields returned by getDeclaredFields(), we introduced a condition to filter out the fields(synthetic and final fields) that are not useful for the testing.


### How this has been tested?

**Java:** openjdk version "17.0.8"
**Maven:** Apache Maven 3.6.3

1) **Module build** - Successful
Command used - 
```
mvn install -pl core -am -DskipTests
```

2) **Regular test**  - Successful
Commands used - 

```
mvn -pl rt/frontend/jaxrs/ -Dtest=org.apache.cxf.jaxrs.utils.JAXBUtilsTest#extendedXmlJavaTypeAdapter
```

```
mvn -pl rt/frontend/jaxrs/ -Dtest=org.apache.cxf.jaxrs.utils.JAXBUtilsTest#simpleXmlJavaTypeAdapter
```

3) **NonDex test**  - Failed
Command used - 
```
mvn -pl rt/frontend/jaxrs/ edu.illinois:nondex-maven-plugin:2.1.7-SNAPSHOT:nondex -Dtest=org.apache.cxf.jaxrs.utils.JAXBUtilsTest#extendedXmlJavaTypeAdapter
```

```
mvn -pl rt/frontend/jaxrs/ edu.illinois:nondex-maven-plugin:2.1.7-SNAPSHOT:nondex -Dtest=org.apache.cxf.jaxrs.utils.JAXBUtilsTest#simpleXmlJavaTypeAdapter
```

NonDex test passed after the fix.


