### PR TITLE
Improve tracing test diagnostics for flaky test investigation

### DIFF
--- a/systests/tracing/src/test/java/org/apache/cxf/systest/HasSize.java
+++ b/systests/tracing/src/test/java/org/apache/cxf/systest/HasSize.java
@@ -1,0 +1,52 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.cxf.systest;
+
+import java.util.Collection;
+
+import org.hamcrest.Description;
+import org.hamcrest.TypeSafeMatcher;
+
+public class HasSize extends TypeSafeMatcher<Collection<?>> {
+    private final int expectedSize;
+
+    public HasSize(int expectedSize) {
+        this.expectedSize = expectedSize;
+    }
+
+    @Override
+    protected boolean matchesSafely(Collection<?> collection) {
+        return collection.size() == expectedSize;
+    }
+
+    @Override
+    public void describeTo(Description description) {
+        description.appendText("a collection with size ").appendValue(expectedSize);
+    }
+
+    @Override
+    protected void describeMismatchSafely(Collection<?> collection, Description description) {
+        description.appendText("size was ").appendValue(collection.size())
+            .appendText(", contents: ").appendValue(collection);
+    }
+
+    public static HasSize hasSize(int size) {
+        return new HasSize(size);
+    }
+}

--- a/systests/tracing/src/test/java/org/apache/cxf/systest/brave/jaxrs/AbstractBraveTracingTest.java
+++ b/systests/tracing/src/test/java/org/apache/cxf/systest/brave/jaxrs/AbstractBraveTracingTest.java
@@ -265,9 +265,10 @@ public abstract class AbstractBraveTracingTest extends AbstractClientServerTestB
         }
 
         // Await till flush happens, usually a second is enough
-        await().atMost(Duration.ofSeconds(5L)).until(()-> TestSpanHandler.getAllSpans().size() == 4);
+        await().atMost(Duration.ofSeconds(5L)).untilAsserted(() -> assertThat(
+            "Unexpected span count. Spans: " + TestSpanHandler.getAllSpans(),
+            TestSpanHandler.getAllSpans().size(), equalTo(4)));
 
-        assertThat(TestSpanHandler.getAllSpans().size(), equalTo(4));
         assertThat(TestSpanHandler.getAllSpans().get(3).name(), equalTo("test span"));
     }
 
@@ -292,9 +293,10 @@ public abstract class AbstractBraveTracingTest extends AbstractClientServerTestB
         }
 
         // Await till flush happens, usually a second is enough
-        await().atMost(Duration.ofSeconds(5L)).until(()-> TestSpanHandler.getAllSpans().size() == 4);
+        await().atMost(Duration.ofSeconds(5L)).untilAsserted(() -> assertThat(
+            "Unexpected span count. Spans: " + TestSpanHandler.getAllSpans(),
+            TestSpanHandler.getAllSpans().size(), equalTo(4)));
 
-        assertThat(TestSpanHandler.getAllSpans().size(), equalTo(4));
         assertThat(TestSpanHandler.getAllSpans().get(3).name(), equalTo("test span"));
     }
 
@@ -340,8 +342,9 @@ public abstract class AbstractBraveTracingTest extends AbstractClientServerTestB
         try {
             client.get();
         } finally {
-            await().atMost(Duration.ofSeconds(5L)).until(()-> TestSpanHandler.getAllSpans().size() == 2);
-            assertThat(TestSpanHandler.getAllSpans().size(), equalTo(2));
+            await().atMost(Duration.ofSeconds(5L)).untilAsserted(() -> assertThat(
+                "Unexpected span count. Spans: " + TestSpanHandler.getAllSpans(),
+                TestSpanHandler.getAllSpans().size(), equalTo(2)));
             assertThat(TestSpanHandler.getAllSpans().get(0).name(), equalTo("GET " + client.getCurrentURI()));
             assertThat(TestSpanHandler.getAllSpans().get(0).tags(), hasKey("error"));
             assertThat(TestSpanHandler.getAllSpans().get(1).name(), equalTo("GET /bookstore/books/long"));

--- a/systests/tracing/src/test/java/org/apache/cxf/systest/brave/jaxrs/AbstractBraveTracingTest.java
+++ b/systests/tracing/src/test/java/org/apache/cxf/systest/brave/jaxrs/AbstractBraveTracingTest.java
@@ -49,6 +49,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
+import static org.apache.cxf.systest.HasSize.hasSize;
 import static org.apache.cxf.systest.brave.BraveTestSupport.PARENT_SPAN_ID_NAME;
 import static org.apache.cxf.systest.brave.BraveTestSupport.SAMPLED_NAME;
 import static org.apache.cxf.systest.brave.BraveTestSupport.SPAN_ID_NAME;
@@ -265,9 +266,8 @@ public abstract class AbstractBraveTracingTest extends AbstractClientServerTestB
         }
 
         // Await till flush happens, usually a second is enough
-        await().atMost(Duration.ofSeconds(5L)).untilAsserted(() -> assertThat(
-            "Unexpected span count. Spans: " + TestSpanHandler.getAllSpans(),
-            TestSpanHandler.getAllSpans().size(), equalTo(4)));
+        await().atMost(Duration.ofSeconds(5L)).untilAsserted(() ->
+            assertThat(TestSpanHandler.getAllSpans(), hasSize(4)));
 
         assertThat(TestSpanHandler.getAllSpans().get(3).name(), equalTo("test span"));
     }
@@ -293,9 +293,8 @@ public abstract class AbstractBraveTracingTest extends AbstractClientServerTestB
         }
 
         // Await till flush happens, usually a second is enough
