### PR TITLE
Add check to prevent redundant values in headers when using GZIPOutInterceptor

### DIFF
--- a/core/src/main/java/org/apache/cxf/transport/common/gzip/GZIPOutInterceptor.java
+++ b/core/src/main/java/org/apache/cxf/transport/common/gzip/GZIPOutInterceptor.java
@@ -337,7 +337,10 @@ public class GZIPOutInterceptor extends AbstractPhaseInterceptor<Message> {
         if (header.isEmpty()) {
             header.add(value);
         } else {
-            header.set(0, header.get(0) + "," + value);
+            String existingValue = header.get(0);
+            if (!existingValue.contains(value)) {
+                header.set(0, existingValue + "," + value);
+            }
         }
     }
     public void setForce(boolean force) {

--- a/core/src/main/java/org/apache/cxf/transport/common/gzip/GZIPOutInterceptor.java
+++ b/core/src/main/java/org/apache/cxf/transport/common/gzip/GZIPOutInterceptor.java
@@ -323,24 +323,14 @@ public class GZIPOutInterceptor extends AbstractPhaseInterceptor<Message> {
      * @param value the value to add
      */
     private static void addHeader(Message message, String name, String value) {
-        Map<String, List<String>> protocolHeaders = CastUtils.cast((Map<?, ?>)message
-            .get(Message.PROTOCOL_HEADERS));
-        if (protocolHeaders == null) {
-            protocolHeaders = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
-            message.put(Message.PROTOCOL_HEADERS, protocolHeaders);
+        Map<String, List<String>> headers = CastUtils.cast((Map<?, ?>)message.get(Message.PROTOCOL_HEADERS));
+        if (headers == null) {
+            headers = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
+            message.put(Message.PROTOCOL_HEADERS, headers);
         }
-        List<String> header = CastUtils.cast((List<?>)protocolHeaders.get(name));
-        if (header == null) {
-            header = new ArrayList<>();
-            protocolHeaders.put(name, header);
-        }
-        if (header.isEmpty()) {
+        List<String> header = headers.computeIfAbsent(name, k -> new ArrayList<>());
+        if (header.isEmpty() || !header.contains(value)) {
             header.add(value);
-        } else {
-            String existingValue = header.get(0);
-            if (!existingValue.contains(value)) {
-                header.set(0, existingValue + "," + value);
-            }
         }
     }
     public void setForce(boolean force) {


### PR DESCRIPTION
I use a custom feature to retry a client request if it fails. Unfortunately, on each attempt, the `Content-Encoding` header is modified to add `gzip`, giving `Content-Encoding: gzip,gzip` on the 2nd attempt.

I've added a small check before adding the value to the header, to make sure it's not already defined with the expected value.