### PR TITLE
CXF-9060 Only import java.net.URI when necessary to avoid unused import warnings

### DIFF
--- a/tools/wsdlto/frontend/jaxws/src/main/java/org/apache/cxf/tools/wsdlto/frontend/jaxws/template/service.vm
+++ b/tools/wsdlto/frontend/jaxws/src/main/java/org/apache/cxf/tools/wsdlto/frontend/jaxws/template/service.vm
@@ -23,8 +23,8 @@ package $service.PackageName;
 
 #if ($wsdlLocation != "" && not($useGetResource) && not($wsdlLocation.startsWith("classpath:")))
 import java.net.MalformedURLException;
-#end
 import java.net.URI;
+#end
 import java.net.URL;
 #if ($markGenerated == "true")
 import jakarta.annotation.Generated;


### PR DESCRIPTION
## Changes
 - Modified `service.vm` template  to only import `java.net.URI` when necessary to avoid unused import warnings