### PR TITLE
Fixes NPE if ClientImpl has been closed/destroyed before the end of invokation

### DIFF
--- a/core/src/main/java/org/apache/cxf/endpoint/ClientImpl.java
+++ b/core/src/main/java/org/apache/cxf/endpoint/ClientImpl.java
@@ -543,7 +543,7 @@ public class ClientImpl
                 Integer responseCode = (Integer)exchange.get(Message.RESPONSE_CODE);
                 resContext.put(MessageContext.HTTP_RESPONSE_CODE, responseCode);
                 resContext.put(org.apache.cxf.message.Message.RESPONSE_CODE, responseCode);
-                if(null != responseContext) {
+                if (null != responseContext) {
                     setResponseContext(resContext);
                 }
             }

--- a/core/src/main/java/org/apache/cxf/endpoint/ClientImpl.java
+++ b/core/src/main/java/org/apache/cxf/endpoint/ClientImpl.java
@@ -539,11 +539,13 @@ public class ClientImpl
             return processResult(message, exchange, oi, resContext);
         } finally {
             //ensure ResponseContext has HTTP RESPONSE CODE
-            if (null != exchange && null != responseContext) {
+            if (null != exchange) {
                 Integer responseCode = (Integer)exchange.get(Message.RESPONSE_CODE);
                 resContext.put(MessageContext.HTTP_RESPONSE_CODE, responseCode);
                 resContext.put(org.apache.cxf.message.Message.RESPONSE_CODE, responseCode);
-                setResponseContext(resContext);
+                if(null != responseContext) {
+                    setResponseContext(resContext);
+                }
             }
             if (origLoader != null) {
                 origLoader.reset();

--- a/core/src/main/java/org/apache/cxf/endpoint/ClientImpl.java
+++ b/core/src/main/java/org/apache/cxf/endpoint/ClientImpl.java
@@ -539,7 +539,7 @@ public class ClientImpl
             return processResult(message, exchange, oi, resContext);
         } finally {
             //ensure ResponseContext has HTTP RESPONSE CODE
-            if (null != exchange) {
+            if (null != exchange && null != responseContext) {
                 Integer responseCode = (Integer)exchange.get(Message.RESPONSE_CODE);
                 resContext.put(MessageContext.HTTP_RESPONSE_CODE, responseCode);
                 resContext.put(org.apache.cxf.message.Message.RESPONSE_CODE, responseCode);


### PR DESCRIPTION
Hi,

We are facing a random crash in our tests in `ClientImpl` with the following stacktrace:

```
Caused by: java.lang.NullPointerException: Cannot invoke "java.util.Map.put(Object, Object)" because "this.responseContext" is null
        at org.apache.cxf.endpoint.ClientImpl.setResponseContext(ClientImpl.java:288)
        at org.apache.cxf.endpoint.ClientImpl.doInvoke(ClientImpl.java:546)
        at org.apache.cxf.endpoint.ClientImpl.invoke(ClientImpl.java:441)
        at org.apache.cxf.endpoint.ClientImpl.invoke(ClientImpl.java:356)
        at org.apache.cxf.endpoint.ClientImpl.invoke(ClientImpl.java:314)
        at org.apache.cxf.endpoint.ClientImpl.invoke(ClientImpl.java:334)
        at org.apache.cxf.endpoint.ClientImpl.invoke(ClientImpl.java:320)
        ...
```

The bug seems to appear "randomly" after many calls being sent through the WebService in our integration tests. Taken one-by-one, all the calls are working correctly, so it seems there is *something* else causing this error (for instance a fault) but we aren't able to see it because this NPE.