### PR TITLE
CXF-8966 : Validation of nillable tags fails 

### DIFF
--- a/core/src/test/java/org/apache/cxf/databinding/source/XMLStreamDataReaderTest.java
+++ b/core/src/test/java/org/apache/cxf/databinding/source/XMLStreamDataReaderTest.java
@@ -22,19 +22,45 @@ package org.apache.cxf.databinding.source;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.URL;
 
+import javax.xml.XMLConstants;
 import javax.xml.namespace.QName;
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.stream.XMLInputFactory;
 import javax.xml.stream.XMLStreamReader;
+import javax.xml.transform.dom.DOMSource;
+import javax.xml.validation.Schema;
+import javax.xml.validation.SchemaFactory;
 
+import org.w3c.dom.Document;
+
+import com.ctc.wstx.msv.W3CSchemaFactory;
+
+import org.apache.cxf.endpoint.Endpoint;
 import org.apache.cxf.interceptor.Fault;
+import org.apache.cxf.message.Exchange;
+import org.apache.cxf.message.ExchangeImpl;
 import org.apache.cxf.message.Message;
 import org.apache.cxf.message.MessageImpl;
+import org.apache.cxf.service.Service;
+import org.apache.cxf.service.ServiceImpl;
+import org.apache.cxf.service.model.MessageInfo;
+import org.apache.cxf.service.model.MessagePartInfo;
+import org.apache.cxf.service.model.ServiceInfo;
 import org.apache.cxf.staxutils.StaxUtils;
+import org.codehaus.stax2.XMLStreamReader2;
+import org.codehaus.stax2.validation.XMLValidationSchema;
 
 import org.junit.Test;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 /**
  *
@@ -90,6 +116,78 @@ public class XMLStreamDataReaderTest {
         }
 
         ((XMLStreamReader)obj).close();
+    }
+
+    @Test
+    public void testValid() throws Exception {
+        testValidate("resources/schema.xsd", "resources/test-valid.xml", false);
+    }
+
+    @Test
+    public void testInValid() throws Exception {
+        testValidate("resources/schema.xsd", "resources/test-invalid.xml", true);
+    }
+
+
+    private void testValidate(String schemaPath, String xmlPath, boolean exceptionExpected) throws Exception {
+
+        //create schema
+        DocumentBuilderFactory documentBuilderFactory = DocumentBuilderFactory.newInstance();
+        documentBuilderFactory.setNamespaceAware(true);
+        DocumentBuilder documentBuilder = documentBuilderFactory.newDocumentBuilder();
+        URL schemaURI = getClass().getResource(schemaPath);
+        Document wsdl = documentBuilder.parse(schemaURI.openStream());
+        String wsdlSystemId = schemaURI.toExternalForm();
+        DOMSource source = new DOMSource(wsdl);
+        source.setSystemId(wsdlSystemId);
+        source.setSystemId(wsdlSystemId);
+
+        XMLValidationSchema schemaw3c =
+                W3CSchemaFactory.newInstance(XMLValidationSchema.SCHEMA_ID_W3C_SCHEMA).createSchema(schemaURI);
+        SchemaFactory schemaFactory = SchemaFactory.newInstance(XMLConstants.W3C_XML_SCHEMA_NS_URI);
+        Schema schema = schemaFactory.newSchema(schemaURI);
+
+        XMLStreamDataReader reader = new XMLStreamDataReader();
+        reader.setSchema(schema);
+
+
+        InputStream testIS = getClass().getResourceAsStream(xmlPath);
+        Message msg = new MessageImpl();
+        Exchange exchange = new ExchangeImpl();
+
+        ServiceInfo serviceInfo =  new ServiceInfo();
+
+        Endpoint endpoint = mock(Endpoint.class);
+        when(endpoint.get(XMLValidationSchema.class.getName())).thenReturn(schemaw3c);
+
+        Service svc = new ServiceImpl(serviceInfo);
+
+        exchange.put(Service.class, svc);
+        exchange.put(Endpoint.class, endpoint);
+
+        msg.setExchange(exchange);
+        msg.setContent(InputStream.class, testIS);
+        reader.setProperty(Message.class.getName(), msg);
+
+        XMLInputFactory xmlFactory = XMLInputFactory.newInstance();
+        XMLStreamReader2 xmlStreamReader = (XMLStreamReader2) xmlFactory.createXMLStreamReader(testIS, "utf-8");
+
+        MessageInfo messageInfo = new MessageInfo(null,
+                MessageInfo.Type.INPUT,
+                new QName("http://www.test.org/services",
+                        "NullTestOperationRequest"));
+        MessagePartInfo messagePartInfo  = new MessagePartInfo(new QName(
+                "http://www.test.org/services", "NullTestOperationRequest"), messageInfo);
+        messagePartInfo.setElement(true);
+        boolean exceptionCaught = false;
+        try {
+            reader.read(messagePartInfo, xmlStreamReader);
+        } catch (Fault fault) {
+            exceptionCaught = true;
+        }  catch (Exception exc) {
+            fail(exc.getMessage());
+        }
+        assertEquals(exceptionExpected, exceptionCaught);
     }
 
     private static class TestInputStream extends ByteArrayInputStream {

--- a/core/src/test/java/org/apache/cxf/databinding/source/resources/schema.xsd
+++ b/core/src/test/java/org/apache/cxf/databinding/source/resources/schema.xsd
@@ -1,0 +1,11 @@
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" targetNamespace="http://www.test.org/service/">
+    <xsd:element name="NullTestOperationRequest" nillable="true">
+        <xsd:complexType>
+            <xsd:sequence>
+                <xsd:element nillable="true" name="inInt" type="xsd:int" maxOccurs="1" minOccurs="0" ></xsd:element>
+                <xsd:element nillable="true" name="inInteger" type="xsd:integer" maxOccurs="1" minOccurs="0" ></xsd:element>
+                <xsd:element nillable="true" name="inString" type="xsd:string" maxOccurs="1" minOccurs="0" ></xsd:element>
+            </xsd:sequence>
+        </xsd:complexType>
+    </xsd:element>
+</xsd:schema>

--- a/core/src/test/java/org/apache/cxf/databinding/source/resources/test-invalid.xml
+++ b/core/src/test/java/org/apache/cxf/databinding/source/resources/test-invalid.xml
@@ -1,0 +1,5 @@
+<ser:NullTestOperationRequest xmlns:ser="http://www.test.org/service/">
+
+    <inInt xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="false"/>
+
+</ser:NullTestOperationRequest>

--- a/core/src/test/java/org/apache/cxf/databinding/source/resources/test-valid.xml
+++ b/core/src/test/java/org/apache/cxf/databinding/source/resources/test-valid.xml
@@ -1,0 +1,7 @@
+<ser:NullTestOperationRequest xmlns:ser="http://www.test.org/service/">
+
+    <inInt xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+    <inInteger xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+    <inString xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+
+</ser:NullTestOperationRequest>


### PR DESCRIPTION
Change xml validation strategy to use the Woodstox validation when reading instead of having a reader and a writer to a nulloutput because this method is not able to handle the xsi:nil=true attributes.

**Previous  Algorithm :**

- Transform the input to a DOMSource Object
- create a XMLReader from this new object and a XMLWriter to a nulloutput
- setup the wookdstock validation on the writer if possible
- Create a filtered Reader to remove external references
- Copy the filterReader to the Null Writer
- if setup fails, use XOP validation

**Suggested algorithm :**

- create a filtered reader from the input to remove external references
- setup the wookdstock validation on the reader if possible
- call read
- if setup fails, use XOP validation