### PR TITLE
[CXF-8982] add optional namespace prefix in template

### DIFF
--- a/rt/features/logging/src/main/java/org/apache/cxf/ext/logging/MaskSensitiveHelper.java
+++ b/rt/features/logging/src/main/java/org/apache/cxf/ext/logging/MaskSensitiveHelper.java
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License. You may obtain a copy of the License at
- *
+ * <p>
  * http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -27,7 +27,12 @@ import org.apache.cxf.message.Message;
 
 public class MaskSensitiveHelper {
     private static final String ELEMENT_NAME_TEMPLATE = "-ELEMENT_NAME-";
-    private static final String MATCH_PATTERN_XML_TEMPLATE = "(<(\\w+:)?-ELEMENT_NAME-.*?>)(.*?)(</(\\w+:)?-ELEMENT_NAME->)";
+    // see https://www.w3.org/TR/REC-xml-names/#NT-NCName for allowed chars in namespace prefix
+    private static final String PATTERN_XML_NAMESPACE_PREFIX = "[\\w.\\-\\u00B7\\u00C0-\\u00D6\\u00D8-\\u00F6" +
+            "\\u00F8-\\u02FF\\u0300-\\u037D\\u037F-\\u1FFF\\u200C-\\u200D\\u203F-\\u2040\\u2070-\\u218F" +
+            "\\u2C00-\\u2FEF\\u3001-\\uD7FF\\uF900-\\uFDCF\\uFDF0-\\uFFFD]+";
+    private static final String MATCH_PATTERN_XML_TEMPLATE = "(<(" + PATTERN_XML_NAMESPACE_PREFIX
+            + ":)?-ELEMENT_NAME-.*?>)(.*?)(</(" + PATTERN_XML_NAMESPACE_PREFIX + ":)?-ELEMENT_NAME->)";
     private static final String REPLACEMENT_XML_TEMPLATE = "$1XXX$4";
     private static final String MATCH_PATTERN_JSON_TEMPLATE = "\"-ELEMENT_NAME-\"[ \\t]*:[ \\t]*\"(.*?)\"";
     private static final String REPLACEMENT_JSON_TEMPLATE = "\"-ELEMENT_NAME-\": \"XXX\"";
@@ -64,9 +69,9 @@ public class MaskSensitiveHelper {
     }
 
     private void addReplacementPair(final String matchPatternTemplate,
-                                    final String replacementTemplate,
-                                    final String sensitiveName,
-                                    final Set<ReplacementPair> replacements) {
+            final String replacementTemplate,
+            final String sensitiveName,
+            final Set<ReplacementPair> replacements) {
         final String matchPatternXML = matchPatternTemplate.replaceAll(ELEMENT_NAME_TEMPLATE, sensitiveName);
         final String replacementXML = replacementTemplate.replaceAll(ELEMENT_NAME_TEMPLATE, sensitiveName);
         replacements.add(new ReplacementPair(matchPatternXML, replacementXML));

--- a/rt/features/logging/src/main/java/org/apache/cxf/ext/logging/MaskSensitiveHelper.java
+++ b/rt/features/logging/src/main/java/org/apache/cxf/ext/logging/MaskSensitiveHelper.java
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License. You may obtain a copy of the License at
- * <p>
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * <p>
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -28,9 +28,9 @@ import org.apache.cxf.message.Message;
 public class MaskSensitiveHelper {
     private static final String ELEMENT_NAME_TEMPLATE = "-ELEMENT_NAME-";
     // see https://www.w3.org/TR/REC-xml-names/#NT-NCName for allowed chars in namespace prefix
-    private static final String PATTERN_XML_NAMESPACE_PREFIX = "[\\w.\\-\\u00B7\\u00C0-\\u00D6\\u00D8-\\u00F6" +
-            "\\u00F8-\\u02FF\\u0300-\\u037D\\u037F-\\u1FFF\\u200C-\\u200D\\u203F-\\u2040\\u2070-\\u218F" +
-            "\\u2C00-\\u2FEF\\u3001-\\uD7FF\\uF900-\\uFDCF\\uFDF0-\\uFFFD]+";
+    private static final String PATTERN_XML_NAMESPACE_PREFIX = "[\\w.\\-\\u00B7\\u00C0-\\u00D6\\u00D8-\\u00F6"
+            + "\\u00F8-\\u02FF\\u0300-\\u037D\\u037F-\\u1FFF\\u200C-\\u200D\\u203F-\\u2040\\u2070-\\u218F"
+            + "\\u2C00-\\u2FEF\\u3001-\\uD7FF\\uF900-\\uFDCF\\uFDF0-\\uFFFD]+";
     private static final String MATCH_PATTERN_XML_TEMPLATE = "(<(" + PATTERN_XML_NAMESPACE_PREFIX
             + ":)?-ELEMENT_NAME-.*?>)(.*?)(</(" + PATTERN_XML_NAMESPACE_PREFIX + ":)?-ELEMENT_NAME->)";
     private static final String REPLACEMENT_XML_TEMPLATE = "$1XXX$4";
@@ -69,9 +69,9 @@ public class MaskSensitiveHelper {
     }
 
     private void addReplacementPair(final String matchPatternTemplate,
-            final String replacementTemplate,
-            final String sensitiveName,
-            final Set<ReplacementPair> replacements) {
+                                    final String replacementTemplate,
+                                    final String sensitiveName,
+                                    final Set<ReplacementPair> replacements) {
         final String matchPatternXML = matchPatternTemplate.replaceAll(ELEMENT_NAME_TEMPLATE, sensitiveName);
         final String replacementXML = replacementTemplate.replaceAll(ELEMENT_NAME_TEMPLATE, sensitiveName);
         replacements.add(new ReplacementPair(matchPatternXML, replacementXML));

--- a/rt/features/logging/src/main/java/org/apache/cxf/ext/logging/MaskSensitiveHelper.java
+++ b/rt/features/logging/src/main/java/org/apache/cxf/ext/logging/MaskSensitiveHelper.java
@@ -27,8 +27,8 @@ import org.apache.cxf.message.Message;
 
 public class MaskSensitiveHelper {
     private static final String ELEMENT_NAME_TEMPLATE = "-ELEMENT_NAME-";
-    private static final String MATCH_PATTERN_XML_TEMPLATE = "(<-ELEMENT_NAME-.*?>)(.*?)(</-ELEMENT_NAME->)";
-    private static final String REPLACEMENT_XML_TEMPLATE = "$1XXX$3";
+    private static final String MATCH_PATTERN_XML_TEMPLATE = "(<(\\w+:)?-ELEMENT_NAME-.*?>)(.*?)(</(\\w+:)?-ELEMENT_NAME->)";
+    private static final String REPLACEMENT_XML_TEMPLATE = "$1XXX$4";
     private static final String MATCH_PATTERN_JSON_TEMPLATE = "\"-ELEMENT_NAME-\"[ \\t]*:[ \\t]*\"(.*?)\"";
     private static final String REPLACEMENT_JSON_TEMPLATE = "\"-ELEMENT_NAME-\": \"XXX\"";
     private static final String MASKED_HEADER_VALUE = "XXX";
@@ -55,7 +55,7 @@ public class MaskSensitiveHelper {
         replacementsJSON.clear();
         addSensitiveElementNames(inSensitiveElementNames);
     }
-    
+
     public void addSensitiveElementNames(final Set<String> inSensitiveElementNames) {
         for (final String sensitiveName : inSensitiveElementNames) {
             addReplacementPair(MATCH_PATTERN_XML_TEMPLATE, REPLACEMENT_XML_TEMPLATE, sensitiveName, replacementsXML);

--- a/rt/features/logging/src/test/java/org/apache/cxf/ext/logging/MaskSensitiveHelperTest.java
+++ b/rt/features/logging/src/test/java/org/apache/cxf/ext/logging/MaskSensitiveHelperTest.java
@@ -45,6 +45,7 @@ import static org.junit.Assert.assertNotNull;
 
 @RunWith(Parameterized.class)
 public class MaskSensitiveHelperTest {
+
     private static final String SENSITIVE_LOGGING_CONTENT_XML =
             "<user>testUser</user><password>my secret password</password>";
     private static final String MASKED_LOGGING_CONTENT_XML =
@@ -59,13 +60,19 @@ public class MaskSensitiveHelperTest {
             "\"user\":\"testUser\", \"password\": \"my secret password\"";
     private static final String MASKED_LOGGING_CONTENT_JSON =
             "\"user\":\"testUser\", \"password\": \"XXX\"";
-    
+
     private static final String SENSITIVE_LOGGING_MULTIPLE_ELEMENT_XML =
         "<item><user>testUser1</user><password myAttribute=\"test\">my secret password 1</password></item>"
             + "<item><user>testUser2</user><password>my secret password 2</password></item>";
     private static final String MASKED_LOGGING_MULTIPLE_ELEMENT_XML =
         "<item><user>testUser1</user><password myAttribute=\"test\">XXX</password></item>"
             + "<item><user>testUser2</user><password>XXX</password></item>";
+
+    private static final String SENSITIVE_LOGGING_CONTENT_XML_WITH_NAMESPACE =
+            "<ns:user>testUser</ns:user><ns:password>my secret password</ns:password>";
+
+    private static final String MASKED_LOGGING_CONTENT_XML_WITH_NAMESPACE =
+            "<ns:user>testUser</ns:user><ns:password>XXX</ns:password>";
 
     private static final Set<String> SENSITIVE_ELEMENTS = new HashSet<>(Arrays.asList("password"));
     private static final String APPLICATION_XML = "application/xml";
@@ -87,6 +94,7 @@ public class MaskSensitiveHelperTest {
             {SENSITIVE_LOGGING_CONTENT_XML, MASKED_LOGGING_CONTENT_XML, APPLICATION_XML},
             {SENSITIVE_LOGGING_CONTENT_XML_WITH_ATTRIBUTE, MASKED_LOGGING_CONTENT_XML_WITH_ATTRIBUTE, APPLICATION_XML},
             {SENSITIVE_LOGGING_MULTIPLE_ELEMENT_XML, MASKED_LOGGING_MULTIPLE_ELEMENT_XML, APPLICATION_XML},
+            {SENSITIVE_LOGGING_CONTENT_XML_WITH_NAMESPACE, MASKED_LOGGING_CONTENT_XML_WITH_NAMESPACE, APPLICATION_XML},
             {SENSITIVE_LOGGING_CONTENT_JSON, MASKED_LOGGING_CONTENT_JSON, APPLICATION_JSON}
         });
     }


### PR DESCRIPTION
This is a proposal fix for CXF-8982. The request also contains a new test case to assess it works as expected without breaking anything else.
By changing the regexp, the MaskSensitiveHelper supports masking XML element values where the element contains a namespace prefix without changing the semantics or the intention of the class.