### PR TITLE
Flaky test fixed

### DIFF
--- a/tools/wadlto/jaxrs/src/test/java/org/apache/cxf/tools/wadlto/jaxrs/JAXRSContainerTest.java
+++ b/tools/wadlto/jaxrs/src/test/java/org/apache/cxf/tools/wadlto/jaxrs/JAXRSContainerTest.java
@@ -27,7 +27,7 @@ import java.net.URL;
 import java.net.URLClassLoader;
 import java.nio.file.Files;
 import java.util.Arrays;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -178,7 +178,7 @@ public class JAXRSContainerTest extends ProcessorTestBase {
         ClassCollector cc = context.get(ClassCollector.class);
         assertEquals(2, cc.getServiceClassNames().size());
 
-        final Map<String, Class<?>[]> methods = new HashMap<>();
+        final Map<String, Class<?>[]> methods = new LinkedHashMap<>();
         methods.put("listRepositories", new Class<?>[] {});
         methods.put("createRepository", new Class<?>[] {java.io.IOException.class});
         methods.put("deleteRepository",

--- a/tools/wadlto/jaxrs/src/test/java/org/apache/cxf/tools/wadlto/jaxrs/JAXRSContainerTest.java
+++ b/tools/wadlto/jaxrs/src/test/java/org/apache/cxf/tools/wadlto/jaxrs/JAXRSContainerTest.java
@@ -186,7 +186,7 @@ public class JAXRSContainerTest extends ProcessorTestBase {
         methods.put("postThename", new Class<?>[] {java.io.IOException.class, java.lang.NoSuchMethodException.class});
         try (URLClassLoader loader = new URLClassLoader(new URL[]{output.toURI().toURL()})) {
             for (String className : cc.getServiceClassNames().values()) {
-                final Class<?> generatedClass = loader.loadClass(className);      
+                final Class<?> generatedClass = loader.loadClass(className);
                 for (Map.Entry<String, Class<?>[]> entry : methods.entrySet()) {
                     Method m;
                     try {

--- a/tools/wadlto/jaxrs/src/test/java/org/apache/cxf/tools/wadlto/jaxrs/JAXRSContainerTest.java
+++ b/tools/wadlto/jaxrs/src/test/java/org/apache/cxf/tools/wadlto/jaxrs/JAXRSContainerTest.java
@@ -26,9 +26,12 @@ import java.net.URISyntaxException;
 import java.net.URL;
 import java.net.URLClassLoader;
 import java.nio.file.Files;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import jakarta.validation.Valid;
 import jakarta.ws.rs.Consumes;
@@ -48,7 +51,6 @@ import org.apache.cxf.tools.wadlto.WadlToolConstants;
 
 import org.junit.Test;
 
-import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -184,7 +186,7 @@ public class JAXRSContainerTest extends ProcessorTestBase {
         methods.put("postThename", new Class<?>[] {java.io.IOException.class, java.lang.NoSuchMethodException.class});
         try (URLClassLoader loader = new URLClassLoader(new URL[]{output.toURI().toURL()})) {
             for (String className : cc.getServiceClassNames().values()) {
-                final Class<?> generatedClass = loader.loadClass(className);
+                final Class<?> generatedClass = loader.loadClass(className);      
                 for (Map.Entry<String, Class<?>[]> entry : methods.entrySet()) {
                     Method m;
                     try {
@@ -192,7 +194,24 @@ public class JAXRSContainerTest extends ProcessorTestBase {
                     } catch (NoSuchMethodException e) {
                         m = generatedClass.getMethod(entry.getKey(), String.class, String.class);
                     }
-                    assertArrayEquals(entry.getValue(), m.getExceptionTypes());
+                    ClassLoader classLoader = generatedClass.getClassLoader();
+                    Class<?>[] expectedExceptions = new Class<?>[entry.getValue().length];
+                    for (int i = 0; i < entry.getValue().length; i++) {
+                        expectedExceptions[i] = classLoader.loadClass(entry.getValue()[i].getName());
+                    }
+
+                    // Compare exception class names
+                    Set<String> expectedExceptionNames = Arrays.stream(expectedExceptions)
+                        .map(Class::getName)
+                        .collect(Collectors.toSet());
+
+                    Set<String> actualExceptionNames = Arrays.stream(m.getExceptionTypes())
+                        .map(Class::getName)
+                        .collect(Collectors.toSet());
+
+                    assertEquals("Exceptions for method " + m.getName() + " do not match.",
+                        expectedExceptionNames, actualExceptionNames);
+                    
                 }
             }
         }


### PR DESCRIPTION
Dear Maintainers,

Our [Nondex](https://github.com/TestingResearchIllinois/NonDex) tool has detected a potential flaky test at `org.apache.cxf.tools.wadlto.jaxrs.JAXRSContainerTest.testThrows`. This flakiness is caused by an ordering issue when iterating over a HashMap and using assertArrayEquals in the unit test.

The issue with map.entrySet() lies in the fact that HashMap does not guarantee any specific iteration order for its entries. This lack of deterministic ordering introduces an element of randomness to the test execution, causing unreliable test results. Here are some reasons why this can happen:

Non-Deterministic Ordering in HashMap: HashMap inherently has no fixed order for its elements, and this order can change across different runs or Java versions. As a result, iterating over map.entrySet() may yield entries in a different sequence each time, depending on factors like hash code distribution and hash collisions.

Use of assertArrayEquals: The assertArrayEquals method in JUnit (and similar testing frameworks) checks for exact order in array elements. When the test iterates over a HashMap and collects entries into an array for comparison, any change in iteration order will cause assertArrayEquals to fail, even if the contents of the array are logically the same.

Impact on Test Consistency: This ordering inconsistency means that the test can pass or fail unpredictably, depending on the iteration order of the HashMap. Such flaky behavior can cause false negatives, where a test fails not because of a bug in the code under test, but due to the non-deterministic nature of HashMap ordering.

Concurrency and Threading Issues: If there are multiple threads accessing or modifying the HashMap during the test (intentionally or unintentionally), this can further exacerbate flakiness. Any modification to the map’s state while iterating can lead to ConcurrentModificationException or silent changes in iteration order.

Thus, we have suggested:
1. HashMap to LinkedHashMap
2. assertArrayEquals to assertEquals with Set collections