### PR TITLE
CXF-9143: Remove Jakarta Mail Dependency

### DIFF
--- a/distribution/src/main/release/samples/mtom/pom.xml
+++ b/distribution/src/main/release/samples/mtom/pom.xml
@@ -133,8 +133,8 @@
             <artifactId>angus-activation</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.eclipse.angus</groupId>
-            <artifactId>angus-mail</artifactId>
+            <groupId>jakarta.mail</groupId>
+            <artifactId>jakarta.mail-api</artifactId>
         </dependency>
     </dependencies>
 </project>

--- a/rt/bindings/soap/pom.xml
+++ b/rt/bindings/soap/pom.xml
@@ -42,6 +42,11 @@
     </properties>
     <dependencies>
         <dependency>
+            <groupId>jakarta.mail</groupId>
+            <artifactId>jakarta.mail-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>jakarta.xml.soap</groupId>
             <artifactId>jakarta.xml.soap-api</artifactId>
         </dependency>
@@ -93,11 +98,6 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.eclipse.angus</groupId>
-            <artifactId>angus-mail</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/rt/frontend/jaxrs/pom.xml
+++ b/rt/frontend/jaxrs/pom.xml
@@ -94,6 +94,11 @@
             <artifactId>jakarta.annotation-api</artifactId>
         </dependency>
         <dependency>
+            <groupId>jakarta.mail</groupId>
+            <artifactId>jakarta.mail-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-transports-http</artifactId>
             <version>${project.version}</version>
@@ -156,11 +161,6 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-jdk14</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.eclipse.angus</groupId>
-            <artifactId>angus-mail</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/rt/frontend/jaxws/pom.xml
+++ b/rt/frontend/jaxws/pom.xml
@@ -178,8 +178,8 @@
             <artifactId>angus-activation</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.eclipse.angus</groupId>
-            <artifactId>angus-mail</artifactId>
+            <groupId>jakarta.mail</groupId>
+            <artifactId>jakarta.mail-api</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/rt/frontend/simple/pom.xml
+++ b/rt/frontend/simple/pom.xml
@@ -126,8 +126,9 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>org.eclipse.angus</groupId>
-            <artifactId>angus-mail</artifactId>
+            <groupId>jakarta.mail</groupId>
+            <artifactId>jakarta.mail-api</artifactId>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 </project>

--- a/systests/container-integration/grizzly/pom.xml
+++ b/systests/container-integration/grizzly/pom.xml
@@ -74,11 +74,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.eclipse.angus</groupId>
-            <artifactId>angus-mail</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
         </dependency>

--- a/systests/jaxws/pom.xml
+++ b/systests/jaxws/pom.xml
@@ -103,10 +103,6 @@
             <artifactId>angus-activation</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.eclipse.angus</groupId>
-            <artifactId>angus-mail</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-core</artifactId>
             <version>${project.version}</version>
@@ -129,6 +125,10 @@
         <dependency>
             <groupId>com.sun.xml.messaging.saaj</groupId>
             <artifactId>saaj-impl</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.mail</groupId>
+            <artifactId>jakarta.mail-api</artifactId>
         </dependency>
         <dependency>
             <groupId>jakarta.xml.ws</groupId>

--- a/systests/transport-jms/pom.xml
+++ b/systests/transport-jms/pom.xml
@@ -220,8 +220,8 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.eclipse.angus</groupId>
-            <artifactId>angus-mail</artifactId>
+            <groupId>jakarta.mail</groupId>
+            <artifactId>jakarta.mail-api</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/systests/uncategorized/pom.xml
+++ b/systests/uncategorized/pom.xml
@@ -335,8 +335,8 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.eclipse.angus</groupId>
-            <artifactId>angus-mail</artifactId>
+            <groupId>jakarta.mail</groupId>
+            <artifactId>jakarta.mail-api</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
The Jakarta Mail API is only used in Test Sources and example projects, but is a compile time dependency of `cxf-rt-frontend-simple`. The dependencies on a Mail API Implementation (Apache Angus Mail) are replaced with the Mail API when no actual implementation is required.