### PR TITLE
[CXF-8965] Apache CXF Netty Integration, URI not encoded

### DIFF
--- a/rt/transports/http-netty/netty-client/src/main/java/org/apache/cxf/transport/http/netty/client/NettyHttpClientRequest.java
+++ b/rt/transports/http-netty/netty-client/src/main/java/org/apache/cxf/transport/http/netty/client/NettyHttpClientRequest.java
@@ -6,7 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License. You may obtain a copy of the License at
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY

--- a/rt/transports/http-netty/netty-client/src/main/java/org/apache/cxf/transport/http/netty/client/NettyHttpClientRequest.java
+++ b/rt/transports/http-netty/netty-client/src/main/java/org/apache/cxf/transport/http/netty/client/NettyHttpClientRequest.java
@@ -6,9 +6,7 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License. You may obtain a copy of the License at
- *
  * http://www.apache.org/licenses/LICENSE-2.0
- *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -55,7 +53,7 @@ public class NettyHttpClientRequest {
         this.request  =
             new DefaultFullHttpRequest(HttpVersion.HTTP_1_1,
                                        HttpMethod.valueOf(method),
-                                       uri.getPath(), content);
+                                       uri.getRawPath(), content);
         // setup the default headers
         request.headers().set("Connection", "keep-alive");
         request.headers().set("Host", uri.getHost() + ":"

--- a/rt/transports/http-netty/netty-client/src/test/java/org/apache/cxf/transport/http/netty/client/NettyHttpClientRequestTest.java
+++ b/rt/transports/http-netty/netty-client/src/test/java/org/apache/cxf/transport/http/netty/client/NettyHttpClientRequestTest.java
@@ -6,7 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License. You may obtain a copy of the License at
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY

--- a/rt/transports/http-netty/netty-client/src/test/java/org/apache/cxf/transport/http/netty/client/NettyHttpClientRequestTest.java
+++ b/rt/transports/http-netty/netty-client/src/test/java/org/apache/cxf/transport/http/netty/client/NettyHttpClientRequestTest.java
@@ -1,0 +1,42 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.cxf.transport.http.netty.client;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+
+import io.netty.buffer.ByteBufAllocator;
+import io.netty.buffer.EmptyByteBuf;
+import io.netty.handler.codec.http.HttpRequest;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class NettyHttpClientRequestTest {
+
+    @Test
+    public void testCreateRequest() throws URISyntaxException {
+
+        URI uri = new URI("http://localhost:8080/my%20path");
+        NettyHttpClientRequest nettyHttpClientRequest = new NettyHttpClientRequest(uri, "GET", false);
+        nettyHttpClientRequest.createRequest(new EmptyByteBuf(ByteBufAllocator.DEFAULT));
+
+        HttpRequest httpRequest = nettyHttpClientRequest.getRequest();
+        Assert.assertEquals("/my%20path", httpRequest.uri());
+        Assert.assertEquals("/my path", uri.getPath());
+    }
+}

--- a/systests/transport-hc5/src/test/java/org/apache/cxf/systest/hc5/http2/AbstractApacheClientServerHttp2Test.java
+++ b/systests/transport-hc5/src/test/java/org/apache/cxf/systest/hc5/http2/AbstractApacheClientServerHttp2Test.java
@@ -79,6 +79,21 @@ abstract class AbstractApacheClientServerHttp2Test extends AbstractBusClientServ
     }
 
     @Test
