### PR TITLE
CXF-9142 Change async tracing tests to be order-agnostic

### DIFF
--- a/systests/tracing/src/test/java/org/apache/cxf/systest/jaxrs/tracing/opentracing/OpenTracingTracingTest.java
+++ b/systests/tracing/src/test/java/org/apache/cxf/systest/jaxrs/tracing/opentracing/OpenTracingTracingTest.java
@@ -196,13 +196,30 @@ public class OpenTracingTracingTest extends AbstractClientServerTestBase {
         final Response r = withTrace(createWebClient("/bookstore/books/async"), spanId).get();
         assertEquals(Status.OK.getStatusCode(), r.getStatus());
 
-        await().atMost(Duration.ofSeconds(1L)).until(()-> REPORTER.getSpans().size() == 2);
+        int spanSize = 2;
+        await().atMost(Duration.ofSeconds(1L)).until(()-> REPORTER.getSpans().size() == spanSize);
 
-        assertThat(REPORTER.getSpans().size(), equalTo(2));
-        assertEquals("Processing books", REPORTER.getSpans().get(0).getOperationName());
-        assertEquals("GET /bookstore/books/async", REPORTER.getSpans().get(1).getOperationName());
-        assertThat(REPORTER.getSpans().get(1).getReferences(), not(empty()));
-        assertThat(REPORTER.getSpans().get(1).getReferences().get(0).getSpanContext().getSpanId(),
+        assertThat(REPORTER.getSpans().size(), equalTo(spanSize));
+        boolean foundProcessing = false;
+        for (int i = 0; i < spanSize; i++) {
+            if ("Processing books".equals(REPORTER.getSpans().get(i).getOperationName())) {
+                foundProcessing = true;
+            }
+        }
+        assertTrue("Could not find Processing books in span getOperationName()", foundProcessing);
+
+        boolean foundAsync = false;
+        int getIndex = -1;
+        for (int i = 0; i < spanSize; i++) {
+            if ("GET /bookstore/books/async".equals(REPORTER.getSpans().get(i).getOperationName())) {
+                foundAsync = true;
+                getIndex = 1;
+            }
+        }
+        assertTrue("Could not find GET /bookstore/books/async in span getOperationName()", foundAsync);
+
+        assertThat(REPORTER.getSpans().get(getIndex).getReferences(), not(empty()));
+        assertThat(REPORTER.getSpans().get(getIndex).getReferences().get(0).getSpanContext().getSpanId(),
             equalTo(spanId.getSpanId()));
     }
 
@@ -222,11 +239,24 @@ public class OpenTracingTracingTest extends AbstractClientServerTestBase {
         final Response r = createWebClient("/bookstore/books/async").get();
         assertEquals(Status.OK.getStatusCode(), r.getStatus());
 
-        await().atMost(Duration.ofSeconds(1L)).until(()-> REPORTER.getSpans().size() == 2);
+        int spanSize = 2;
+        await().atMost(Duration.ofSeconds(1L)).until(()-> REPORTER.getSpans().size() == spanSize);
 
-        assertThat(REPORTER.getSpans().size(), equalTo(2));
-        assertThat(REPORTER.getSpans().get(0).getOperationName(), equalTo("Processing books"));
-        assertThat(REPORTER.getSpans().get(1).getOperationName(), equalTo("GET /bookstore/books/async"));
+        assertThat(REPORTER.getSpans().size(), equalTo(spanSize));
+        boolean foundProcessing = false;
+        for (int i = 0; i < spanSize; i++) {
+            if ("Processing books".equals(REPORTER.getSpans().get(i).getOperationName())) {
+                foundProcessing = true;
+            }
+        }
+        assertTrue("Could not find Processing books in span getOperationName()", foundProcessing);
+
+        boolean foundAsync = false;
+        for (int i = 0; i < spanSize; i++) {
+            if ("GET /bookstore/books/async".equals(REPORTER.getSpans().get(i).getOperationName())) {
+                foundAsync = true;
+            }
+        }
     }
 
     @Test


### PR DESCRIPTION
https://issues.apache.org/jira/browse/CXF-9142

Change the async tracing tests so that the order of the responses no longer matters.