### PR TITLE
CXF-8962: HttpClientHTTPConduit sets Content-Type Header for DELETE requests with empty body

### DIFF
--- a/rt/transports/http/src/main/java/org/apache/cxf/transport/http/Headers.java
+++ b/rt/transports/http/src/main/java/org/apache/cxf/transport/http/Headers.java
@@ -66,7 +66,7 @@ public class Headers {
     public static final String HTTP_HEADERS_LINK = "Link";
     public static final String EMPTY_REQUEST_PROPERTY = "org.apache.cxf.empty.request";
     public static final String USER_AGENT = initUserAgent();
-    private static final String SET_EMPTY_REQUEST_CT_PROPERTY = "set.content.type.for.empty.request";
+    public static final String SET_EMPTY_REQUEST_CT_PROPERTY = "set.content.type.for.empty.request";
     private static final TimeZone TIME_ZONE_GMT = TimeZone.getTimeZone("GMT");
     private static final Logger LOG = LogUtils.getL7dLogger(Headers.class);
 

--- a/rt/transports/http/src/main/java/org/apache/cxf/transport/http/HttpClientHTTPConduit.java
+++ b/rt/transports/http/src/main/java/org/apache/cxf/transport/http/HttpClientHTTPConduit.java
@@ -567,9 +567,26 @@ public class HttpClientHTTPConduit extends URLConnectionHTTPConduit {
             }
             if (!h.headerMap().containsKey("User-Agent")) {
                 rb.header("User-Agent", Headers.USER_AGENT);
-            }   
+            }
+
             if (hasCT || !KNOWN_HTTP_VERBS_WITH_NO_CONTENT.contains(outMessage.get(Message.HTTP_REQUEST_METHOD))) {
-                rb.header(HttpHeaderHelper.CONTENT_TYPE, h.determineContentType());
+                boolean dropContentType = false;
+                boolean emptyRequest = PropertyUtils.isTrue(outMessage.get(Headers.EMPTY_REQUEST_PROPERTY));
+
+                // If it is an empty request (without a request body) then check further if CT still needs be set
+                if (emptyRequest) {
+                    final Object setCtForEmptyRequestProp = outMessage
+                        .getContextualProperty(Headers.SET_EMPTY_REQUEST_CT_PROPERTY);
+                    if (setCtForEmptyRequestProp != null) {
+                        // If SET_EMPTY_REQUEST_CT_PROPERTY is set then do as a user prefers.
+                        // CT will be dropped if setting CT for empty requests was explicitly disabled
+                        dropContentType = PropertyUtils.isFalse(setCtForEmptyRequestProp);
+                    }
+                }
+
+                if (!dropContentType) {
+                    rb.header(HttpHeaderHelper.CONTENT_TYPE, h.determineContentType());
+                }
             }            
         }
         

--- a/systests/jaxrs/src/test/java/org/apache/cxf/systest/jaxrs/EmptyBookServer.java
+++ b/systests/jaxrs/src/test/java/org/apache/cxf/systest/jaxrs/EmptyBookServer.java
@@ -1,0 +1,46 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.cxf.systest.jaxrs;
+
+import org.apache.cxf.Bus;
+import org.apache.cxf.endpoint.Server;
+import org.apache.cxf.jaxrs.JAXRSServerFactoryBean;
+import org.apache.cxf.jaxrs.lifecycle.SingletonResourceProvider;
+import org.apache.cxf.testutil.common.AbstractServerTestServerBase;
+
+public class EmptyBookServer extends AbstractServerTestServerBase {
+    public static final String PORT = allocatePort(EmptyBookServer.class);
+
+    @Override
+    protected Server createServer(Bus bus) throws Exception {
+        final JAXRSServerFactoryBean sf = new JAXRSServerFactoryBean();
+        sf.setResourceClasses(EmptyBookStore.class);
+        sf.setResourceProvider(EmptyBookStore.class,
+            new SingletonResourceProvider(new EmptyBookStore(), true));
+        sf.setAddress("http://localhost:" + PORT + "/");
+        sf.setBus(bus);
+        return sf.create();
+    }
+
+    public static void main(String[] args) throws Exception {
+        new EmptyBookServer().start();
+    }
+
+}

--- a/systests/jaxrs/src/test/java/org/apache/cxf/systest/jaxrs/EmptyBookStore.java
+++ b/systests/jaxrs/src/test/java/org/apache/cxf/systest/jaxrs/EmptyBookStore.java
@@ -1,0 +1,46 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.cxf.systest.jaxrs;
+
+import jakarta.ws.rs.DELETE;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.HttpHeaders;
+
+@Path("/bookstore")
+public class EmptyBookStore {
+    @GET
+    public void get(@Context HttpHeaders headers) {
+        if (headers.getHeaderString("Content-Type") != null) {
+            throw new IllegalStateException("'Content-Type' header is not expected");
+        }
+    }
+
+    @DELETE
+    public void delete(@Context HttpHeaders headers) {
+        if (headers.getHeaderString("Content-Type") != null) {
+            throw new IllegalStateException("'Content-Type' header is not expected");
+        }
+    }
+
+}
+
+

--- a/systests/jaxrs/src/test/java/org/apache/cxf/systest/jaxrs/JAXRSClientServerEmptyBookTest.java
+++ b/systests/jaxrs/src/test/java/org/apache/cxf/systest/jaxrs/JAXRSClientServerEmptyBookTest.java
@@ -1,0 +1,63 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.cxf.systest.jaxrs;
+
+import jakarta.ws.rs.core.Response;
+import org.apache.cxf.Bus;
+import org.apache.cxf.jaxrs.client.WebClient;
+import org.apache.cxf.jaxrs.model.AbstractResourceInfo;
+import org.apache.cxf.testutil.common.AbstractBusClientServerTestBase;
+import org.apache.cxf.transport.http.Headers;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertTrue;
+
+public class JAXRSClientServerEmptyBookTest extends AbstractBusClientServerTestBase {
+    public static final String PORT = EmptyBookServer.PORT;
+    
+    @BeforeClass
+    public static void startServers() throws Exception {
+        AbstractResourceInfo.clearAllMaps();
+        assertTrue("server did not launch correctly", launchServer(EmptyBookServer.class, true));
+
+        final Bus bus = createStaticBus();
+        bus.setProperty(Headers.SET_EMPTY_REQUEST_CT_PROPERTY, false);
+    }
+
+    @Test
+    public void testContentTypeEmptyGet() throws Exception {
+        String address = "http://localhost:" + PORT + "/bookstore/";
+        WebClient wc = WebClient.create(address);
+        final Response r = wc.get();
+        assertThat(r.getStatus(), equalTo(204));
+    }
+    
+    @Test
+    public void testContentTypeEmptyDelete() throws Exception {
+        String address = "http://localhost:" + PORT + "/bookstore/";
+        WebClient wc = WebClient.create(address);
+        final Response r = wc.delete();
+        assertThat(r.getStatus(), equalTo(204));
+    }
+}


### PR DESCRIPTION
Add support of `set.content.type.for.empty.request` contextual property to `HttpClientHTTPConduit`