+    public void testBookEncodedWithHttp2() throws Exception {
+        final WebClient client = createWebClient("/web/bookstore/book%20names", true);
+        assertThat(WebClient.getConfig(client).getHttpConduit(), instanceOf(AsyncHTTPConduit.class));
+        
+        final Response response = client
+            .accept("text/plain")
+            .get();
+        
+        assertThat(response.getStatus(), equalTo(200));
+        assertEquals("CXF in Action", response.readEntity(String.class));
+
+        client.close();
+    }
+
+    @Test
     public void testGetBookStreamHttp2() throws Exception {
         final WebClient client = createWebClient("/web/bookstore/bookstream", true);
         assertThat(WebClient.getConfig(client).getHttpConduit(), instanceOf(AsyncHTTPConduit.class));
@@ -97,6 +112,18 @@ abstract class AbstractApacheClientServerHttp2Test extends AbstractBusClientServ
     @Test
     public void testBookWithHttp() throws Exception {
         final WebClient client = createWebClient("/web/bookstore/booknames", false);
+        
+        try (Response resp = client.get()) {
+            assertThat(resp.getStatus(), equalTo(200));
+            assertEquals("CXF in Action", resp.readEntity(String.class));
+        }
+        
+        client.close();
+    }
+
+    @Test
+    public void testBookEncodedWithHttp() throws Exception {
+        final WebClient client = createWebClient("/web/bookstore/book%20names", false);
         
         try (Response resp = client.get()) {
             assertThat(resp.getStatus(), equalTo(200));

--- a/systests/transport-hc5/src/test/java/org/apache/cxf/systest/hc5/http2/BookStore.java
+++ b/systests/transport-hc5/src/test/java/org/apache/cxf/systest/hc5/http2/BookStore.java
@@ -35,7 +35,14 @@ public class BookStore {
     @GET
     @Path("/booknames")
     @Produces("text/plain")
-    public byte[] getBookName() {
+    public byte[] getBookNames() {
+        return "CXF in Action".getBytes();
+    }
+
+    @GET
+    @Path("/book names")
+    @Produces("text/plain")
+    public byte[] getBookNamesEncoded() {
         return "CXF in Action".getBytes();
     }
 

--- a/systests/transport-netty/src/test/java/org/apache/cxf/systest/http2/netty/AbstractNettyClientServerHttp2Test.java
+++ b/systests/transport-netty/src/test/java/org/apache/cxf/systest/http2/netty/AbstractNettyClientServerHttp2Test.java
@@ -78,6 +78,21 @@ abstract class AbstractNettyClientServerHttp2Test extends AbstractBusClientServe
     }
 
     @Test
+    public void testBookEncodedWithHttp2() throws Exception {
+        final WebClient client = createWebClient("/web/bookstore/book%20names", true);
+        assertThat(WebClient.getConfig(client).getHttpConduit(), instanceOf(NettyHttpConduit.class));
+        
+        final Response response = client
+            .accept("text/plain")
+            .get();
+        
+        assertThat(response.getStatus(), equalTo(200));
+        assertEquals("CXF in Action", response.readEntity(String.class));
+
+        client.close();
+    }
+
+    @Test
     public void testGetBookStreamHttp2() throws Exception {
         final WebClient client = createWebClient("/web/bookstore/bookstream", true);
         assertThat(WebClient.getConfig(client).getHttpConduit(), instanceOf(NettyHttpConduit.class));
@@ -96,6 +111,18 @@ abstract class AbstractNettyClientServerHttp2Test extends AbstractBusClientServe
     @Test
     public void testBookWithHttp() throws Exception {
         final WebClient client = createWebClient("/web/bookstore/booknames", false);
+        
+        try (Response resp = client.get()) {
+            assertThat(resp.getStatus(), equalTo(200));
+            assertEquals("CXF in Action", resp.readEntity(String.class));
+        }
+        
+        client.close();
+    }
+
+    @Test
+    public void testBookEncodedWithHttp() throws Exception {
+        final WebClient client = createWebClient("/web/bookstore/book%20names", false);
         
         try (Response resp = client.get()) {
             assertThat(resp.getStatus(), equalTo(200));

--- a/systests/transport-netty/src/test/java/org/apache/cxf/systest/http2/netty/BookStore.java
+++ b/systests/transport-netty/src/test/java/org/apache/cxf/systest/http2/netty/BookStore.java
@@ -39,7 +39,14 @@ public class BookStore {
     @GET
     @Path("/booknames")
     @Produces("text/plain")
-    public byte[] getBookName() {
+    public byte[] getBookNames() {
+        return "CXF in Action".getBytes();
+    }
+
+    @GET
+    @Path("/book names")
+    @Produces("text/plain")
+    public byte[] getBookNamesEncoded() {
         return "CXF in Action".getBytes();
     }
 


### PR DESCRIPTION
Used getRawPath of URI instead of getPath to ensure that URL encoding is happening for the path as well