### PR TITLE
Extract Openfeign version to samples/pom.xml in order to simplify dependency updates / backports

### DIFF
--- a/distribution/src/main/release/samples/jax_rs/tracing_micrometer/pom.xml
+++ b/distribution/src/main/release/samples/jax_rs/tracing_micrometer/pom.xml
@@ -131,17 +131,17 @@
         <dependency>
             <groupId>io.github.openfeign</groupId>
             <artifactId>feign-core</artifactId>
-            <version>13.3</version>
+            <version>${cxf.openfeign.version}</version>
         </dependency>
         <dependency>
             <groupId>io.github.openfeign</groupId>
             <artifactId>feign-httpclient</artifactId>
-            <version>13.3</version>
+            <version>${cxf.openfeign.version}</version>
         </dependency>
         <dependency>
             <groupId>io.github.openfeign</groupId>
             <artifactId>feign-micrometer</artifactId>
-            <version>13.3</version>
+            <version>${cxf.openfeign.version}</version>
         </dependency>
         <dependency>
             <groupId>io.micrometer</groupId>

--- a/distribution/src/main/release/samples/jax_rs/tracing_opentelemetry/pom.xml
+++ b/distribution/src/main/release/samples/jax_rs/tracing_opentelemetry/pom.xml
@@ -131,12 +131,12 @@
         <dependency>
             <groupId>io.github.openfeign</groupId>
             <artifactId>feign-core</artifactId>
-            <version>13.3</version>
+            <version>${cxf.openfeign.version}</version>
         </dependency>
         <dependency>
             <groupId>io.github.openfeign</groupId>
             <artifactId>feign-httpclient</artifactId>
-            <version>13.3</version>
+            <version>${cxf.openfeign.version}</version>
         </dependency>
         <dependency>
             <groupId>io.github.openfeign.opentracing</groupId>

--- a/distribution/src/main/release/samples/jax_rs/tracing_opentracing/pom.xml
+++ b/distribution/src/main/release/samples/jax_rs/tracing_opentracing/pom.xml
@@ -134,12 +134,12 @@
         <dependency>
             <groupId>io.github.openfeign</groupId>
             <artifactId>feign-core</artifactId>
-            <version>13.3</version>
+            <version>${cxf.openfeign.version}</version>
         </dependency>
         <dependency>
             <groupId>io.github.openfeign</groupId>
             <artifactId>feign-httpclient</artifactId>
-            <version>13.3</version>
+            <version>${cxf.openfeign.version}</version>
         </dependency>
         <dependency>
             <groupId>io.github.openfeign.opentracing</groupId>

--- a/distribution/src/main/release/samples/pom.xml
+++ b/distribution/src/main/release/samples/pom.xml
@@ -52,6 +52,7 @@
         <cxf.jboss.narayana.version>5.13.1.Final</cxf.jboss.narayana.version>
         <cxf.narayana.spring.boot.version>2.6.7</cxf.narayana.spring.boot.version>
         <cxf.camel.version>4.7.0</cxf.camel.version>
+        <cxf.openfeign.version>13.3</cxf.openfeign.version>
     </properties>
     <dependencies>
         <dependency>


### PR DESCRIPTION
Extract Openfeign version to samples/pom.xml in order to simplify dependency updates / backports