### PR TITLE
only load the lifecycle, bus and event once to make test faster

### DIFF
--- a/systests/cdi/cdi-owb/cdi-producers-owb/src/test/java/org/apache/cxf/systest/jaxrs/cdi/unwrapper/ClassUnwrapperTest.java
+++ b/systests/cdi/cdi-owb/cdi-producers-owb/src/test/java/org/apache/cxf/systest/jaxrs/cdi/unwrapper/ClassUnwrapperTest.java
@@ -31,8 +31,8 @@ import org.apache.cxf.systests.cdi.base.BookStoreRequestFilter;
 import org.apache.webbeans.config.WebBeansContext;
 import org.apache.webbeans.spi.ContainerLifecycle;
 
-import org.junit.After;
-import org.junit.Before;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 import static org.hamcrest.CoreMatchers.equalTo;
@@ -43,12 +43,12 @@ import static org.mockito.Mockito.mock;
 
 
 public class ClassUnwrapperTest {
-    private Bus bus;
-    private ContainerLifecycle lifecycle;
-    private ServletContextEvent event;
+    private static Bus bus;
+    private static ContainerLifecycle lifecycle;
+    private static ServletContextEvent event;
     
-    @Before
-    public void setUp() {
+    @BeforeClass
+    public static void setUp() {
         event = new ServletContextEvent(mock(ServletContext.class));
         lifecycle = WebBeansContext.currentInstance().getService(ContainerLifecycle.class);
         lifecycle.startApplication(event);
@@ -56,15 +56,15 @@ public class ClassUnwrapperTest {
     }
 
     @SuppressWarnings("unchecked")
-    private<T> T getBeanReference(Class<T> clazz) {
+    private static <T> T getBeanReference(Class<T> clazz) {
         final BeanManager beanManager = lifecycle.getBeanManager();
         final Set<Bean<?>> beans = beanManager.getBeans(clazz);
         final Bean<?> bean = beanManager.resolve(beans);
         return (T)beanManager.getReference(bean, clazz, beanManager.createCreationalContext(bean));
     }
 
-    @After
-    public void tearDown() {
+    @AfterClass
+    public static void tearDown() {
         lifecycle.stopApplication(event);
     }
     


### PR DESCRIPTION
The test class `ClassUnwrapperTest` tries to load the `lifecycle`, `bus` and `event` before every test runs in this test class.

For `event`, the test class `ServletContextEvent` creates it with a mocked class and it is only used when starting the application using `lifecycle`.

For `lifecycle`, it is only used to start an application with the `event` and called with `getBeanManager()`.

For `bus`, it is only used to get certain properties of certain class name.

For all these three fields, the two tests inside the `ClassUnwrapperTest` are not trying to modify them but just accessing them. Repeatly creating `lifecycle`, `bus` and `event` object will increase the cost of running tests. When run on our own machine, the test runtime can jump from `5.4858 s` to `4.5919 s` after applying the changes.