-        await().atMost(Duration.ofSeconds(5L)).untilAsserted(() -> assertThat(
-            "Unexpected span count. Spans: " + TestSpanHandler.getAllSpans(),
-            TestSpanHandler.getAllSpans().size(), equalTo(4)));
+        await().atMost(Duration.ofSeconds(5L)).untilAsserted(() ->
+            assertThat(TestSpanHandler.getAllSpans(), hasSize(4)));
 
         assertThat(TestSpanHandler.getAllSpans().get(3).name(), equalTo("test span"));
     }
@@ -342,9 +341,8 @@ public abstract class AbstractBraveTracingTest extends AbstractClientServerTestB
         try {
             client.get();
         } finally {
-            await().atMost(Duration.ofSeconds(5L)).untilAsserted(() -> assertThat(
-                "Unexpected span count. Spans: " + TestSpanHandler.getAllSpans(),
-                TestSpanHandler.getAllSpans().size(), equalTo(2)));
+            await().atMost(Duration.ofSeconds(5L)).untilAsserted(() ->
+                assertThat(TestSpanHandler.getAllSpans(), hasSize(2)));
             assertThat(TestSpanHandler.getAllSpans().get(0).name(), equalTo("GET " + client.getCurrentURI()));
             assertThat(TestSpanHandler.getAllSpans().get(0).tags(), hasKey("error"));
             assertThat(TestSpanHandler.getAllSpans().get(1).name(), equalTo("GET /bookstore/books/long"));

--- a/systests/tracing/src/test/java/org/apache/cxf/systest/brave/jaxws/AbstractBraveTracingTest.java
+++ b/systests/tracing/src/test/java/org/apache/cxf/systest/brave/jaxws/AbstractBraveTracingTest.java
@@ -204,7 +204,9 @@ public abstract class AbstractBraveTracingTest extends AbstractClientServerTestB
             service.orderBooks();
     
             // Await till flush happens, usually every second
-            await().atMost(Duration.ofSeconds(5L)).until(() -> TestSpanHandler.getAllSpans().size() == 2);
+            await().atMost(Duration.ofSeconds(5L)).untilAsserted(() -> assertThat(
+                "Unexpected span count. Spans: " + TestSpanHandler.getAllSpans(),
+                TestSpanHandler.getAllSpans().size(), equalTo(2)));
 
             assertThat(TestSpanHandler.getAllSpans().get(0).name(), equalTo("POST /BookStore"));
             assertThat(TestSpanHandler.getAllSpans().get(1).name(),

--- a/systests/tracing/src/test/java/org/apache/cxf/systest/brave/jaxws/AbstractBraveTracingTest.java
+++ b/systests/tracing/src/test/java/org/apache/cxf/systest/brave/jaxws/AbstractBraveTracingTest.java
@@ -45,6 +45,7 @@ import org.apache.cxf.testutil.common.AbstractClientServerTestBase;
 
 import org.junit.Test;
 
+import static org.apache.cxf.systest.HasSize.hasSize;
 import static org.apache.cxf.systest.brave.BraveTestSupport.PARENT_SPAN_ID_NAME;
 import static org.apache.cxf.systest.brave.BraveTestSupport.SAMPLED_NAME;
 import static org.apache.cxf.systest.brave.BraveTestSupport.SPAN_ID_NAME;
@@ -204,9 +205,8 @@ public abstract class AbstractBraveTracingTest extends AbstractClientServerTestB
             service.orderBooks();
     
             // Await till flush happens, usually every second
-            await().atMost(Duration.ofSeconds(5L)).untilAsserted(() -> assertThat(
-                "Unexpected span count. Spans: " + TestSpanHandler.getAllSpans(),
-                TestSpanHandler.getAllSpans().size(), equalTo(2)));
+            await().atMost(Duration.ofSeconds(5L)).untilAsserted(() ->
+                assertThat(TestSpanHandler.getAllSpans(), hasSize(2)));
 
             assertThat(TestSpanHandler.getAllSpans().get(0).name(), equalTo("POST /BookStore"));
             assertThat(TestSpanHandler.getAllSpans().get(1).name(),

--- a/systests/tracing/src/test/java/org/apache/cxf/systest/jaxrs/tracing/opentelemetry/JaxrsOpenTelemetryTracingTest.java
+++ b/systests/tracing/src/test/java/org/apache/cxf/systest/jaxrs/tracing/opentelemetry/JaxrsOpenTelemetryTracingTest.java
@@ -257,10 +257,11 @@ public class JaxrsOpenTelemetryTracingTest extends AbstractClientServerTestBase 
             final Response r = withTrace(createWebClient("/bookstore/books/async")).get();
             assertEquals(Status.OK.getStatusCode(), r.getStatus());
 
-            await().atMost(Duration.ofSeconds(5L)).until(() -> otelRule.getSpans().size() == 2);
+            await().atMost(Duration.ofSeconds(5L)).untilAsserted(() -> assertThat(
+                "Unexpected span count. Spans: " + otelRule.getSpans(),
+                otelRule.getSpans().size(), equalTo(2)));
 
             final List<SpanData> spans = getSpansSorted();
-            assertThat(spans.size(), equalTo(2));
 
             assertEquals("Processing books", spans.get(0).getName());
             assertEquals("GET /bookstore/books/async", spans.get(1).getName());
@@ -287,10 +288,11 @@ public class JaxrsOpenTelemetryTracingTest extends AbstractClientServerTestBase 
         final Response r = createWebClient("/bookstore/books/async").get();
         assertEquals(Status.OK.getStatusCode(), r.getStatus());
 
-        await().atMost(Duration.ofSeconds(5L)).until(() -> otelRule.getSpans().size() == 2);
+        await().atMost(Duration.ofSeconds(5L)).untilAsserted(() -> assertThat(
+            "Unexpected span count. Spans: " + otelRule.getSpans(),
+            otelRule.getSpans().size(), equalTo(2)));
 
         final List<SpanData> spans = getSpansSorted();
-        assertThat(spans.size(), equalTo(2));
         assertThat(spans.get(0).getName(), equalTo("Processing books"));
         assertThat(spans.get(1).getName(), equalTo("GET /bookstore/books/async"));
     }
@@ -303,9 +305,10 @@ public class JaxrsOpenTelemetryTracingTest extends AbstractClientServerTestBase 
         final Response r = client.async().get().get(1L, TimeUnit.SECONDS);
         assertEquals(Status.OK.getStatusCode(), r.getStatus());
 
-        await().atMost(Duration.ofSeconds(5L)).until(() -> otelRule.getSpans().size() == 3);
+        await().atMost(Duration.ofSeconds(5L)).untilAsserted(() -> assertThat(
+            "Unexpected span count. Spans: " + otelRule.getSpans(),
+            otelRule.getSpans().size(), equalTo(3)));
 
-        assertThat(otelRule.getSpans().size(), equalTo(3));
         assertThat(otelRule.getSpans().get(0).getName(), equalTo("Get Books"));
         assertThat(otelRule.getSpans().get(1).getName(), equalTo("GET /bookstore/books"));
         assertThat(otelRule.getSpans().get(1).getKind(), equalTo(SpanKind.SERVER));
@@ -373,9 +376,10 @@ public class JaxrsOpenTelemetryTracingTest extends AbstractClientServerTestBase 
         }
 
         // Await till flush happens, usually every second
-        await().atMost(Duration.ofSeconds(5L)).until(() -> otelRule.getSpans().size() == 4);
+        await().atMost(Duration.ofSeconds(5L)).untilAsserted(() -> assertThat(
+            "Unexpected span count. Spans: " + otelRule.getSpans(),
+            otelRule.getSpans().size(), equalTo(4)));
 
-        assertThat(otelRule.getSpans().size(), equalTo(4));
         assertThat(otelRule.getSpans().get(3).getName(), equalTo("test span"));
         assertThat(otelRule.getSpans().get(3).getParentSpanContext().isValid(), equalTo(false));
     }
