### PR TITLE
CXF-8993: Migrate from net.sf.cglib (cglib) to org.springframework.cglib (spring)

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -47,7 +47,7 @@
             com.sun.xml*;resolution:=optional,
             com.sun.codemodel.writer;resolution:=optional,
             org.slf4j*;resolution:=optional;version="${cxf.osgi.slf4j.version}",
-            net.sf.cglib*;resolution:=optional;version="${cxf.cglib.osgi.version}",
+            org.springframework.cglib*;resolution:=optional;version="${cxf.osgi.spring.version}",
             org.springframework.aop*;resolution:=optional;version="${cxf.osgi.spring.version}",
             org.springframework.beans*;resolution:=optional;version="${cxf.osgi.spring.version}",
             org.springframework.context*;resolution:=optional;version="${cxf.osgi.spring.version}",
@@ -121,11 +121,6 @@
             <artifactId>jcl-over-slf4j</artifactId>
             <optional>true</optional>
             <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>cglib</groupId>
-            <artifactId>cglib-nodep</artifactId>
-            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.woodstox</groupId>

--- a/core/src/main/java/org/apache/cxf/common/util/CglibProxyHelper.java
+++ b/core/src/main/java/org/apache/cxf/common/util/CglibProxyHelper.java
@@ -23,9 +23,9 @@ import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.List;
 
