### PR TITLE
[CXF-9042] Fixed non-idempotent unit tests

### DIFF
--- a/rt/management/src/test/java/org/apache/cxf/management/InstrumentationManagerTest.java
+++ b/rt/management/src/test/java/org/apache/cxf/management/InstrumentationManagerTest.java
@@ -89,28 +89,30 @@ public class InstrumentationManagerTest {
         ObjectName name = new ObjectName(ManagementConstants.DEFAULT_DOMAIN_NAME
                                          + ":type=WorkQueues,*");
         Set<ObjectName> s = mbs.queryNames(name, null);
-        assertEquals(2, s.size());
-        Iterator<ObjectName> it = s.iterator();
-        while (it.hasNext()) {
-            ObjectName n = it.next();
-            Long result =
-                (Long)mbs.invoke(n, "getWorkQueueMaxSize", new Object[0], new String[0]);
-            assertEquals(result, Long.valueOf(256));
-            Integer hwm =
-                (Integer)mbs.invoke(n, "getHighWaterMark", new Object[0], new String[0]);
-            if (n.getCanonicalName().contains("test-wq")) {
-                assertEquals(10, hwm.intValue());
-            } else {
-                assertEquals(15, hwm.intValue());
+        try {
+            assertEquals(2, s.size());
+            Iterator<ObjectName> it = s.iterator();
+            while (it.hasNext()) {
+                ObjectName n = it.next();
+                Long result =
+                    (Long)mbs.invoke(n, "getWorkQueueMaxSize", new Object[0], new String[0]);
+                assertEquals(result, Long.valueOf(256));
+                Integer hwm =
+                    (Integer)mbs.invoke(n, "getHighWaterMark", new Object[0], new String[0]);
+                if (n.getCanonicalName().contains("test-wq")) {
+                    assertEquals(10, hwm.intValue());
+                } else {
+                    assertEquals(15, hwm.intValue());
+                }
             }
+        } finally {
+            // Unregister MBeans at the end of the test
+            Iterator<ObjectName> it2 = s.iterator();
+            while (it2.hasNext()) {
+                mbs.unregisterMBean(it2.next());
+            }
+            bus.shutdown(true);
         }
-
-        // Unregister MBeans at the end of the test
-        Iterator<ObjectName> it2 = s.iterator();
-        while (it2.hasNext()) {
-            mbs.unregisterMBean(it2.next());
-        }
-        bus.shutdown(true);
     }
 
     @Test

--- a/rt/management/src/test/java/org/apache/cxf/management/InstrumentationManagerTest.java
+++ b/rt/management/src/test/java/org/apache/cxf/management/InstrumentationManagerTest.java
@@ -105,6 +105,11 @@ public class InstrumentationManagerTest {
             }
         }
 
+        // Unregister MBeans at the end of the test
+        Iterator<ObjectName> it2 = s.iterator();
+        while (it2.hasNext()) {
+            mbs.unregisterMBean(it2.next());
+        }
         bus.shutdown(true);
     }
 

