### PR TITLE
Allow JDK23 compatibility for Subject#getSubject

### DIFF
--- a/rt/features/logging/src/main/java/org/apache/cxf/ext/logging/event/DefaultLogEventMapper.java
+++ b/rt/features/logging/src/main/java/org/apache/cxf/ext/logging/event/DefaultLogEventMapper.java
@@ -141,9 +141,16 @@ public class DefaultLogEventMapper {
     }
 
     private Iterator<? extends Object> getJAASPrincipals() {
-        Subject subject = Subject.getSubject(AccessController.getContext());
-        return subject != null && subject.getPrincipals() != null
-            ? subject.getPrincipals().iterator() : Collections.emptyIterator();
+        try {
+            Subject subject = Subject.getSubject(AccessController.getContext());
+            return subject != null && subject.getPrincipals() != null
+                    ? subject.getPrincipals().iterator() : Collections.emptyIterator();
+        } catch (UnsupportedOperationException e) {
+            // JDK 23: The terminally deprecated method Subject.getSubject(AccessControlContext) has been re-specified
+            // to throw UnsupportedOperationException if invoked when a Security Manager is not allowed.
+            // see https://jdk.java.net/23/release-notes#JDK-8296244
+            return Collections.emptyIterator();
+        }
     }
 
     private Map<String, String> getHeaders(Message message) {


### PR DESCRIPTION
As reported by [JDK 23 release notes](https://jdk.java.net/23/release-notes#JDK-8296244):

> The terminally deprecated method Subject.getSubject(AccessControlContext) has been re-specified to throw UnsupportedOperationException if invoked when a Security Manager is not allowed.

The proposed change allows to run flawlessly under JDK 23.