### PR TITLE
CXF-8975: Missing ending CRLF in multipart request

### DIFF
--- a/core/src/main/java/org/apache/cxf/attachment/AttachmentSerializer.java
+++ b/core/src/main/java/org/apache/cxf/attachment/AttachmentSerializer.java
@@ -327,7 +327,7 @@ public class AttachmentSerializer {
         StringWriter writer = new StringWriter();
         writer.write("\r\n--");
         writer.write(bodyBoundary);
-        writer.write("--");
+        writer.write("--\r\n");
         out.write(writer.getBuffer().toString().getBytes(encoding));
         out.flush();
     }


### PR DESCRIPTION
Please find attached my pull-request regarding the ticket I reported on https://issues.apache.org/jira/browse/CXF-8975 concerning a serializing issue in multipart message.

Please note that I made the fix for the 3.5.x branch, but that it should also be applied to the 3.1.x branch. However, I've been unable to compile the branch on my Windows workstation due to the default encoding of the generated files, as well as several unit tests that don't pass