### PR TITLE
[CXF-8999] Skip testKerberosViaCustomTokenAction when on IBM Java

### DIFF
--- a/systests/kerberos/src/test/java/org/apache/cxf/systest/kerberos/wssec/kerberos/KerberosTokenTest.java
+++ b/systests/kerberos/src/test/java/org/apache/cxf/systest/kerberos/wssec/kerberos/KerberosTokenTest.java
@@ -396,6 +396,10 @@ public class KerberosTokenTest extends AbstractBusClientServerTestBase {
 
     @org.junit.Test
     public void testKerberosViaCustomTokenAction() throws Exception {
+        if (!runTests) {
+            return;
+        }
+
         SpringBusFactory bf = new SpringBusFactory();
         URL busFile = KerberosTokenTest.class.getResource("client.xml");
 


### PR DESCRIPTION
KerberosTokenTest testKerberosViaCustomTokenAction should not run on IBM Java.

The test case fails on ClassNotFound com.ibm.security.jgss.InquireType - this is thrown due to wss4j-ws-security-common having a hard coded check for IBM Java to use the above mentioned class. 

Most of the test cases in KerberosTokenTest are set to avoid running when on IBM, I believe this test case should also be set to not run. A future improvement would be to update wss4j-ws-security-common to be IBM Semeru friendly, then update CXF accordingly.

Tested on MacOS 14.4.1 with IBM Semeru 17.