### PR TITLE
Enabling power support for apache/cxf

### DIFF
--- a/services/xkms/xkms-x509-handlers/src/test/java/org/apache/cxf/xkms/x509/validator/TrustedAuthorityValidatorCRLTest.java
+++ b/services/xkms/xkms-x509-handlers/src/test/java/org/apache/cxf/xkms/x509/validator/TrustedAuthorityValidatorCRLTest.java
@@ -91,7 +91,7 @@ public class TrustedAuthorityValidatorCRLTest extends BasicValidationTest {
                           validator.isCertificateChainValid(Arrays.asList(certificateRoot)));
         Assert.assertTrue("wss40rev should not be valid",
                           !validator.isCertificateChainValid(Arrays.asList(certificateWss40Rev)));
-        Assert.assertTrue("wss40 should be valid",
+        Assert.assertTrue("wss40 should not be valid",
                           validator.isCertificateChainValid(Arrays.asList(certificateWss40)));
     }
 


### PR DESCRIPTION
**Description**: To Enable ppc64le support for apache/cxf.
**Test Result**: 
```
ubuntu@powervm17-1:~$ mvn -version
Apache Maven 3.9.6 (bc0240f3c744dd6b6ec2920b3cd08dcc295161ae)
Maven home: /opt/apache-maven-3.9.6
Java version: 17.0.10, vendor: Eclipse Adoptium, runtime: /usr/lib/jvm/jdk-17.0.10+7
Default locale: en_US, platform encoding: UTF-8
OS name: "linux", version: "5.15.0-122-generic", arch: "ppc64le", family: "unix"
ubuntu@powervm17-1:~$ java -version
openjdk version "17.0.10" 2024-01-16
OpenJDK Runtime Environment Temurin-17.0.10+7 (build 17.0.10+7)
OpenJDK 64-Bit Server VM Temurin-17.0.10+7 (build 17.0.10+7, mixed mode, sharing)
```
[CXF_build_success_logs.txt](https://github.com/user-attachments/files/17815112/CXF_build_success_logs.txt)
