### PR TITLE
Reduce equal method candidates log from WARNING to FINE

### DIFF
--- a/rt/frontend/jaxrs/src/main/java/org/apache/cxf/jaxrs/model/OperationResourceInfoComparatorBase.java
+++ b/rt/frontend/jaxrs/src/main/java/org/apache/cxf/jaxrs/model/OperationResourceInfoComparatorBase.java
@@ -98,8 +98,8 @@ public abstract class OperationResourceInfoComparatorBase {
                 e1.getClassResourceInfo().getServiceClass().getName() + "#" + e1.getMethodToInvoke().getName();
             String m2Name =
                 e2.getClassResourceInfo().getServiceClass().getName() + "#" + e2.getMethodToInvoke().getName();
-            LOG.warning("Both " + m1Name + " and " + m2Name + " are equal candidates for handling the current request"
-                        + " which can lead to unpredictable results");
+            LOG.fine("Both " + m1Name + " and " + m2Name + " are equal candidates for handling the current request"
+                     + " which can lead to unpredictable results");
         }
         return result;
     }

--- a/rt/frontend/jaxrs/src/main/java/org/apache/cxf/jaxrs/model/OperationResourceInfoComparatorBase.java
+++ b/rt/frontend/jaxrs/src/main/java/org/apache/cxf/jaxrs/model/OperationResourceInfoComparatorBase.java
@@ -98,8 +98,8 @@ public abstract class OperationResourceInfoComparatorBase {
                 e1.getClassResourceInfo().getServiceClass().getName() + "#" + e1.getMethodToInvoke().getName();
             String m2Name =
                 e2.getClassResourceInfo().getServiceClass().getName() + "#" + e2.getMethodToInvoke().getName();
-            LOG.fine("Both " + m1Name + " and " + m2Name + " are equal candidates for handling the current request"
-                     + " which can lead to unpredictable results");
+            LOG.fine(() -> "Both " + m1Name + " and " + m2Name
+                     + " are equal candidates for handling the current request");
         }
         return result;
     }


### PR DESCRIPTION
## Summary

- Downgrades the "Both X and Y are equal candidates for handling the current request" log message from `WARNING` to `FINE` (debug) level in `OperationResourceInfoComparatorBase`
- This message fires during normal CORS preflight handling where `CrossOriginResourceSharingFilter.findPreflightMethod()` uses `MediaType.WILDCARD`, causing all methods on the same path to match equally
- The behavior is deterministic (stable sort order) so the warning is misleading — it says "unpredictable results" but the results are actually predictable
- Users debugging ambiguous routing can still see this message by enabling FINE logging

Supersedes #862 with a simpler fix — rather than changing the CORS filter to pass real media types, we simply reduce the noise level of a message that fires in expected scenarios.

## Test plan

- [x] Compiles cleanly
- [ ] CI verification

🤖 Generated with [Claude Code](https://claude.com/claude-code)