### PR TITLE
[CXF-9019] Jaxws spi unit test coverage enhancement.

### DIFF
--- a/rt/frontend/jaxws/src/test/java/org/apache/cxf/jaxws/spi/ProviderImplTest.java
+++ b/rt/frontend/jaxws/src/test/java/org/apache/cxf/jaxws/spi/ProviderImplTest.java
@@ -19,9 +19,6 @@
 
 package org.apache.cxf.jaxws.spi;
 
-import jakarta.xml.ws.EndpointReference;
-import jakarta.xml.ws.WebServiceContext;
-import jakarta.xml.ws.spi.Invoker;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.net.URL;
@@ -36,30 +33,33 @@ import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.transform.Result;
 import javax.xml.transform.stream.StreamResult;
 
+import org.w3c.dom.Element;
+
+import jakarta.xml.ws.Endpoint;
+import jakarta.xml.ws.EndpointReference;
+import jakarta.xml.ws.WebServiceContext;
+import jakarta.xml.ws.WebServiceException;
+import jakarta.xml.ws.WebServiceFeature;
+import jakarta.xml.ws.spi.Invoker;
+import jakarta.xml.ws.spi.ServiceDelegate;
+import jakarta.xml.ws.wsaddressing.W3CEndpointReference;
 import org.apache.cxf.Bus;
+import org.apache.cxf.BusFactory;
 import org.apache.cxf.binding.BindingFactoryManager;
 import org.apache.cxf.binding.soap.SoapBindingConstants;
 import org.apache.cxf.binding.soap.SoapBindingFactory;
 import org.apache.cxf.binding.soap.SoapTransportFactory;
+import org.apache.cxf.jaxws.EndpointImpl;
+import org.apache.cxf.jaxws.ServiceImpl;
 import org.apache.cxf.test.AbstractCXFTest;
 import org.apache.cxf.transport.ConduitInitiatorManager;
 import org.apache.cxf.transport.DestinationFactoryManager;
 import org.apache.cxf.transport.local.LocalTransportFactory;
 import org.apache.cxf.ws.addressing.EndpointReferenceType;
 import org.apache.hello_world_soap_http.GreeterImpl;
-import org.junit.Before;
-import org.w3c.dom.Element;
-
-import jakarta.xml.ws.Endpoint;
-import jakarta.xml.ws.WebServiceException;
-import jakarta.xml.ws.WebServiceFeature;
-import jakarta.xml.ws.spi.ServiceDelegate;
-import jakarta.xml.ws.wsaddressing.W3CEndpointReference;
-import org.apache.cxf.BusFactory;
-import org.apache.cxf.jaxws.EndpointImpl;
-import org.apache.cxf.jaxws.ServiceImpl;
 
 import org.junit.After;