-import net.sf.cglib.proxy.Enhancer;
-import net.sf.cglib.proxy.MethodInterceptor;
-import net.sf.cglib.proxy.MethodProxy;
+import org.springframework.cglib.proxy.Enhancer;
+import org.springframework.cglib.proxy.MethodInterceptor;
+import org.springframework.cglib.proxy.MethodProxy;
 
 
 /**
@@ -33,9 +33,9 @@ import net.sf.cglib.proxy.MethodProxy;
  */
 class CglibProxyHelper extends ProxyHelper {
     CglibProxyHelper() throws Exception {
-        Class.forName("net.sf.cglib.proxy.Enhancer");
-        Class.forName("net.sf.cglib.proxy.MethodInterceptor");
-        Class.forName("net.sf.cglib.proxy.MethodProxy");
+        Class.forName("org.springframework.cglib.proxy.Enhancer");
+        Class.forName("org.springframework.cglib.proxy.MethodInterceptor");
+        Class.forName("org.springframework.cglib.proxy.MethodProxy");
     }
 
     @Override

--- a/core/src/test/java/org/apache/cxf/common/injection/ResourceInjectorTest.java
+++ b/core/src/test/java/org/apache/cxf/common/injection/ResourceInjectorTest.java
@@ -31,11 +31,11 @@ import jakarta.annotation.PostConstruct;
 import jakarta.annotation.PreDestroy;
 import jakarta.annotation.Resource;
 import jakarta.annotation.Resources;
-import net.sf.cglib.proxy.Enhancer;
-import net.sf.cglib.proxy.MethodInterceptor;
-import net.sf.cglib.proxy.MethodProxy;
 import org.apache.cxf.resource.ResourceManager;
 import org.apache.cxf.resource.ResourceResolver;
+import org.springframework.cglib.proxy.Enhancer;
+import org.springframework.cglib.proxy.MethodInterceptor;
+import org.springframework.cglib.proxy.MethodProxy;
 
 import org.junit.Test;
 

--- a/core/src/test/java/org/apache/cxf/common/util/ClassHelperTest.java
+++ b/core/src/test/java/org/apache/cxf/common/util/ClassHelperTest.java
@@ -23,12 +23,12 @@ import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
 import java.util.function.Function;
 
-import net.sf.cglib.proxy.Callback;
-import net.sf.cglib.proxy.Enhancer;
 import org.apache.cxf.Bus;
 import org.apache.cxf.BusFactory;
 import org.springframework.aop.AfterReturningAdvice;
 import org.springframework.aop.framework.ProxyFactory;
+import org.springframework.cglib.proxy.Callback;
+import org.springframework.cglib.proxy.Enhancer;
 
 import org.junit.After;
 import org.junit.Before;
@@ -83,7 +83,7 @@ public class ClassHelperTest {
 
         springAopObject = proxyFactory.getProxy();
         
-        final Callback callback = new net.sf.cglib.proxy.InvocationHandler() {
+        final Callback callback = new org.springframework.cglib.proxy.InvocationHandler() {
             @Override
             public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
                 return null;

--- a/distribution/javadoc/pom.xml
+++ b/distribution/javadoc/pom.xml
@@ -261,10 +261,6 @@
             <artifactId>wsdl4j</artifactId>
         </dependency>
         <dependency>
-            <groupId>cglib</groupId>
-            <artifactId>cglib-nodep</artifactId>
-        </dependency>
-        <dependency>
             <groupId>jdom</groupId>
             <artifactId>jdom</artifactId>
             <version>${cxf.jdom.version}</version>

--- a/distribution/src/main/release/samples/ruby_spring_support/pom.xml
+++ b/distribution/src/main/release/samples/ruby_spring_support/pom.xml
@@ -127,10 +127,6 @@
             <version>9.4.6.0</version>
         </dependency>
         <dependency>
-            <groupId>cglib</groupId>
-            <artifactId>cglib-nodep</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-context</artifactId>
         </dependency>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -74,7 +74,6 @@
         <cxf.osgi.jakarta.mail.version>[2,3)</cxf.osgi.jakarta.mail.version>
         <cxf.osgi.jakarta.servlet.version>[5,6)</cxf.osgi.jakarta.servlet.version>
         <cxf.osgi.jakarta.xml.ws.version>[3,4)</cxf.osgi.jakarta.xml.ws.version>
-        <cxf.cglib.osgi.version>[3.3,3.4)</cxf.cglib.osgi.version>
         <cxf.osgi.cdi.version>[3,4)</cxf.osgi.cdi.version>
         <cxf.osgi.jakarta.jwsapi.version>[3,4)</cxf.osgi.jakarta.jwsapi.version>
         <cxf.osgi.saaj.version>[2,3)</cxf.osgi.saaj.version>
@@ -267,7 +266,6 @@
         <cxf.reflections.bundle.version>0.9.11_2</cxf.reflections.bundle.version>
         <cxf.rhino.bundle.version>1.7.13_1</cxf.rhino.bundle.version>
         <cxf.servicemix.aspectj.version>1.9.1_1</cxf.servicemix.aspectj.version>
-        <cxf.servicemix.cglib.version>3.3.0_1</cxf.servicemix.cglib.version>
         <cxf.servicemix.jakarta.el.version>3.0.0_1</cxf.servicemix.jakarta.el.version>
         <cxf.servicemix.jaxrs.specs.version>2.9.1</cxf.servicemix.jaxrs.specs.version>
         <cxf.servicemix.jodatime.version>2.3_1</cxf.servicemix.jodatime.version>
@@ -788,11 +786,6 @@
                         <artifactId>jakarta.activation</artifactId>
                     </exclusion>
                 </exclusions>
-            </dependency>
-            <dependency>
-                <groupId>cglib</groupId>
-                <artifactId>cglib-nodep</artifactId>
-                <version>3.3.0</version>
             </dependency>
             <dependency>
                 <groupId>com.sun.xml.fastinfoset</groupId>

--- a/rt/rs/client/pom.xml
+++ b/rt/rs/client/pom.xml
@@ -95,11 +95,6 @@
             <optional>true</optional>
         </dependency>
         <dependency>
-            <groupId>cglib</groupId>
-            <artifactId>cglib-nodep</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>${cxf.servlet-api.group}</groupId>
             <artifactId>${cxf.servlet-api.artifact}</artifactId>
             <scope>test</scope>

--- a/rt/rs/microprofile-client/pom.xml
+++ b/rt/rs/microprofile-client/pom.xml
@@ -147,11 +147,6 @@
             <optional>true</optional>
         </dependency>
         <dependency>
-            <groupId>cglib</groupId>
-            <artifactId>cglib-nodep</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>${cxf.servlet-api.group}</groupId>
             <artifactId>${cxf.servlet-api.artifact}</artifactId>
             <scope>test</scope>

--- a/systests/jaxrs/pom.xml
+++ b/systests/jaxrs/pom.xml
@@ -348,11 +348,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>cglib</groupId>
-            <artifactId>cglib-nodep</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>jakarta.management.j2ee</groupId>
             <artifactId>jakarta.management.j2ee-api</artifactId>
             <scope>test</scope>

--- a/systests/rs-security/pom.xml
+++ b/systests/rs-security/pom.xml
@@ -133,11 +133,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>cglib</groupId>
-            <artifactId>cglib-nodep</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>jakarta.management.j2ee</groupId>
             <artifactId>jakarta.management.j2ee-api</artifactId>
             <scope>test</scope>

--- a/systests/transport-hc5/pom.xml
+++ b/systests/transport-hc5/pom.xml
@@ -175,11 +175,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>cglib</groupId>
-            <artifactId>cglib-nodep</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-beans</artifactId>
             <scope>test</scope>

--- a/systests/uncategorized/pom.xml
+++ b/systests/uncategorized/pom.xml
@@ -294,11 +294,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>cglib</groupId>
-            <artifactId>cglib-nodep</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>jakarta.management.j2ee</groupId>
             <artifactId>jakarta.management.j2ee-api</artifactId>
             <scope>test</scope>


### PR DESCRIPTION
The cglib [1] is not actively developed anymore and haven't seen any releases since 2019. It does not work with baselines of JDK-17 or above (since it shades old ASM version):

```
 java.lang.IllegalArgumentException: Unsupported class file major version 61 at net.sf.cglib.asm.$ClassReader.<init>(ClassReader.java:195) at net.sf.cglib.asm.$ClassReader.<init>(ClassReader.java:176) at net.sf.cglib.asm.$ClassReader.<init>(ClassReader.java:162) at net.sf.cglib.asm.$ClassReader.<init>(ClassReader.java:283) at net.sf.cglib.core.DuplicatesPredicate.<init>(DuplicatesPredicate.java:93) at net.sf.cglib.proxy.Enhancer.getMethods(Enhancer.java:557) at net.sf.cglib.proxy.Enhancer.generateClass(Enhancer.java:575) at net.sf.cglib.core.DefaultGeneratorStrategy.generate(DefaultGeneratorStrategy.java:25) at net.sf.cglib.core.AbstractClassGenerator.generate(AbstractClassGenerator.java:332) at net.sf.cglib.proxy.Enhancer.generate(Enhancer.java:492) at net.sf.cglib.core.AbstractClassGenerator$ClassLoaderData$3.apply(AbstractClassGenerator.java:96) at net.sf.cglib.core.AbstractClassGenerator$ClassLoaderData$3.apply(AbstractClassGenerator.java:94) at net.sf.cglib.core.internal.LoadingCache$2.call(LoadingCache.java:54) at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264) at net.sf.cglib.core.internal.LoadingCache.createEntry(LoadingCache.java:61) at net.sf.cglib.core.internal.LoadingCache.get(LoadingCache.java:34) at net.sf.cglib.core.AbstractClassGenerator$ClassLoaderData.get(AbstractClassGenerator.java:119) at net.sf.cglib.core.AbstractClassGenerator.create(AbstractClassGenerator.java:294) at net.sf.cglib.proxy.Enhancer.createHelper(Enhancer.java:480) at net.sf.cglib.proxy.Enhancer.create(Enhancer.java:305) at org.apache.cxf.common.util.CglibProxyHelper.getProxyInternal(CglibProxyHelper.java:71) at org.apache.cxf.common.util.ProxyHelper.getProxy(ProxyHelper.java:137) at org.apache.cxf.jaxrs.client.JAXRSClientFactoryBean.createWithValues(JAXRSClientFactoryBean.java:326) at org.apache.cxf.jaxrs.client.JAXRSClientFactoryBean.create(JAXRSClientFactoryBean.java:283) at org.apache.cxf.jaxrs.client.JAXRSClientFactoryBeanTest.testCreateClientWithTwoUserResources(JAXRSClientFactoryBeanTest.java:126) at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method) at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77) at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) at java.base/java.lang.reflect.Method.invoke(Method.java:568) at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:59) at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12) at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:56) at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17) at org.junit.runners.ParentRunner$3.evaluate(ParentRunner.java:306) at org.junit.runners.BlockJUnit4ClassRunner$1.evaluate(BlockJUnit4ClassRunner.java:100) at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:366) at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:103) at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:63) at org.junit.runners.ParentRunner$4.run(ParentRunner.java:331) at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:79) at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:329) at org.junit.runners.ParentRunner.access$100(ParentRunner.java:66) at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:293) at org.junit.runners.ParentRunner$3.evaluate(ParentRunner.java:306) at org.junit.runners.ParentRunner.run(ParentRunner.java:413) at org.apache.maven.surefire.junit4.JUnit4Provider.execute(JUnit4Provider.java:316) at org.apache.maven.surefire.junit4.JUnit4Provider.executeWithRerun(JUnit4Provider.java:240) at org.apache.maven.surefire.junit4.JUnit4Provider.executeTestSet(JUnit4Provider.java:214) at org.apache.maven.surefire.junit4.JUnit4Provider.invoke(JUnit4Provider.java:155) at org.apache.maven.surefire.booter.ForkedBooter.runSuitesInProcess(ForkedBooter.java:385) at org.apache.maven.surefire.booter.ForkedBooter.execute(ForkedBooter.java:162) at org.apache.maven.surefire.booter.ForkedBooter.run(ForkedBooter.java:507) at org.apache.maven.surefire.booter.ForkedBooter.main(ForkedBooter.java:495)

```

[1] https://github.com/cglib/cglib