@@ -392,9 +396,10 @@ public class JaxrsOpenTelemetryTracingTest extends AbstractClientServerTestBase 
             assertThat(Span.current().getSpanContext().getSpanId(),
                        equalTo(span.getSpanContext().getSpanId()));
 
-            await().atMost(Duration.ofSeconds(5L)).until(() -> otelRule.getSpans().size() == 3);
+            await().atMost(Duration.ofSeconds(5L)).untilAsserted(() -> assertThat(
+                "Unexpected span count. Spans: " + otelRule.getSpans(),
+                otelRule.getSpans().size(), equalTo(3)));
 
-            assertThat(otelRule.getSpans().size(), equalTo(3));
             assertThat(otelRule.getSpans().get(0).getName(), equalTo("Get Books"));
             assertThat(otelRule.getSpans().get(0).getParentSpanContext(), notNullValue());
             assertThat(otelRule.getSpans().get(1).getName(), equalTo("GET /bookstore/books"));
@@ -406,9 +411,10 @@ public class JaxrsOpenTelemetryTracingTest extends AbstractClientServerTestBase 
         }
 
         // Await till flush happens, usually every second
-        await().atMost(Duration.ofSeconds(5L)).until(() -> otelRule.getSpans().size() == 4);
+        await().atMost(Duration.ofSeconds(5L)).untilAsserted(() -> assertThat(
+            "Unexpected span count. Spans: " + otelRule.getSpans(),
+            otelRule.getSpans().size(), equalTo(4)));
 
-        assertThat(otelRule.getSpans().size(), equalTo(4));
         assertThat(otelRule.getSpans().get(3).getName(), equalTo("test span"));
         assertThat(otelRule.getSpans().get(3).getParentSpanContext().isValid(), equalTo(false));
     }
