### PR TITLE
[CXF-8994] CorbaConduitTest no longer requires IBM JDK activation.

### DIFF
--- a/rt/bindings/corba/src/test/java/org/apache/cxf/binding/corba/CorbaConduitTest.java
+++ b/rt/bindings/corba/src/test/java/org/apache/cxf/binding/corba/CorbaConduitTest.java
@@ -116,13 +116,6 @@ public class CorbaConduitTest {
                          "SimpleCORBAPort");
 
         CorbaDestination destination = new CorbaDestination(endpointInfo, orbConfig);
-
-        if (System.getProperty("java.vendor").contains("IBM")) {
-            //IBM requires it to activate to resolve it, but cannot
-            //activate on sun without more config
-            destination.activate();
-        }
-
         CorbaConduit conduit = new CorbaConduit(endpointInfo, destination.getAddress(), orbConfig);
         CorbaMessage message = new CorbaMessage(new MessageImpl());
         try {
@@ -352,7 +345,7 @@ public class CorbaConduitTest {
 
         org.omg.CORBA.Object obj = mock(org.omg.CORBA.Object.class);
         when(message.get(CorbaConstants.CORBA_ENDPOINT_OBJECT)).thenReturn(obj);
-        
+
         //msg.put(CorbaConstants.CORBA_ENDPOINT_OBJECT, obj);
         Request r = mock(Request.class);
         NVList nvList = orb.create_list(0);


### PR DESCRIPTION
CorbaConduitTest no longer requires IBM JDK destination activation routine.

With the patch applied the CorbaConduitTests pass when builting on IBM Java.

Build tested on:
MacOS 14.4.1, AArch64, with Azul Zulu 17, IBM Semeru 17.
Windows 11 Pro, Intel x64, with IBM Semeru 17.
CentOS Stream 9, PPC64LE, with Eclipse Temurin 17, IBM Semeru 17.
