### PR TITLE
CXF-7396: CachedOutputStream doesn't delete temp files

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -175,6 +175,11 @@
             <artifactId>saaj-impl</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.awaitility</groupId>
+            <artifactId>awaitility</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/core/src/main/java/org/apache/cxf/bus/extension/ExtensionManagerBus.java
+++ b/core/src/main/java/org/apache/cxf/bus/extension/ExtensionManagerBus.java
@@ -141,7 +141,6 @@ public class ExtensionManagerBus extends AbstractBasicInterceptorProvider implem
         if (null == this.getExtension(BindingFactoryManager.class)) {
             new BindingFactoryManagerImpl(this);
         }
-
         extensionManager.load(new String[] {ExtensionManagerImpl.BUS_EXTENSION_RESOURCE});
         extensionManager.activateAllByType(ResourceResolver.class);
 

--- a/core/src/main/java/org/apache/cxf/bus/extension/ExtensionManagerBus.java
+++ b/core/src/main/java/org/apache/cxf/bus/extension/ExtensionManagerBus.java
@@ -141,6 +141,7 @@ public class ExtensionManagerBus extends AbstractBasicInterceptorProvider implem
         if (null == this.getExtension(BindingFactoryManager.class)) {
             new BindingFactoryManagerImpl(this);
         }
+
         extensionManager.load(new String[] {ExtensionManagerImpl.BUS_EXTENSION_RESOURCE});
         extensionManager.activateAllByType(ResourceResolver.class);
 

