### PR TITLE
Fix FormUtils.isFormPostRequest to handle content-type with parameters

### DIFF
--- a/rt/frontend/jaxrs/src/main/java/org/apache/cxf/jaxrs/utils/FormUtils.java
+++ b/rt/frontend/jaxrs/src/main/java/org/apache/cxf/jaxrs/utils/FormUtils.java
@@ -306,7 +306,9 @@ public final class FormUtils {
     }
 
     public static boolean isFormPostRequest(Message m) {
-        return MediaType.APPLICATION_FORM_URLENCODED.equals(m.get(Message.CONTENT_TYPE))
+        String contentType = (String) m.get(Message.CONTENT_TYPE);
+        return contentType != null
+            && contentType.startsWith(MediaType.APPLICATION_FORM_URLENCODED)
             && HttpMethod.POST.equals(m.get(Message.HTTP_REQUEST_METHOD));
     }
 }


### PR DESCRIPTION
## Summary
`FormUtils.isFormPostRequest()` uses `equals()` to match the content type, but in practice the `Content-Type` header can include parameters like `application/x-www-form-urlencoded; charset=UTF-8`.

This is extremely common — jQuery's `$.ajax()` sends exactly this content type by default. With the current code, form POST data is silently not recognized for these requests.

The fix uses `startsWith` instead of `equals`, consistent with how `FormEncodingProvider` already handles content types with charset parameters (see `FormEncodingProviderTest` lines [264](https://github.com/apache/cxf/blob/main/rt/frontend/jaxrs/src/test/java/org/apache/cxf/jaxrs/provider/FormEncodingProviderTest.java#L264) and [283](https://github.com/apache/cxf/blob/main/rt/frontend/jaxrs/src/test/java/org/apache/cxf/jaxrs/provider/FormEncodingProviderTest.java#L283)).

Split out from #2955 per review feedback.

## Test plan
- [x] `rt/frontend/jaxrs` module compiles and tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)