### PR TITLE
CXF-8978: Codegen plugin fails with IBM JDK

### DIFF
--- a/maven-plugins/codegen-plugin/pom.xml
+++ b/maven-plugins/codegen-plugin/pom.xml
@@ -206,21 +206,4 @@
             </plugin>
         </plugins>
     </build>
-    <profiles>
-        <profile>
-            <id>ibmjdk</id>
-            <activation>
-                <property>
-                    <name>java.vendor</name>
-                    <value>IBM Corporation</value>
-                </property>
-            </activation>
-            <dependencies>
-                <dependency>
-                    <groupId>xerces</groupId>
-                    <artifactId>xercesImpl</artifactId>
-                </dependency>
-            </dependencies>
-        </profile>
-    </profiles>
 </project>


### PR DESCRIPTION
Remove Maven profile 'ibmjdk' containing invalid Xerces dependency declaration. Dependency to Xerces was removed with CXF-8912.