### PR TITLE
Backmerge commit 17d58fb767 to branch `3.6.x-fixes`: Use URI factory to parse WSDL location (#1858)

### DIFF
--- a/tools/wsdlto/frontend/jaxws/src/main/java/org/apache/cxf/tools/wsdlto/frontend/jaxws/template/service.vm
+++ b/tools/wsdlto/frontend/jaxws/src/main/java/org/apache/cxf/tools/wsdlto/frontend/jaxws/template/service.vm
@@ -24,6 +24,7 @@ package $service.PackageName;
 #if ($wsdlLocation != "" && not($useGetResource) && not($wsdlLocation.startsWith("classpath:")))
 import java.net.MalformedURLException;
 #end
+import java.net.URI;
 import java.net.URL;
 #if ($markGenerated == "true")
 import javax.annotation.Generated;
@@ -120,7 +121,7 @@ public class ${service.Name} extends ${serviceSuperclass} {
 #else
         URL url = null;
         try {
-            url = new URL("$wsdlLocation");
+            url = URI.create("$wsdlLocation").toURL();
         } catch (MalformedURLException e) {
 #if ($serviceTarget == "cxf")
             LogUtils.getL7dLogger(${service.Name}.class)


### PR DESCRIPTION
This silences a Java 20+ warning also for those who still use CXF 3.x.

This is not my commit, I just backmerged it from `main`. Alternatively to merging this PR, you could merge from `main` too.