### PR TITLE
Try to fix timeout error by using countdownlatch

### DIFF
--- a/rt/transports/jms/src/test/java/org/apache/cxf/transport/jms/RequestResponseTest.java
+++ b/rt/transports/jms/src/test/java/org/apache/cxf/transport/jms/RequestResponseTest.java
@@ -63,15 +63,8 @@ public class RequestResponseTest extends AbstractJMSTester {
     public void testRequestTopicResponseStaticQueue() throws Exception {
         EndpointInfo ei = setupServiceInfo("http://cxf.apache.org/jms_simple", "/wsdl/jms_spec_testsuite.wsdl",
                          "JMSSimpleService002X", "SimplePortTopicRequestQueueResponse");
-        System.out.println("Starting test with topic request and static queue response");
-    
         sendAndReceiveMessages(ei, true);
-        
-        System.out.println("First send and receive completed. Starting second test with queue request and response");
-        
         sendAndReceiveMessages(ei, false);
-        
-        System.out.println("Test completed successfully");
     }
 
     private void sendAndReceiveMessages(EndpointInfo ei, boolean synchronous)


### PR DESCRIPTION
Fix the synchronous problem on test testRequestTopicResponseStaticQueue. For details see the [CXF-8393](https://issues.apache.org/jira/browse/CXF-8807)

NOTE using debugging tool [NonDex ](https://github.com/TestingResearchIllinois/NonDex) for checking the flaky test time out problem.