@@ -443,8 +449,9 @@ public class JaxrsOpenTelemetryTracingTest extends AbstractClientServerTestBase 
         try {
             client.get();
         } finally {
-            await().atMost(Duration.ofSeconds(5L)).until(() -> otelRule.getSpans().size() == 2);
-            assertThat(otelRule.getSpans().toString(), otelRule.getSpans().size(), equalTo(2));
+            await().atMost(Duration.ofSeconds(5L)).untilAsserted(() -> assertThat(
+                "Unexpected span count. Spans: " + otelRule.getSpans(),
+                otelRule.getSpans().size(), equalTo(2)));
             assertThat(otelRule.getSpans().get(0).getName(), equalTo("GET " + client.getCurrentURI()));
             assertThat(otelRule.getSpans().get(0).getStatus().getStatusCode(), equalTo(StatusCode.ERROR));
             assertThat(otelRule.getSpans().get(1).getName(), equalTo("GET /bookstore/books/long"));

--- a/systests/tracing/src/test/java/org/apache/cxf/systest/jaxrs/tracing/opentelemetry/JaxrsOpenTelemetryTracingTest.java
+++ b/systests/tracing/src/test/java/org/apache/cxf/systest/jaxrs/tracing/opentelemetry/JaxrsOpenTelemetryTracingTest.java
@@ -79,6 +79,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
+import static org.apache.cxf.systest.HasSize.hasSize;
 import static org.apache.cxf.systest.jaxrs.tracing.opentelemetry.HasAttribute.hasAttribute;
 import static org.apache.cxf.systest.jaxrs.tracing.opentelemetry.HasSpan.hasSpan;
 import static org.apache.cxf.systest.jaxrs.tracing.opentelemetry.IsLogContaining.hasItem;
@@ -257,9 +258,7 @@ public class JaxrsOpenTelemetryTracingTest extends AbstractClientServerTestBase 
             final Response r = withTrace(createWebClient("/bookstore/books/async")).get();
             assertEquals(Status.OK.getStatusCode(), r.getStatus());
 
-            await().atMost(Duration.ofSeconds(5L)).untilAsserted(() -> assertThat(
-                "Unexpected span count. Spans: " + otelRule.getSpans(),
-                otelRule.getSpans().size(), equalTo(2)));
+            await().atMost(Duration.ofSeconds(5L)).untilAsserted(() -> assertThat(otelRule.getSpans(), hasSize(2)));
 
             final List<SpanData> spans = getSpansSorted();
 
@@ -288,9 +287,7 @@ public class JaxrsOpenTelemetryTracingTest extends AbstractClientServerTestBase 
         final Response r = createWebClient("/bookstore/books/async").get();
         assertEquals(Status.OK.getStatusCode(), r.getStatus());
 
-        await().atMost(Duration.ofSeconds(5L)).untilAsserted(() -> assertThat(
-            "Unexpected span count. Spans: " + otelRule.getSpans(),
-            otelRule.getSpans().size(), equalTo(2)));
+        await().atMost(Duration.ofSeconds(5L)).untilAsserted(() -> assertThat(otelRule.getSpans(), hasSize(2)));
 
         final List<SpanData> spans = getSpansSorted();
         assertThat(spans.get(0).getName(), equalTo("Processing books"));
@@ -305,9 +302,7 @@ public class JaxrsOpenTelemetryTracingTest extends AbstractClientServerTestBase 
         final Response r = client.async().get().get(1L, TimeUnit.SECONDS);
         assertEquals(Status.OK.getStatusCode(), r.getStatus());
 
-        await().atMost(Duration.ofSeconds(5L)).untilAsserted(() -> assertThat(
-            "Unexpected span count. Spans: " + otelRule.getSpans(),
-            otelRule.getSpans().size(), equalTo(3)));
+        await().atMost(Duration.ofSeconds(5L)).untilAsserted(() -> assertThat(otelRule.getSpans(), hasSize(3)));
 
         assertThat(otelRule.getSpans().get(0).getName(), equalTo("Get Books"));
         assertThat(otelRule.getSpans().get(1).getName(), equalTo("GET /bookstore/books"));
@@ -376,9 +371,7 @@ public class JaxrsOpenTelemetryTracingTest extends AbstractClientServerTestBase 
         }
 
         // Await till flush happens, usually every second
-        await().atMost(Duration.ofSeconds(5L)).untilAsserted(() -> assertThat(
-            "Unexpected span count. Spans: " + otelRule.getSpans(),
-            otelRule.getSpans().size(), equalTo(4)));
+        await().atMost(Duration.ofSeconds(5L)).untilAsserted(() -> assertThat(otelRule.getSpans(), hasSize(4)));
 
         assertThat(otelRule.getSpans().get(3).getName(), equalTo("test span"));
         assertThat(otelRule.getSpans().get(3).getParentSpanContext().isValid(), equalTo(false));
@@ -396,9 +389,7 @@ public class JaxrsOpenTelemetryTracingTest extends AbstractClientServerTestBase 
             assertThat(Span.current().getSpanContext().getSpanId(),
                        equalTo(span.getSpanContext().getSpanId()));
 
-            await().atMost(Duration.ofSeconds(5L)).untilAsserted(() -> assertThat(
-                "Unexpected span count. Spans: " + otelRule.getSpans(),
-                otelRule.getSpans().size(), equalTo(3)));
+            await().atMost(Duration.ofSeconds(5L)).untilAsserted(() -> assertThat(otelRule.getSpans(), hasSize(3)));
 
             assertThat(otelRule.getSpans().get(0).getName(), equalTo("Get Books"));
             assertThat(otelRule.getSpans().get(0).getParentSpanContext(), notNullValue());
@@ -411,9 +402,7 @@ public class JaxrsOpenTelemetryTracingTest extends AbstractClientServerTestBase 
         }
 
         // Await till flush happens, usually every second
-        await().atMost(Duration.ofSeconds(5L)).untilAsserted(() -> assertThat(
-            "Unexpected span count. Spans: " + otelRule.getSpans(),
-            otelRule.getSpans().size(), equalTo(4)));
+        await().atMost(Duration.ofSeconds(5L)).untilAsserted(() -> assertThat(otelRule.getSpans(), hasSize(4)));
 
         assertThat(otelRule.getSpans().get(3).getName(), equalTo("test span"));
         assertThat(otelRule.getSpans().get(3).getParentSpanContext().isValid(), equalTo(false));
