### PR TITLE
CXF-9132 When the domain name changes, not execute 'release'

### DIFF
--- a/rt/transports/http/src/main/java/org/apache/cxf/transport/http/HttpClientHTTPConduit.java
+++ b/rt/transports/http/src/main/java/org/apache/cxf/transport/http/HttpClientHTTPConduit.java
@@ -352,7 +352,6 @@ public class HttpClientHTTPConduit extends URLConnectionHTTPConduit {
         if (sslURL != null && isSslTargetDifferent(sslURL, uri)) {
             sslURL = null;
             if (clientRef != null) {
-                clientRef.release();
                 clientRef = null;
             }
         }


### PR DESCRIPTION
When the domain name changes, 'acquire' is not executed and 'release' is executed, resulting in inconsistent count.