### PR TITLE
CXF-9071 rework deprecated CDI method

### DIFF
--- a/integration/cdi/src/main/java/org/apache/cxf/cdi/CdiServerConfigurableFactory.java
+++ b/integration/cdi/src/main/java/org/apache/cxf/cdi/CdiServerConfigurableFactory.java
@@ -67,7 +67,7 @@ public class CdiServerConfigurableFactory implements ServerConfigurableFactory {
                 final CreationalContext<?> context = beanManager.createCreationalContext(bean);
                 
                 if (!beanManager.isNormalScope(bean.getScope())) {
-                    beanManager.fireEvent(new DisposableCreationalContext(context));
+                    beanManager.getEvent().fire(new DisposableCreationalContext(context));
                 }
 
                 return beanManager.getReference(bean, cls, context);

--- a/integration/cdi/src/main/java/org/apache/cxf/cdi/JAXRSCdiResourceExtension.java
+++ b/integration/cdi/src/main/java/org/apache/cxf/cdi/JAXRSCdiResourceExtension.java
@@ -165,7 +165,7 @@ public class JAXRSCdiResourceExtension implements Extension {
                 "jakarta.servlet.http.HttpServletRequest",
                 "jakarta.servlet.ServletContext"));
         }
-        beanManager.fireEvent(this);
+        beanManager.getEvent().fire(this);
     }
 
     /**


### PR DESCRIPTION
BeanManager#fireEvent got deprecated in CDI-2.0 (2016) and in CDI-4.0 it gets finally removed.

Note that this patch is only for CXF-4.0.x. The changes are already applied in CXF-4.1.0 on the main branch.