### PR TITLE
[CXF-9134] Do not wrap Attachment into another Attachment

### DIFF
--- a/rt/rs/client/src/main/java/org/apache/cxf/jaxrs/client/ClientProxyImpl.java
+++ b/rt/rs/client/src/main/java/org/apache/cxf/jaxrs/client/ClientProxyImpl.java
@@ -801,7 +801,11 @@ public class ClientProxyImpl extends AbstractClient implements
             if (part != null) {
                 Object partObject = params[p.getIndex()];
                 if (partObject != null) {
-                    atts.add(new Attachment(part.value(), part.type(), partObject));
+                    if (partObject instanceof Attachment) {
+                        atts.add((Attachment)partObject);
+                    } else {
+                        atts.add(new Attachment(part.value(), part.type(), partObject));
+                    }
                 }
             }
         });

--- a/systests/jaxrs/src/test/java/org/apache/cxf/systest/jaxrs/JAXRSMultipartTest.java
+++ b/systests/jaxrs/src/test/java/org/apache/cxf/systest/jaxrs/JAXRSMultipartTest.java
@@ -512,6 +512,19 @@ public class JAXRSMultipartTest extends AbstractBusClientServerTestBase {
     }
 
     @Test
+    public void attachmentIsNotWrappedIntoAnotherAttachment() throws Exception {
+        MultipartStore store =
+                JAXRSClientFactory.create("http://localhost:" + PORT, MultipartStore.class);
+
+        Attachment attachment =
+                new Attachment("audio", MediaType.APPLICATION_OCTET_STREAM, new byte[]{42});
+
+        Book b = store.addAudioBook(new Book("CXF in Action", 125L), attachment);
+        assertEquals(125L, b.getId());
+        assertEquals("CXF in Action - 42", b.getName());
+    }
+
+    @Test
     public void testNullPartProxy() throws Exception {
         MultipartStore store =
             JAXRSClientFactory.create("http://localhost:" + PORT, MultipartStore.class);

--- a/systests/jaxrs/src/test/java/org/apache/cxf/systest/jaxrs/MultipartStore.java
+++ b/systests/jaxrs/src/test/java/org/apache/cxf/systest/jaxrs/MultipartStore.java
@@ -470,6 +470,17 @@ public class MultipartStore {
     }
 
     @POST
+    @Path("/books/audiofiles")
+    @Consumes("multipart/related")
+    @Produces("text/xml")
+    public Book addAudioBook(
+            @Multipart(value = "book", type = "application/json") Book book,
+            @Multipart(value = "audio") Attachment audioFile) throws Exception {
+        String payload = String.valueOf(audioFile.getDataHandler().getContent().toString().getBytes()[0]);
+        return new Book(book.getName() + " - " + payload, book.getId());
+    }
+
+    @POST
     @Path("/books/jaxbandsimpleparts")
     @Consumes("multipart/related")
     @Produces("text/xml")


### PR DESCRIPTION
This supports interfaces generated by openapi jaxrs-cxf generator