### PR TITLE
Fix AttachmentMtomChunkingTest port collision with AttachmentChunkingTest

### DIFF
--- a/systests/jaxws/src/test/java/org/apache/cxf/systest/jaxws/AttachmentMtomChunkingTest.java
+++ b/systests/jaxws/src/test/java/org/apache/cxf/systest/jaxws/AttachmentMtomChunkingTest.java
@@ -44,7 +44,7 @@ import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
 public class AttachmentMtomChunkingTest extends AbstractAttachmentChunkingTest {
-    private static final String PORT = allocatePort(DownloadServer.class);
+    private static final String PORT = allocatePort(AttachmentMtomChunkingTest.class);
     private static final Logger LOG = LogUtils.getLogger(AttachmentMtomChunkingTest.class);
 
     public static class DownloadServer extends AbstractBusTestServerBase {


### PR DESCRIPTION
## Summary

- Both `AttachmentChunkingTest` and `AttachmentMtomChunkingTest` have inner classes named `DownloadServer`
- Both use `allocatePort(DownloadServer.class)` which resolves to the same port via `TestUtil` (stores under the simple class name `DownloadServer`)
- When both tests run in the same JVM, the second test fails with `ListenerRegistrationException: Soap 1.1 endpoint already registered on address`
- Fix: use `allocatePort(AttachmentMtomChunkingTest.class)` to get a distinct port

## Test plan

- [ ] Both `AttachmentChunkingTest` and `AttachmentMtomChunkingTest` pass in the same surefire fork

🤖 Generated with [Claude Code](https://claude.com/claude-code)