### PR TITLE
CXF-9011: WSDLTo JAXWS Frontend service.vm Velocity template uses deprecated URL constructor

### DIFF
--- a/tools/wsdlto/frontend/jaxws/src/main/java/org/apache/cxf/tools/wsdlto/frontend/jaxws/template/service.vm
+++ b/tools/wsdlto/frontend/jaxws/src/main/java/org/apache/cxf/tools/wsdlto/frontend/jaxws/template/service.vm
@@ -24,6 +24,7 @@ package $service.PackageName;
 #if ($wsdlLocation != "" && not($useGetResource) && not($wsdlLocation.startsWith("classpath:")))
 import java.net.MalformedURLException;
 #end
+import java.net.URI;
 import java.net.URL;
 #if ($markGenerated == "true")
 import jakarta.annotation.Generated;
@@ -120,7 +121,7 @@ public class ${service.Name} extends ${serviceSuperclass} {
 #else
         URL url = null;
         try {
-            url = new URL("$wsdlLocation");
+            url = URI.create("$wsdlLocation").toURL();
         } catch (MalformedURLException e) {
 #if ($serviceTarget == "cxf")
             LogUtils.getL7dLogger(${service.Name}.class)


### PR DESCRIPTION
## Changes

- Modified `service.vm` template to use `URI.create` factory method to parse `$wsdlLocation`.
- Convert back to `URI` since `jakarta.xml.ws.Service` only accepts a `URL`

Targets `main`, but I think it can be backported to `4.0.x-fixes` as well.