--- a/core/src/main/java/org/apache/cxf/io/CachedConstants.java
+++ b/core/src/main/java/org/apache/cxf/io/CachedConstants.java
@@ -73,8 +73,8 @@ public final class CachedConstants {
 
     /**
      * The delay (in ms) for cleaning up unclosed {@code CachedOutputStream} instances. 30 minutes
-     * is specified by default. If the value of the delay is set to 0 (or is negative), the cleaner
-     * will be disabled.
+     * is specified by default, the minimum value is 2 seconds. If the value of the delay is set to
+     * 0 (or is negative), the cleaner will be deactivated.
      */
     public static final String CLEANER_DELAY_BUS_PROP =
         "bus.io.CachedOutputStreamCleaner.Delay";

--- a/core/src/main/java/org/apache/cxf/io/CachedConstants.java
+++ b/core/src/main/java/org/apache/cxf/io/CachedConstants.java
@@ -71,6 +71,14 @@ public final class CachedConstants {
     public static final String CIPHER_TRANSFORMATION_BUS_PROP =
         "bus.io.CachedOutputStream.CipherTransformation";
 
+    /**
+     * The delay (in ms) for cleaning up unclosed {@code CachedOutputStream} instances. 30 minutes
+     * is specified by default. If the value of the delay is set to 0 (or is negative), the cleaner
+     * will be disabled.
+     */
+    public static final String CLEANER_DELAY_BUS_PROP =
+        "bus.io.CachedOutputStreamCleaner.Delay";
+
     private CachedConstants() {
         // complete
     }

--- a/core/src/main/java/org/apache/cxf/io/CachedOutputStreamCleaner.java
+++ b/core/src/main/java/org/apache/cxf/io/CachedOutputStreamCleaner.java
@@ -1,0 +1,43 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.cxf.io;
+
+import java.io.Closeable;
+
+/**
+ * The {@link Bus} extension to clean up unclosed {@link CachedOutputStream} instances (and alike) backed by
+ * temporary files (leading to disk fill, see https://issues.apache.org/jira/browse/CXF-7396. 
+ */
+public interface CachedOutputStreamCleaner {
+    /**
+     * Run the clean up
+     */
+    void clean();
+
+    /**
+     * Register the stream instance for the clean up
+     */
+    void unregister(Closeable closeable);
+
+    /**
+     * Unregister the stream instance from the clean up (closed properly)
+     */
+    void register(Closeable closeable);
+}

--- a/core/src/main/java/org/apache/cxf/io/DelayedCachedOutputStreamCleaner.java
+++ b/core/src/main/java/org/apache/cxf/io/DelayedCachedOutputStreamCleaner.java
@@ -1,0 +1,180 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.cxf.io;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.Objects;
+import java.util.Timer;
+import java.util.TimerTask;
+import java.util.concurrent.DelayQueue;
+import java.util.concurrent.Delayed;
+import java.util.concurrent.TimeUnit;
+import java.util.logging.Logger;
+
+import jakarta.annotation.Resource;
+import org.apache.cxf.Bus;
+import org.apache.cxf.buslifecycle.BusLifeCycleListener;
+import org.apache.cxf.buslifecycle.BusLifeCycleManager;
+import org.apache.cxf.common.logging.LogUtils;
+
+public final class DelayedCachedOutputStreamCleaner implements CachedOutputStreamCleaner, BusLifeCycleListener {
+    private static final Logger LOG = LogUtils.getL7dLogger(DelayedCachedOutputStreamCleaner.class);
+
+    private long delay; /* default is 30 minutes, in milliseconds */
+    private final DelayQueue<DelayedCloseable> queue = new DelayQueue<>();
+    private Timer timer;
+
+    private static final class DelayedCloseable implements Delayed {
+        private final Closeable closeable;
+        private final long expiredAt;
+        
+        DelayedCloseable(final Closeable closeable, final long delay) {
+            this.closeable = closeable;
+            this.expiredAt = System.nanoTime() + delay;
+        }
+
+        @Override
+        public int compareTo(Delayed o) {
+            return Long.compare(getDelay(TimeUnit.NANOSECONDS), o.getDelay(TimeUnit.NANOSECONDS));
+        }
+
+        @Override
+        public long getDelay(TimeUnit unit) {
+            return unit.convert(expiredAt - System.nanoTime(), TimeUnit.NANOSECONDS);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(closeable);
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj) {
+                return true;
+            }
+            
+            if (obj == null) {
+                return false;
+            }
+            
+            if (getClass() != obj.getClass()) {
+                return false;
+            }
+            
+            final DelayedCloseable other = (DelayedCloseable) obj;
+            return Objects.equals(closeable, other.closeable);
+        }
+    }
+
+    @Resource
+    public void setBus(Bus bus) {
+        Number delayValue = null;
+        BusLifeCycleManager busLifeCycleManager = null;
+
+        if (bus != null) {
+            delayValue = (Number) bus.getProperty(CachedConstants.CLEANER_DELAY_BUS_PROP);
+            busLifeCycleManager = bus.getExtension(BusLifeCycleManager.class);
+        }
+        
+        if (delayValue == null) {
+            delay = TimeUnit.MILLISECONDS.convert(30, TimeUnit.MINUTES);
+        } else {
+            final long value = delayValue.longValue();
+            if (value > 0) {
+                delay = value; /* already in milliseconds */
+            }
+        }
+
+        if (busLifeCycleManager != null) {
+            busLifeCycleManager.registerLifeCycleListener(this);
+        }
+        
+        if (timer != null) {
+            timer.cancel();
+            timer = null;
+        }
+
+        if (delay > 0) {
+            timer = new Timer("DelayedCachedOutputStreamCleaner", true);
+            timer.scheduleAtFixedRate(new TimerTask() {
+                @Override
+                public void run() {
+                    clean();
+                }
+            }, 0, Math.max(1, delay >> 1));
+        }
+
+    }
+    
+    @Override
+    public void register(Closeable closeable) {
+        queue.put(new DelayedCloseable(closeable, delay));
+    }
+
+    @Override
+    public void unregister(Closeable closeable) {
+        queue.remove(new DelayedCloseable(closeable, delay));
+    }
+
+    @Override
+    public void clean() {
+        final Collection<DelayedCloseable> closeables = new ArrayList<>();
+        queue.drainTo(closeables);
+        clean(closeables);
+    }
+    
+    @Override
+    public void initComplete() {
+    }
+    
+    @Override
+    public void postShutdown() {
+    }
+    
+    @Override
+    public void preShutdown() {
+        if (timer != null) {
+            timer.cancel();
+        }
+    }
+
+    public void forceClean() {
+        clean(queue);
+    }
+
+    private void clean(Collection<DelayedCloseable> closeables) {
+        final Iterator<DelayedCloseable> iterator = closeables.iterator();
+        while (iterator.hasNext()) {
+            final DelayedCloseable next = iterator.next();
+            try {
+                iterator.remove();
+                LOG.warning("Unclosed (leaked?) stream detected: " + next.closeable);
+                next.closeable.close();
+            } catch (final IOException | RuntimeException ex) {
+                LOG.warning("Unable to close (leaked?) stream: " + ex.getMessage());
+            }
+        }
+    }
+}

--- a/core/src/main/resources/META-INF/cxf/bus-extensions.txt
+++ b/core/src/main/resources/META-INF/cxf/bus-extensions.txt
@@ -11,4 +11,4 @@ org.apache.cxf.bus.resource.ResourceManagerImpl:org.apache.cxf.resource.Resource
 org.apache.cxf.catalog.OASISCatalogManager:org.apache.cxf.catalog.OASISCatalogManager:true
 org.apache.cxf.common.util.ASMHelperImpl:org.apache.cxf.common.util.ASMHelper:true
 org.apache.cxf.common.spi.ClassLoaderProxyService:org.apache.cxf.common.spi.ClassLoaderService:true
-
+org.apache.cxf.io.DelayedCachedOutputStreamCleaner:org.apache.cxf.io.CachedOutputStreamCleaner:true

--- a/core/src/test/java/org/apache/cxf/io/DelayedCachedOutputStreamCleanerTest.java
+++ b/core/src/test/java/org/apache/cxf/io/DelayedCachedOutputStreamCleanerTest.java
@@ -1,0 +1,164 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.cxf.io;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.apache.cxf.Bus;
+import org.apache.cxf.bus.extension.ExtensionManagerBus;
+
+import org.junit.After;
+import org.junit.Test;
+
+import static org.awaitility.Awaitility.await;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class DelayedCachedOutputStreamCleanerTest {
+    private Bus bus;
+
+    @After
+    public void tearDown() {
+        bus.shutdown(true);
+        bus = null;
+    }
+    
+    @Test
+    public void testNoop() {
+        final Map<String, Object> properties = Collections.singletonMap(CachedConstants.CLEANER_DELAY_BUS_PROP, 0);
+        bus = new ExtensionManagerBus(new HashMap<>(), properties);
+        
+        final CachedOutputStreamCleaner cleaner = bus.getExtension(CachedOutputStreamCleaner.class);
+        assertThat(cleaner, instanceOf(DelayedCachedOutputStreamCleaner.class)); /* noop */
+    }
+    
+    @Test
+    public void testForceClean() throws InterruptedException {
+        bus = new ExtensionManagerBus();
+        
+        final CachedOutputStreamCleaner cleaner = bus.getExtension(CachedOutputStreamCleaner.class);
+        assertThat(cleaner, instanceOf(DelayedCachedOutputStreamCleaner.class));
+        
+        final AtomicBoolean latch = new AtomicBoolean(false);
+        final Closeable closeable = () -> latch.compareAndSet(false, true);
+        cleaner.register(closeable);
+        
+        final DelayedCachedOutputStreamCleaner delayedCleaner = (DelayedCachedOutputStreamCleaner) cleaner;
+        delayedCleaner.forceClean();
+        
+        // Await for Closeable::close to be called
+        assertThat(latch.get(), is(true));
+    }
+    
+    @Test
+    public void testClean() throws InterruptedException {
+        final AtomicInteger latch = new AtomicInteger();
+        final Closeable closeable1 = () -> latch.incrementAndGet();
+        final Closeable closeable2 = () -> latch.incrementAndGet();
+
+        /* Delay of 2.5 seconds */
+        final Map<String, Object> properties = Collections.singletonMap(CachedConstants.CLEANER_DELAY_BUS_PROP, 2500);
+        bus = new ExtensionManagerBus(new HashMap<>(), properties);
+
+        final CachedOutputStreamCleaner cleaner = bus.getExtension(CachedOutputStreamCleaner.class);
+        cleaner.register(closeable1);
+        cleaner.register(closeable2);
+
+        // Await for Closeable::close to be called on schedule
+        await().atMost(5, TimeUnit.SECONDS).untilAtomic(latch, equalTo(2));
+        assertThat(cleaner, instanceOf(DelayedCachedOutputStreamCleaner.class));
+    }
+    
+    @Test
+    public void testForceCleanForEmpty() throws InterruptedException {
+        bus = new ExtensionManagerBus();
+
+        final CachedOutputStreamCleaner cleaner = bus.getExtension(CachedOutputStreamCleaner.class);
+        assertThat(cleaner, instanceOf(DelayedCachedOutputStreamCleaner.class));
+        
+        final AtomicBoolean latch = new AtomicBoolean(false);
+        final Closeable closeable = () -> latch.compareAndSet(false, true);
+
+        cleaner.register(closeable);
+        cleaner.unregister(closeable);
+        
+        final DelayedCachedOutputStreamCleaner delayedCleaner = (DelayedCachedOutputStreamCleaner) cleaner;
+        delayedCleaner.forceClean();
+        
+        // Closeable::close should not be called
+        assertThat(latch.get(), is(false));
+    }
+    
+    @Test
+    public void testForceCleanException() throws InterruptedException {
+        bus = new ExtensionManagerBus();
+
+        final CachedOutputStreamCleaner cleaner = bus.getExtension(CachedOutputStreamCleaner.class);
+        assertThat(cleaner, instanceOf(DelayedCachedOutputStreamCleaner.class));
+        
+        final AtomicInteger latch = new AtomicInteger();
+        final Closeable closeable2 = () -> latch.incrementAndGet();
+        final Closeable closeable1 = () -> {
+            latch.incrementAndGet();
+            throw new IOException("Simulated");
+        };
+        cleaner.register(closeable1);
+        cleaner.register(closeable2);
+
+        final DelayedCachedOutputStreamCleaner delayedCleaner = (DelayedCachedOutputStreamCleaner) cleaner;
+        delayedCleaner.forceClean();
+
+        // Try to call force clean one more time
+        delayedCleaner.forceClean();
+        
+        // Await for Closeable::close to be called
+        assertThat(latch.get(), equalTo(2));
+    }
+    
+    @Test
+    public void testBusLifecycle() throws InterruptedException {
+        /* Delay of 2.5 seconds */
+        final Map<String, Object> properties = Collections.singletonMap(CachedConstants.CLEANER_DELAY_BUS_PROP, 2500);
+        bus = new ExtensionManagerBus(new HashMap<>(), properties);
+
+        final AtomicBoolean latch = new AtomicBoolean();
+        final Closeable closeable = () -> latch.compareAndSet(false, true);
+
+        bus.setProperty(CachedConstants.CLEANER_DELAY_BUS_PROP, 2500); /* 2.5 seconds */
+        final CachedOutputStreamCleaner cleaner = bus.getExtension(CachedOutputStreamCleaner.class);
+        cleaner.register(closeable);
+
+        // Closes the bus, the cleaner should cancel the internal timer(s)
+        bus.shutdown(true);
+
+        // The Closeable::close should not be called since timer(s) is cancelled
+        await().during(3, TimeUnit.SECONDS).untilAtomic(latch, is(false));
+    }
+
+}

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -275,7 +275,6 @@
         <cxf.wsdl4j.bundle.version>1.6.3_1</cxf.wsdl4j.bundle.version>
         <cxf.xmlresolver.bundle.version>1.2_5</cxf.xmlresolver.bundle.version>
         <cxf.xpp3.bundle.version>1.1.4c_6</cxf.xpp3.bundle.version>
-        <!-- Downgrade to 4.2.0 due to https://github.com/awaitility/awaitility/pull/279 -->
         <cxf.awaitility.version>4.2.2</cxf.awaitility.version>
     </properties>
     <build>


### PR DESCRIPTION
`CachedOutputStream` doesn't delete temp files. it turned out to be very challenging to handle all the edge (and non-edge) cases where `CachedOutputStream`s  (or derived) streams stay unclosed. This change does not solve the root cause of the problem but offers at least a mitigation strategy in a shape of `CachedOutputStreamCleaner` that tracks unclosed `CachedOutputStream`s  (or derived) streams and periodically tries to close those out.