@@ -449,9 +438,7 @@ public class JaxrsOpenTelemetryTracingTest extends AbstractClientServerTestBase 
         try {
             client.get();
         } finally {
-            await().atMost(Duration.ofSeconds(5L)).untilAsserted(() -> assertThat(
-                "Unexpected span count. Spans: " + otelRule.getSpans(),
-                otelRule.getSpans().size(), equalTo(2)));
+            await().atMost(Duration.ofSeconds(5L)).untilAsserted(() -> assertThat(otelRule.getSpans(), hasSize(2)));
             assertThat(otelRule.getSpans().get(0).getName(), equalTo("GET " + client.getCurrentURI()));
             assertThat(otelRule.getSpans().get(0).getStatus().getStatusCode(), equalTo(StatusCode.ERROR));
             assertThat(otelRule.getSpans().get(1).getName(), equalTo("GET /bookstore/books/long"));

--- a/systests/tracing/src/test/java/org/apache/cxf/systest/jaxrs/tracing/opentracing/JaxrsOpenTracingTracingTest.java
+++ b/systests/tracing/src/test/java/org/apache/cxf/systest/jaxrs/tracing/opentracing/JaxrsOpenTracingTracingTest.java
@@ -199,10 +199,11 @@ public class JaxrsOpenTracingTracingTest extends AbstractClientServerTestBase {
         final Response r = withTrace(createWebClient("/bookstore/books/async"), spanId).get();
         assertEquals(Status.OK.getStatusCode(), r.getStatus());
 
-        await().atMost(Duration.ofSeconds(5L)).until(()-> REPORTER.getSpans().size() == 2);
+        await().atMost(Duration.ofSeconds(5L)).untilAsserted(() -> assertThat(
+            "Unexpected span count. Spans: " + REPORTER.getSpans(),
+            REPORTER.getSpans().size(), equalTo(2)));
 
         final List<JaegerSpan> spans = getSpansSorted();
-        assertThat(spans.size(), equalTo(2));
         assertEquals("Processing books", spans.get(0).getOperationName());
         assertEquals("GET /bookstore/books/async", spans.get(1).getOperationName());
         assertThat(spans.get(1).getReferences(), not(empty()));
@@ -226,10 +227,11 @@ public class JaxrsOpenTracingTracingTest extends AbstractClientServerTestBase {
         final Response r = createWebClient("/bookstore/books/async").get();
         assertEquals(Status.OK.getStatusCode(), r.getStatus());
 
-        await().atMost(Duration.ofSeconds(5L)).until(()-> REPORTER.getSpans().size() == 2);
+        await().atMost(Duration.ofSeconds(5L)).untilAsserted(() -> assertThat(
+            "Unexpected span count. Spans: " + REPORTER.getSpans(),
+            REPORTER.getSpans().size(), equalTo(2)));
 
         final List<JaegerSpan> spans = getSpansSorted();
-        assertThat(spans.size(), equalTo(2));
         assertThat(spans.get(0).getOperationName(), equalTo("Processing books"));
         assertThat(spans.get(1).getOperationName(), equalTo("GET /bookstore/books/async"));
     }
@@ -241,9 +243,10 @@ public class JaxrsOpenTracingTracingTest extends AbstractClientServerTestBase {
         final Response r = client.async().get().get(1L, TimeUnit.SECONDS);
         assertEquals(Status.OK.getStatusCode(), r.getStatus());
 
-        await().atMost(Duration.ofSeconds(5L)).until(()-> REPORTER.getSpans().size() == 3);
+        await().atMost(Duration.ofSeconds(5L)).untilAsserted(() -> assertThat(
+            "Unexpected span count. Spans: " + REPORTER.getSpans(),
+            REPORTER.getSpans().size(), equalTo(3)));
 
-        assertThat(REPORTER.getSpans().size(), equalTo(3));
         assertThat(REPORTER.getSpans().get(0).getOperationName(), equalTo("Get Books"));
         assertThat(REPORTER.getSpans().get(1).getOperationName(), equalTo("GET /bookstore/books"));
         assertThat(REPORTER.getSpans().get(1).getTags(), hasItem(Tags.SPAN_KIND.getKey(), Tags.SPAN_KIND_SERVER));
@@ -325,9 +328,10 @@ public class JaxrsOpenTracingTracingTest extends AbstractClientServerTestBase {
         }
 
         // Await till flush happens, usually every second
-        await().atMost(Duration.ofSeconds(5L)).until(()-> REPORTER.getSpans().size() == 4);
+        await().atMost(Duration.ofSeconds(5L)).untilAsserted(() -> assertThat(
+            "Unexpected span count. Spans: " + REPORTER.getSpans(),
+            REPORTER.getSpans().size(), equalTo(4)));
 
-        assertThat(REPORTER.getSpans().size(), equalTo(4));
         assertThat(REPORTER.getSpans().get(3).getOperationName(), equalTo("test span"));
         assertThat(REPORTER.getSpans().get(3).getReferences(), empty());
     }
@@ -342,9 +346,10 @@ public class JaxrsOpenTracingTracingTest extends AbstractClientServerTestBase {
             assertEquals(Status.OK.getStatusCode(), r.getStatus());
             assertThat(tracer.activeSpan().context(), equalTo(span.context()));
 
-            await().atMost(Duration.ofSeconds(5L)).until(()-> REPORTER.getSpans().size() == 3);
+            await().atMost(Duration.ofSeconds(5L)).untilAsserted(() -> assertThat(
+                "Unexpected span count. Spans: " + REPORTER.getSpans(),
+                REPORTER.getSpans().size(), equalTo(3)));
 
-            assertThat(REPORTER.getSpans().size(), equalTo(3));
             assertThat(REPORTER.getSpans().get(0).getOperationName(), equalTo("Get Books"));
             assertThat(REPORTER.getSpans().get(0).getReferences(), not(empty()));
             assertThat(REPORTER.getSpans().get(1).getOperationName(), equalTo("GET /bookstore/books"));
@@ -356,9 +361,10 @@ public class JaxrsOpenTracingTracingTest extends AbstractClientServerTestBase {
         }
 
         // Await till flush happens, usually every second
-        await().atMost(Duration.ofSeconds(5L)).until(()-> REPORTER.getSpans().size() == 4);
+        await().atMost(Duration.ofSeconds(5L)).untilAsserted(() -> assertThat(
+            "Unexpected span count. Spans: " + REPORTER.getSpans(),
+            REPORTER.getSpans().size(), equalTo(4)));
 
-        assertThat(REPORTER.getSpans().size(), equalTo(4));
         assertThat(REPORTER.getSpans().get(3).getOperationName(), equalTo("test span"));
         assertThat(REPORTER.getSpans().get(3).getReferences(), empty());
     }
@@ -391,8 +397,9 @@ public class JaxrsOpenTracingTracingTest extends AbstractClientServerTestBase {
         try {
             client.get();
         } finally {
-            await().atMost(Duration.ofSeconds(5L)).until(()-> REPORTER.getSpans().size() == 2);
-            assertThat(REPORTER.getSpans().toString(), REPORTER.getSpans().size(), equalTo(2));
+            await().atMost(Duration.ofSeconds(5L)).untilAsserted(() -> assertThat(
+                "Unexpected span count. Spans: " + REPORTER.getSpans(),
+                REPORTER.getSpans().size(), equalTo(2)));
             assertThat(REPORTER.getSpans().get(0).getOperationName(), equalTo("GET " + client.getCurrentURI()));
             assertThat(REPORTER.getSpans().get(0).getTags(), hasItem(Tags.ERROR.getKey(), Boolean.TRUE));
             assertThat(REPORTER.getSpans().get(1).getOperationName(), equalTo("GET /bookstore/books/long"));

--- a/systests/tracing/src/test/java/org/apache/cxf/systest/jaxrs/tracing/opentracing/JaxrsOpenTracingTracingTest.java
+++ b/systests/tracing/src/test/java/org/apache/cxf/systest/jaxrs/tracing/opentracing/JaxrsOpenTracingTracingTest.java
@@ -70,6 +70,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
+import static org.apache.cxf.systest.HasSize.hasSize;
 import static org.apache.cxf.systest.jaxrs.tracing.opentracing.HasSpan.hasSpan;
 import static org.apache.cxf.systest.jaxrs.tracing.opentracing.IsLogContaining.hasItem;
 import static org.apache.cxf.systest.jaxrs.tracing.opentracing.IsTagContaining.hasItem;
@@ -199,9 +200,7 @@ public class JaxrsOpenTracingTracingTest extends AbstractClientServerTestBase {
         final Response r = withTrace(createWebClient("/bookstore/books/async"), spanId).get();
         assertEquals(Status.OK.getStatusCode(), r.getStatus());
 
-        await().atMost(Duration.ofSeconds(5L)).untilAsserted(() -> assertThat(
-            "Unexpected span count. Spans: " + REPORTER.getSpans(),
-            REPORTER.getSpans().size(), equalTo(2)));
+        await().atMost(Duration.ofSeconds(5L)).untilAsserted(() -> assertThat(REPORTER.getSpans(), hasSize(2)));
 
         final List<JaegerSpan> spans = getSpansSorted();
         assertEquals("Processing books", spans.get(0).getOperationName());
@@ -227,9 +226,7 @@ public class JaxrsOpenTracingTracingTest extends AbstractClientServerTestBase {
         final Response r = createWebClient("/bookstore/books/async").get();
         assertEquals(Status.OK.getStatusCode(), r.getStatus());
 
-        await().atMost(Duration.ofSeconds(5L)).untilAsserted(() -> assertThat(
-            "Unexpected span count. Spans: " + REPORTER.getSpans(),
-            REPORTER.getSpans().size(), equalTo(2)));
+        await().atMost(Duration.ofSeconds(5L)).untilAsserted(() -> assertThat(REPORTER.getSpans(), hasSize(2)));
 
         final List<JaegerSpan> spans = getSpansSorted();
         assertThat(spans.get(0).getOperationName(), equalTo("Processing books"));
@@ -243,9 +240,7 @@ public class JaxrsOpenTracingTracingTest extends AbstractClientServerTestBase {
         final Response r = client.async().get().get(1L, TimeUnit.SECONDS);
         assertEquals(Status.OK.getStatusCode(), r.getStatus());
 
-        await().atMost(Duration.ofSeconds(5L)).untilAsserted(() -> assertThat(
-            "Unexpected span count. Spans: " + REPORTER.getSpans(),
-            REPORTER.getSpans().size(), equalTo(3)));
+        await().atMost(Duration.ofSeconds(5L)).untilAsserted(() -> assertThat(REPORTER.getSpans(), hasSize(3)));
 
         assertThat(REPORTER.getSpans().get(0).getOperationName(), equalTo("Get Books"));
         assertThat(REPORTER.getSpans().get(1).getOperationName(), equalTo("GET /bookstore/books"));
@@ -328,9 +323,7 @@ public class JaxrsOpenTracingTracingTest extends AbstractClientServerTestBase {
         }
 
         // Await till flush happens, usually every second
-        await().atMost(Duration.ofSeconds(5L)).untilAsserted(() -> assertThat(
-            "Unexpected span count. Spans: " + REPORTER.getSpans(),
-            REPORTER.getSpans().size(), equalTo(4)));
+        await().atMost(Duration.ofSeconds(5L)).untilAsserted(() -> assertThat(REPORTER.getSpans(), hasSize(4)));
 
         assertThat(REPORTER.getSpans().get(3).getOperationName(), equalTo("test span"));
         assertThat(REPORTER.getSpans().get(3).getReferences(), empty());
@@ -346,9 +339,7 @@ public class JaxrsOpenTracingTracingTest extends AbstractClientServerTestBase {
             assertEquals(Status.OK.getStatusCode(), r.getStatus());
             assertThat(tracer.activeSpan().context(), equalTo(span.context()));
 
-            await().atMost(Duration.ofSeconds(5L)).untilAsserted(() -> assertThat(
-                "Unexpected span count. Spans: " + REPORTER.getSpans(),
-                REPORTER.getSpans().size(), equalTo(3)));
+            await().atMost(Duration.ofSeconds(5L)).untilAsserted(() -> assertThat(REPORTER.getSpans(), hasSize(3)));
 
             assertThat(REPORTER.getSpans().get(0).getOperationName(), equalTo("Get Books"));
             assertThat(REPORTER.getSpans().get(0).getReferences(), not(empty()));
@@ -361,9 +352,7 @@ public class JaxrsOpenTracingTracingTest extends AbstractClientServerTestBase {
         }
 
         // Await till flush happens, usually every second
-        await().atMost(Duration.ofSeconds(5L)).untilAsserted(() -> assertThat(
-            "Unexpected span count. Spans: " + REPORTER.getSpans(),
-            REPORTER.getSpans().size(), equalTo(4)));
+        await().atMost(Duration.ofSeconds(5L)).untilAsserted(() -> assertThat(REPORTER.getSpans(), hasSize(4)));
 
         assertThat(REPORTER.getSpans().get(3).getOperationName(), equalTo("test span"));
         assertThat(REPORTER.getSpans().get(3).getReferences(), empty());
@@ -397,9 +386,7 @@ public class JaxrsOpenTracingTracingTest extends AbstractClientServerTestBase {
         try {
             client.get();
         } finally {
-            await().atMost(Duration.ofSeconds(5L)).untilAsserted(() -> assertThat(
-                "Unexpected span count. Spans: " + REPORTER.getSpans(),
-                REPORTER.getSpans().size(), equalTo(2)));
+            await().atMost(Duration.ofSeconds(5L)).untilAsserted(() -> assertThat(REPORTER.getSpans(), hasSize(2)));
             assertThat(REPORTER.getSpans().get(0).getOperationName(), equalTo("GET " + client.getCurrentURI()));
             assertThat(REPORTER.getSpans().get(0).getTags(), hasItem(Tags.ERROR.getKey(), Boolean.TRUE));
             assertThat(REPORTER.getSpans().get(1).getOperationName(), equalTo("GET /bookstore/books/long"));

--- a/systests/tracing/src/test/java/org/apache/cxf/systest/jaxws/tracing/opentelemetry/JaxwsOpenTelemetryTracingTest.java
+++ b/systests/tracing/src/test/java/org/apache/cxf/systest/jaxws/tracing/opentelemetry/JaxwsOpenTelemetryTracingTest.java
@@ -247,9 +247,10 @@ public class JaxwsOpenTelemetryTracingTest extends AbstractClientServerTestBase 
             }
 
             // Await till flush happens, usually every second
-            await().atMost(Duration.ofSeconds(5L)).until(() -> otelRule.getSpans().size() == 4);
+            await().atMost(Duration.ofSeconds(5L)).untilAsserted(() -> assertThat(
+                "Unexpected span count. Spans: " + otelRule.getSpans(),
+                otelRule.getSpans().size(), equalTo(4)));
 
-            assertThat(otelRule.getSpans().size(), equalTo(4));
             assertThat(otelRule.getSpans().get(3).getName(), equalTo("test span"));
             assertThat(otelRule.getSpans().get(3).getParentSpanContext().isValid(), equalTo(false));
         }
@@ -331,7 +332,9 @@ public class JaxwsOpenTelemetryTracingTest extends AbstractClientServerTestBase 
         service.orderBooks();
 
         // Await till flush happens, usually every second
-        await().atMost(Duration.ofSeconds(5L)).until(() -> otelRule.getSpans().size() == 2);
+        await().atMost(Duration.ofSeconds(5L)).untilAsserted(() -> assertThat(
+            "Unexpected span count. Spans: " + otelRule.getSpans(),
+            otelRule.getSpans().size(), equalTo(2)));
 
         assertThat(otelRule.getSpans().get(0).getName(), equalTo("POST /BookStore"));
         assertThat(otelRule.getSpans().get(1).getName(),

--- a/systests/tracing/src/test/java/org/apache/cxf/systest/jaxws/tracing/opentelemetry/JaxwsOpenTelemetryTracingTest.java
+++ b/systests/tracing/src/test/java/org/apache/cxf/systest/jaxws/tracing/opentelemetry/JaxwsOpenTelemetryTracingTest.java
@@ -66,6 +66,7 @@ import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
 
+import static org.apache.cxf.systest.HasSize.hasSize;
 import static org.apache.cxf.systest.jaxrs.tracing.opentelemetry.HasAttribute.hasAttribute;
 import static org.awaitility.Awaitility.await;
 import static org.hamcrest.CoreMatchers.containsString;
@@ -247,9 +248,7 @@ public class JaxwsOpenTelemetryTracingTest extends AbstractClientServerTestBase 
             }
 
             // Await till flush happens, usually every second
-            await().atMost(Duration.ofSeconds(5L)).untilAsserted(() -> assertThat(
-                "Unexpected span count. Spans: " + otelRule.getSpans(),
-                otelRule.getSpans().size(), equalTo(4)));
+            await().atMost(Duration.ofSeconds(5L)).untilAsserted(() -> assertThat(otelRule.getSpans(), hasSize(4)));
 
             assertThat(otelRule.getSpans().get(3).getName(), equalTo("test span"));
             assertThat(otelRule.getSpans().get(3).getParentSpanContext().isValid(), equalTo(false));
@@ -332,9 +331,7 @@ public class JaxwsOpenTelemetryTracingTest extends AbstractClientServerTestBase 
         service.orderBooks();
 
         // Await till flush happens, usually every second
-        await().atMost(Duration.ofSeconds(5L)).untilAsserted(() -> assertThat(
-            "Unexpected span count. Spans: " + otelRule.getSpans(),
-            otelRule.getSpans().size(), equalTo(2)));
+        await().atMost(Duration.ofSeconds(5L)).untilAsserted(() -> assertThat(otelRule.getSpans(), hasSize(2)));
 
         assertThat(otelRule.getSpans().get(0).getName(), equalTo("POST /BookStore"));
         assertThat(otelRule.getSpans().get(1).getName(),

--- a/systests/tracing/src/test/java/org/apache/cxf/systest/jaxws/tracing/opentracing/JaxwsOpenTracingTracingTest.java
+++ b/systests/tracing/src/test/java/org/apache/cxf/systest/jaxws/tracing/opentracing/JaxwsOpenTracingTracingTest.java
@@ -178,9 +178,10 @@ public class JaxwsOpenTracingTracingTest extends AbstractClientServerTestBase {
         }
 
         // Await till flush happens, usually every second
-        await().atMost(Duration.ofSeconds(5L)).until(()-> REPORTER.getSpans().size() == 4);
+        await().atMost(Duration.ofSeconds(5L)).untilAsserted(() -> assertThat(
+            "Unexpected span count. Spans: " + REPORTER.getSpans(),
+            REPORTER.getSpans().size(), equalTo(4)));
 
-        assertThat(REPORTER.getSpans().size(), equalTo(4));
         assertThat(REPORTER.getSpans().get(3).getOperationName(), equalTo("test span"));
         assertThat(REPORTER.getSpans().get(3).getReferences(), empty());
     }
@@ -234,7 +235,9 @@ public class JaxwsOpenTracingTracingTest extends AbstractClientServerTestBase {
         service.orderBooks();
 
         // Await till flush happens, usually every second
-        await().atMost(Duration.ofSeconds(5L)).until(() -> REPORTER.getSpans().size() == 2);
+        await().atMost(Duration.ofSeconds(5L)).untilAsserted(() -> assertThat(
+            "Unexpected span count. Spans: " + REPORTER.getSpans(),
+            REPORTER.getSpans().size(), equalTo(2)));
 
         assertThat(REPORTER.getSpans().get(0).getOperationName(), equalTo("POST /BookStore"));
         assertThat(REPORTER.getSpans().get(1).getOperationName(),

--- a/systests/tracing/src/test/java/org/apache/cxf/systest/jaxws/tracing/opentracing/JaxwsOpenTracingTracingTest.java
+++ b/systests/tracing/src/test/java/org/apache/cxf/systest/jaxws/tracing/opentracing/JaxwsOpenTracingTracingTest.java
@@ -57,6 +57,7 @@ import org.junit.After;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
+import static org.apache.cxf.systest.HasSize.hasSize;
 import static org.apache.cxf.systest.jaxrs.tracing.opentracing.IsTagContaining.hasItem;
 import static org.awaitility.Awaitility.await;
 import static org.hamcrest.CoreMatchers.equalTo;
@@ -178,9 +179,7 @@ public class JaxwsOpenTracingTracingTest extends AbstractClientServerTestBase {
         }
 
         // Await till flush happens, usually every second
-        await().atMost(Duration.ofSeconds(5L)).untilAsserted(() -> assertThat(
-            "Unexpected span count. Spans: " + REPORTER.getSpans(),
-            REPORTER.getSpans().size(), equalTo(4)));
+        await().atMost(Duration.ofSeconds(5L)).untilAsserted(() -> assertThat(REPORTER.getSpans(), hasSize(4)));
 
         assertThat(REPORTER.getSpans().get(3).getOperationName(), equalTo("test span"));
         assertThat(REPORTER.getSpans().get(3).getReferences(), empty());
@@ -235,9 +234,7 @@ public class JaxwsOpenTracingTracingTest extends AbstractClientServerTestBase {
         service.orderBooks();
 
         // Await till flush happens, usually every second
-        await().atMost(Duration.ofSeconds(5L)).untilAsserted(() -> assertThat(
-            "Unexpected span count. Spans: " + REPORTER.getSpans(),
-            REPORTER.getSpans().size(), equalTo(2)));
+        await().atMost(Duration.ofSeconds(5L)).untilAsserted(() -> assertThat(REPORTER.getSpans(), hasSize(2)));
 
         assertThat(REPORTER.getSpans().get(0).getOperationName(), equalTo("POST /BookStore"));
         assertThat(REPORTER.getSpans().get(1).getOperationName(),


### PR DESCRIPTION
## Summary

- Replace `await().until(() -> spans.size() == N)` with `await().untilAsserted(() -> assertThat(message, size, equalTo(N)))` across all tracing system tests (Brave, OpenTelemetry, OpenTracing; JAX-RS and JAX-WS)
- When the Awaitility wait times out, the error message now includes the actual span count **and** the full list of collected spans
- This diagnostic improvement will help determine whether flaky failures (see #2971) are caused by: missing spans (count < expected), extra spans from cross-test contamination (count > expected), or a pure timing issue

## Context

Related to #2971 and the discussion about root-causing the flaky tracing test failures. @reta pointed out that the thread-safety fix alone may not address all failures, since the OTel tests also fail despite using thread-safe `InMemorySpanExporter`. This PR adds diagnostic output so that when CI fails, we can see exactly what spans were collected and identify the root cause.

## Test plan

- [x] Compilation verified locally (`mvn compile test-compile -pl systests/tracing`)
- [ ] CI build should pass — no behavioral changes, only improved error messages on failure
- [ ] When a tracing test times out in CI, the error message should now show the span list contents

_Claude Code on behalf of Guillaume Nodet_

🤖 Generated with [Claude Code](https://claude.com/claude-code)