--- a/services/sts/sts-core/src/test/java/org/apache/cxf/sts/operation/ValidateJWTTransformationTest.java
+++ b/services/sts/sts-core/src/test/java/org/apache/cxf/sts/operation/ValidateJWTTransformationTest.java
@@ -206,9 +206,7 @@ public class ValidateJWTTransformationTest {
         TokenProviderResponse providerResponse = createJWT();
         Element wrapper = createTokenWrapper((String)providerResponse.getToken());
         Document doc = wrapper.getOwnerDocument();
-        if (doc.getDocumentElement() == null) {
-            wrapper = (Element)doc.appendChild(wrapper);
-        }
+        wrapper = (Element)doc.appendChild(wrapper);
 
         ValidateTargetType validateTarget = new ValidateTargetType();
         validateTarget.setAny(wrapper);
@@ -340,7 +338,7 @@ public class ValidateJWTTransformationTest {
     }
 
     private Element createTokenWrapper(String token) {
-        Document doc = DOMUtils.getEmptyDocument();
+        Document doc = DOMUtils.createDocument();
         Element tokenWrapper = doc.createElementNS(null, "TokenWrapper");
         tokenWrapper.setTextContent(token);
         return tokenWrapper;

--- a/services/sts/sts-core/src/test/java/org/apache/cxf/sts/operation/ValidateJWTTransformationTest.java
+++ b/services/sts/sts-core/src/test/java/org/apache/cxf/sts/operation/ValidateJWTTransformationTest.java
@@ -206,7 +206,9 @@ public class ValidateJWTTransformationTest {
         TokenProviderResponse providerResponse = createJWT();
         Element wrapper = createTokenWrapper((String)providerResponse.getToken());
         Document doc = wrapper.getOwnerDocument();
-        wrapper = (Element)doc.appendChild(wrapper);
+        if (doc.getDocumentElement() == null) {
+            wrapper = (Element)doc.appendChild(wrapper);
+        }
 
         ValidateTargetType validateTarget = new ValidateTargetType();
         validateTarget.setAny(wrapper);

--- a/systests/jaxws/src/test/java/org/apache/cxf/systest/dispatch/DispatchClientServerTest.java
+++ b/systests/jaxws/src/test/java/org/apache/cxf/systest/dispatch/DispatchClientServerTest.java
@@ -659,6 +659,11 @@ public class DispatchClientServerTest extends AbstractBusClientServerTestBase {
 
     @Test
     public void testJAXBObjectPAYLOADWithFeature() throws Exception {
+        // Save initial counts
+        int initialCount = TestDispatchFeature.getCount();
+        int initialInInterceptorCount = TestDispatchFeature.getInInterceptorCount();
+        int initialOutInterceptorCount = TestDispatchFeature.getOutInterceptorCount();
+
         createBus("org/apache/cxf/systest/dispatch/client-config.xml");
         BusFactory.setThreadDefaultBus(bus);
 
@@ -688,15 +693,13 @@ public class DispatchClientServerTest extends AbstractBusClientServerTestBase {
         String responseValue = ((GreetMeResponse)response).getResponseType();
         assertEquals("Expected string, " + expected, expected, responseValue);
 
-        assertEquals("Feature should be applied", 1, TestDispatchFeature.getCount());
+        assertEquals("Feature should be applied", initialCount + 1, TestDispatchFeature.getCount());
         assertEquals("Feature based interceptors should be added",
-                     1, TestDispatchFeature.getCount());
-
+                    initialCount + 1, TestDispatchFeature.getCount());
         assertEquals("Feature based In interceptors has be added to in chain.",
-                     1, TestDispatchFeature.getInInterceptorCount());
-
+                    initialInInterceptorCount + 1, TestDispatchFeature.getInInterceptorCount());
         assertEquals("Feature based interceptors has to be added to out chain.",
-                     1, TestDispatchFeature.getOutInterceptorCount());
+                    initialOutInterceptorCount + 1, TestDispatchFeature.getOutInterceptorCount());
         bus.shutdown(true);
     }
 


### PR DESCRIPTION
Fixes https://issues.apache.org/jira/browse/CXF-9042

# The Problem


Some unit tests are non-idempotent, as they pass in the first run but fail in the second run in the same environment. A fix is necessary since unit tests shall be self-contained, ensuring that the state of the system under test is consistent at the beginning of each test. In practice, fixing non-idempotent tests can help proactively avoid state pollution that results in test order dependency (which could cause problems under test selection, prioritization or parallelization).


# Reproduce


Using the `NIOInspector` plugin that supports rerunning JUnit tests in the same environment. Use `org.apache.cxf.management.InstrumentationManagerTest#testWorkQueueInstrumentation` as an example:
```
cd rt/management
mvn edu.illinois:NIOInspector:rerun -Dtest=org.apache.cxf.management.InstrumentationManagerTest#testWorkQueueInstrumentation

```


# 3 Non-Idempotent Tests & Proposed Fix
## org.apache.cxf.management.InstrumentationManagerTest#testWorkQueueInstrumentation
Reason: The test creates and registers `MBean`s in the `MBeanServer` every time it runs, but it does not properly clean up those `MBean`s after the test execution. As a result, when the test is repeatedly run in the same environment, the number of `MBean`s registered with the `MBeanServer` accumulates, causing `s.size()` to increase.


Error message of the test in the repeated run:
```
java.lang.AssertionError: expected:<2> but was:<4>
	at org.junit.Assert.fail(Assert.java:89)
	at org.junit.Assert.failNotEquals(Assert.java:835)
	at org.junit.Assert.assertEquals(Assert.java:647)
	at org.junit.Assert.assertEquals(Assert.java:633)
	at org.apache.cxf.management.InstrumentationManagerTest.testWorkQueueInstrumentation(InstrumentationManagerTest.java:91)
```
Fix: Unregister `MBean`s at the end of the test.


## org.apache.cxf.sts.operation.ValidateJWTTransformationTest#testJWTToSAMLTransformationRealm
Reason: The line `wrapper = (Element) doc.getDocumentElement().appendChild(wrapper);` is not idempotent. This is because each time this line is executed, it attempts to append the wrapper element to the document's root element. If the wrapper element has already been appended to the root (as done in a previous test run), attempting to append it again will violate the document's tree structure, resulting in `org.w3c.dom.DOMException`.

Error message in the repeated run:
```
org.w3c.dom.DOMException: HIERARCHY_REQUEST_ERR: An attempt was made to insert a node where it is not permitted.
	at java.xml/com.sun.org.apache.xerces.internal.dom.CoreDocumentImpl.insertBefore(CoreDocumentImpl.java:439)
	at java.xml/com.sun.org.apache.xerces.internal.dom.NodeImpl.appendChild(NodeImpl.java:230)
	at org.apache.cxf.sts.operation.ValidateJWTTransformationTest.testJWTToSAMLTransformationRealm(ValidateJWTTransformationTest.java:209)
```
Fix: Add a checker to avoid appending the `wrapper` if it is already part of the document.



## org.apache.cxf.systest.dispatch.DispatchClientServerTest#testJAXBObjectPAYLOADWithFeature
Reason: The static counters in `TestDispatchFeature` and `TestInInterceptor` gets incremented repeatedly when `testJAXBObjectPAYLOADWithFeature()` is repeatedly run. The counters will be 1 in the first test run, but will be 2 in the second run and so on.


Error message  in the repeated run:
```
java.lang.AssertionError: Feature should be applied expected:<1> but was:<2>
	at org.junit.Assert.fail(Assert.java:89)
	at org.junit.Assert.failNotEquals(Assert.java:835)
	at org.junit.Assert.assertEquals(Assert.java:647)
	at org.apache.cxf.systest.dispatch.DispatchClientServerTest.testJAXBObjectPAYLOADWithFeature(DispatchClientServerTest.java:691)
```
Fix:  Save the initial counts of the `TestDispatchFeature` before creating the bus, and then comparing the increments in the assertion checks.


# Verifying this change
After the patch, running the tests repeatedly in the same environment will not lead to failures.

