### PR TITLE
Updating ActiveMQ to 5.17.7

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -77,7 +77,7 @@
         <cxf.osgi.javax.xml.ws.version>[0,3)</cxf.osgi.javax.xml.ws.version>
 
         <!-- please maintain alphabetical order here -->
-        <cxf.activemq.version>5.17.6</cxf.activemq.version>
+        <cxf.activemq.version>5.17.7</cxf.activemq.version>
         <cxf.ahc.version>2.12.4</cxf.ahc.version>
         <cxf.arquillian.version>1.6.0.Final</cxf.arquillian.version>
         <cxf.arquillian.weld.container.version>2.0.1.Final</cxf.arquillian.weld.container.version>


### PR DESCRIPTION
Fix for https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2025-27533