### PR TITLE
CXF-9076: Exception message is not unmarshalled with JDK17+ (limit the fix to JDK standard library exceptions)

### DIFF
--- a/systests/jaxws/src/test/java/org/apache/cxf/systest/jaxws/ClientServerExceptionServer.java
+++ b/systests/jaxws/src/test/java/org/apache/cxf/systest/jaxws/ClientServerExceptionServer.java
@@ -33,6 +33,11 @@ public class ClientServerExceptionServer extends AbstractBusTestServerBase {
         public String saySomething(String text) throws IllegalArgumentException {
             throw new IllegalArgumentException("Simulated!");
         }
+
+        @Override
+        public String sayNothing(String text) throws SayException {
+            throw new SayException("Simulated!", 100);
+        }
     }
 
     protected void run() {

--- a/systests/jaxws/src/test/java/org/apache/cxf/systest/jaxws/ClientServerExceptionTest.java
+++ b/systests/jaxws/src/test/java/org/apache/cxf/systest/jaxws/ClientServerExceptionTest.java
@@ -27,6 +27,7 @@ import javax.xml.namespace.QName;
 import jakarta.xml.ws.Service;
 import org.apache.cxf.testutil.common.AbstractBusClientServerTestBase;
 
+import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
@@ -35,20 +36,33 @@ import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
 public class ClientServerExceptionTest extends AbstractBusClientServerTestBase {
+    private ExceptionService port;
+
     @BeforeClass
     public static void startServers() throws Exception {
         assertTrue("server did not launch correctly", launchServer(ClientServerExceptionServer.class, true));
     }
 
-    @Test
-    public void exceptionMessageIsPreserved() throws MalformedURLException {
+    @Before
+    public void setUp() throws Exception {
         URL wsdlURL = new URL("http://localhost:" + ClientServerExceptionServer.PORT + "/ExceptionService?wsdl");
         QName qname = new QName("http://cxf.apache.org/", "ExceptionService");
         Service service = Service.create(wsdlURL, qname);
-        ExceptionService port = service.getPort(ExceptionService.class);
+        port = service.getPort(ExceptionService.class);
+    }
 
+    @Test
+    public void exceptionMessageIsPreserved() throws MalformedURLException {
         final IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
             () -> port.saySomething("Hello World!"));
         assertEquals("Simulated!", ex.getMessage());
+    }
+
+    @Test
+    public void exceptionCustomExceptionMessageIsPreserved() throws MalformedURLException {
+        final SayException ex = assertThrows(SayException.class,
+            () -> port.sayNothing("Hello World!"));
+        assertEquals("Simulated!", ex.getMessage());
+        assertEquals(100, ex.getCode());
     }
 }

--- a/systests/jaxws/src/test/java/org/apache/cxf/systest/jaxws/SayException.java
+++ b/systests/jaxws/src/test/java/org/apache/cxf/systest/jaxws/SayException.java
@@ -19,10 +19,20 @@
 
 package org.apache.cxf.systest.jaxws;
 
-import jakarta.jws.WebService;
+public class SayException extends Exception {
+    private static final long serialVersionUID = 1L;
+    private final int code;
 
-@WebService
-interface ExceptionService {
-    String saySomething(String text) throws IllegalArgumentException;
-    String sayNothing(String text) throws SayException;
+    public SayException() {
+        this(null, 0);
+    }
+
+    public SayException(final String message, final int code) {
+        super(message);
+        this.code = code;
+    }
+
+    public int getCode() {
+        return code;
+    }
 }


### PR DESCRIPTION
Exception message is not unmarshalled with JDK17+ (limit the fix to JDK standard library exceptions)