### PR TITLE
Add null guards for ManagedRMEndpoint

### DIFF
--- a/rt/ws/rm/src/main/java/org/apache/cxf/ws/rm/ManagedRMEndpoint.java
+++ b/rt/ws/rm/src/main/java/org/apache/cxf/ws/rm/ManagedRMEndpoint.java
@@ -23,6 +23,7 @@ import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 import javax.management.JMException;
 import javax.management.ObjectName;
@@ -118,7 +119,7 @@ public class ManagedRMEndpoint implements ManagedComponent {
     }
 
     public ManagedRMEndpoint(RMEndpoint endpoint) {
-        this.endpoint = endpoint;
+        this.endpoint = Objects.requireNonNull(endpoint, "endpoint");
     }
 
     /* (non-Javadoc)

--- a/rt/ws/rm/src/test/java/org/apache/cxf/ws/rm/ManagedRMEndpointTest.java
+++ b/rt/ws/rm/src/test/java/org/apache/cxf/ws/rm/ManagedRMEndpointTest.java
@@ -1,0 +1,33 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.cxf.ws.rm;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertThrows;
+
+public class ManagedRMEndpointTest {
+    @Test
+    public void testNullEndpoint() throws Exception {
+        assertThrows(NullPointerException.class, () -> {
+            new ManagedRMEndpoint(null);
+        });
+    }
+}


### PR DESCRIPTION
The `endpoint` parameter passed to the constructor of `ManagedRMEndpoint` is immediately saved to a private property, and cannot be changed later with any public method.
As such, passing `null` into the constructor has little use, throws a `NullPointerException` at a wholly unrelated position and time, and causes difficult debugging should this happen.
This commit implements a fail-fast guard against `null`.