### PR TITLE
Fix RFC 9068 compliance: set typ header to at+jwt for JWT access tokens

### DIFF
--- a/rt/rs/security/jose-parent/jose/src/main/java/org/apache/cxf/rs/security/jose/common/JoseConstants.java
+++ b/rt/rs/security/jose-parent/jose/src/main/java/org/apache/cxf/rs/security/jose/common/JoseConstants.java
@@ -43,6 +43,7 @@ public final class JoseConstants extends RSSecurityConstants {
     public static final String JWS_HEADER_B64_STATUS_HEADER = "b64";
 
     public static final String TYPE_JWT = "JWT";
+    public static final String TYPE_AT_JWT = "at+jwt";
     public static final String TYPE_JOSE = "JOSE";
     public static final String TYPE_JOSE_JSON = "JOSE+JSON";
     public static final String MEDIA_TYPE_JOSE = "application/jose";

--- a/rt/rs/security/jose-parent/jose/src/main/java/org/apache/cxf/rs/security/jose/common/JoseType.java
+++ b/rt/rs/security/jose-parent/jose/src/main/java/org/apache/cxf/rs/security/jose/common/JoseType.java
@@ -22,7 +22,8 @@ package org.apache.cxf.rs.security.jose.common;
 public enum JoseType {
     JOSE(JoseConstants.TYPE_JOSE),
     JOSE_JSON(JoseConstants.TYPE_JOSE_JSON),
-    JWT(JoseConstants.TYPE_JWT);
+    JWT(JoseConstants.TYPE_JWT),
+    AT_JWT(JoseConstants.TYPE_AT_JWT);
 
     private final String type;
     JoseType(String type) {
@@ -33,6 +34,8 @@ public enum JoseType {
             return null;
         } else if (JoseConstants.TYPE_JOSE_JSON.equals(type)) {
             return JOSE_JSON;
+        } else if (JoseConstants.TYPE_AT_JWT.equals(type)) {
+            return AT_JWT;
         } else {
             return valueOf(type);
         }

--- a/rt/rs/security/oauth-parent/oauth2/src/main/java/org/apache/cxf/rs/security/oauth2/provider/AbstractOAuthDataProvider.java
+++ b/rt/rs/security/oauth-parent/oauth2/src/main/java/org/apache/cxf/rs/security/oauth2/provider/AbstractOAuthDataProvider.java
@@ -27,6 +27,7 @@ import java.util.Map;
 import jakarta.ws.rs.core.MultivaluedMap;
 import org.apache.cxf.jaxrs.ext.MessageContext;
 import org.apache.cxf.rs.security.jose.common.JoseConstants;
+import org.apache.cxf.rs.security.jose.common.JoseType;
 import org.apache.cxf.rs.security.jose.jwt.JwtClaims;
 import org.apache.cxf.rs.security.jose.jwt.JwtConstants;
 import org.apache.cxf.rs.security.jose.jwt.JwtToken;
@@ -669,7 +670,11 @@ public abstract class AbstractOAuthDataProvider implements OAuthDataProvider, Cl
         // It will JWS-sign (default) and/or JWE-encrypt
         OAuthJoseJwtProducer processor =
             getJwtAccessTokenProducer() == null ? new OAuthJoseJwtProducer() : getJwtAccessTokenProducer();
-        return processor.processJwt(new JwtToken(jwtCliams));
+        JwtToken jwt = new JwtToken(jwtCliams);
+        // RFC 9068 Section 2.1: JWT access tokens MUST set typ to "at+jwt"
+        jwt.getJwsHeaders().setType(JoseType.AT_JWT);
+        jwt.getJweHeaders().setType(JoseType.AT_JWT);
+        return processor.processJwt(jwt);
     }
 
     public Map<String, String> getJwtAccessTokenClaimMap() {


### PR DESCRIPTION
## Summary

CXF supports JWT-formatted access tokens via `useJwtFormatForAccessTokens`, but the produced tokens are missing the `typ: at+jwt` header required by [RFC 9068 Section 2.1](https://datatracker.ietf.org/doc/html/rfc9068#section-2.1):

> The JWT MUST contain a typ header parameter with the value at+jwt

Without this header, any RFC 9068-compliant resource server would reject CXF-issued JWT access tokens. This is a spec compliance bug.

### Changes

- **`JoseConstants`**: Added `TYPE_AT_JWT = "at+jwt"` constant
- **`JoseType`**: Added `AT_JWT` enum member with proper `getType()` lookup (since `at+jwt` can't be a Java identifier, it needs explicit handling like `JOSE_JSON`)
- **`AbstractOAuthDataProvider.processJwtAccessToken()`**: Sets the `at+jwt` type on **both** JWS and JWE headers, handling both the sign-only and sign+encrypt cases per RFC 9068 Section 2.1 and Section 4

This is a proper implementation incorporating @reta's review feedback from #990 (using the type system properly and handling both JWS and JWE).

Closes #990

## Test plan
- [x] `JwsCompactReaderWriterTest` — passes
- [x] `OAuth2JwtFiltersTest` — 5 tests pass
- [x] `JAXRSOAuth2TlsTest` — 5 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)