### PR TITLE
Downgrade grizzly to 4.0.2; grizzly-http-server has broken parentage

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -120,7 +120,7 @@
         <cxf.geronimo.openapi.version>1.0.15</cxf.geronimo.openapi.version>
         <cxf.glassfish.el.version>4.0.2</cxf.glassfish.el.version>
         <cxf.glassfish.json.version>2.0.1</cxf.glassfish.json.version>
-        <cxf.grizzly.version>5.0.0</cxf.grizzly.version>
+        <cxf.grizzly.version>4.0.2</cxf.grizzly.version>
         <cxf.hamcrest.version>3.0</cxf.hamcrest.version>
         <cxf.hazelcast.version>5.6.0</cxf.hazelcast.version>
         <cxf.hibernate.em.version>7.3.0.Final</cxf.hibernate.em.version>


### PR DESCRIPTION
I'm getting the following error on trying to build cxf 4.2.0 (I changed the version) :

`  [ERROR] Failed to execute goal on project cxf-systests-ci-grizzly: Could not
  resolve dependencies for project
  org.apache.cxf.systests:cxf-systests-ci-grizzly:jar:4.2.0-rhbac-SNAPSHOT: Failed
  to collect dependencies at org.glassfish.grizzly:grizzly-http-server:jar:5.0.0:
  Failed to read artifact descriptor for
  org.glassfish.grizzly:grizzly-http-server:jar:5.0.0: Could not find artifact
  org.glassfish.grizzly:grizzly-bom:pom:5.0.0-SNAPSHOT in fuse-repository
  (https://fuse-build-repository.fusesource-jenkins.hosted.psi.rdu2.redhat.com/repos
  itory/maven-public/) -> [Help 1]`

The error here is that grizzly-http-server has broken parentage : grizzly-http-server points to grizzly-project 5.0.0 which has a parent of grizzly-bom 5.0.0-SNAPSHOT (should be 5.0.0) 

See the 
https://repo1.maven.org/maven2/org/glassfish/grizzly/grizzly-project/5.0.0/grizzly-project-5.0.0.pom

```
<parent>
<groupId>org.glassfish.grizzly</groupId>
<artifactId>grizzly-bom</artifactId>
<version>5.0.0-SNAPSHOT</version>
<relativePath>boms/bom/pom.xml</relativePath>
</parent>
```

Since this error is in the parentage, I don't think this can be fixed with a dependencyManagement override.     Might be best to downgrade until a 5.0.1 or newer is available.