### PR TITLE
If is unnecessary - return value is same with or without the if

### DIFF
--- a/tools/validator/src/main/java/org/apache/cxf/tools/validator/internal/Stax2DOM.java
+++ b/tools/validator/src/main/java/org/apache/cxf/tools/validator/internal/Stax2DOM.java
@@ -43,9 +43,6 @@ public class Stax2DOM {
     public Document getDocument(String wsdl) throws ToolException {
         try {
             URI wsdlURI = new URI(URIParserUtil.getAbsoluteURI(wsdl));
-            if (wsdlURI.toString().startsWith("http")) {
-                return getDocument(wsdlURI.toURL());
-            }
             return getDocument(wsdlURI.toURL());
         } catch (ToolException e) {
             throw e;


### PR DESCRIPTION
coverity SAST tool is saying that the if here is unnecessary and that the return value is the same with or without the if.   

Error: IDENTICAL_BRANCHES (CWE-398):
tools/validator/src/main/java/org/apache/cxf/tools/validator/internal/Stax2DOM.java:49:13: implicit_else: The code from the above if-then branch is identical to the code after the if statement.
tools/validator/src/main/java/org/apache/cxf/tools/validator/internal/Stax2DOM.java:46:13: identical_branches: The same code is executed when the condition "wsdlURI.toString().startsWith("http")" is true or false, because the code in the if-then branch and after the if statement is identical. Should the if statement be removed?

```

#   44|           try {
#   45|               URI wsdlURI = new URI(URIParserUtil.getAbsoluteURI(wsdl));
#   46|->             if (wsdlURI.toString().startsWith("http")) {
#   47|                   return getDocument(wsdlURI.toURL());
#   48|               }
```