### PR TITLE
CXF-9055 Follow OpenTelemetry semconv for trace span and its attributes

### DIFF
--- a/integration/tracing/tracing-opentelemetry/pom.xml
+++ b/integration/tracing/tracing-opentelemetry/pom.xml
@@ -47,6 +47,11 @@
             <optional>true</optional>
         </dependency>
         <dependency>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <scope>test</scope>

--- a/integration/tracing/tracing-opentelemetry/src/main/java/org/apache/cxf/tracing/opentelemetry/OpenTelemetryStartInterceptor.java
+++ b/integration/tracing/tracing-opentelemetry/src/main/java/org/apache/cxf/tracing/opentelemetry/OpenTelemetryStartInterceptor.java
@@ -21,14 +21,20 @@ package org.apache.cxf.tracing.opentelemetry;
 import java.util.List;
 import java.util.Map;
 
+import jakarta.servlet.http.HttpServletRequest;
 import org.apache.cxf.common.injection.NoJSR250Annotations;
 import org.apache.cxf.helpers.CastUtils;
 import org.apache.cxf.interceptor.Fault;
 import org.apache.cxf.message.Message;
 import org.apache.cxf.phase.Phase;
+import org.apache.cxf.transport.http.AbstractHTTPDestination;
 
 import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.Tracer;
+import io.opentelemetry.semconv.ClientAttributes;
+import io.opentelemetry.semconv.NetworkAttributes;
+import io.opentelemetry.semconv.UserAgentAttributes;
 
 @NoJSR250Annotations
 public class OpenTelemetryStartInterceptor extends AbstractOpenTelemetryInterceptor {
@@ -50,6 +56,24 @@ public class OpenTelemetryStartInterceptor extends AbstractOpenTelemetryIntercep
 
         if (holder != null) {
             message.getExchange().put(TRACE_SPAN, holder);
+        }
+
+        HttpServletRequest request = (HttpServletRequest)message.get(AbstractHTTPDestination.HTTP_REQUEST);
+        if (request != null) {
+            Span span = holder.getScope().getSpan();
+            span.setAttribute(ClientAttributes.CLIENT_ADDRESS, request.getRemoteAddr());
+            span.setAttribute(ClientAttributes.CLIENT_PORT, request.getRemotePort());
+            span.setAttribute(NetworkAttributes.NETWORK_PEER_ADDRESS, request.getRemoteAddr());
+            span.setAttribute(NetworkAttributes.NETWORK_PEER_PORT, request.getRemotePort());
+            String protocol = request.getProtocol();
+            if (protocol != null && protocol.contains("/")) {
+                String protocolVersion = protocol.split("/")[1];
+                span.setAttribute(NetworkAttributes.NETWORK_PROTOCOL_VERSION, protocolVersion);
+            }
+
+            if (request.getHeader("User-Agent") != null) {
+                span.setAttribute(UserAgentAttributes.USER_AGENT_ORIGINAL, request.getHeader("User-Agent"));
+            }
         }
     }
 }

--- a/integration/tracing/tracing-opentelemetry/src/main/java/org/apache/cxf/tracing/opentelemetry/jaxrs/OpenTelemetryProvider.java
+++ b/integration/tracing/tracing-opentelemetry/src/main/java/org/apache/cxf/tracing/opentelemetry/jaxrs/OpenTelemetryProvider.java
@@ -21,6 +21,7 @@ package org.apache.cxf.tracing.opentelemetry.jaxrs;
 import java.io.IOException;
 import java.lang.annotation.Annotation;
 
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.ws.rs.container.ContainerRequestContext;
 import jakarta.ws.rs.container.ContainerRequestFilter;
 import jakarta.ws.rs.container.ContainerResponseContext;
@@ -33,13 +34,20 @@ import org.apache.cxf.tracing.opentelemetry.AbstractOpenTelemetryProvider;
 import org.apache.cxf.tracing.opentelemetry.TraceScope;
 
 import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.Tracer;
+import io.opentelemetry.semconv.ClientAttributes;
+import io.opentelemetry.semconv.NetworkAttributes;
+import io.opentelemetry.semconv.UserAgentAttributes;
 
 @Provider
 public class OpenTelemetryProvider extends AbstractOpenTelemetryProvider
     implements ContainerRequestFilter, ContainerResponseFilter {
     @Context
     private ResourceInfo resourceInfo;
+
+    @Context
+    private HttpServletRequest request;
 
     public OpenTelemetryProvider(final OpenTelemetry openTelemetry, final String instrumentationName) {
         super(openTelemetry, instrumentationName);
@@ -52,9 +60,24 @@ public class OpenTelemetryProvider extends AbstractOpenTelemetryProvider
     @Override
     public void filter(final ContainerRequestContext requestContext) throws IOException {
         final TraceScopeHolder<TraceScope> holder = super.startTraceSpan(requestContext.getHeaders(),
-                                                                         requestContext.getUriInfo()
-                                                                             .getRequestUri(),
+                                                                         requestContext.getUriInfo().getRequestUri(),
                                                                          requestContext.getMethod());
+
+
+
+        if (request != null) {
+            Span span = holder.getScope().getSpan();
+            span.setAttribute(ClientAttributes.CLIENT_ADDRESS, request.getRemoteAddr());
+            span.setAttribute(ClientAttributes.CLIENT_PORT, request.getRemotePort());
+            span.setAttribute(NetworkAttributes.NETWORK_PEER_ADDRESS, request.getRemoteAddr());
+            span.setAttribute(NetworkAttributes.NETWORK_PEER_PORT, request.getRemotePort());
+            String protocol = request.getProtocol();
+            if (protocol != null && protocol.contains("/")) {
+                String protocolVersion = protocol.split("/")[1];
+                span.setAttribute(NetworkAttributes.NETWORK_PROTOCOL_VERSION, protocolVersion);
+            }
+            span.setAttribute(UserAgentAttributes.USER_AGENT_ORIGINAL, request.getHeader("User-Agent"));
+        }
 
         if (holder != null) {
             requestContext.setProperty(TRACE_SPAN, holder);
@@ -64,8 +87,7 @@ public class OpenTelemetryProvider extends AbstractOpenTelemetryProvider
     @SuppressWarnings("unchecked")
     @Override
     public void filter(final ContainerRequestContext requestContext,
-                       final ContainerResponseContext responseContext)
-        throws IOException {
+                       final ContainerResponseContext responseContext) {
         super.stopTraceSpan(requestContext.getHeaders(), responseContext.getHeaders(),
                             responseContext.getStatus(),
                             (TraceScopeHolder<TraceScope>)requestContext.getProperty(TRACE_SPAN));


### PR DESCRIPTION
* Add missing span attributes to comply with [OpenTelemetry semantic conventions](https://opentelemetry.io/docs/specs/semconv/http/http-spans/)
* Test the span attribute names and values
* Couldn't add the attributes "network.protocol.version" for the client http span, because we didn't find a way to find its value.

Link to the Jira ticket: [CXF-9055 Follow OpenTelemetry semantic conventions for trace span and its attributes ](https://issues.apache.org/jira/browse/CXF-9055)