### PR TITLE
CXF-9093: Client does not send entire payload (if size ~> 2500 bytes) when hc5, TLS1.3 are used

### DIFF
--- a/systests/transport-hc5/pom.xml
+++ b/systests/transport-hc5/pom.xml
@@ -82,6 +82,8 @@
                         <configuration>
                             <systemPropertyVariables>
                                 <org.apache.cxf.transport.http.forceURLConnection>true</org.apache.cxf.transport.http.forceURLConnection>
+                                <!-- See please https://issues.apache.org/jira/browse/HTTPCORE-775 -->
+                                <jsse.SSLEngine.acceptLargeFragments>true</jsse.SSLEngine.acceptLargeFragments>
                             </systemPropertyVariables>
                         </configuration>
                     </execution>
@@ -90,6 +92,8 @@
                         <configuration>
                             <systemPropertyVariables>
                                 <org.apache.cxf.transport.http.forceURLConnection>false</org.apache.cxf.transport.http.forceURLConnection>
+                                <!-- See please https://issues.apache.org/jira/browse/HTTPCORE-775 -->
+                                <jsse.SSLEngine.acceptLargeFragments>true</jsse.SSLEngine.acceptLargeFragments>
                             </systemPropertyVariables>
                         </configuration>
                     </execution>

--- a/systests/transport-hc5/src/test/resources/org/apache/cxf/systest/hc5/https/clientauth/client-auth-server.xml
+++ b/systests/transport-hc5/src/test/resources/org/apache/cxf/systest/hc5/https/clientauth/client-auth-server.xml
@@ -54,7 +54,7 @@
                      address="https://localhost:${testutil.ports.ClientAuthServer}/SoapContext/HttpsPort" 
                      serviceName="s:SOAPService" 
                      endpointName="e:HttpsPort" depends-on="direct-trust-tls-settings"/>
-    
+
      <httpj:engine-factory id="chain-trust-tls-settings">
         <httpj:engine port="${testutil.ports.ClientAuthServer.2}">
             <httpj:tlsServerParameters>
@@ -76,5 +76,26 @@
                      address="https://localhost:${testutil.ports.ClientAuthServer.2}/SoapContext/HttpsPort" 
                      serviceName="s:SOAPService" 
                      endpointName="e:HttpsPort" depends-on="chain-trust-tls-settings"/>
-    
+
+    <httpj:engine-factory id="direct-trust-tls-1.3-settings">
+        <httpj:engine port="${testutil.ports.ClientAuthServer.3}">
+            <httpj:tlsServerParameters secureSocketProtocol="TLSv1.3">
+                <sec:keyManagers keyPassword="password">
+                    <sec:keyStore type="jks" password="password" resource="keys/Bethal.jks"/>
+                </sec:keyManagers>
+                <sec:trustManagers>
+                    <sec:keyStore type="jks" password="password" resource="keys/Truststore.jks"/>
+                </sec:trustManagers>
+                <sec:clientAuthentication want="true" required="true"/>
+            </httpj:tlsServerParameters>
+        </httpj:engine>
+    </httpj:engine-factory>
+
+    <jaxws:endpoint xmlns:e="http://apache.org/hello_world/services" 
+                     xmlns:s="http://apache.org/hello_world/services" 
+                     id="DirectTrustServerTls1.3" 
+                     implementor="org.apache.cxf.systest.hc5.GreeterImpl" 
+                     address="https://localhost:${testutil.ports.ClientAuthServer.3}/SoapContext/HttpsPort" 
+                     serviceName="s:SOAPService" 
+                     endpointName="e:HttpsPort" depends-on="direct-trust-tls-1.3-settings"/>
 </beans>

--- a/systests/transport-hc5/src/test/resources/org/apache/cxf/systest/hc5/https/clientauth/client-auth-tls-1.3.xml
+++ b/systests/transport-hc5/src/test/resources/org/apache/cxf/systest/hc5/https/clientauth/client-auth-tls-1.3.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License. You may obtain a copy of the License at
+ 
+ http://www.apache.org/licenses/LICENSE-2.0
+ 
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied. See the License for the
+ specific language governing permissions and limitations
+ under the License.
+-->
+<beans xmlns="http://www.springframework.org/schema/beans"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:http="http://cxf.apache.org/transports/http/configuration"
+    xmlns:jaxws="http://cxf.apache.org/jaxws"
+    xmlns:cxf="http://cxf.apache.org/core"
+    xmlns:p="http://cxf.apache.org/policy"
+    xmlns:sec="http://cxf.apache.org/configuration/security"
+    xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd http://cxf.apache.org/jaxws http://cxf.apache.org/schemas/jaxws.xsd http://cxf.apache.org/transports/http/configuration http://cxf.apache.org/schemas/configuration/http-conf.xsd http://cxf.apache.org/configuration/security http://cxf.apache.org/schemas/configuration/security.xsd http://cxf.apache.org/core http://cxf.apache.org/schemas/core.xsd http://cxf.apache.org/policy http://cxf.apache.org/schemas/policy.xsd">
+    
+    <cxf:bus>
+        <cxf:features>
+            <cxf:logging/>
+        </cxf:features>
+    </cxf:bus>
+    <http:conduit name="https://localhost:.*">
+        <http:tlsClientParameters disableCNCheck="true" secureSocketProtocol="TLSv1.3">
+            <sec:keyManagers keyPassword="password">
+                <sec:keyStore type="jks" password="password" resource="keys/Morpit.jks"/>
+            </sec:keyManagers>
+            <sec:trustManagers>
+                <sec:keyStore type="jks" password="password" resource="keys/Truststore.jks"/>
+            </sec:trustManagers>
+        </http:tlsClientParameters>
+    </http:conduit>
+</beans>


### PR DESCRIPTION
Client does not send entire payload (if size ~> 2500 bytes) when hc5, TLS1.3 are used