### PR TITLE
Remove h from ESCAPED_CHARS in JsonMapObjectReaderWriter

### DIFF
--- a/rt/rs/extensions/json-basic/src/main/java/org/apache/cxf/jaxrs/json/basic/JsonMapObjectReaderWriter.java
+++ b/rt/rs/extensions/json-basic/src/main/java/org/apache/cxf/jaxrs/json/basic/JsonMapObjectReaderWriter.java
@@ -49,7 +49,6 @@ public class JsonMapObjectReaderWriter {
         chars.add('/');
         chars.add('b');
         chars.add('f');
-        chars.add('h');
         chars.add('r');
         chars.add('t');
         ESCAPED_CHARS = Collections.unmodifiableSet(chars);

--- a/rt/rs/extensions/json-basic/src/main/java/org/apache/cxf/jaxrs/json/basic/JsonMapObjectReaderWriter.java
+++ b/rt/rs/extensions/json-basic/src/main/java/org/apache/cxf/jaxrs/json/basic/JsonMapObjectReaderWriter.java
@@ -49,6 +49,7 @@ public class JsonMapObjectReaderWriter {
         chars.add('/');
         chars.add('b');
         chars.add('f');
+        chars.add('n');
         chars.add('r');
         chars.add('t');
         ESCAPED_CHARS = Collections.unmodifiableSet(chars);


### PR DESCRIPTION
The JsonMapObjectReaderWriter class maintains a list of [ESCAPED_CHARS](https://github.com/apache/cxf/blob/main/rt/rs/extensions/json-basic/src/main/java/org/apache/cxf/jaxrs/json/basic/JsonMapObjectReaderWriter.java#L45-L56) which includes special characters that need to be escaped like the newline (`\n`) and tab (`\t`) characters. This list also includes `\h`, but I can't find any links to official documentation about this character needing to be escaped. 

According to this [SO post](https://stackoverflow.com/a/27516892) which details escaped characters in JSON, it also does not include `\h` in this list. 

I'm opening a PR to discuss removing this from the list. 

Issue in OpenSearch where this issue is discussed: https://github.com/opensearch-project/security/issues/2531#issuecomment-2111309193


Simple test case which demonstrates the difference:

```
package org.opensearch.security.auth;

import org.apache.cxf.rs.security.jose.jwk.JsonWebKey;
import org.apache.cxf.rs.security.jose.jwk.KeyType;
import org.apache.cxf.rs.security.jose.jwk.PublicKeyUse;
import org.apache.cxf.rs.security.jose.jws.JwsUtils;
import org.apache.cxf.rs.security.jose.jwt.JoseJwtProducer;
import org.apache.cxf.rs.security.jose.jwt.JwtClaims;
import org.apache.cxf.rs.security.jose.jwt.JwtToken;
import org.apache.cxf.rs.security.jose.jwt.JwtUtils;
import org.junit.Test;

public class CXFTests {
    @Test
    public void testBase64URLUtility() {
        JoseJwtProducer jwtProducer = new JoseJwtProducer();
        JsonWebKey jwk = new JsonWebKey();

        jwk.setKeyType(KeyType.OCTET);
        jwk.setAlgorithm("HS512");
        jwk.setPublicKeyUse(PublicKeyUse.SIGN);
        jwk.setProperty("k", "<exchangeKey>");
        jwtProducer.setSignatureProvider(JwsUtils.getSignatureProvider(jwk));

        JwtClaims jwtClaims1 = new JwtClaims();
        JwtToken jwt1 = new JwtToken(jwtClaims1);
        jwtClaims1.setSubject("user1\\nexample");

        JwtClaims jwtClaims2 = new JwtClaims();
        JwtToken jwt2 = new JwtToken(jwtClaims2);
        jwtClaims2.setSubject("user2\\hexample");


        String encodedJwt1 = jwtProducer.processJwt(jwt1);
        String encodedJwt2 = jwtProducer.processJwt(jwt2);

        System.out.println("encodedJwt1: " + encodedJwt1);
        System.out.println("encodedJwt2: " + encodedJwt2);

        System.out.println("jwt1.toJson: " + JwtUtils.claimsToJson(jwt1.getClaims(), null));
        System.out.println("jwt2.toJson: " + JwtUtils.claimsToJson(jwt2.getClaims(), null));
    }
}
```

Output:

```
encodedJwt1: eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ1c2VyMVxcbmV4YW1wbGUifQ.iFP82Rq_EsEDkL4X7gaa21q0k4Yt81ybMWnqM2QgS55R1xKE8NARWZEQrjvA5lZwT4368-61BUeix7ufmdOz0A
encodedJwt2: eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ1c2VyMlxoZXhhbXBsZSJ9.O-glz6XD7guP4DemL6nyAnEVgGb4XcyLprtcHnpVGoFCe37eEW7UFi8MTmJ8D3JvJoLso1OfKiLkYTHjRecUcw
jwt1.toJson: {"sub":"user1\\nexample"}
jwt2.toJson: {"sub":"user2\hexample"}
```

jwt2 has an invalid payload.