### PR TITLE
Fix OAuth2 test flakiness from Response/WebClient resource leaks

### DIFF
--- a/systests/rs-security/src/test/java/org/apache/cxf/systest/jaxrs/security/oauth2/common/OAuth2TestUtils.java
+++ b/systests/rs-security/src/test/java/org/apache/cxf/systest/jaxrs/security/oauth2/common/OAuth2TestUtils.java
@@ -125,8 +125,12 @@ public final class OAuth2TestUtils {
 
         client.path(parameters.getPath());
         Response response = client.get();
-
-        OAuthAuthorizationData authzData = response.readEntity(OAuthAuthorizationData.class);
+        OAuthAuthorizationData authzData;
+        try {
+            authzData = response.readEntity(OAuthAuthorizationData.class);
+        } finally {
+            response.close();
+        }
         return getLocation(client, authzData, parameters.getState());
     }
 
@@ -159,7 +163,12 @@ public final class OAuth2TestUtils {
         form.param("oauthDecision", "allow");
 
         Response response = client.post(form);
-        String location = response.getHeaderString("Location");
+        String location;
+        try {
+            location = response.getHeaderString("Location");
+        } finally {
+            response.close();
+        }
         if (state != null) {
             Assert.assertTrue(location.contains("state=" + state));
         }

--- a/systests/rs-security/src/test/java/org/apache/cxf/systest/jaxrs/security/oauth2/grants/AuthorizationGrantTest.java
+++ b/systests/rs-security/src/test/java/org/apache/cxf/systest/jaxrs/security/oauth2/grants/AuthorizationGrantTest.java
@@ -126,6 +126,7 @@ public class AuthorizationGrantTest extends AbstractBusClientServerTestBase {
         // Get Authorization Code
         String code = OAuth2TestUtils.getAuthorizationCode(client);
         assertNotNull(code);
+        client.close();
 
         // Now get the access token
         client = WebClient.create(address, "consumer-id", "this-is-a-secret", null);
@@ -133,6 +134,7 @@ public class AuthorizationGrantTest extends AbstractBusClientServerTestBase {
         ClientAccessToken accessToken =
             OAuth2TestUtils.getAccessTokenWithAuthorizationCode(client, code);
         assertNotNull(accessToken.getTokenKey());
+        client.close();
 
         if (isAccessTokenInJWTFormat()) {
             validateAccessToken(accessToken.getTokenKey());
@@ -165,6 +167,7 @@ public class AuthorizationGrantTest extends AbstractBusClientServerTestBase {
         String location = OAuth2TestUtils.getLocation(client, authzData, null);
         String code =  OAuth2TestUtils.getSubstring(location, "code");
         assertNotNull(code);
+        client.close();
 
         // Now get the access token
         client = WebClient.create(address, "consumer-id", "this-is-a-secret", null);
@@ -172,6 +175,7 @@ public class AuthorizationGrantTest extends AbstractBusClientServerTestBase {
         ClientAccessToken accessToken =
             OAuth2TestUtils.getAccessTokenWithAuthorizationCode(client, code);
         assertNotNull(accessToken.getTokenKey());
+        client.close();
 
         if (isAccessTokenInJWTFormat()) {
             validateAccessToken(accessToken.getTokenKey());
@@ -190,6 +194,7 @@ public class AuthorizationGrantTest extends AbstractBusClientServerTestBase {
         // Get Authorization Code
         String code = OAuth2TestUtils.getAuthorizationCode(client);
         assertNotNull(code);
+        client.close();
 
         // Now get the access token
         client = WebClient.create(address, OAuth2TestUtils.setupProviders(),
@@ -214,6 +219,7 @@ public class AuthorizationGrantTest extends AbstractBusClientServerTestBase {
         accessToken = client.post(form, ClientAccessToken.class);
         assertNotNull(accessToken.getTokenKey());
         assertNotNull(accessToken.getRefreshToken());
+        client.close();
 
         if (isAccessTokenInJWTFormat()) {
             validateAccessToken(accessToken.getTokenKey());
@@ -232,6 +238,7 @@ public class AuthorizationGrantTest extends AbstractBusClientServerTestBase {
         // Get Authorization Code
         String code = OAuth2TestUtils.getAuthorizationCode(client, "read_balance");
         assertNotNull(code);
+        client.close();
 
         // Now get the access token
         client = WebClient.create(address, OAuth2TestUtils.setupProviders(),
@@ -258,6 +265,7 @@ public class AuthorizationGrantTest extends AbstractBusClientServerTestBase {
         assertNotNull(accessToken.getTokenKey());
         assertNotNull(accessToken.getRefreshToken());
         assertEquals("read_balance", accessToken.getApprovedScope());
+        client.close();
 
         if (isAccessTokenInJWTFormat()) {
             validateAccessToken(accessToken.getTokenKey());
@@ -277,6 +285,7 @@ public class AuthorizationGrantTest extends AbstractBusClientServerTestBase {
         // Get Authorization Code
         String code = OAuth2TestUtils.getAuthorizationCode(client, "read_balance");
         assertNotNull(code);
+        client.close();
 
         // Now get the access token
         client = WebClient.create(address, OAuth2TestUtils.setupProviders(),
@@ -302,6 +311,7 @@ public class AuthorizationGrantTest extends AbstractBusClientServerTestBase {
         assertNotNull(accessToken.getTokenKey());
         assertNotNull(accessToken.getRefreshToken());
 //        assertEquals("read_balance", accessToken.getApprovedScope());
+        client.close();
 
         if (isAccessTokenInJWTFormat()) {
             validateAccessToken(accessToken.getTokenKey());
@@ -320,6 +330,7 @@ public class AuthorizationGrantTest extends AbstractBusClientServerTestBase {
         // Get Authorization Code
         String code = OAuth2TestUtils.getAuthorizationCode(client, "read_balance");
         assertNotNull(code);
+        client.close();
 
         // Now get the access token
         client = WebClient.create(address, "consumer-id", "this-is-a-secret", null);
@@ -327,6 +338,7 @@ public class AuthorizationGrantTest extends AbstractBusClientServerTestBase {
         ClientAccessToken accessToken =
             OAuth2TestUtils.getAccessTokenWithAuthorizationCode(client, code);
         assertNotNull(accessToken.getTokenKey());
+        client.close();
     }
 
     @org.junit.Test
@@ -343,6 +355,7 @@ public class AuthorizationGrantTest extends AbstractBusClientServerTestBase {
         String code = OAuth2TestUtils.getAuthorizationCode(client, "read_balance", "consumer-id",
                                                            null, state);
         assertNotNull(code);
+        client.close();
 
         // Now get the access token
         client = WebClient.create(address, "consumer-id", "this-is-a-secret", null);
@@ -350,6 +363,7 @@ public class AuthorizationGrantTest extends AbstractBusClientServerTestBase {
         ClientAccessToken accessToken =
             OAuth2TestUtils.getAccessTokenWithAuthorizationCode(client, code);
         assertNotNull(accessToken.getTokenKey());
+        client.close();
     }
 
     @org.junit.Test
@@ -364,6 +378,7 @@ public class AuthorizationGrantTest extends AbstractBusClientServerTestBase {
         // Get Authorization Code
         String code = OAuth2TestUtils.getAuthorizationCode(client, null, "consumer-id-aud");
         assertNotNull(code);
+        client.close();
 
         // Now get the access token
         client = WebClient.create(address, "consumer-id-aud", "this-is-a-secret", null);
@@ -383,6 +398,7 @@ public class AuthorizationGrantTest extends AbstractBusClientServerTestBase {
             OAuth2TestUtils.getAccessTokenWithAuthorizationCode(client, code,
                                                                 "consumer-id-aud", audience);
         assertNotNull(accessToken.getTokenKey());
+        client.close();
     }
 
     @org.junit.Test
@@ -414,10 +430,15 @@ public class AuthorizationGrantTest extends AbstractBusClientServerTestBase {
         form.param("oauthDecision", "allow");
 
         Response response = client.post(form);
-
-        String location = response.getHeaderString("Location");
+        String location;
+        try {
+            location = response.getHeaderString("Location");
+        } finally {
+            response.close();
+        }
         String accessToken = OAuth2TestUtils.getSubstring(location, "access_token");
         assertNotNull(accessToken);
+        client.close();
 
         if (isAccessTokenInJWTFormat()) {
             validateAccessToken(accessToken);
@@ -442,6 +463,7 @@ public class AuthorizationGrantTest extends AbstractBusClientServerTestBase {
         ClientAccessToken accessToken = client.post(form, ClientAccessToken.class);
         assertNotNull(accessToken.getTokenKey());
         assertNotNull(accessToken.getRefreshToken());
+        client.close();
 
         if (isAccessTokenInJWTFormat()) {
             validateAccessToken(accessToken.getTokenKey());
@@ -464,6 +486,7 @@ public class AuthorizationGrantTest extends AbstractBusClientServerTestBase {
         ClientAccessToken accessToken = client.post(form, ClientAccessToken.class);
         assertNotNull(accessToken.getTokenKey());
         assertNotNull(accessToken.getRefreshToken());
+        client.close();
 
         if (isAccessTokenInJWTFormat()) {
             validateAccessToken(accessToken.getTokenKey());
@@ -491,6 +514,7 @@ public class AuthorizationGrantTest extends AbstractBusClientServerTestBase {
         ClientAccessToken accessToken = client.post(form, ClientAccessToken.class);
         assertNotNull(accessToken.getTokenKey());
         assertNotNull(accessToken.getRefreshToken());
+        client.close();
 
         if (isAccessTokenInJWTFormat()) {
             validateAccessToken(accessToken.getTokenKey());
@@ -519,6 +543,7 @@ public class AuthorizationGrantTest extends AbstractBusClientServerTestBase {
         ClientAccessToken accessToken = client.post(form, ClientAccessToken.class);
         assertNotNull(accessToken.getTokenKey());
         assertNotNull(accessToken.getRefreshToken());
+        client.close();
 
         if (isAccessTokenInJWTFormat()) {
             validateAccessToken(accessToken.getTokenKey());

--- a/systests/rs-security/src/test/java/org/apache/cxf/systest/jaxrs/security/oauth2/grants/PublicClientTest.java
+++ b/systests/rs-security/src/test/java/org/apache/cxf/systest/jaxrs/security/oauth2/grants/PublicClientTest.java
@@ -111,6 +111,8 @@ public class PublicClientTest extends AbstractClientServerTestBase {
             fail("Failure expected on a missing (registered) redirectURI");
         } catch (Exception ex) {
             // expected
+        } finally {
+            client.close();
         }
     }
 
@@ -166,12 +168,14 @@ public class PublicClientTest extends AbstractClientServerTestBase {
         String location = OAuth2TestUtils.getLocation(client, parameters);
         String code = OAuth2TestUtils.getSubstring(location, "code");
         assertNotNull(code);
+        client.close();
 
         // Now get the access token
         client = WebClient.create(tokenServiceAddress, busFile.toString());
         ClientAccessToken accessToken =
             OAuth2TestUtils.getAccessTokenWithAuthorizationCode(client, code, "consumer-id", null, codeVerifier);
         assertNotNull(accessToken.getTokenKey());
+        client.close();
     }
 
     private void testPKCEMissingVerifier(CodeVerifierTransformer transformer) {
@@ -196,6 +200,7 @@ public class PublicClientTest extends AbstractClientServerTestBase {
         String location = OAuth2TestUtils.getLocation(client, parameters);
         String code = OAuth2TestUtils.getSubstring(location, "code");
         assertNotNull(code);
+        client.close();
 
         // Now get the access token
         client = WebClient.create(tokenServiceAddress, busFile.toString());
@@ -204,6 +209,8 @@ public class PublicClientTest extends AbstractClientServerTestBase {
             fail("Failure expected on a missing verifier");
         } catch (OAuthServiceException ex) {
             assertFalse(ex.getError().getError().isEmpty());
+        } finally {
+            client.close();
         }
     }
 
@@ -229,6 +236,7 @@ public class PublicClientTest extends AbstractClientServerTestBase {
         String location = OAuth2TestUtils.getLocation(client, parameters);
         String code = OAuth2TestUtils.getSubstring(location, "code");
         assertNotNull(code);
+        client.close();
 
         // Now get the access token
         client = WebClient.create(tokenServiceAddress, busFile.toString());
@@ -239,6 +247,8 @@ public class PublicClientTest extends AbstractClientServerTestBase {
             fail("Failure expected on a different verifier");
         } catch (OAuthServiceException ex) {
             assertFalse(ex.getError().getError().isEmpty());
+        } finally {
+            client.close();
         }
     }
 


### PR DESCRIPTION
## Summary
- Close `Response` objects in `OAuth2TestUtils.getLocation()` methods using try-finally blocks to prevent HTTP connection pool exhaustion under CI load with surefire retries
- Close `WebClient` instances in `AuthorizationGrantTest` and `PublicClientTest` after use to release HTTP connections
- No functional changes — only resource cleanup additions

## Test plan
- [x] `mvn -B validate -pl systests/rs-security` passes (checkstyle/PMD clean)
- [ ] Full systests/rs-security test suite passes without flaky failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)