### PR TITLE
reuse the same WebClient instance and fix CXF-8992 if it's threadsafe

### DIFF
--- a/rt/rs/client/src/main/java/org/apache/cxf/jaxrs/client/spec/ClientImpl.java
+++ b/rt/rs/client/src/main/java/org/apache/cxf/jaxrs/client/spec/ClientImpl.java
@@ -232,6 +232,7 @@ public class ClientImpl implements Client {
         private Configurable<WebTarget> configImpl;
         private UriBuilder uriBuilder;
         private WebClient targetClient;
+        private boolean threadSafeTargetClient;
 
 
         public WebTargetImpl(UriBuilder uriBuilder,
@@ -310,7 +311,7 @@ public class ClientImpl implements Client {
                 cxfFeature.initialize(clientCfg, clientCfg.getBus());
             }
             // Start building the invocation
-            return new InvocationBuilderImpl(WebClient.fromClient(targetClient),
+            return new InvocationBuilderImpl(threadSafeTargetClient ? targetClient : WebClient.fromClient(targetClient),
                                              getConfiguration());
         }
         private void setConnectionProperties(Map<String, Object> configProps, ClientConfiguration clientCfg) {
@@ -361,6 +362,7 @@ public class ClientImpl implements Client {
                     }
                 }
                 targetClient = bean.createWebClient();
+                threadSafeTargetClient = threadSafe;
                 ClientImpl.this.baseClients.add(targetClient);
             } else if (!targetClient.getCurrentURI().equals(uri)) {
                 targetClient.to(uri.toString(), false);
@@ -470,7 +472,7 @@ public class ClientImpl implements Client {
         private WebTarget newWebTarget(UriBuilder newBuilder) {
             WebClient newClient;
             if (targetClient != null) {
-                newClient = WebClient.fromClient(targetClient);
+                newClient = threadSafeTargetClient ? targetClient : WebClient.fromClient(targetClient);
             } else {
                 newClient = null;
             }

--- a/systests/jaxrs/src/test/java/org/apache/cxf/systest/jaxrs/JAXRSMultithreadedClientTest.java
+++ b/systests/jaxrs/src/test/java/org/apache/cxf/systest/jaxrs/JAXRSMultithreadedClientTest.java
@@ -27,10 +27,13 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 
+import jakarta.ws.rs.client.ClientBuilder;
+import jakarta.ws.rs.client.WebTarget;
 import jakarta.ws.rs.core.MultivaluedMap;
 import jakarta.ws.rs.core.Response;
 import org.apache.cxf.helpers.IOUtils;
 import org.apache.cxf.jaxrs.client.Client;
+import org.apache.cxf.jaxrs.client.ClientProperties;
 import org.apache.cxf.jaxrs.client.JAXRSClientFactory;
 import org.apache.cxf.jaxrs.client.JAXRSClientFactoryBean;
 import org.apache.cxf.jaxrs.client.WebClient;
@@ -75,6 +78,18 @@ public class JAXRSMultithreadedClientTest extends AbstractBusClientServerTestBas
         WebClient client = WebClient.create("http://localhost:" + PORT + "/bookstore/booksecho");
         client.type("text/plain").accept("text/plain").header("CustomHeader", "CustomValue");
         runWebClients(client, 10, true, false);
+    }
+
+    @Test
+    public void testWebTargetGC() throws Exception {
+        WebTarget target = ClientBuilder.newClient().target("http://localhost:" + PORT + "/bookstore/booksecho")
+            .property(ClientProperties.THREAD_SAFE_CLIENT_PROP, true);
+
+        target.request().get().getStatus();
+
+        System.gc();
+
+        target.request().get().getStatus();
     }
 
     @Test


### PR DESCRIPTION
When the `WebClient` is thread safe, it should be fine to reuse it instead of calling `WebClient.fromClient()`. Additionally, this fixes (at least in cases when the `WebClient` is thread safe) an issue due to GC: https://issues.apache.org/jira/browse/CXF-8992