### PR TITLE
Fix enforcer violation due to update to latest maven-javadoc-plugin 3.10.0

### DIFF
--- a/maven-plugins/java2wadl-plugin/pom.xml
+++ b/maven-plugins/java2wadl-plugin/pom.xml
@@ -124,6 +124,10 @@
                     <groupId>org.apache.maven</groupId>
                     <artifactId>maven-toolchain</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>org.apache.maven.doxia</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
 


### PR DESCRIPTION
Fix enforcer violation due to update to latest maven-javadoc-plugin 3.10.0:

```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-enforcer-plugin:3.5.0:enforce (enforce-maven) on project cxf-coverage-report: 
[ERROR] Rule 2: org.apache.maven.enforcer.rules.dependency.BannedDependencies failed with message:
[ERROR] org.apache.cxf:cxf-coverage-report:pom:4.1.0-SNAPSHOT
[ERROR]    org.apache.cxf:cxf-java2wadl-plugin:jar:4.1.0-SNAPSHOT
[ERROR]       org.apache.maven.plugins:maven-javadoc-plugin:jar:3.10.0
[ERROR]          org.apache.maven.doxia:doxia-site-renderer:jar:2.0.0-M19
[ERROR]             org.eclipse.sisu:org.eclipse.sisu.plexus:jar:0.9.0.M2
[ERROR]                javax.annotation:javax.annotation-api:jar:1.2 <--- banned via the exclude/include list
[ERROR] -> [Help 1]
[ERROR] 
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR] 
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/MojoExecutionException
[ERROR] 
[ERROR] After correcting the problems, you can r
```