### PR TITLE
Exception for getUserPrincipal() in AbstractHTTPDestination is slurped since CXF 4.1.x

### DIFF
--- a/rt/transports/http/src/main/java/org/apache/cxf/transport/http/AbstractHTTPDestination.java
+++ b/rt/transports/http/src/main/java/org/apache/cxf/transport/http/AbstractHTTPDestination.java
@@ -408,11 +408,7 @@ public abstract class AbstractHTTPDestination
 
         SecurityContext httpSecurityContext = new SecurityContext() {
             public Principal getUserPrincipal() {
-                try {
-                    return req.getUserPrincipal();
-                } catch (Exception ex) {
-                    return null;
-                }
+                return req.getUserPrincipal();
             }
             public boolean isUserInRole(String role) {
                 return req.isUserInRole(role);

--- a/rt/transports/http/src/main/java/org/apache/cxf/transport/http/AbstractHTTPDestination.java
+++ b/rt/transports/http/src/main/java/org/apache/cxf/transport/http/AbstractHTTPDestination.java
@@ -408,7 +408,15 @@ public abstract class AbstractHTTPDestination
 
         SecurityContext httpSecurityContext = new SecurityContext() {
             public Principal getUserPrincipal() {
-                return req.getUserPrincipal();
+                try {
+                    return req.getUserPrincipal();
+                } catch (Exception e) {
+                    if (e instanceof NullPointerException) {
+                        //jetty 12 related
+                        return null;
+                    }
+                    throw e;
+                }
             }
             public boolean isUserInRole(String role) {
                 return req.isUserInRole(role);


### PR DESCRIPTION
Hi all,

I am currently checking the integration of CXF 4.1.0-SNAPSHOT into TomEE 10 and I noticed a change in `AbstractHTTPDestination`.

An additional `try-catch` was added around `getUserPrincipal()` catching any kind of `Exception` and just returning `null`. 

Was this intentional (or required by the spec)? I think, that we shouldn't catch everything here.

I noticed this change by debugging TomEE's Microprofile JWT integration and one specific TCK test was failing:

```
org.eclipse.microprofile.jwt.tck.container.jaxrs.EmptyTokenTest#invalidToken
```

The provided token is invalid, we cannot parse a principal out of it and since it is in an invalid format anyway, our impl will throw an exception.
This exception is now caught and mapped to `null`, which is quite bad (as it will just return http 200 instead of 401). 

wdyt?