### PR TITLE
CXF-9146 Fix MemoryLeak in HttpClientHttpConduit

### DIFF
--- a/core/src/main/java/org/apache/cxf/io/AbstractWrappedOutputStream.java
+++ b/core/src/main/java/org/apache/cxf/io/AbstractWrappedOutputStream.java
@@ -75,6 +75,7 @@ public abstract class AbstractWrappedOutputStream extends OutputStream {
     public void close() throws IOException {
         if (wrappedStream != null) {
             wrappedStream.close();
+            wrappedStream = null;
         }
     }
 

--- a/rt/transports/http/src/main/java/org/apache/cxf/transport/http/HTTPConduit.java
+++ b/rt/transports/http/src/main/java/org/apache/cxf/transport/http/HTTPConduit.java
@@ -1421,6 +1421,7 @@ public abstract class HTTPConduit
                 } finally {
                     if (cachingForRetransmission && cachedStream != null) {
                         cachedStream.close();
+                        cachedStream = null;
                     }
                 }
             } catch (HttpRetryException e) {

--- a/rt/transports/http/src/main/java/org/apache/cxf/transport/http/HttpClientHTTPConduit.java
+++ b/rt/transports/http/src/main/java/org/apache/cxf/transport/http/HttpClientHTTPConduit.java
@@ -844,9 +844,6 @@ public class HttpClientHTTPConduit extends URLConnectionHTTPConduit {
                     } catch (IOException e) {
                         logStackTrace(e);
                     }
-                    if (wrappedStream == pout){
-                        wrappedStream = null;
-                    }
                     pout = null;
                 }
                 if (publisher != null) {

--- a/rt/transports/http/src/main/java/org/apache/cxf/transport/http/HttpClientHTTPConduit.java
+++ b/rt/transports/http/src/main/java/org/apache/cxf/transport/http/HttpClientHTTPConduit.java
@@ -844,6 +844,9 @@ public class HttpClientHTTPConduit extends URLConnectionHTTPConduit {
                     } catch (IOException e) {
                         logStackTrace(e);
                     }
+                    if (wrappedStream == pout){
+                        wrappedStream = null;
+                    }
                     pout = null;
                 }
                 if (publisher != null) {


### PR DESCRIPTION
If the wrappedStream corresponds to pout then it should be nulled as well. this fixes a memoryleak caused when pout is a PipedOutputStream, as the pipe holds a strong reference to the client thread which must be nulled to avoid MemoryLeaks in class like ThreadLocalClientState, which utilizes the same thread as a key for weakhashmap which in turn points to this very outputstream. this means that the thread is both the key and within the value of an entry of the weakhashamp, and as per the javadoc of said class, the GC cannot detect these cycles. to break this cycle, not only pout but also the wrappedStream needs to be nulled.

An alternative, simpler solution would be to always null the wrappedStream, but I did not debug the code enough to be sure if this is safe in all usecases like the retransmission. I am also not sure if it would also be necessary to null the cachedOutputStream, as it could point to the PipedOutputStream as well.

I've tried to keep the fix simpler this time, if you need additional tests, then let me now.