### PR TITLE
[CXF-9048] Update the WSS4J tests

### DIFF
--- a/rt/ws/security/src/test/java/org/apache/cxf/ws/security/wss4j/WSS4JInOutTest.java
+++ b/rt/ws/security/src/test/java/org/apache/cxf/ws/security/wss4j/WSS4JInOutTest.java
@@ -230,6 +230,7 @@ public class WSS4JInOutTest extends AbstractSecurityTest {
         outProperties.put(ConfigurationConstants.USER, alias);
         outProperties.put(ConfigurationConstants.ENC_KEY_TRANSPORT, WSS4JConstants.KEYWRAP_AES128);
         outProperties.put(ConfigurationConstants.ENC_KEY_AGREEMENT_METHOD, WSS4JConstants.AGREEMENT_METHOD_ECDH_ES);
+        outProperties.put(ConfigurationConstants.ENC_KEY_DERIVATION_FUNCTION, WSS4JConstants.KEYDERIVATION_CONCATKDF);
 
         Map<String, Object> inProperties = new HashMap<>();
         inProperties.put(ConfigurationConstants.ACTION, ConfigurationConstants.ENCRYPTION);


### PR DESCRIPTION
Update the Integration test for WSS4J with KeyDerivation function. For details see the [CXF-9048](https://issues.apache.org/jira/browse/CXF-9048)

NOTE Before the merge the  version wss4j 3.0.4 with the xmlsec 3.0.5 must be released