### PR TITLE
Fix flaky CircuitBreakerFailoverTest timing issues

### DIFF
--- a/systests/jaxrs/src/test/java/org/apache/cxf/systest/jaxrs/failover/AbstractFailoverTest.java
+++ b/systests/jaxrs/src/test/java/org/apache/cxf/systest/jaxrs/failover/AbstractFailoverTest.java
@@ -63,7 +63,7 @@ public abstract class AbstractFailoverTest extends AbstractBusClientServerTestBa
                    launchServer(Server.class, true));
         boolean activeReplica1Started = false;
         boolean activeReplica2Started = false;
-        for (int i = 0; i < 10; i++) {
+        for (int i = 0; i < 50; i++) {
             if (!activeReplica1Started) {
                 activeReplica1Started = checkReplica(Server.ADDRESS2);
             }
@@ -73,7 +73,7 @@ public abstract class AbstractFailoverTest extends AbstractBusClientServerTestBa
             if (activeReplica1Started && activeReplica2Started) {
                 break;
             }
-            Thread.sleep(100L);
+            Thread.sleep(200L);
         }
     }
 

--- a/systests/jaxrs/src/test/java/org/apache/cxf/systest/jaxrs/failover/CircuitBreakerFailoverTest.java
+++ b/systests/jaxrs/src/test/java/org/apache/cxf/systest/jaxrs/failover/CircuitBreakerFailoverTest.java
@@ -88,7 +88,7 @@ public class CircuitBreakerFailoverTest extends AbstractFailoverTest {
             }
 
             // Let's wait a bit more than circuit breaker timeout
-            Thread.sleep(4000);
+            Thread.sleep(6000);
         }
     }
 


### PR DESCRIPTION
## Summary
- Increase server readiness check timeout from 1s (10×100ms) to 10s (50×200ms) to allow sufficient time for server startup in CI
- Increase circuit breaker timeout sleep from 4s to 6s (double the 3s circuit breaker timeout) to provide adequate margin on slow CI

The `testSequentialStrategyWithElapsingCircuitBreakerTimeout` test uses a 3s circuit breaker timeout but only waits 4s (33% margin), which is insufficient on slow CI systems.

## Test plan
- [ ] CI passes without CircuitBreakerFailoverTest failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)