### PR TITLE
CXF-9118: DelayedCachedOutputStreamCleaner may expire streams prematurely

### DIFF
--- a/core/src/main/java/org/apache/cxf/io/DelayedCachedOutputStreamCleaner.java
+++ b/core/src/main/java/org/apache/cxf/io/DelayedCachedOutputStreamCleaner.java
@@ -144,7 +144,7 @@ public final class DelayedCachedOutputStreamCleaner implements CachedOutputStrea
         
         DelayedCloseable(final Closeable closeable, final long delay) {
             this.closeable = closeable;
-            this.expireAt = System.nanoTime() + delay;
+            this.expireAt = System.nanoTime() + TimeUnit.NANOSECONDS.convert(delay, TimeUnit.MILLISECONDS);
         }
 
         @Override


### PR DESCRIPTION
`DelayedCachedOutputStreamCleaner` may expire streams prematurely