### PR TITLE
CXF-9114: ClientRequestContext#getConfiguration always return null in the MicroProfile RestClient

### DIFF
--- a/rt/rs/microprofile-client/src/main/java/org/apache/cxf/microprofile/client/proxy/MicroProfileClientProxyImpl.java
+++ b/rt/rs/microprofile-client/src/main/java/org/apache/cxf/microprofile/client/proxy/MicroProfileClientProxyImpl.java
@@ -139,6 +139,7 @@ public class MicroProfileClientProxyImpl extends ClientProxyImpl {
     private void init(ExecutorService executorService, Configuration configuration) {
         cfg.getRequestContext().put(EXECUTOR_SERVICE_PROPERTY, executorService);
         cfg.getRequestContext().putAll(configuration.getProperties());
+        cfg.getRequestContext().put(Configuration.class.getName(), configuration);
 
         List<Interceptor<? extends Message>>inboundChain = cfg.getInInterceptors();
         inboundChain.add(new MPAsyncInvocationInterceptorPostAsyncImpl());

--- a/rt/rs/microprofile-client/src/test/java/org/apache/cxf/microprofile/client/mock/InvokedMethodClientRequestFilter.java
+++ b/rt/rs/microprofile-client/src/test/java/org/apache/cxf/microprofile/client/mock/InvokedMethodClientRequestFilter.java
@@ -25,6 +25,7 @@ import jakarta.ws.rs.PUT;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.client.ClientRequestContext;
 import jakarta.ws.rs.client.ClientRequestFilter;
+import jakarta.ws.rs.core.Configuration;
 import jakarta.ws.rs.core.Response;
 
 public class InvokedMethodClientRequestFilter implements ClientRequestFilter {
@@ -32,6 +33,11 @@ public class InvokedMethodClientRequestFilter implements ClientRequestFilter {
     @Override
     public void filter(ClientRequestContext ctx) throws IOException {
         try {
+            final Configuration configuration = ctx.getConfiguration();
+            if (configuration == null) {
+                throw new NullPointerException("Configuration is null");
+            }
+
             Method m = (Method) ctx.getProperty("org.eclipse.microprofile.rest.client.invokedMethod");
 
             Path path = m.getAnnotation(Path.class);


### PR DESCRIPTION
ClientRequestContext#getConfiguration always return null in the MicroProfile RestClient