### PR TITLE
CXF-9117: cxf-rt-ws-security fails if JCache is not on the classpath

### DIFF
--- a/rt/ws/security/src/main/java/org/apache/cxf/ws/security/cache/jcache/JCacheReplayCache.java
+++ b/rt/ws/security/src/main/java/org/apache/cxf/ws/security/cache/jcache/JCacheReplayCache.java
@@ -30,7 +30,7 @@ import javax.cache.expiry.Duration;
 import javax.cache.expiry.ExpiryPolicy;
 import javax.cache.spi.CachingProvider;
 
-import org.apache.cxf.ws.security.utils.JCacheUtils;
+import org.apache.cxf.ws.security.utils.JCacheSupport;
 import org.apache.wss4j.common.cache.EHCacheExpiry;
 import org.apache.wss4j.common.cache.EHCacheValue;
 import org.apache.wss4j.common.cache.ReplayCache;
@@ -59,7 +59,7 @@ class JCacheReplayCache implements ReplayCache {
         try {
             final CachingProvider cachingProvider = Caching.getCachingProvider();
             cacheManager = cachingProvider.getCacheManager(); 
-            cache = JCacheUtils.getOrCreate(cacheManager, key, String.class, EHCacheValue.class,
+            cache = JCacheSupport.getOrCreate(cacheManager, key, String.class, EHCacheValue.class,
                 cacheConfiguration -> cacheConfiguration.setExpiryPolicyFactory(() -> new ExpiryPolicy() {
                     @Override
                     public Duration getExpiryForCreation() {

--- a/rt/ws/security/src/main/java/org/apache/cxf/ws/security/tokenstore/TokenStoreFactory.java
+++ b/rt/ws/security/src/main/java/org/apache/cxf/ws/security/tokenstore/TokenStoreFactory.java
@@ -21,7 +21,7 @@ package org.apache.cxf.ws.security.tokenstore;
 
 import org.apache.cxf.message.Message;
 import org.apache.cxf.ws.security.tokenstore.jcache.JCacheTokenStoreFactory;
-import org.apache.cxf.ws.security.utils.JCacheUtils;
+import org.apache.cxf.ws.security.utils.JCacheUtil;
 import org.apache.wss4j.common.cache.WSS4JCacheUtil;
 
 /**
@@ -32,7 +32,7 @@ public abstract class TokenStoreFactory {
     public static TokenStoreFactory newInstance() {
         if (WSS4JCacheUtil.isEhCacheInstalled()) {
             return new EHCacheTokenStoreFactory();
-        } else if (JCacheUtils.isJCacheInstalled()) {
+        } else if (JCacheUtil.isJCacheInstalled()) {
             return new JCacheTokenStoreFactory();
         } else {
             return new MemoryTokenStoreFactory();

--- a/rt/ws/security/src/main/java/org/apache/cxf/ws/security/tokenstore/jcache/JCacheTokenStore.java
+++ b/rt/ws/security/src/main/java/org/apache/cxf/ws/security/tokenstore/jcache/JCacheTokenStore.java
@@ -37,7 +37,7 @@ import org.apache.cxf.common.util.StringUtils;
 import org.apache.cxf.ws.security.tokenstore.SecurityToken;
 import org.apache.cxf.ws.security.tokenstore.TokenStore;
 import org.apache.cxf.ws.security.tokenstore.TokenStoreException;
-import org.apache.cxf.ws.security.utils.JCacheUtils;
+import org.apache.cxf.ws.security.utils.JCacheSupport;
 
 /**
  * An in-memory JCache implementation of the TokenStore interface. The default TTL is 60 minutes
@@ -66,7 +66,7 @@ public class JCacheTokenStore implements TokenStore, Closeable, BusLifeCycleList
             final CachingProvider cachingProvider = Caching.getCachingProvider();
             cacheManager = cachingProvider.getCacheManager(configFileURL.toURI(),
                     SecurityToken.class.getClassLoader()); 
-            cache = JCacheUtils.getOrCreate(cacheManager, key, String.class, SecurityToken.class);
+            cache = JCacheSupport.getOrCreate(cacheManager, key, String.class, SecurityToken.class);
         } catch (Exception e) {
             throw new TokenStoreException(e);
         }

--- a/rt/ws/security/src/main/java/org/apache/cxf/ws/security/utils/JCacheSupport.java
+++ b/rt/ws/security/src/main/java/org/apache/cxf/ws/security/utils/JCacheSupport.java
@@ -1,0 +1,49 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.cxf.ws.security.utils;
+
+import java.util.function.Function;
+
+import javax.cache.Cache;
+import javax.cache.CacheManager;
+import javax.cache.configuration.MutableConfiguration;
+
+public final class JCacheSupport {
+    private JCacheSupport() {
+    }
+    
+    public static <K, V> Cache<K, V> getOrCreate(CacheManager cacheManager, String name, Class<K> kclass,
+            Class<V> vclass) {
+        return getOrCreate(cacheManager, name, kclass, vclass, Function.identity());
+    }
+
+    public static <K, V> Cache<K, V> getOrCreate(CacheManager cacheManager, String name, Class<K> kclass,
+            Class<V> vclass, Function<MutableConfiguration<K, V>, MutableConfiguration<K, V>> customizer) {
+
+        final Cache<K, V> cache = cacheManager.getCache(name, kclass, vclass);
+        if (cache != null) {
+            return cache;
+        }
+
+        MutableConfiguration<K, V> cacheConfiguration = new MutableConfiguration<>();
+        cacheConfiguration = customizer.apply(cacheConfiguration.setTypes(kclass, vclass));
+
+        return cacheManager.createCache(name, cacheConfiguration);
+    }
+}

--- a/rt/ws/security/src/main/java/org/apache/cxf/ws/security/utils/JCacheUtil.java
+++ b/rt/ws/security/src/main/java/org/apache/cxf/ws/security/utils/JCacheUtil.java
@@ -20,17 +20,12 @@ package org.apache.cxf.ws.security.utils;
 
 import java.lang.invoke.MethodHandles;
 import java.lang.invoke.MethodType;
-import java.util.function.Function;
 import java.util.logging.Logger;
-
-import javax.cache.Cache;
-import javax.cache.CacheManager;
-import javax.cache.configuration.MutableConfiguration;
 
 import org.apache.cxf.common.logging.LogUtils;
 
-public final class JCacheUtils {
-    private static final Logger LOG = LogUtils.getL7dLogger(JCacheUtils.class);
+public final class JCacheUtil {
+    private static final Logger LOG = LogUtils.getL7dLogger(JCacheUtil.class);
     private static final boolean JCACHE_INSTALLED;
 
     static {
@@ -50,26 +45,7 @@ public final class JCacheUtils {
         JCACHE_INSTALLED = jcacheInstalled;
     }
 
-    private JCacheUtils() {
-    }
-    
-    public static <K, V> Cache<K, V> getOrCreate(CacheManager cacheManager, String name, Class<K> kclass,
-            Class<V> vclass) {
-        return getOrCreate(cacheManager, name, kclass, vclass, Function.identity());
-    }
-
-    public static <K, V> Cache<K, V> getOrCreate(CacheManager cacheManager, String name, Class<K> kclass,
-            Class<V> vclass, Function<MutableConfiguration<K, V>, MutableConfiguration<K, V>> customizer) {
-
-        final Cache<K, V> cache = cacheManager.getCache(name, kclass, vclass);
-        if (cache != null) {
-            return cache;
-        }
-
-        MutableConfiguration<K, V> cacheConfiguration = new MutableConfiguration<>();
-        cacheConfiguration = customizer.apply(cacheConfiguration.setTypes(kclass, vclass));
-
-        return cacheManager.createCache(name, cacheConfiguration);
+    private JCacheUtil() {
     }
 
     public static boolean isJCacheInstalled() {

--- a/rt/ws/security/src/main/java/org/apache/cxf/ws/security/wss4j/WSS4JUtils.java
+++ b/rt/ws/security/src/main/java/org/apache/cxf/ws/security/wss4j/WSS4JUtils.java
@@ -51,7 +51,7 @@ import org.apache.cxf.ws.security.cache.jcache.CXFJCacheReplayCache;
 import org.apache.cxf.ws.security.tokenstore.SecurityToken;
 import org.apache.cxf.ws.security.tokenstore.TokenStoreException;
 import org.apache.cxf.ws.security.tokenstore.TokenStoreUtils;
-import org.apache.cxf.ws.security.utils.JCacheUtils;
+import org.apache.cxf.ws.security.utils.JCacheUtil;
 import org.apache.wss4j.common.cache.MemoryReplayCache;
 import org.apache.wss4j.common.cache.ReplayCache;
 import org.apache.wss4j.common.cache.WSS4JCacheUtil;
@@ -148,7 +148,7 @@ public final class WSS4JUtils {
                             throw new WSSecurityException(WSSecurityException.ErrorCode.FAILURE, ex);
                         }
                         replayCache = new CXFEHCacheReplayCache(cacheKey, bus, diskstoreParent);
-                    } else if (JCacheUtils.isJCacheInstalled()) {
+                    } else if (JCacheUtil.isJCacheInstalled()) {
                         Bus bus = message.getExchange().getBus();
                         replayCache = new CXFJCacheReplayCache(cacheKey, bus);
                     } else {

--- a/services/sts/sts-core/src/main/java/org/apache/cxf/sts/cache/jcache/JCacheIdentityCache.java
+++ b/services/sts/sts-core/src/main/java/org/apache/cxf/sts/cache/jcache/JCacheIdentityCache.java
@@ -48,7 +48,7 @@ import org.apache.cxf.sts.IdentityMapper;
 import org.apache.cxf.sts.cache.AbstractIdentityCache;
 import org.apache.cxf.sts.cache.EHCacheIdentityValue;
 import org.apache.cxf.ws.security.tokenstore.TokenStoreFactory;
-import org.apache.cxf.ws.security.utils.JCacheUtils;
+import org.apache.cxf.ws.security.utils.JCacheSupport;
 
 /**
  * A JCache based cache to cache identities in different realms where
@@ -92,7 +92,7 @@ public class JCacheIdentityCache extends AbstractIdentityCache
         final URL xmlConfigURL = configFileURL != null ? configFileURL : getDefaultConfigFileURL();
         try {
             cacheManager = cachingProvider.getCacheManager(xmlConfigURL.toURI(), getClass().getClassLoader());
-            cache = JCacheUtils.getOrCreate(cacheManager, KEY, String.class, EHCacheIdentityValue.class);
+            cache = JCacheSupport.getOrCreate(cacheManager, KEY, String.class, EHCacheIdentityValue.class);
         } catch (final URISyntaxException ex) {
             throw new IllegalStateException("Unable to convert " + xmlConfigURL + " to URI", ex);
         } 

--- a/services/xkms/xkms-client/src/main/java/org/apache/cxf/xkms/cache/jcache/JCacheXKMSClientCache.java
+++ b/services/xkms/xkms-client/src/main/java/org/apache/cxf/xkms/cache/jcache/JCacheXKMSClientCache.java
@@ -33,7 +33,7 @@ import org.apache.cxf.Bus;
 import org.apache.cxf.BusFactory;
 import org.apache.cxf.buslifecycle.BusLifeCycleListener;
 import org.apache.cxf.buslifecycle.BusLifeCycleManager;
-import org.apache.cxf.ws.security.utils.JCacheUtils;
+import org.apache.cxf.ws.security.utils.JCacheSupport;
 import org.apache.cxf.xkms.cache.XKMSCacheToken;
 import org.apache.cxf.xkms.cache.XKMSClientCache;
 import org.apache.cxf.xkms.cache.XKMSClientCacheException;
@@ -65,7 +65,7 @@ public class JCacheXKMSClientCache implements XKMSClientCache, BusLifeCycleListe
         final CachingProvider cachingProvider = Caching.getCachingProvider();
         cacheManager = cachingProvider.getCacheManager(); 
 
-        cache = JCacheUtils.getOrCreate(cacheManager, cacheKey, String.class, XKMSCacheToken.class,
+        cache = JCacheSupport.getOrCreate(cacheManager, cacheKey, String.class, XKMSCacheToken.class,
             cacheConfiguration -> cacheConfiguration.setExpiryPolicyFactory(() -> new ExpiryPolicy() {
                 @Override
                 public Duration getExpiryForCreation() {


### PR DESCRIPTION
`cxf-rt-ws-security` fails if JCache is not on the classpath