### PR TITLE
CXF-8746: Support forcing GET method on 301/302 redirects

### DIFF
--- a/rt/transports/http/src/main/java/org/apache/cxf/transport/http/HTTPConduit.java
+++ b/rt/transports/http/src/main/java/org/apache/cxf/transport/http/HTTPConduit.java
@@ -205,6 +205,7 @@ public abstract class HTTPConduit
     private static final String AUTO_REDIRECT_ALLOW_REL_URI = "http.redirect.relative.uri";
     private static final String AUTO_REDIRECT_ALLOWED_URI = "http.redirect.allowed.uri";
     private static final String AUTO_REDIRECT_MAX_SAME_URI_COUNT = "http.redirect.max.same.uri.count";
+    private static final String AUTO_REDIRECT_FORCE_GET = "http.redirect.force.GET";
 
     private static final String HTTP_POST_METHOD = "POST";
     private static final String HTTP_GET_METHOD = "GET";
@@ -1545,6 +1546,16 @@ public abstract class HTTPConduit
 
             if (newURL != null) {
                 new Headers(outMessage).removeAuthorizationHeaders();
+
+                // RFC 7231 Sections 6.4.2/6.4.3: For historical reasons, a user agent MAY
+                // change the request method from POST to GET for 301/302 redirects.
+                // This is enabled via the "http.redirect.force.GET" property.
+                int responseCode = getResponseCode();
+                if ((responseCode == HttpURLConnection.HTTP_MOVED_PERM
+                        || responseCode == HttpURLConnection.HTTP_MOVED_TEMP)
+                        && MessageUtils.getContextualBoolean(outMessage, AUTO_REDIRECT_FORCE_GET)) {
+                    outMessage.put(Message.HTTP_REQUEST_METHOD, HTTP_GET_METHOD);
+                }
 
                 // If user configured this Conduit with preemptive authorization
                 // it is meant to make it to the end. (Too bad that information


### PR DESCRIPTION
## Summary

- Adds `http.redirect.force.GET` property to `HTTPConduit` that changes the request method from POST to GET on 301 (Moved Permanently) and 302 (Found) redirects
- Per RFC 7231 Sections 6.4.2/6.4.3, user agents have historically changed POST to GET on these redirects. This property enables that behavior when set to `true`
- Minimal change: sets `Message.HTTP_REQUEST_METHOD` on the outMessage before `retransmit()`, which naturally flows through `setupConnection()` and skips body output for GET

## Usage

```java
WebClient wc = WebClient.create(address);
WebClient.getConfig(wc).getRequestContext().put("http.redirect.force.GET", "true");
WebClient.getConfig(wc).getHttpConduit().getClient().setAutoRedirect(true);
```

Or via Spring/Blueprint configuration:
```xml
<http-conf:conduit name="*.http-conduit">
    <http-conf:client AutoRedirect="true"/>
</http-conf:conduit>
```
With the context property `http.redirect.force.GET` set to `true`.

## Context

Supersedes #977 with a cleaner, non-API-breaking approach. The original PR threaded a `boolean forceGET` parameter through abstract method signatures across multiple transport implementations (URLConnection, HC5, Netty), which was overly invasive. This implementation requires changes only in `HTTPConduit.java` and follows the same pattern as existing `http.redirect.*` properties.

## Test plan

- [x] Existing `HTTPConduitURLEasyMockTest` redirect tests pass
- [ ] CI verification

🤖 Generated with [Claude Code](https://claude.com/claude-code)