### PR TITLE
CXF-8983: cxf-services-sts-core should depend on cxf-rt-rs-security-jose instead of cxf-rt-rs-security-jose-jaxrs

### DIFF
--- a/services/sts/sts-core/pom.xml
+++ b/services/sts/sts-core/pom.xml
@@ -67,7 +67,7 @@
         </dependency>
         <dependency>
             <groupId>org.apache.cxf</groupId>
-            <artifactId>cxf-rt-rs-security-jose-jaxrs</artifactId>
+            <artifactId>cxf-rt-rs-security-jose</artifactId>
             <version>${project.version}</version>
             <scope>compile</scope>
         </dependency>


### PR DESCRIPTION
https://issues.apache.org/jira/browse/CXF-8983