### PR TITLE
Updating Artemis to 2.35.0

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -87,7 +87,7 @@
         <cxf.osgi.jakarta.transaction.version>[2,3)</cxf.osgi.jakarta.transaction.version>
 
         <!-- please maintain alphabetical order here -->
-        <cxf.activemq.artemis.version>2.31.2</cxf.activemq.artemis.version>
+        <cxf.activemq.artemis.version>2.35.0</cxf.activemq.artemis.version>
         <cxf.ahc.version>2.12.3</cxf.ahc.version>
         <cxf.arquillian.version>1.8.0.Final</cxf.arquillian.version>
         <cxf.arquillian.weld.container.version>3.0.2.Final</cxf.arquillian.weld.container.version>


### PR DESCRIPTION
The current Artemis version is pulling a vulnerable Commons Configuration2 version into the lib folder...
