### PR TITLE
Scoped SBOM (cyclonedx-maven-plugin) to release and deploy Apache Maven profiles only

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -368,6 +368,10 @@
                             </gpgArguments>
                         </configuration>
                     </plugin>
+                    <plugin>
+                        <groupId>org.cyclonedx</groupId>
+                        <artifactId>cyclonedx-maven-plugin</artifactId>
+                    </plugin>
                 </plugins>
             </build>
         </profile>
@@ -402,6 +406,10 @@
                                 </goals>
                             </execution>
                         </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.cyclonedx</groupId>
+                        <artifactId>cyclonedx-maven-plugin</artifactId>
                     </plugin>
                 </plugins>
             </build>
@@ -719,10 +727,6 @@
                         </goals>
                     </execution>
                 </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.cyclonedx</groupId>
-                <artifactId>cyclonedx-maven-plugin</artifactId>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
At the moment, we always generate SBOMs on every build, it significantly slows the builds down. The suggestion is to generate SBOMs at deploy / release time only, when we really need those artifacts to be published (somewhat Inspired by Apache Camel approach https://github.com/apache/camel/blob/main/pom.xml#L801)