### PR TITLE
CXF-9085: Java features should be preferred to Guava

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -118,7 +118,6 @@
         <cxf.geronimo.openapi.version>1.0.15</cxf.geronimo.openapi.version>
         <cxf.glassfish.el.version>4.0.2</cxf.glassfish.el.version>
         <cxf.glassfish.json.version>2.0.1</cxf.glassfish.json.version>
-        <cxf.guava.version>32.1.3-jre</cxf.guava.version>
         <cxf.hamcrest.version>3.0</cxf.hamcrest.version>
         <cxf.hazelcast.version>5.5.0</cxf.hazelcast.version>
         <cxf.hibernate.em.version>6.5.2.Final</cxf.hibernate.em.version>

--- a/systests/jaxws/src/test/java/org/apache/cxf/systest/jaxws/ClientServerTest.java
+++ b/systests/jaxws/src/test/java/org/apache/cxf/systest/jaxws/ClientServerTest.java
@@ -30,6 +30,7 @@ import java.net.HttpURLConnection;
 import java.net.URL;
 import java.net.http.HttpConnectTimeoutException;
 import java.net.http.HttpTimeoutException;
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -46,8 +47,6 @@ import javax.xml.namespace.QName;
 import javax.xml.transform.stream.StreamSource;
 
 import org.w3c.dom.Document;
-
-import com.google.common.io.Files;
 
 import jakarta.xml.ws.AsyncHandler;
 import jakarta.xml.ws.BindingProvider;
@@ -1017,7 +1016,7 @@ public class ClientServerTest extends AbstractBusClientServerTestBase {
     
     @Test
     public void testEchoProviderThresholdAsync() throws Exception {
-        final File f = Files.createTempDir();
+        final File f = Files.createTempDirectory(null).toFile();
         LOG.info("Using temp folder: " + f.getAbsolutePath());
         
         System.setProperty("org.apache.cxf.io.CachedOutputStream.OutputDirectory", f.getAbsolutePath());
@@ -1048,7 +1047,7 @@ public class ClientServerTest extends AbstractBusClientServerTestBase {
     
     @Test
     public void testEchoProviderThresholdAsyncThrows() throws Exception {
-        final File f = Files.createTempDir();
+        final File f = Files.createTempDirectory(null).toFile();
         LOG.info("Using temp folder: " + f.getAbsolutePath());
         
         System.setProperty("org.apache.cxf.io.CachedOutputStream.OutputDirectory", f.getAbsolutePath());
@@ -1081,7 +1080,7 @@ public class ClientServerTest extends AbstractBusClientServerTestBase {
 
     @Test
     public void testEchoProviderThresholdTimeout() throws Exception {
-        final File f = Files.createTempDir();
+        final File f = Files.createTempDirectory(null).toFile();
         LOG.info("Using temp folder: " + f.getAbsolutePath());
         
         System.setProperty("org.apache.cxf.io.CachedOutputStream.OutputDirectory", f.getAbsolutePath());


### PR DESCRIPTION
Replace use of Google Guava with JDK API.

Replace `com.google.common.io.Files.createTempDir` with `java.nio.file.Files.createTempDirectory`.

See
https://sonarsource.github.io/rspec/#/rspec/S4738
"Java features should be preferred to Guava"