### PR TITLE
Put a max default configurable limit on the Jose P2C parameter

### DIFF
--- a/rt/rs/security/jose-parent/jose/src/main/java/org/apache/cxf/rs/security/jose/common/JoseConstants.java
+++ b/rt/rs/security/jose-parent/jose/src/main/java/org/apache/cxf/rs/security/jose/common/JoseConstants.java
@@ -192,6 +192,11 @@ public final class JoseConstants extends RSSecurityConstants {
      */
     public static final String RSSEC_ENCRYPTION_PBES2_COUNT = "rs.security.encryption.pbes2.count";
 
+    /**
+     * The max value for the "p2c" (PBES2 count) Header Parameter used for decryption. The default is 1_000_000.
+     */
+    public static final String RSSEC_DECRYPTION_MAX_PBES2_COUNT = "rs.security.decryption.max.pbes2.count";
+
     //
     // JWT specific configuration
     //

--- a/rt/rs/security/jose-parent/jose/src/main/java/org/apache/cxf/rs/security/jose/jwe/JweUtils.java
+++ b/rt/rs/security/jose-parent/jose/src/main/java/org/apache/cxf/rs/security/jose/jwe/JweUtils.java
@@ -568,7 +568,10 @@ public final class JweUtils {
                 if (password == null) {
                     throw new JweException(JweException.Error.KEY_DECRYPTION_FAILURE);
                 }
-                keyDecryptionProvider = new PbesHmacAesWrapKeyDecryptionAlgorithm(new String(password));
+                int pbes2Count = MessageUtils.getContextualInteger(m, 
+                    JoseConstants.RSSEC_DECRYPTION_MAX_PBES2_COUNT, 1_000_000);
+
+                keyDecryptionProvider = new PbesHmacAesWrapKeyDecryptionAlgorithm(new String(password), pbes2Count);
             } else {
                 PrivateKey privateKey = KeyManagementUtils.loadPrivateKey(m, props, KeyOperation.DECRYPT);
                 if (keyAlgo == null) {

--- a/rt/rs/security/jose-parent/jose/src/test/java/org/apache/cxf/rs/security/jose/jwe/JwePbeHmacAesWrapTest.java
+++ b/rt/rs/security/jose-parent/jose/src/test/java/org/apache/cxf/rs/security/jose/jwe/JwePbeHmacAesWrapTest.java
@@ -20,12 +20,14 @@ package org.apache.cxf.rs.security.jose.jwe;
 
 import java.nio.charset.StandardCharsets;
 
+import org.apache.cxf.rs.security.jose.common.JoseException;
 import org.apache.cxf.rs.security.jose.jwa.ContentAlgorithm;
 import org.apache.cxf.rs.security.jose.jwa.KeyAlgorithm;
 
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 
 public class JwePbeHmacAesWrapTest {
     
@@ -63,5 +65,37 @@ public class JwePbeHmacAesWrapTest {
         String decryptedText = decryption.decrypt(jweContent).getContentText();
         assertEquals(specPlainText, decryptedText);
 
+    }
+
+    @Test
+    public void testDecryptWithInvalidLargeP2CValue() throws Exception {
+        final String specPlainText = "Live long and prosper.";
+        JweHeaders headers = new JweHeaders();
+        headers.setKeyEncryptionAlgorithm(KeyAlgorithm.PBES2_HS256_A128KW);
+        headers.setContentEncryptionAlgorithm(ContentAlgorithm.A128GCM);
+        final String password = "Thus from my lips, by yours, my sin is purged.";
+        KeyEncryptionProvider keyEncryption =
+            new PbesHmacAesWrapKeyEncryptionAlgorithm(password, 1_500_000, KeyAlgorithm.PBES2_HS256_A128KW, false);
+        JweEncryptionProvider encryption = new JweEncryption(keyEncryption,
+            new AesGcmContentEncryptionAlgorithm(ContentAlgorithm.A128GCM));
+        String jweContent = encryption.encrypt(specPlainText.getBytes(StandardCharsets.UTF_8), null);
+
+        // 1. It should fail by default
+        PbesHmacAesWrapKeyDecryptionAlgorithm keyDecryption = new PbesHmacAesWrapKeyDecryptionAlgorithm(password);
+        JweDecryptionProvider decryption = new JweDecryption(keyDecryption,
+                                               new AesGcmContentDecryptionAlgorithm(ContentAlgorithm.A128GCM));
+        try {
+            decryption.decrypt(jweContent).getContentText();
+            fail("Failure expected on a too large p2c value");
+        } catch (JoseException ex) {
+            // expected
+        }
+
+        // 2. Now we allow 1.5M iterations and it passes
+        keyDecryption = new PbesHmacAesWrapKeyDecryptionAlgorithm(password, 1_500_000);
+        decryption = new JweDecryption(keyDecryption,
+                                               new AesGcmContentDecryptionAlgorithm(ContentAlgorithm.A128GCM));
+        String decryptedText = decryption.decrypt(jweContent).getContentText();
+        assertEquals(specPlainText, decryptedText);
     }
 }


### PR DESCRIPTION
Default to 1_000_000 as the max value allowed by default for the Jose P2C parameter as per https://bitbucket.org/connect2id/nimbus-jose-jwt/commits/3b3b77e