### PR TITLE
Added null check to DataWriterImpl when calling getLastMTOMElementName

### DIFF
--- a/rt/databinding/jaxb/src/main/java/org/apache/cxf/jaxb/io/DataWriterImpl.java
+++ b/rt/databinding/jaxb/src/main/java/org/apache/cxf/jaxb/io/DataWriterImpl.java
@@ -101,7 +101,8 @@ public class DataWriterImpl<T> extends JAXBDataBase implements DataWriter<T> {
             // CXF-1194/CXF-7438 this hack is specific to MTOM, so pretty safe to leave in
             // here before calling the origHandler.
             String msg = event.getMessage();
-            if ((msg.startsWith("cvc-type.3.1.2") || msg.startsWith("cvc-complex-type.2.2"))
+            if (marshaller.getLastMTOMElementName() != null
+                && (msg.startsWith("cvc-type.3.1.2") || msg.startsWith("cvc-complex-type.2.2"))
                 && msg.contains(marshaller.getLastMTOMElementName().getLocalPart())) {
                 return true;
             }


### PR DESCRIPTION
I experienced a side effect with the solution created for CXF-1194/CXF-7438 which can result in the following error:

> org.apache.cxf.interceptor.Fault: Marshalling Error: Cannot invoke "javax.xml.namespace.QName.getLocalPart()" because the return value of "org.apache.cxf.jaxb.attachment.JAXBAttachmentMarshaller.getLastMTOMElementName()" is null
> 	at org.apache.cxf.jaxb.JAXBEncoderDecoder.marshall(JAXBEncoderDecoder.java:269)
> 	at org.apache.cxf.jaxb.io.DataWriterImpl.write(DataWriterImpl.java:238)
> 	at org.apache.cxf.interceptor.AbstractOutDatabindingInterceptor.writeParts(AbstractOutDatabindingInterceptor.java:137)
> 	at org.apache.cxf.wsdl.interceptors.BareOutInterceptor.handleMessage(BareOutInterceptor.java:68)
> 	at org.apache.cxf.phase.PhaseInterceptorChain.doIntercept(PhaseInterceptorChain.java:307)
> 	at org.apache.cxf.interceptor.OutgoingChainInterceptor.handleMessage(OutgoingChainInterceptor.java:90)
> 	at org.apache.cxf.phase.PhaseInterceptorChain.doIntercept(PhaseInterceptorChain.java:307)
> 	at org.apache.cxf.transport.ChainInitiationObserver.onMessage(ChainInitiationObserver.java:121)
> 	at org.apache.cxf.transport.http.AbstractHTTPDestination.invoke(AbstractHTTPDestination.java:267)
> 	at org.apache.cxf.transport.servlet.ServletController.invokeDestination(ServletController.java:233)
> 	at org.apache.cxf.transport.servlet.ServletController.invoke(ServletController.java:207)
> 	at org.apache.cxf.transport.servlet.ServletController.invoke(ServletController.java:159)
> 	at org.apache.cxf.transport.servlet.CXFNonSpringServlet.invoke(CXFNonSpringServlet.java:224)
> 	at org.apache.cxf.transport.servlet.AbstractHTTPServlet.handleRequest(AbstractHTTPServlet.java:303)
> 	at org.apache.cxf.transport.servlet.AbstractHTTPServlet.doPost(AbstractHTTPServlet.java:216)
> 	at jakarta.servlet.http.HttpServlet.service(HttpServlet.java:590)
> 	at org.apache.cxf.transport.servlet.AbstractHTTPServlet.service(AbstractHTTPServlet.java:278)
> 	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:195)
> 	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:140)
> 	at org.apache.tomcat.websocket.server.WsFilter.doFilter(WsFilter.java:51)
> 	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:164)
> 	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:140)
> 	at org.springframework.web.filter.CompositeFilter$VirtualFilterChain.doFilter(CompositeFilter.java:108)
> 	at org.springframework.security.web.FilterChainProxy.lambda$doFilterInternal$3(FilterChainProxy.java:231)
> 	at org.springframework.security.web.ObservationFilterChainDecorator$FilterObservation$SimpleFilterObservation.lambda$wrap$1(ObservationFilterChainDecorator.java:479)
> 	at org.springframework.security.web.ObservationFilterChainDecorator$AroundFilterObservation$SimpleAroundFilterObservation.lambda$wrap$1(ObservationFilterChainDecorator.java:340)
> 	at org.springframework.security.web.ObservationFilterChainDecorator.lambda$wrapSecured$0(ObservationFilterChainDecorator.java:82)
> 	at org.springframework.security.web.ObservationFilterChainDecorator$VirtualFilterChain.doFilter(ObservationFilterChainDecorator.java:128)
> 	at org.springframework.security.web.access.ExceptionTranslationFilter.doFilter(ExceptionTranslationFilter.java:126)
> 	at org.springframework.security.web.access.ExceptionTranslationFilter.doFilter(ExceptionTranslationFilter.java:120)
> 	at org.springframework.security.web.ObservationFilterChainDecorator$ObservationFilter.wrapFilter(ObservationFilterChainDecorator.java:240)
> 	at org.springframework.security.web.ObservationFilterChainDecorator$ObservationFilter.doFilter(ObservationFilterChainDecorator.java:227)
> 	at org.springframework.security.web.ObservationFilterChainDecorator$VirtualFilterChain.doFilter(ObservationFilterChainDecorator.java:137)
> 	at org.springframework.security.web.authentication.AnonymousAuthenticationFilter.doFilter(AnonymousAuthenticationFilter.java:100)
> 	at org.springframework.security.web.ObservationFilterChainDecorator$ObservationFilter.wrapFilter(ObservationFilterChainDecorator.java:240)
> 	at org.springframework.security.web.ObservationFilterChainDecorator$ObservationFilter.doFilter(ObservationFilterChainDecorator.java:227)
> 	at org.springframework.security.web.ObservationFilterChainDecorator$VirtualFilterChain.doFilter(ObservationFilterChainDecorator.java:137)
> 	at org.springframework.security.web.servletapi.SecurityContextHolderAwareRequestFilter.doFilter(SecurityContextHolderAwareRequestFilter.java:179)
> 	at org.springframework.security.web.ObservationFilterChainDecorator$ObservationFilter.wrapFilter(ObservationFilterChainDecorator.java:240)
> 	at org.springframework.security.web.ObservationFilterChainDecorator$ObservationFilter.doFilter(ObservationFilterChainDecorator.java:227)
> 	at org.springframework.security.web.ObservationFilterChainDecorator$VirtualFilterChain.doFilter(ObservationFilterChainDecorator.java:137)
> 	at org.springframework.security.web.savedrequest.RequestCacheAwareFilter.doFilter(RequestCacheAwareFilter.java:63)
> 	at org.springframework.security.web.ObservationFilterChainDecorator$ObservationFilter.wrapFilter(ObservationFilterChainDecorator.java:240)
> 	at org.springframework.security.web.ObservationFilterChainDecorator$ObservationFilter.doFilter(ObservationFilterChainDecorator.java:227)
> 	at org.springframework.security.web.ObservationFilterChainDecorator$VirtualFilterChain.doFilter(ObservationFilterChainDecorator.java:137)
> 	at org.springframework.security.web.authentication.logout.LogoutFilter.doFilter(LogoutFilter.java:107)
> 	at org.springframework.security.web.authentication.logout.LogoutFilter.doFilter(LogoutFilter.java:93)
> 	at org.springframework.security.web.ObservationFilterChainDecorator$ObservationFilter.wrapFilter(ObservationFilterChainDecorator.java:240)
> 	at org.springframework.security.web.ObservationFilterChainDecorator$ObservationFilter.doFilter(ObservationFilterChainDecorator.java:227)
> 	at org.springframework.security.web.ObservationFilterChainDecorator$VirtualFilterChain.doFilter(ObservationFilterChainDecorator.java:137)
> 	at org.springframework.security.web.header.HeaderWriterFilter.doHeadersAfter(HeaderWriterFilter.java:90)
> 	at org.springframework.security.web.header.HeaderWriterFilter.doFilterInternal(HeaderWriterFilter.java:75)
> 	at org.springframework.web.filter.OncePerRequestFilter.doFilter(OncePerRequestFilter.java:116)
> 	at org.springframework.security.web.ObservationFilterChainDecorator$ObservationFilter.wrapFilter(ObservationFilterChainDecorator.java:240)
> 	at org.springframework.security.web.ObservationFilterChainDecorator$ObservationFilter.doFilter(ObservationFilterChainDecorator.java:227)
> 	at org.springframework.security.web.ObservationFilterChainDecorator$VirtualFilterChain.doFilter(ObservationFilterChainDecorator.java:137)
> 	at org.springframework.security.web.context.SecurityContextHolderFilter.doFilter(SecurityContextHolderFilter.java:82)
> 	at org.springframework.security.web.context.SecurityContextHolderFilter.doFilter(SecurityContextHolderFilter.java:69)
> 	at org.springframework.security.web.ObservationFilterChainDecorator$ObservationFilter.wrapFilter(ObservationFilterChainDecorator.java:240)
> 	at org.springframework.security.web.ObservationFilterChainDecorator$ObservationFilter.doFilter(ObservationFilterChainDecorator.java:227)
> 	at org.springframework.security.web.ObservationFilterChainDecorator$VirtualFilterChain.doFilter(ObservationFilterChainDecorator.java:137)
> 	at org.springframework.security.web.context.request.async.WebAsyncManagerIntegrationFilter.doFilterInternal(WebAsyncManagerIntegrationFilter.java:62)
> 	at org.springframework.web.filter.OncePerRequestFilter.doFilter(OncePerRequestFilter.java:116)
> 	at org.springframework.security.web.ObservationFilterChainDecorator$ObservationFilter.wrapFilter(ObservationFilterChainDecorator.java:240)
> 	at org.springframework.security.web.ObservationFilterChainDecorator$ObservationFilter.doFilter(ObservationFilterChainDecorator.java:227)
> 	at org.springframework.security.web.ObservationFilterChainDecorator$VirtualFilterChain.doFilter(ObservationFilterChainDecorator.java:137)
> 	at org.springframework.security.web.session.DisableEncodeUrlFilter.doFilterInternal(DisableEncodeUrlFilter.java:42)
> 	at org.springframework.web.filter.OncePerRequestFilter.doFilter(OncePerRequestFilter.java:116)
> 	at org.springframework.security.web.ObservationFilterChainDecorator$ObservationFilter.wrapFilter(ObservationFilterChainDecorator.java:240)
> 	at org.springframework.security.web.ObservationFilterChainDecorator$AroundFilterObservation$SimpleAroundFilterObservation.lambda$wrap$0(ObservationFilterChainDecorator.java:323)
> 	at org.springframework.security.web.ObservationFilterChainDecorator$ObservationFilter.doFilter(ObservationFilterChainDecorator.java:224)
> 	at org.springframework.security.web.ObservationFilterChainDecorator$VirtualFilterChain.doFilter(ObservationFilterChainDecorator.java:137)
> 	at org.springframework.security.web.FilterChainProxy.doFilterInternal(FilterChainProxy.java:233)
> 	at org.springframework.security.web.FilterChainProxy.doFilter(FilterChainProxy.java:191)
> 	at org.springframework.web.filter.CompositeFilter$VirtualFilterChain.doFilter(CompositeFilter.java:113)
> 	at org.springframework.web.servlet.handler.HandlerMappingIntrospector.lambda$createCacheFilter$3(HandlerMappingIntrospector.java:195)
> 	at org.springframework.web.filter.CompositeFilter$VirtualFilterChain.doFilter(CompositeFilter.java:113)
> 	at org.springframework.web.filter.CompositeFilter.doFilter(CompositeFilter.java:74)
> 	at org.springframework.security.config.annotation.web.configuration.WebMvcSecurityConfiguration$CompositeFilterChainProxy.doFilter(WebMvcSecurityConfiguration.java:230)
> 	at org.springframework.web.filter.DelegatingFilterProxy.invokeDelegate(DelegatingFilterProxy.java:362)
> 	at org.springframework.web.filter.DelegatingFilterProxy.doFilter(DelegatingFilterProxy.java:278)
> 	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:164)
> 	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:140)
> 	at org.springframework.web.filter.RequestContextFilter.doFilterInternal(RequestContextFilter.java:100)
> 	at org.springframework.web.filter.OncePerRequestFilter.doFilter(OncePerRequestFilter.java:116)
> 	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:164)
> 	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:140)
> 	at org.springframework.web.filter.FormContentFilter.doFilterInternal(FormContentFilter.java:93)
> 	at org.springframework.web.filter.OncePerRequestFilter.doFilter(OncePerRequestFilter.java:116)
> 	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:164)
> 	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:140)
> 	at org.springframework.web.filter.ServerHttpObservationFilter.doFilterInternal(ServerHttpObservationFilter.java:113)
> 	at org.springframework.web.filter.OncePerRequestFilter.doFilter(OncePerRequestFilter.java:116)
> 	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:164)
> 	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:140)
> 	at org.springframework.web.filter.CharacterEncodingFilter.doFilterInternal(CharacterEncodingFilter.java:201)
> 	at org.springframework.web.filter.OncePerRequestFilter.doFilter(OncePerRequestFilter.java:116)
> 	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:164)
> 	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:140)
> 	at org.apache.catalina.core.StandardWrapperValve.invoke(StandardWrapperValve.java:167)
> 	at org.apache.catalina.core.StandardContextValve.invoke(StandardContextValve.java:90)
> 	at org.apache.catalina.authenticator.AuthenticatorBase.invoke(AuthenticatorBase.java:483)
> 	at org.apache.catalina.core.StandardHostValve.invoke(StandardHostValve.java:115)
> 	at org.apache.catalina.valves.ErrorReportValve.invoke(ErrorReportValve.java:93)
> 	at org.apache.catalina.core.StandardEngineValve.invoke(StandardEngineValve.java:74)
> 	at org.apache.catalina.valves.RemoteIpValve.invoke(RemoteIpValve.java:731)
> 	at org.apache.catalina.connector.CoyoteAdapter.service(CoyoteAdapter.java:344)
> 	at org.apache.coyote.http11.Http11Processor.service(Http11Processor.java:397)
> 	at org.apache.coyote.AbstractProcessorLight.process(AbstractProcessorLight.java:63)
> 	at org.apache.coyote.AbstractProtocol$ConnectionHandler.process(AbstractProtocol.java:905)
> 	at org.apache.tomcat.util.net.NioEndpoint$SocketProcessor.doRun(NioEndpoint.java:1743)
> 	at org.apache.tomcat.util.net.SocketProcessorBase.run(SocketProcessorBase.java:52)
> 	at java.base/java.lang.VirtualThread.run(VirtualThread.java:309)
> Caused by: java.lang.NullPointerException: Cannot invoke "javax.xml.namespace.QName.getLocalPart()" because the return value of "org.apache.cxf.jaxb.attachment.JAXBAttachmentMarshaller.getLastMTOMElementName()" is null
> 	at org.apache.cxf.jaxb.io.DataWriterImpl$MtomValidationHandler.handleEvent(DataWriterImpl.java:105)
> 	at org.glassfish.jaxb.runtime.v2.runtime.XMLSerializer.handleEvent(XMLSerializer.java:995)
> 	at org.glassfish.jaxb.runtime.v2.runtime.Coordinator.propagateEvent(Coordinator.java:155)
> 	at org.glassfish.jaxb.runtime.v2.runtime.Coordinator.fatalError(Coordinator.java:137)
> 	at org.glassfish.jaxb.runtime.v2.util.FatalAdapter.error(FatalAdapter.java:36)
> 	at java.xml/com.sun.org.apache.xerces.internal.util.ErrorHandlerWrapper.error(ErrorHandlerWrapper.java:138)
> 	at java.xml/com.sun.org.apache.xerces.internal.impl.XMLErrorReporter.reportError(XMLErrorReporter.java:396)
> 	at java.xml/com.sun.org.apache.xerces.internal.impl.XMLErrorReporter.reportError(XMLErrorReporter.java:327)
> 	at java.xml/com.sun.org.apache.xerces.internal.impl.XMLErrorReporter.reportError(XMLErrorReporter.java:284)
> 	at java.xml/com.sun.org.apache.xerces.internal.impl.xs.XMLSchemaValidator$XSIErrorReporter.reportError(XMLSchemaValidator.java:512)
> 	at java.xml/com.sun.org.apache.xerces.internal.impl.xs.XMLSchemaValidator.reportSchemaError(XMLSchemaValidator.java:3596)
> 	at java.xml/com.sun.org.apache.xerces.internal.impl.xs.XMLSchemaValidator.elementLocallyValidComplexType(XMLSchemaValidator.java:3473)
> 	at java.xml/com.sun.org.apache.xerces.internal.impl.xs.XMLSchemaValidator.elementLocallyValidType(XMLSchemaValidator.java:3441)
> 	at java.xml/com.sun.org.apache.xerces.internal.impl.xs.XMLSchemaValidator.processElementContent(XMLSchemaValidator.java:3343)
> 	at java.xml/com.sun.org.apache.xerces.internal.impl.xs.XMLSchemaValidator.handleEndElement(XMLSchemaValidator.java:2373)
> 	at java.xml/com.sun.org.apache.xerces.internal.impl.xs.XMLSchemaValidator.endElement(XMLSchemaValidator.java:944)
> 	at java.xml/com.sun.org.apache.xerces.internal.jaxp.validation.ValidatorHandlerImpl.endElement(ValidatorHandlerImpl.java:585)
> 	at java.xml/org.xml.sax.helpers.XMLFilterImpl.endElement(XMLFilterImpl.java:558)
> 	at org.glassfish.jaxb.runtime.v2.runtime.output.SAXOutput.endTag(SAXOutput.java:105)
> 	at org.glassfish.jaxb.runtime.v2.runtime.output.XmlOutputAbstractImpl.endTag(XmlOutputAbstractImpl.java:105)
> 	at org.glassfish.jaxb.runtime.v2.runtime.output.ForkXmlOutput.endTag(ForkXmlOutput.java:59)
> 	at org.glassfish.jaxb.runtime.v2.runtime.output.MTOMXmlOutput.endTag(MTOMXmlOutput.java:85)
> 	at org.glassfish.jaxb.runtime.v2.runtime.output.NamespaceContextImpl$Element.endElement(NamespaceContextImpl.java:477)
> 	at org.glassfish.jaxb.runtime.v2.runtime.XMLSerializer.endElement(XMLSerializer.java:279)
> 	at org.glassfish.jaxb.runtime.v2.runtime.property.SingleElementNodeProperty.serializeBody(SingleElementNodeProperty.java:130)
> 	at org.glassfish.jaxb.runtime.v2.runtime.ClassBeanInfoImpl.serializeBody(ClassBeanInfoImpl.java:334)
> 	at org.glassfish.jaxb.runtime.v2.runtime.XMLSerializer.childAsXsiType(XMLSerializer.java:659)
> 	at org.glassfish.jaxb.runtime.v2.runtime.property.ArrayElementNodeProperty.serializeItem(ArrayElementNodeProperty.java:38)
> 	at org.glassfish.jaxb.runtime.v2.runtime.property.ArrayElementProperty.serializeListBody(ArrayElementProperty.java:132)
> 	at org.glassfish.jaxb.runtime.v2.runtime.property.ArrayERProperty.serializeBody(ArrayERProperty.java:122)
> 	at org.glassfish.jaxb.runtime.v2.runtime.ClassBeanInfoImpl.serializeBody(ClassBeanInfoImpl.java:334)
> 	at org.glassfish.jaxb.runtime.v2.runtime.ClassBeanInfoImpl.serializeBody(ClassBeanInfoImpl.java:325)
> 	at org.glassfish.jaxb.runtime.v2.runtime.ClassBeanInfoImpl.serializeBody(ClassBeanInfoImpl.java:325)
> 	at org.glassfish.jaxb.runtime.v2.runtime.ClassBeanInfoImpl.serializeBody(ClassBeanInfoImpl.java:325)
> 	at org.glassfish.jaxb.runtime.v2.runtime.XMLSerializer.childAsXsiType(XMLSerializer.java:659)
> 	at org.glassfish.jaxb.runtime.v2.runtime.property.ArrayElementNodeProperty.serializeItem(ArrayElementNodeProperty.java:38)
> 	at org.glassfish.jaxb.runtime.v2.runtime.property.ArrayElementProperty.serializeListBody(ArrayElementProperty.java:132)
> 	at org.glassfish.jaxb.runtime.v2.runtime.property.ArrayERProperty.serializeBody(ArrayERProperty.java:122)
> 	at org.glassfish.jaxb.runtime.v2.runtime.ClassBeanInfoImpl.serializeBody(ClassBeanInfoImpl.java:334)
> 	at org.glassfish.jaxb.runtime.v2.runtime.XMLSerializer.childAsXsiType(XMLSerializer.java:659)
> 	at org.glassfish.jaxb.runtime.v2.runtime.property.ArrayElementNodeProperty.serializeItem(ArrayElementNodeProperty.java:38)
> 	at org.glassfish.jaxb.runtime.v2.runtime.property.ArrayElementProperty.serializeListBody(ArrayElementProperty.java:132)
> 	at org.glassfish.jaxb.runtime.v2.runtime.property.ArrayERProperty.serializeBody(ArrayERProperty.java:122)
> 	at org.glassfish.jaxb.runtime.v2.runtime.ClassBeanInfoImpl.serializeBody(ClassBeanInfoImpl.java:334)
> 	at org.glassfish.jaxb.runtime.v2.runtime.XMLSerializer.childAsXsiType(XMLSerializer.java:659)
> 	at org.glassfish.jaxb.runtime.v2.runtime.property.SingleElementNodeProperty.serializeBody(SingleElementNodeProperty.java:128)
> 	at org.glassfish.jaxb.runtime.v2.runtime.ClassBeanInfoImpl.serializeBody(ClassBeanInfoImpl.java:334)
> 	at org.glassfish.jaxb.runtime.v2.runtime.XMLSerializer.childAsXsiType(XMLSerializer.java:659)
> 	at org.glassfish.jaxb.runtime.v2.runtime.property.ArrayElementNodeProperty.serializeItem(ArrayElementNodeProperty.java:38)
> 	at org.glassfish.jaxb.runtime.v2.runtime.property.ArrayElementProperty.serializeListBody(ArrayElementProperty.java:132)
> 	at org.glassfish.jaxb.runtime.v2.runtime.property.ArrayERProperty.serializeBody(ArrayERProperty.java:122)
> 	at org.glassfish.jaxb.runtime.v2.runtime.ClassBeanInfoImpl.serializeBody(ClassBeanInfoImpl.java:334)
> 	at org.glassfish.jaxb.runtime.v2.runtime.XMLSerializer.childAsXsiType(XMLSerializer.java:659)
> 	at org.glassfish.jaxb.runtime.v2.runtime.property.SingleElementNodeProperty.serializeBody(SingleElementNodeProperty.java:128)
> 	at org.glassfish.jaxb.runtime.v2.runtime.ClassBeanInfoImpl.serializeBody(ClassBeanInfoImpl.java:334)
> 	at org.glassfish.jaxb.runtime.v2.runtime.XMLSerializer.childAsXsiType(XMLSerializer.java:659)
> 	at org.glassfish.jaxb.runtime.v2.runtime.property.SingleElementNodeProperty.serializeBody(SingleElementNodeProperty.java:128)
> 	at org.glassfish.jaxb.runtime.v2.runtime.ClassBeanInfoImpl.serializeBody(ClassBeanInfoImpl.java:334)
> 	at org.glassfish.jaxb.runtime.v2.runtime.XMLSerializer.childAsXsiType(XMLSerializer.java:659)
> 	at org.glassfish.jaxb.runtime.v2.runtime.ElementBeanInfoImpl$1.serializeBody(ElementBeanInfoImpl.java:120)
> 	at org.glassfish.jaxb.runtime.v2.runtime.ElementBeanInfoImpl$1.serializeBody(ElementBeanInfoImpl.java:93)
> 	at org.glassfish.jaxb.runtime.v2.runtime.ElementBeanInfoImpl.serializeBody(ElementBeanInfoImpl.java:316)
> 	at org.glassfish.jaxb.runtime.v2.runtime.ElementBeanInfoImpl.serializeRoot(ElementBeanInfoImpl.java:324)
> 	at org.glassfish.jaxb.runtime.v2.runtime.ElementBeanInfoImpl.serializeRoot(ElementBeanInfoImpl.java:38)
> 	at org.glassfish.jaxb.runtime.v2.runtime.XMLSerializer.childAsRoot(XMLSerializer.java:456)
> 	at org.glassfish.jaxb.runtime.v2.runtime.MarshallerImpl.write(MarshallerImpl.java:265)
> 	at org.glassfish.jaxb.runtime.v2.runtime.MarshallerImpl.marshal(MarshallerImpl.java:123)
> 	at org.apache.cxf.jaxb.JAXBEncoderDecoder.writeObject(JAXBEncoderDecoder.java:640)
> 	at org.apache.cxf.jaxb.JAXBEncoderDecoder.marshall(JAXBEncoderDecoder.java:244)
> 	... 112 common frames omitted

I propose this additional null check to fix this issue. I currently can not provide test data to reproduce but I hope this makes sense.