### PR TITLE
CXF-9110: Fix extensive memory usage with enabled LoggingFeature

### DIFF
--- a/core/src/main/java/org/apache/cxf/io/CachedOutputStream.java
+++ b/core/src/main/java/org/apache/cxf/io/CachedOutputStream.java
@@ -283,8 +283,10 @@ public class CachedOutputStream extends OutputStream {
                     }
                 } finally {
                     streamList.remove(currentStream);
+                    // we are not backed by file anymore, unregister from the cleaner
                     if (cachedOutputStreamCleaner != null) {
                         cachedOutputStreamCleaner.unregister(currentStream);
+                        cachedOutputStreamCleaner.unregister(this);
                     }
                     deleteTempFile();
                     inmem = true;

--- a/core/src/main/java/org/apache/cxf/io/CachedOutputStreamCleaner.java
+++ b/core/src/main/java/org/apache/cxf/io/CachedOutputStreamCleaner.java
@@ -40,4 +40,12 @@ public interface CachedOutputStreamCleaner {
      * Unregister the stream instance from the clean up (closed properly)
      */
     void register(Closeable closeable);
+
+    /**
+     * The exact or approximate (depending on the implementation) size of the cleaner queue
+     * @return exact or approximate (depending on the implementation) size of the cleaner queue
+     */
+    default int size() {
+        return 0;
+    }
 }

--- a/core/src/main/java/org/apache/cxf/io/DelayedCachedOutputStreamCleaner.java
+++ b/core/src/main/java/org/apache/cxf/io/DelayedCachedOutputStreamCleaner.java
@@ -167,7 +167,8 @@ public final class DelayedCachedOutputStreamCleaner implements CachedOutputStrea
             }
             
             final DelayedCloseable other = (DelayedCloseable) obj;
-            return Objects.equals(closeable, other.closeable);
+            //  because of the broken Liskov Substitution Principle, check in two ways to find equal streams
+            return Objects.equals(other.closeable, closeable) || Objects.equals(closeable, other.closeable);
         }
     }
 

--- a/core/src/main/java/org/apache/cxf/io/DelayedCachedOutputStreamCleaner.java
+++ b/core/src/main/java/org/apache/cxf/io/DelayedCachedOutputStreamCleaner.java
@@ -52,19 +52,24 @@ public final class DelayedCachedOutputStreamCleaner implements CachedOutputStrea
         @Override
         default void register(Closeable closeable) {
         }
-        
+
         @Override
         default void unregister(Closeable closeable) {
         }
-        
+
         @Override
         default void close() {
         }
-        
+
         @Override
         default void clean() {
         }
-        
+
+        @Override
+        default int size() {
+            return 0;
+        }
+
         default void forceClean() {
         }
     }
@@ -101,18 +106,23 @@ public final class DelayedCachedOutputStreamCleaner implements CachedOutputStrea
             queue.drainTo(closeables);
             clean(closeables);
         }
-        
+
         @Override
         public void forceClean() {
             clean(queue);
         }
-        
+
         @Override
         public void close()  {
             timer.cancel();
             queue.clear();
         }
-        
+
+        @Override
+        public int size() {
+            return queue.size();
+        }
+
         private void clean(Collection<DelayedCloseable> closeables) {
             final Iterator<DelayedCloseable> iterator = closeables.iterator();
             while (iterator.hasNext()) {
@@ -167,8 +177,7 @@ public final class DelayedCachedOutputStreamCleaner implements CachedOutputStrea
             }
             
             final DelayedCloseable other = (DelayedCloseable) obj;
-            //  because of the broken Liskov Substitution Principle, check in two ways to find equal streams
-            return Objects.equals(other.closeable, closeable) || Objects.equals(closeable, other.closeable);
+            return Objects.equals(closeable, other.closeable);
         }
     }
 
@@ -223,6 +232,11 @@ public final class DelayedCachedOutputStreamCleaner implements CachedOutputStrea
     @Override
     public void unregister(Closeable closeable) {
         cleaner.unregister(closeable);
+    }
+
+    @Override
+    public int size() {
+        return cleaner.size();
     }
 
     @Override

--- a/rt/rs/client/src/test/java/org/apache/cxf/jaxrs/client/logging/TestServiceRest.java
+++ b/rt/rs/client/src/test/java/org/apache/cxf/jaxrs/client/logging/TestServiceRest.java
@@ -19,6 +19,7 @@
 package org.apache.cxf.jaxrs.client.logging;
 
 import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.PathParam;
 
@@ -26,6 +27,11 @@ public class TestServiceRest {
     @GET
     @Path("{msg}")
     public String echo(@PathParam("msg") String msg) {
+        return msg;
+    }
+
+    @POST
+    public String post(String msg) {
         return msg;
     }
 

--- a/rt/rs/client/src/test/java/org/apache/cxf/jaxrs/client/logging/TestServiceRest.java
+++ b/rt/rs/client/src/test/java/org/apache/cxf/jaxrs/client/logging/TestServiceRest.java
@@ -34,5 +34,5 @@ public class TestServiceRest {
     public String post(String msg) {
         return msg;
     }
-
 }
+


### PR DESCRIPTION
 Fix extensive memory usage with enabled LoggingFeature, cherry-picking some changes from https://github.com/apache/cxf/pull/2275