### PR TITLE
[CXF-9010] Update benchmark soap http doc lit suite for CXF 4.1.x

### DIFF
--- a/benchmark/performance/base/pom.xml
+++ b/benchmark/performance/base/pom.xml
@@ -7,9 +7,9 @@
     to you under the Apache License, Version 2.0 (the
     "License"); you may not use this file except in compliance
     with the License. You may obtain a copy of the License at
-    
+
     http://www.apache.org/licenses/LICENSE-2.0
-    
+
     Unless required by applicable law or agreed to in writing,
     software distributed under the License is distributed on an
     "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -27,7 +27,7 @@
     <description>Apache CXF Benchmark Base</description>
     <url>https://cxf.apache.org</url>
     <properties>
-        <cxf.version>4.0.0-SNAPSHOT</cxf.version>
+        <cxf.version>4.1.0-SNAPSHOT</cxf.version>
     </properties>
     <build>
         <defaultGoal>install</defaultGoal>

--- a/benchmark/performance/soap_http_doc_lit/pom.xml
+++ b/benchmark/performance/soap_http_doc_lit/pom.xml
@@ -7,9 +7,9 @@
     to you under the Apache License, Version 2.0 (the
     "License"); you may not use this file except in compliance
     with the License. You may obtain a copy of the License at
-    
+
     http://www.apache.org/licenses/LICENSE-2.0
-    
+
     Unless required by applicable law or agreed to in writing,
     software distributed under the License is distributed on an
     "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -17,7 +17,10 @@
     specific language governing permissions and limitations
     under the License.
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.apache.cxf.benchmark</groupId>
     <artifactId>cxf-benchmark-soapdoclit</artifactId>
@@ -26,9 +29,13 @@
     <name>Apache CXF Benchmark SOAP/HTTP/Doc/Lit</name>
     <description>Apache CXF Benchmark SOAP/HTTP/Doc/Lit</description>
     <url>https://cxf.apache.org</url>
+
     <properties>
-        <cxf.version>4.0.0-SNAPSHOT</cxf.version>
+        <cxf.version>4.1.0-SNAPSHOT</cxf.version>
+        <cxf.slf4j.version>2.0.13</cxf.slf4j.version>
+        <maven.war.plugin.version>3.4.0</maven.war.plugin.version>
     </properties>
+
     <dependencies>
         <dependency>
             <groupId>org.apache.cxf.benchmark</groupId>
@@ -59,11 +66,17 @@
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-ws-security</artifactId>
             <version>${cxf.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.ehcache</groupId>
+                    <artifactId>ehcache</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-jdk14</artifactId>
-            <version>1.6.1</version>
+            <version>${cxf.slf4j.version}</version>
         </dependency>
     </dependencies>
     <build>
@@ -90,6 +103,11 @@
         </plugins>
         <pluginManagement>
             <plugins>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-war-plugin</artifactId>
+                    <version>${maven.war.plugin.version}</version>
+                </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-compiler-plugin</artifactId>

--- a/benchmark/performance/soap_http_doc_lit/src/main/java/org/apache/cxf/performance/complex_type/common/KeystorePasswordCallback.java
+++ b/benchmark/performance/soap_http_doc_lit/src/main/java/org/apache/cxf/performance/complex_type/common/KeystorePasswordCallback.java
@@ -26,7 +26,7 @@ import javax.security.auth.callback.Callback;
 import javax.security.auth.callback.CallbackHandler;
 import javax.security.auth.callback.UnsupportedCallbackException;
 
-import org.apache.ws.security.WSPasswordCallback;
+import org.apache.wss4j.common.ext.WSPasswordCallback;
 
 /**
  */


### PR DESCRIPTION
Tested on:

MacOS 14.4.1, M2 Max, IBM Semeru 17 & Azul Zulu 17, Maven 3.9.5.
Windows 11 Pro, Intel, IBM Semeru 17, Maven 3.9.5
Ubuntu 22.04 LTS, Intel, Eclipse Adoptium 17, Maven 3.9.5
CentOS Stream 9, PPC64LE, Eclipse Adoptium 17 & IBM Semeru 17, Maven 3.9.6