### PR TITLE
Updating Mina to 2.1.10

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -172,7 +172,7 @@
         <cxf.microprofile.config.version>2.0</cxf.microprofile.config.version>
         <cxf.microprofile.rest.client.version>2.0</cxf.microprofile.rest.client.version>
         <cxf.microprofile.openapi.version>2.0</cxf.microprofile.openapi.version>
-        <cxf.mina.version>2.1.5</cxf.mina.version>
+        <cxf.mina.version>2.1.10</cxf.mina.version>
         <cxf.mockito.version>5.15.2</cxf.mockito.version>
         <cxf.msv.version>2022.7</cxf.msv.version>
         <cxf.neethi.version>3.2.1</cxf.neethi.version>


### PR DESCRIPTION
──────────────────────────┤
│ org.apache.mina:mina-core (mina-core-2.1.5.jar) │ CVE-2024-52046 │ CRITICAL │ fixed  │ 2.1.5             │ 2.2.4, 2.1.10, 2.0.27 │ mina-core: Apache MINA: applications using unbounded │
│                                                 │                │          │        │                   │                       │ deserialization may allow RCE                        │
│                                                 │                │          │        │                   │                       │ https://avd.aquasec.com/nvd/cve-2024-52046           │
└─────────────────────────────────────────────────┴────────────────┴──────────┴─