### PR TITLE
[CXF-9067] Fix MaskSensitiveHelper incorrectly matching wrapper element

### DIFF
--- a/rt/features/logging/src/main/java/org/apache/cxf/ext/logging/MaskSensitiveHelper.java
+++ b/rt/features/logging/src/main/java/org/apache/cxf/ext/logging/MaskSensitiveHelper.java
@@ -32,7 +32,7 @@ public class MaskSensitiveHelper {
             + "\\u00F8-\\u02FF\\u0300-\\u037D\\u037F-\\u1FFF\\u200C-\\u200D\\u203F-\\u2040\\u2070-\\u218F"
             + "\\u2C00-\\u2FEF\\u3001-\\uD7FF\\uF900-\\uFDCF\\uFDF0-\\uFFFD]+";
     private static final String MATCH_PATTERN_XML_TEMPLATE = "(<(" + PATTERN_XML_NAMESPACE_PREFIX
-            + ":)?-ELEMENT_NAME-.*?>)(.*?)(</(" + PATTERN_XML_NAMESPACE_PREFIX + ":)?-ELEMENT_NAME->)";
+            + ":)?-ELEMENT_NAME-\\b[^>]*>)(.*?)(</(" + PATTERN_XML_NAMESPACE_PREFIX + ":)?-ELEMENT_NAME->)";
     private static final String REPLACEMENT_XML_TEMPLATE = "$1XXX$4";
     private static final String MATCH_PATTERN_JSON_TEMPLATE = "\"-ELEMENT_NAME-\"[ \\t]*:[ \\t]*\"(.*?)\"";
     private static final String REPLACEMENT_JSON_TEMPLATE = "\"-ELEMENT_NAME-\": \"XXX\"";

--- a/rt/features/logging/src/test/java/org/apache/cxf/ext/logging/MaskSensitiveHelperTest.java
+++ b/rt/features/logging/src/test/java/org/apache/cxf/ext/logging/MaskSensitiveHelperTest.java
@@ -56,6 +56,11 @@ public class MaskSensitiveHelperTest {
     private static final String MASKED_LOGGING_CONTENT_XML_WITH_ATTRIBUTE =
             "<user>testUser</user><password myAttribute=\"test\">XXX</password>";
 
+    private static final String SENSITIVE_LOGGING_CONTENT_XML_WITH_WRAPPER =
+        "<passwords><password>my secret password</password></passwords>";
+    private static final String MASKED_LOGGING_CONTENT_XML_WITH_WITH_WRAPPER =
+        "<passwords><password>XXX</password></passwords>";
+
     private static final String SENSITIVE_LOGGING_CONTENT_JSON =
             "\"user\":\"testUser\", \"password\": \"my secret password\"";
     private static final String MASKED_LOGGING_CONTENT_JSON =
@@ -93,6 +98,7 @@ public class MaskSensitiveHelperTest {
         return Arrays.asList(new Object[][] {
             {SENSITIVE_LOGGING_CONTENT_XML, MASKED_LOGGING_CONTENT_XML, APPLICATION_XML},
             {SENSITIVE_LOGGING_CONTENT_XML_WITH_ATTRIBUTE, MASKED_LOGGING_CONTENT_XML_WITH_ATTRIBUTE, APPLICATION_XML},
+            {SENSITIVE_LOGGING_CONTENT_XML_WITH_WRAPPER, MASKED_LOGGING_CONTENT_XML_WITH_WITH_WRAPPER, APPLICATION_XML},
             {SENSITIVE_LOGGING_MULTIPLE_ELEMENT_XML, MASKED_LOGGING_MULTIPLE_ELEMENT_XML, APPLICATION_XML},
             {SENSITIVE_LOGGING_CONTENT_XML_WITH_NAMESPACE, MASKED_LOGGING_CONTENT_XML_WITH_NAMESPACE, APPLICATION_XML},
             {SENSITIVE_LOGGING_CONTENT_JSON, MASKED_LOGGING_CONTENT_JSON, APPLICATION_JSON}


### PR DESCRIPTION
- Update the regex pattern in `MATCH_PATTERN_XML_TEMPLATE` to strictly match the element name, avoiding incorrect matches with similar names.
- Add new test cases in `MaskSensitiveHelperTest` to verify the correct masking of sensitive data within wrapper elements.