### PR TITLE
Fix ExecutorService leak in WS-RM oneway tests

### DIFF
--- a/systests/ws-rm/src/test/java/org/apache/cxf/systest/ws/rm/DeliveryAssuranceOnewayTest.java
+++ b/systests/ws-rm/src/test/java/org/apache/cxf/systest/ws/rm/DeliveryAssuranceOnewayTest.java
@@ -76,6 +76,7 @@ public class DeliveryAssuranceOnewayTest extends AbstractBusClientServerTestBase
     private Endpoint endpoint;
     private Bus greeterBus;
     private Greeter greeter;
+    private ExecutorService executorService;
 
     @After
     public void tearDown() throws Exception {
@@ -88,6 +89,13 @@ public class DeliveryAssuranceOnewayTest extends AbstractBusClientServerTestBase
             stopServer();
         } catch (Throwable t) {
             //ignore
+        }
+        if (executorService != null) {
+            executorService.shutdown();
+            if (!executorService.awaitTermination(10, TimeUnit.SECONDS)) {
+                executorService.shutdownNow();
+            }
+            executorService = null;
         }
         Thread.sleep(100);
     }
@@ -380,6 +388,9 @@ public class DeliveryAssuranceOnewayTest extends AbstractBusClientServerTestBase
 
         if (null != executor) {
             gs.setExecutor(executor);
+            if (executor instanceof ExecutorService) {
+                this.executorService = (ExecutorService) executor;
+            }
         }
 
         greeter = gs.getGreeterPort();

--- a/systests/ws-rm/src/test/java/org/apache/cxf/systest/ws/rm/MessageCallbackOnewayTest.java
+++ b/systests/ws-rm/src/test/java/org/apache/cxf/systest/ws/rm/MessageCallbackOnewayTest.java
@@ -25,6 +25,7 @@ import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
@@ -81,6 +82,7 @@ public class MessageCallbackOnewayTest extends AbstractBusClientServerTestBase {
     private Bus greeterBus;
     private Greeter greeter;
     private RecordingMessageCallback callback;
+    private ExecutorService executorService;
 
     @After
     public void tearDown() throws Exception {
@@ -93,6 +95,13 @@ public class MessageCallbackOnewayTest extends AbstractBusClientServerTestBase {
             stopServer();
         } catch (Throwable t) {
             //ignore
+        }
+        if (executorService != null) {
+            executorService.shutdown();
+            if (!executorService.awaitTermination(10, TimeUnit.SECONDS)) {
+                executorService.shutdownNow();
+            }
+            executorService = null;
         }
     }
 
@@ -216,6 +225,9 @@ public class MessageCallbackOnewayTest extends AbstractBusClientServerTestBase {
 
         if (null != executor) {
             gs.setExecutor(executor);
+            if (executor instanceof ExecutorService) {
+                this.executorService = (ExecutorService) executor;
+            }
         }
 
         greeter = gs.getGreeterPort();


### PR DESCRIPTION
## Summary
- `DeliveryAssuranceOnewayTest` and `MessageCallbackOnewayTest` create `ExecutorService` instances via `Executors.newSingleThreadExecutor()` in their `*AsyncExecutor` test methods but never shut them down
- The leaked non-daemon threads prevent clean test completion, causing intermittent timeouts in CI (~95-100s for DeliveryAssurance, ~75s for MessageCallback)
- Fix: track the `ExecutorService` in an instance field and shut it down in `tearDown()` with a 10-second grace period before forceful termination

## Test plan
- [ ] CI passes without WS-RM oneway test timeouts
- [ ] Both `DeliveryAssuranceOnewayTest` and `MessageCallbackOnewayTest` complete within their 60s timeout

🤖 Generated with [Claude Code](https://claude.com/claude-code)