+import org.junit.Before;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -71,6 +71,34 @@ import static org.junit.Assert.fail;
 public class ProviderImplTest extends AbstractCXFTest {
 
     protected LocalTransportFactory localTransport;
+
+    private final Invoker validInvoker = new Invoker() {
+        @Override
+        public void inject(WebServiceContext webServiceContext)
+                throws IllegalAccessException, IllegalArgumentException, InvocationTargetException {
+
+        }
+
+        @Override
+        public Object invoke(Method method, Object... objects)
+                throws IllegalAccessException, IllegalArgumentException, InvocationTargetException {
+            return null;
+        }
+    };
+
+    private final Invoker invalidInvoker = new Invoker() {
+        @Override
+        public void inject(WebServiceContext webServiceContext)
+                throws IllegalAccessException, IllegalArgumentException, InvocationTargetException {
+            throw new WebServiceException("Oops");
+        }
+
+        @Override
+        public Object invoke(Method method, Object... objects)
+                throws IllegalAccessException, IllegalArgumentException, InvocationTargetException {
+            return null;
+        }
+    };
 
     @Before
     public void setUpBus() throws Exception {
@@ -348,36 +376,12 @@ public class ProviderImplTest extends AbstractCXFTest {
         BusFactory.setDefaultBus(null);
     }
 
-    private class InvalidImplementor implements jakarta.xml.ws.Provider {
+    private final class InvalidImplementor implements jakarta.xml.ws.Provider {
         @Override
         public Object invoke(Object o) {
             return null;
         }
 
     }
-
-    private Invoker validInvoker = new Invoker() {
-        @Override
-        public void inject(WebServiceContext webServiceContext) throws IllegalAccessException, IllegalArgumentException, InvocationTargetException {
-
-        }
-
-        @Override
-        public Object invoke(Method method, Object... objects) throws IllegalAccessException, IllegalArgumentException, InvocationTargetException {
-            return null;
-        }
-    };
-
-    private Invoker invalidInvoker = new Invoker() {
-        @Override
-        public void inject(WebServiceContext webServiceContext) throws IllegalAccessException, IllegalArgumentException, InvocationTargetException {
-            throw new WebServiceException("Oops");
-        }
-
-        @Override
-        public Object invoke(Method method, Object... objects) throws IllegalAccessException, IllegalArgumentException, InvocationTargetException {
-            return null;
-        }
-    };
 
 }

--- a/rt/frontend/jaxws/src/test/java/org/apache/cxf/jaxws/spi/ProviderImplTest.java
+++ b/rt/frontend/jaxws/src/test/java/org/apache/cxf/jaxws/spi/ProviderImplTest.java
@@ -19,25 +19,91 @@
 
 package org.apache.cxf.jaxws.spi;
 
+import jakarta.xml.ws.EndpointReference;
+import jakarta.xml.ws.WebServiceContext;
+import jakarta.xml.ws.spi.Invoker;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.net.URL;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
 
 import javax.xml.namespace.QName;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.transform.Result;
 import javax.xml.transform.stream.StreamResult;
 
+import org.apache.cxf.Bus;
+import org.apache.cxf.binding.BindingFactoryManager;
+import org.apache.cxf.binding.soap.SoapBindingConstants;
+import org.apache.cxf.binding.soap.SoapBindingFactory;
+import org.apache.cxf.binding.soap.SoapTransportFactory;
+import org.apache.cxf.test.AbstractCXFTest;
+import org.apache.cxf.transport.ConduitInitiatorManager;
+import org.apache.cxf.transport.DestinationFactoryManager;
+import org.apache.cxf.transport.local.LocalTransportFactory;
+import org.apache.cxf.ws.addressing.EndpointReferenceType;
+import org.apache.hello_world_soap_http.GreeterImpl;
+import org.junit.Before;
 import org.w3c.dom.Element;
 
+import jakarta.xml.ws.Endpoint;
+import jakarta.xml.ws.WebServiceException;
+import jakarta.xml.ws.WebServiceFeature;
+import jakarta.xml.ws.spi.ServiceDelegate;
 import jakarta.xml.ws.wsaddressing.W3CEndpointReference;
 import org.apache.cxf.BusFactory;
+import org.apache.cxf.jaxws.EndpointImpl;
+import org.apache.cxf.jaxws.ServiceImpl;
 
 import org.junit.After;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
-public class ProviderImplTest {
+
+
+public class ProviderImplTest extends AbstractCXFTest {
+
+    protected LocalTransportFactory localTransport;
+
+    @Before
+    public void setUpBus() throws Exception {
+        super.setUpBus();
+
+        SoapBindingFactory bindingFactory = new SoapBindingFactory();
+        bindingFactory.setBus(bus);
+        bus.getExtension(BindingFactoryManager.class)
+                .registerBindingFactory("http://schemas.xmlsoap.org/wsdl/soap/", bindingFactory);
+        bus.getExtension(BindingFactoryManager.class)
+                .registerBindingFactory("http://schemas.xmlsoap.org/wsdl/soap/http", bindingFactory);
+
+        DestinationFactoryManager dfm = bus.getExtension(DestinationFactoryManager.class);
+
+        SoapTransportFactory soapDF = new SoapTransportFactory();
+        dfm.registerDestinationFactory("http://schemas.xmlsoap.org/wsdl/soap/", soapDF);
+        dfm.registerDestinationFactory(SoapBindingConstants.SOAP11_BINDING_ID, soapDF);
+        dfm.registerDestinationFactory(SoapBindingConstants.SOAP12_BINDING_ID, soapDF);
+        dfm.registerDestinationFactory("http://cxf.apache.org/transports/local", soapDF);
+
+        localTransport = new LocalTransportFactory();
+        localTransport.setUriPrefixes(new HashSet<>(Arrays.asList("http", "local")));
+        dfm.registerDestinationFactory(LocalTransportFactory.TRANSPORT_ID, localTransport);
+        dfm.registerDestinationFactory("http://cxf.apache.org/transports/http", localTransport);
+        dfm.registerDestinationFactory("http://cxf.apache.org/transports/http/configuration", localTransport);
+
+        ConduitInitiatorManager extension = bus.getExtension(ConduitInitiatorManager.class);
+        extension.registerConduitInitiator(LocalTransportFactory.TRANSPORT_ID, localTransport);
+        extension.registerConduitInitiator("http://schemas.xmlsoap.org/soap/http", localTransport);
+        extension.registerConduitInitiator("http://cxf.apache.org/transports/http", localTransport);
+        extension.registerConduitInitiator("http://cxf.apache.org/transports/http/configuration",
+                localTransport);
+    }
 
     @org.junit.Test
     public void testCreateW3CEpr() throws Exception {
@@ -136,11 +202,182 @@ public class ProviderImplTest {
         assertFalse("ServiceName unexpected", sw.toString().contains("ServiceName"));
     }
 
+    @org.junit.Test
+    public void testCreateServiceDelegate() throws Exception {
+        ProviderImpl provider = new ProviderImpl();
+        URL url = getClass().getResource("/wsdl/default_partname_test.wsdl");
+        QName qName = new QName("http://cxf.com/", "HelloService");
+        Class cls = ServiceImpl.class;
+
+        ServiceDelegate test = provider.createServiceDelegate(url, qName, cls);
+        assertEquals(test.getServiceName(), qName);
+        assertEquals(test.getWSDLDocumentLocation(), url);
+    }
+
+    @org.junit.Test
+    public void testCreateServiceDelegateWebServiceFeatures() throws Exception {
+        ProviderImpl provider = new ProviderImpl();
+        URL url = getClass().getResource("/wsdl/default_partname_test.wsdl");
+        QName qName = new QName("http://cxf.com/", "HelloService");
+        Class cls = ServiceImpl.class;
+
+        WebServiceFeature[] noFeatures = new WebServiceFeature[0];
+
+        ServiceDelegate test = provider.createServiceDelegate(url, qName, cls, noFeatures);
+        assertEquals(test.getServiceName(), qName);
+        assertEquals(test.getWSDLDocumentLocation(), url);
+
+        WebServiceFeature[] unknownFeature = new WebServiceFeature[1];
+        WebServiceFeature webServiceFeature = new WebServiceFeature() {
+            @Override
+            public String getID() {
+                return "12345";
+            }
+        };
+        unknownFeature[0] = webServiceFeature;
+
+        try {
+            provider.createServiceDelegate(url, qName, cls, unknownFeature);
+            fail();
+        } catch (WebServiceException wse) {
+            //expected
+        }
+    }
+
+    @org.junit.Test
+    public void testCreateEndpointImpl() throws Exception {
+        ProviderImpl provider = new ProviderImpl();
+        Bus bus = null;
+        String bindingId = "bindingId";
+        Object implementor = null;
+        WebServiceFeature[] noFeatures = new WebServiceFeature[0];
+        EndpointImpl endpoint = provider.createEndpointImpl(bus, bindingId, implementor, noFeatures);
+        assertEquals(endpoint.getBus(), bus);
+    }
+
+    @org.junit.Test
+    public void testCreateEndpoint() throws Exception {
+        ProviderImpl provider = new ProviderImpl();
+        String bindingId = "http://schemas.xmlsoap.org/wsdl/soap/http";
+        Object implementor = new GreeterImpl();
+        Endpoint endpoint = provider.createEndpoint(bindingId, implementor);
+        assertEquals(endpoint.getImplementor(), implementor);
+
+        try {
+            provider.createEndpoint(bindingId, new InvalidImplementor());
+            fail();
+        } catch (WebServiceException wse) {
+            //expected
+        }
+
+        WebServiceFeature[] noFeatures = new WebServiceFeature[0];
+        endpoint = provider.createEndpoint(bindingId, implementor, noFeatures);
+        assertEquals(endpoint.getImplementor(), implementor);
+
+        try {
+            provider.createEndpoint(bindingId, new InvalidImplementor(), noFeatures);
+            fail();
+        } catch (WebServiceException wse) {
+            //expected
+        }
+
+        try {
+            Invoker invoker = null;
+            provider.createEndpoint(bindingId, InvalidImplementor.class, invoker, noFeatures);
+            fail();
+        } catch (WebServiceException wse) {
+            //expected
+        }
+
+        try {
+            endpoint = provider.createEndpoint(bindingId, GreeterImpl.class, validInvoker, noFeatures);
+            assertEquals(endpoint.getBinding().getBindingID(), bindingId);
+            provider.createEndpoint(bindingId, GreeterImpl.class, invalidInvoker, noFeatures);
+            fail();
+        } catch (WebServiceException wse) {
+            //expected
+        }
+    }
+
+    @org.junit.Test
+    public void testCreateAndPublishEndpoint() throws Exception {
+        ProviderImpl provider = new ProviderImpl();
+        String url = "http://localhost:8080/test";
+        GreeterImpl greeter = new GreeterImpl();
+
+        Endpoint endpoint = provider.createAndPublishEndpoint(url, greeter);
+        assertEquals(endpoint.getImplementor(), greeter);
+    }
+
+    @org.junit.Test
+    public void testCreateAndPublishEndpointWithFeatures() throws Exception {
+        ProviderImpl provider = new ProviderImpl();
+        String url = "http://localhost:8080/test";
+        GreeterImpl greeter = new GreeterImpl();
+        WebServiceFeature[] noFeatures = new WebServiceFeature[0];
+
+        Endpoint endpoint = provider.createAndPublishEndpoint(url, greeter, noFeatures);
+        assertEquals(endpoint.getImplementor(), greeter);
+    }
+
+    @org.junit.Test
+    public void testConvertToInternal() throws Exception {
+        EndpointReference external = new EndpointReference() {
+            @Override
+            public void writeTo(Result result) {
+
+            }
+        };
+
+        EndpointReferenceType endpointReferenceType = ProviderImpl.convertToInternal(external);
+        assertEquals(null, endpointReferenceType);
+
+        QName serviceName = new QName("http://cxf.apache.org", "ServiceName");
+        QName portName = new QName("http://cxf.apache.org", "PortName");
+        ProviderImpl impl = new ProviderImpl();
+        W3CEndpointReference w3Epr = impl.createW3CEndpointReference("http://myaddress", serviceName,
+                portName, null, "wsdlLoc",
+                null);
+        endpointReferenceType = ProviderImpl.convertToInternal(w3Epr);
+        assertEquals("http://myaddress", endpointReferenceType.getAddress().getValue());
+    }
+
+
     @After
     public void tearDown() {
         BusFactory.setDefaultBus(null);
     }
 
+    private class InvalidImplementor implements jakarta.xml.ws.Provider {
+        @Override
+        public Object invoke(Object o) {
+            return null;
+        }
 
+    }
+
+    private Invoker validInvoker = new Invoker() {
+        @Override
+        public void inject(WebServiceContext webServiceContext) throws IllegalAccessException, IllegalArgumentException, InvocationTargetException {
+
+        }
+
+        @Override
+        public Object invoke(Method method, Object... objects) throws IllegalAccessException, IllegalArgumentException, InvocationTargetException {
+            return null;
+        }
+    };
+
+    private Invoker invalidInvoker = new Invoker() {
+        @Override
+        public void inject(WebServiceContext webServiceContext) throws IllegalAccessException, IllegalArgumentException, InvocationTargetException {
+            throw new WebServiceException("Oops");
+        }
+
+        @Override
+        public Object invoke(Method method, Object... objects) throws IllegalAccessException, IllegalArgumentException, InvocationTargetException {
+            return null;
+        }
+    };
 
 }

--- a/rt/frontend/jaxws/src/test/java/org/apache/cxf/jaxws/spi/WrapperClassCreatorProxyServiceTest.java
+++ b/rt/frontend/jaxws/src/test/java/org/apache/cxf/jaxws/spi/WrapperClassCreatorProxyServiceTest.java
@@ -1,0 +1,83 @@
+package org.apache.cxf.jaxws.spi;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+import javax.xml.namespace.QName;
+import org.apache.cxf.binding.BindingFactoryManager;
+import org.apache.cxf.binding.soap.SoapBindingConstants;
+import org.apache.cxf.binding.soap.SoapBindingFactory;
+import org.apache.cxf.binding.soap.SoapTransportFactory;
+import org.apache.cxf.jaxws.support.JaxWsServiceFactoryBean;
+import org.apache.cxf.service.model.DescriptionInfo;
+import org.apache.cxf.service.model.InterfaceInfo;
+import org.apache.cxf.service.model.ServiceInfo;
+import org.apache.cxf.test.AbstractCXFTest;
+import org.apache.cxf.transport.ConduitInitiatorManager;
+import org.apache.cxf.transport.DestinationFactoryManager;
+import org.apache.cxf.transport.local.LocalTransportFactory;
+import org.junit.Before;
+
+import static org.junit.Assert.assertTrue;
+
+public class WrapperClassCreatorProxyServiceTest extends AbstractCXFTest {
+
+    protected LocalTransportFactory localTransport;
+
+    @Before
+    public void setUpBus() throws Exception {
+        super.setUpBus();
+
+        SoapBindingFactory bindingFactory = new SoapBindingFactory();
+        bindingFactory.setBus(bus);
+        bus.getExtension(BindingFactoryManager.class)
+                .registerBindingFactory("http://schemas.xmlsoap.org/wsdl/soap/", bindingFactory);
+        bus.getExtension(BindingFactoryManager.class)
+                .registerBindingFactory("http://schemas.xmlsoap.org/wsdl/soap/http", bindingFactory);
+
+        DestinationFactoryManager dfm = bus.getExtension(DestinationFactoryManager.class);
+
+        SoapTransportFactory soapDF = new SoapTransportFactory();
+        dfm.registerDestinationFactory("http://schemas.xmlsoap.org/wsdl/soap/", soapDF);
+        dfm.registerDestinationFactory(SoapBindingConstants.SOAP11_BINDING_ID, soapDF);
+        dfm.registerDestinationFactory(SoapBindingConstants.SOAP12_BINDING_ID, soapDF);
+        dfm.registerDestinationFactory("http://cxf.apache.org/transports/local", soapDF);
+
+        localTransport = new LocalTransportFactory();
+        localTransport.setUriPrefixes(new HashSet<>(Arrays.asList("http", "local")));
+        dfm.registerDestinationFactory(LocalTransportFactory.TRANSPORT_ID, localTransport);
+        dfm.registerDestinationFactory("http://cxf.apache.org/transports/http", localTransport);
+        dfm.registerDestinationFactory("http://cxf.apache.org/transports/http/configuration", localTransport);
+
+        ConduitInitiatorManager extension = bus.getExtension(ConduitInitiatorManager.class);
+        extension.registerConduitInitiator(LocalTransportFactory.TRANSPORT_ID, localTransport);
+        extension.registerConduitInitiator("http://schemas.xmlsoap.org/soap/http", localTransport);
+        extension.registerConduitInitiator("http://cxf.apache.org/transports/http", localTransport);
+        extension.registerConduitInitiator("http://cxf.apache.org/transports/http/configuration",
+                localTransport);
+    }
+
+    @org.junit.Test
+    public void testGenerate() throws Exception {
+
+        WrapperClassCreatorProxyService service = new WrapperClassCreatorProxyService(bus);
+
+        JaxWsServiceFactoryBean factory = new JaxWsServiceFactoryBean();
+
+        QName serviceName = new QName(
+                "http://apache.org/hello_world_soap_http", "interfaceTest");
+        ServiceInfo serviceInfo = new ServiceInfo();
+        DescriptionInfo descriptionInfo = new DescriptionInfo();
+        descriptionInfo.setName(serviceName);
+        serviceInfo.setDescription(descriptionInfo);
+
+        InterfaceInfo interfaceInfo = new InterfaceInfo(serviceInfo, serviceName);
+        QName sayHi = new QName("urn:test:ns", "sayHi");
+        interfaceInfo.addOperation(sayHi);
+
+        Set<Class<?>> result = service.generate(factory, interfaceInfo, false);
+
+        assertTrue(result.isEmpty());
+    }
+
+}

--- a/rt/frontend/jaxws/src/test/java/org/apache/cxf/jaxws/spi/WrapperClassCreatorProxyServiceTest.java
+++ b/rt/frontend/jaxws/src/test/java/org/apache/cxf/jaxws/spi/WrapperClassCreatorProxyServiceTest.java
@@ -1,3 +1,22 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package org.apache.cxf.jaxws.spi;
 
 import java.util.Arrays;

--- a/rt/frontend/jaxws/src/test/java/org/apache/cxf/jaxws/spi/WrapperClassCreatorProxyServiceTest.java
+++ b/rt/frontend/jaxws/src/test/java/org/apache/cxf/jaxws/spi/WrapperClassCreatorProxyServiceTest.java
@@ -22,7 +22,9 @@ package org.apache.cxf.jaxws.spi;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
+
 import javax.xml.namespace.QName;
+
 import org.apache.cxf.binding.BindingFactoryManager;
 import org.apache.cxf.binding.soap.SoapBindingConstants;
 import org.apache.cxf.binding.soap.SoapBindingFactory;
@@ -35,6 +37,7 @@ import org.apache.cxf.test.AbstractCXFTest;
 import org.apache.cxf.transport.ConduitInitiatorManager;
 import org.apache.cxf.transport.DestinationFactoryManager;
 import org.apache.cxf.transport.local.LocalTransportFactory;
+
 import org.junit.Before;
 
 import static org.junit.Assert.assertTrue;

--- a/rt/frontend/jaxws/src/test/java/org/apache/cxf/jaxws/spi/WrapperClassLoaderTest.java
+++ b/rt/frontend/jaxws/src/test/java/org/apache/cxf/jaxws/spi/WrapperClassLoaderTest.java
@@ -23,7 +23,9 @@ import java.lang.reflect.Method;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
+
 import javax.xml.namespace.QName;
+
 import org.apache.cxf.binding.BindingFactoryManager;
 import org.apache.cxf.binding.soap.SoapBindingConstants;
 import org.apache.cxf.binding.soap.SoapBindingFactory;
@@ -41,6 +43,7 @@ import org.apache.cxf.transport.ConduitInitiatorManager;
 import org.apache.cxf.transport.DestinationFactoryManager;
 import org.apache.cxf.transport.local.LocalTransportFactory;
 import org.apache.cxf.wsdl.service.factory.ReflectionServiceFactoryBean;
+
 import org.junit.Before;
 import org.mockito.Mockito;
 
@@ -145,10 +148,10 @@ public class WrapperClassLoaderTest extends AbstractCXFTest {
         //Setup Input and Output
         MessageInfo inputInfo = new MessageInfo(operationInfo, MessageInfo.Type.INPUT, sayHi);
         inputInfo.addMessagePart(sayHi);
-        operationInfo.setInput( "sayHi", inputInfo);
+        operationInfo.setInput("sayHi", inputInfo);
         MessageInfo outputInfo = new MessageInfo(operationInfo, MessageInfo.Type.OUTPUT, sayHi);
         outputInfo.addMessagePart(sayHi);
-        operationInfo.setOutput( "sayHi", outputInfo);
+        operationInfo.setOutput("sayHi", outputInfo);
 
         Set<Class<?>> result = wrapperClassLoader.generate(factory, interfaceInfo, false);
 

--- a/rt/frontend/jaxws/src/test/java/org/apache/cxf/jaxws/spi/WrapperClassLoaderTest.java
+++ b/rt/frontend/jaxws/src/test/java/org/apache/cxf/jaxws/spi/WrapperClassLoaderTest.java
@@ -1,0 +1,159 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.cxf.jaxws.spi;
+
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+import javax.xml.namespace.QName;
+import org.apache.cxf.binding.BindingFactoryManager;
+import org.apache.cxf.binding.soap.SoapBindingConstants;
+import org.apache.cxf.binding.soap.SoapBindingFactory;
+import org.apache.cxf.binding.soap.SoapTransportFactory;
+import org.apache.cxf.common.spi.GeneratedClassClassLoader;
+import org.apache.cxf.jaxws.service.SayHi;
+import org.apache.cxf.jaxws.support.JaxWsServiceFactoryBean;
+import org.apache.cxf.service.model.DescriptionInfo;
+import org.apache.cxf.service.model.InterfaceInfo;
+import org.apache.cxf.service.model.MessageInfo;
+import org.apache.cxf.service.model.OperationInfo;
+import org.apache.cxf.service.model.ServiceInfo;
+import org.apache.cxf.test.AbstractCXFTest;
+import org.apache.cxf.transport.ConduitInitiatorManager;
+import org.apache.cxf.transport.DestinationFactoryManager;
+import org.apache.cxf.transport.local.LocalTransportFactory;
+import org.apache.cxf.wsdl.service.factory.ReflectionServiceFactoryBean;
+import org.junit.Before;
+import org.mockito.Mockito;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.doReturn;
+
+public class WrapperClassLoaderTest extends AbstractCXFTest {
+
+    protected LocalTransportFactory localTransport;
+
+    @Before
+    public void setUpBus() throws Exception {
+        super.setUpBus();
+
+        GeneratedClassClassLoader.TypeHelperClassLoader mockClassLoader =
+                Mockito.mock(GeneratedClassClassLoader.TypeHelperClassLoader.class);
+        doReturn(SayHi.class).when(mockClassLoader).loadClass("org.apache.cxf.jaxws.service.jaxws_asm.SayHi");
+        bus.setExtension(mockClassLoader, GeneratedClassClassLoader.TypeHelperClassLoader.class);
+
+        SoapBindingFactory bindingFactory = new SoapBindingFactory();
+        bindingFactory.setBus(bus);
+        bus.getExtension(BindingFactoryManager.class)
+                .registerBindingFactory("http://schemas.xmlsoap.org/wsdl/soap/", bindingFactory);
+        bus.getExtension(BindingFactoryManager.class)
+                .registerBindingFactory("http://schemas.xmlsoap.org/wsdl/soap/http", bindingFactory);
+
+        DestinationFactoryManager dfm = bus.getExtension(DestinationFactoryManager.class);
+
+        SoapTransportFactory soapDF = new SoapTransportFactory();
+        dfm.registerDestinationFactory("http://schemas.xmlsoap.org/wsdl/soap/", soapDF);
+        dfm.registerDestinationFactory(SoapBindingConstants.SOAP11_BINDING_ID, soapDF);
+        dfm.registerDestinationFactory(SoapBindingConstants.SOAP12_BINDING_ID, soapDF);
+        dfm.registerDestinationFactory("http://cxf.apache.org/transports/local", soapDF);
+
+        localTransport = new LocalTransportFactory();
+        localTransport.setUriPrefixes(new HashSet<>(Arrays.asList("http", "local")));
+        dfm.registerDestinationFactory(LocalTransportFactory.TRANSPORT_ID, localTransport);
+        dfm.registerDestinationFactory("http://cxf.apache.org/transports/http", localTransport);
+        dfm.registerDestinationFactory("http://cxf.apache.org/transports/http/configuration", localTransport);
+
+        ConduitInitiatorManager extension = bus.getExtension(ConduitInitiatorManager.class);
+        extension.registerConduitInitiator(LocalTransportFactory.TRANSPORT_ID, localTransport);
+        extension.registerConduitInitiator("http://schemas.xmlsoap.org/soap/http", localTransport);
+        extension.registerConduitInitiator("http://cxf.apache.org/transports/http", localTransport);
+        extension.registerConduitInitiator("http://cxf.apache.org/transports/http/configuration",
+                localTransport);
+    }
+
+    @org.junit.Test
+    public void testWrapperClassLoaderWhenNoWrappedOperations() throws Exception {
+        WrapperClassLoader wrapperClassLoader = new WrapperClassLoader(bus);
+        JaxWsServiceFactoryBean factory = new JaxWsServiceFactoryBean();
+
+        QName serviceName = new QName(
+                "http://apache.org/hello_world_soap_http", "interfaceTest");
+        ServiceInfo serviceInfo = new ServiceInfo();
+        DescriptionInfo descriptionInfo = new DescriptionInfo();
+        descriptionInfo.setName(serviceName);
+        serviceInfo.setDescription(descriptionInfo);
+
+        InterfaceInfo interfaceInfo = new InterfaceInfo(serviceInfo, serviceName);
+        QName sayHi = new QName("urn:test:ns", "sayHi");
+        interfaceInfo.addOperation(sayHi);
+
+        Set<Class<?>> result = wrapperClassLoader.generate(factory, interfaceInfo, false);
+
+        assertTrue(result.isEmpty());
+    }
+
+    @org.junit.Test
+    public void testWrapperClassLoaderWithWrappedOperations() throws Exception {
+        WrapperClassLoader wrapperClassLoader = new WrapperClassLoader(bus);
+        JaxWsServiceFactoryBean factory = new JaxWsServiceFactoryBean();
+
+        QName serviceName = new QName(
+                "http://apache.org/hello_world_soap_http", "interfaceTest");
+        ServiceInfo serviceInfo = new ServiceInfo();
+        DescriptionInfo descriptionInfo = new DescriptionInfo();
+        descriptionInfo.setName(serviceName);
+        serviceInfo.setDescription(descriptionInfo);
+
+        InterfaceInfo interfaceInfo = new InterfaceInfo(serviceInfo, serviceName);
+        QName sayHi = new QName("urn:test:ns", "sayHi");
+        OperationInfo operationInfo = interfaceInfo.addOperation(sayHi);
+
+        //Add wrapped operation
+        QName sayHello = new QName("urn:test:ns", "sayHello");
+        OperationInfo wrappedOperation = new OperationInfo();
+        wrappedOperation.setName(sayHello);
+        MessageInfo wrappedInputInfo = new MessageInfo(wrappedOperation, MessageInfo.Type.INPUT, sayHello);
+        wrappedOperation.setInput("sayHello", wrappedInputInfo);
+        MessageInfo wrappedOutputInfo = new MessageInfo(wrappedOperation, MessageInfo.Type.OUTPUT, sayHello);
+        wrappedOperation.setOutput("sayHello", wrappedOutputInfo);
+        operationInfo.setUnwrappedOperation(wrappedOperation);
+
+        //Setup method on operationInfo
+        Method method = Mockito.mock(Method.class);
+        doReturn(SayHi.class).when(method).getDeclaringClass();
+        operationInfo.setProperty(ReflectionServiceFactoryBean.METHOD, method);
+
+        //Setup Input and Output
+        MessageInfo inputInfo = new MessageInfo(operationInfo, MessageInfo.Type.INPUT, sayHi);
+        inputInfo.addMessagePart(sayHi);
+        operationInfo.setInput( "sayHi", inputInfo);
+        MessageInfo outputInfo = new MessageInfo(operationInfo, MessageInfo.Type.OUTPUT, sayHi);
+        outputInfo.addMessagePart(sayHi);
+        operationInfo.setOutput( "sayHi", outputInfo);
+
+        Set<Class<?>> result = wrapperClassLoader.generate(factory, interfaceInfo, false);
+
+        //Both Input and Output Messages will be found on Classpath
+        //org.apache.cxf.jaxws.service.jaxws_asm.SayHi
+        assertEquals(2, result.size());
+    }
+}


### PR DESCRIPTION
The provided unit test enhancement helps provide wider coverage of ProviderImpl, and introduces coverage to the WrapperClassLoader.  

In ProviderImpl we add test cases for most methods - we do not dive too deep into underlying objects/services - those have their own unit tests to assert correctness.

In the case of WrapperClassLoader we mock the class loader behavoir in order to exercise the generate and createWrapperClass functionality.