### PR TITLE
[CXF-9074] Fix problem with custom SSLContext in TLSClientParameters

### DIFF
--- a/rt/transports/http/src/main/java/org/apache/cxf/transport/http/HttpClientHTTPConduit.java
+++ b/rt/transports/http/src/main/java/org/apache/cxf/transport/http/HttpClientHTTPConduit.java
@@ -383,6 +383,7 @@ public class HttpClientHTTPConduit extends URLConnectionHTTPConduit {
                         cb.sslContext(sslContext);
                     }
                     if (sslContext != null) {
+                        cb.sslContext(sslContext);
                         String[] supportedCiphers =  org.apache.cxf.configuration.jsse.SSLUtils
                                 .getSupportedCipherSuites(sslContext);
                         String[] cipherSuites = org.apache.cxf.configuration.jsse.SSLUtils


### PR DESCRIPTION
Fix problem in https communication, when Java HttpClient is used and custom SSLContext is registered in TLSClientParameters. See [CXF-9074]( https://issues.apache.org/jira/browse/CXF-9074)