### PR TITLE
Fix flaky Grizzly EndpointAPITest: use graceful server shutdown

### DIFF
--- a/systests/container-integration/grizzly/src/test/java/org/apache/cxf/systest/grizzly/EndpointAPITest.java
+++ b/systests/container-integration/grizzly/src/test/java/org/apache/cxf/systest/grizzly/EndpointAPITest.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.URL;
+import java.util.concurrent.TimeUnit;
 
 import javax.xml.namespace.QName;
 
@@ -62,7 +63,11 @@ public class EndpointAPITest {
 
     @After
     public void tearDown() {
-        server.shutdownNow();
+        try {
+            server.shutdown().get(10, TimeUnit.SECONDS);
+        } catch (Exception e) {
+            server.shutdownNow();
+        }
         server = null;
     }
 


### PR DESCRIPTION
## Summary

- Replace `shutdownNow()` with graceful `shutdown().get(10, TimeUnit.SECONDS)` in `EndpointAPITest.tearDown()`
- This ensures the Grizzly server fully releases ports and resources before the next test's `setUp()` tries to bind a new port
- Falls back to `shutdownNow()` if graceful shutdown times out

## Test plan

- [ ] CI passes: Grizzly EndpointAPITest should be more stable
- [ ] No other tests affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)