### PR TITLE
CXF-8977: Add support for MTOM Serialization Policy Assertion 1.1

### DIFF
--- a/rt/ws/policy/src/main/java/org/apache/cxf/ws/policy/mtom/MTOMAssertionBuilder.java
+++ b/rt/ws/policy/src/main/java/org/apache/cxf/ws/policy/mtom/MTOMAssertionBuilder.java
@@ -33,7 +33,7 @@ import org.apache.neethi.builders.AssertionBuilder;
 
 public class MTOMAssertionBuilder implements AssertionBuilder<Element> {
     private static final QName[] KNOWN_ELEMENTS
-        = {MetadataConstants.MTOM_ASSERTION_QNAME};
+        = {MetadataConstants.MTOM_ASSERTION_QNAME, MetadataConstants.MTOM11_ASSERTION_QNAME};
 
     public Assertion build(Element elem, AssertionBuilderFactory f) {
         String localName = elem.getLocalName();
@@ -47,6 +47,8 @@ public class MTOMAssertionBuilder implements AssertionBuilder<Element> {
 
         if (MetadataConstants.MTOM_ASSERTION_QNAME.equals(qn)) {
             return new PrimitiveAssertion(MetadataConstants.MTOM_ASSERTION_QNAME, optional);
+        } else if (MetadataConstants.MTOM11_ASSERTION_QNAME.equals(qn)) {
+            return new PrimitiveAssertion(MetadataConstants.MTOM11_ASSERTION_QNAME, optional);
         }
 
         return null;

--- a/rt/ws/policy/src/main/java/org/apache/cxf/ws/policy/mtom/MTOMPolicyInterceptor.java
+++ b/rt/ws/policy/src/main/java/org/apache/cxf/ws/policy/mtom/MTOMPolicyInterceptor.java
@@ -21,6 +21,8 @@ package org.apache.cxf.ws.policy.mtom;
 
 import java.util.Collection;
 
+import javax.xml.namespace.QName;
+
 import org.apache.cxf.interceptor.Fault;
 import org.apache.cxf.message.Message;
 import org.apache.cxf.message.MessageUtils;
@@ -39,7 +41,14 @@ public class MTOMPolicyInterceptor extends AbstractPhaseInterceptor<Message> {
 
         // extract Assertion information
         if (aim != null) {
-            Collection<AssertionInfo> ais = aim.get(MetadataConstants.MTOM_ASSERTION_QNAME);
+            assertAssertion(message, aim, MetadataConstants.MTOM_ASSERTION_QNAME);
+            assertAssertion(message, aim, MetadataConstants.MTOM11_ASSERTION_QNAME);
+        }
+    }
+
+    private static void assertAssertion(Message message, AssertionInfoMap aim, QName type) {
+        Collection<AssertionInfo> ais = aim.get(type);
+        if (ais != null) {
             for (AssertionInfo ai : ais) {
                 if (MessageUtils.isRequestor(message)) {
                     //just turn on MTOM

--- a/rt/ws/policy/src/main/java/org/apache/cxf/ws/policy/mtom/MTOMPolicyInterceptorProvider.java
+++ b/rt/ws/policy/src/main/java/org/apache/cxf/ws/policy/mtom/MTOMPolicyInterceptorProvider.java
@@ -37,6 +37,7 @@ public class MTOMPolicyInterceptorProvider extends AbstractPolicyInterceptorProv
     static {
         Collection<QName> types = new ArrayList<>();
         types.add(MetadataConstants.MTOM_ASSERTION_QNAME);
+        types.add(MetadataConstants.MTOM11_ASSERTION_QNAME);
         ASSERTION_TYPES = types;
     }
 

--- a/rt/ws/policy/src/main/java/org/apache/cxf/ws/policy/mtom/MetadataConstants.java
+++ b/rt/ws/policy/src/main/java/org/apache/cxf/ws/policy/mtom/MetadataConstants.java
@@ -25,6 +25,8 @@ public final class MetadataConstants {
     public static final QName MTOM_ASSERTION_QNAME =
             new QName("http://schemas.xmlsoap.org/ws/2004/09/policy/optimizedmimeserialization",
                     "OptimizedMimeSerialization");
+    public static final QName MTOM11_ASSERTION_QNAME =
+            new QName("http://www.w3.org/2007/08/soap12-mtom-policy", "MTOM");
 
 
     private MetadataConstants() {

--- a/rt/ws/policy/src/main/java/org/apache/cxf/ws/policy/mtom/MetadataConstants.java
+++ b/rt/ws/policy/src/main/java/org/apache/cxf/ws/policy/mtom/MetadataConstants.java
@@ -28,7 +28,6 @@ public final class MetadataConstants {
     public static final QName MTOM11_ASSERTION_QNAME =
             new QName("http://www.w3.org/2007/08/soap12-mtom-policy", "MTOM");
 
-
     private MetadataConstants() {
         //utility class
     }

--- a/systests/uncategorized/src/test/java/org/apache/cxf/systest/mtom/mtom11-policy-optional.xml
+++ b/systests/uncategorized/src/test/java/org/apache/cxf/systest/mtom/mtom11-policy-optional.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements. See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership. The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied. See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+<wsp:Policy xmlns:wsp="http://www.w3.org/2006/07/ws-policy" xmlns:mtom="http://www.w3.org/2007/08/soap12-mtom-policy">
+    <mtom:MTOM wsp:Optional="true"/>
+</wsp:Policy>

--- a/systests/uncategorized/src/test/java/org/apache/cxf/systest/mtom/mtom11-policy.xml
+++ b/systests/uncategorized/src/test/java/org/apache/cxf/systest/mtom/mtom11-policy.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements. See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership. The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied. See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+<wsp:Policy xmlns:wsp="http://www.w3.org/ns/ws-policy" xmlns:mtom="http://www.w3.org/2007/08/soap12-mtom-policy">
+    <mtom:MTOM/>
+</wsp:Policy>


### PR DESCRIPTION
## Summary

Add support for the W3C MTOM Serialization Policy Assertion 1.1 ([WS-MTOMPolicy](http://www.w3.org/2007/08/soap12-mtom-policy)) alongside the existing 1.0 assertion (`OptimizedMimeSerialization` from `http://schemas.xmlsoap.org/ws/2004/09/policy/optimizedmimeserialization`).

This allows CXF to process WSDL/policy documents that use the newer MTOM 1.1 policy namespace, which uses the `{http://www.w3.org/2007/08/soap12-mtom-policy}MTOM` element instead of the older `{http://schemas.xmlsoap.org/ws/2004/09/policy/optimizedmimeserialization}OptimizedMimeSerialization` element.

## Changes

- **`MetadataConstants`**: Add `MTOM11_ASSERTION_QNAME` constant for the W3C MTOM 1.1 namespace
- **`MTOMAssertionBuilder`**: Register and build assertions for both MTOM 1.0 and 1.1 QNames
- **`MTOMPolicyInterceptor`**: Refactor to handle both assertion types via extracted `assertAssertion()` method
- **`MTOMPolicyInterceptorProvider`**: Register both assertion types

## Tests

- Add `testRequiredMtom11` and `testOptionalMtom11` tests mirroring the existing 1.0 tests
- Add `mtom11-policy.xml` and `mtom11-policy-optional.xml` policy files using the W3C MTOM 1.1 namespace
- Refactor `setupServer()` to accept a policy resource name instead of a boolean flag

## JIRA

[CXF-8977](https://issues.apache.org/jira/browse/CXF-8977)