### PR TITLE
fix: do not log complete stream causing OOM

### DIFF
--- a/core/src/main/java/org/apache/cxf/io/DelayedCachedOutputStreamCleaner.java
+++ b/core/src/main/java/org/apache/cxf/io/DelayedCachedOutputStreamCleaner.java
@@ -119,7 +119,7 @@ public final class DelayedCachedOutputStreamCleaner implements CachedOutputStrea
                 final DelayedCloseable next = iterator.next();
                 try {
                     iterator.remove();
-                    LOG.warning("Unclosed (leaked?) stream detected: " + next.closeable);
+                    LOG.warning("Unclosed (leaked?) stream detected: " + next.closeable.hashCode());
                     next.closeable.close();
                 } catch (final IOException | RuntimeException ex) {
                     LOG.warning("Unable to close (leaked?) stream: " + ex.getMessage());


### PR DESCRIPTION
Log the hashCode instead of toString to avoid dumping all the file content in memory and in log because of https://github.com/apache/cxf/blob/main/core/src/main/java/org/apache/cxf/io/CachedOutputStream.java#L423
This cause OOM on our app.

```
Exception in thread "DelayedCachedOutputStreamCleaner" java.lang.OutOfMemoryError: Java heap space
at java.base/java.util.Arrays.copyOf(Arrays.java:3541)                                                                     
at java.base/java.lang.AbstractStringBuilder.ensureCapacityInternal(AbstractStringBuilder.java:242)                        
at java.base/java.lang.AbstractStringBuilder.append(AbstractStringBuilder.java:744)                                        
at java.base/java.lang.StringBuilder.append(StringBuilder.java:233)                                                        
at org.apache.cxf.io.CachedOutputStream.writeCacheTo(CachedOutputStream.java:404)                                          
at org.apache.cxf.io.CachedOutputStream.writeCacheTo(CachedOutputStream.java:382)                                          
at org.apache.cxf.io.CachedOutputStream.toString(CachedOutputStream.java:428)                                              
at java.base/java.lang.StringConcatHelper.stringOf(StringConcatHelper.java:467)                                            
at java.base/java.lang.StringConcatHelper.simpleConcat(StringConcatHelper.java:422)                                        
at java.base/java.lang.invoke.DirectMethodHandle$Holder.invokeStatic(DirectMethodHandle$Holder)                            
at java.base/java.lang.invoke.LambdaForm$MH/0x00007fffa0010800.invoke(LambdaForm$MH)                                       
at java.base/java.lang.invoke.Invokers$Holder.linkToTargetMethod(Invokers$Holder)                                          
at org.apache.cxf.io.DelayedCachedOutputStreamCleaner$DelayedCleanerImpl.clean(DelayedCachedOutputStreamCleaner.java:122)  
at org.apache.cxf.io.DelayedCachedOutputStreamCleaner$DelayedCleanerImpl.clean(DelayedCachedOutputStreamCleaner.java:102)  
at org.apache.cxf.io.DelayedCachedOutputStreamCleaner$DelayedCleanerImpl$1.run(DelayedCachedOutputStreamCleaner.java:83)   
at java.base/java.util.TimerThread.mainLoop(Timer.java:566)                                                                
at java.base/java.util.TimerThread.run(Timer.java:516) 
```