### PR TITLE
[CXF-8997] AbstractSTSToken and TransportBinding Tests use TLSv1 on IBM

### DIFF
--- a/services/sts/systests/basic/src/test/java/org/apache/cxf/systest/sts/stsclient/AbstractSTSTokenTest.java
+++ b/services/sts/systests/basic/src/test/java/org/apache/cxf/systest/sts/stsclient/AbstractSTSTokenTest.java
@@ -161,11 +161,6 @@ public abstract class AbstractSTSTokenTest extends AbstractClientServerTestBase 
 
         SSLContext sc = SSLUtils.getSSLContext(TLSClientParametersUtils.getTLSClientParameters());
         HttpsURLConnection.setDefaultSSLSocketFactory(sc.getSocketFactory());
-
-        // Needed to prevent test failure using IBM JDK
-        if ("IBM Corporation".equals(System.getProperty("java.vendor"))) {
-            System.setProperty("https.protocols", "TLSv1");
-        }
     }
 
     static void validateSecurityToken(SecurityToken token) {

--- a/services/sts/systests/basic/src/test/java/org/apache/cxf/systest/sts/transport/TransportBindingTest.java
+++ b/services/sts/systests/basic/src/test/java/org/apache/cxf/systest/sts/transport/TransportBindingTest.java
@@ -302,11 +302,6 @@ public class TransportBindingTest extends AbstractBusClientServerTestBase {
     @org.junit.Test
     public void testSAML2Dispatch() throws Exception {
 
-        // Needed to prevent test failure using IBM JDK
-        if ("IBM Corporation".equals(System.getProperty("java.vendor"))) {
-            System.setProperty("https.protocols", "TLSv1");
-        }
-
         createBus(getClass().getResource("cxf-client.xml").toString());
 
         URL wsdl = TransportBindingTest.class.getResource("DoubleIt.wsdl");
@@ -341,11 +336,6 @@ public class TransportBindingTest extends AbstractBusClientServerTestBase {
 
     @org.junit.Test
     public void testSAML2DispatchLocation() throws Exception {
-
-        // Needed to prevent test failure using IBM JDK
-        if ("IBM Corporation".equals(System.getProperty("java.vendor"))) {
-            System.setProperty("https.protocols", "TLSv1");
-        }
 
         createBus(getClass().getResource("cxf-client.xml").toString());
 


### PR DESCRIPTION
AbstractSTSTokenTest and TransportBindingTests no longer need to set https protocol to TLSv1 on IBM Java.

Current builds of CXF 4.0.x on IBM Java will fail the AbstractSTSTokenTest and TransportBindingTests due to their use of TLSv1. Note: IBM JDKs disable TLSv1 by default since around Java 8 (https://community.ibm.com/community/user/wasdevops/blogs/hiroko-takamiya1/2021/06/19/ibm-java-80630-disables-tlsv1-tlsv11-by-default-ho).

Removing the test case IBM control flag allows the default TLS to pass the tests.

Patch tested on:
CentOS Stream 9 on POWER with IBM Semeru 17, RedHat OpenJDK 17, and Eclipse Adoptium (Temurin) 17.
Windows 11 Pro on x64 Intel with IBM Semeru 17, and Azul Zulu 17.
MacOS 14.4.1 on AArch64 with IBM Semeru 17, and Amazon Corretto 17.