### PR TITLE
CXF-9161: Some of the OIDCFlowTest fail with timeout (JPA only) when HttpClient instance is shared

### DIFF
--- a/rt/rs/security/oauth-parent/oauth2/src/main/java/org/apache/cxf/rs/security/oauth2/client/OAuthClientUtils.java
+++ b/rt/rs/security/oauth-parent/oauth2/src/main/java/org/apache/cxf/rs/security/oauth2/client/OAuthClientUtils.java
@@ -295,29 +295,30 @@ public final class OAuthClientUtils {
             // in this case the AccessToken service is expected to find a mapping between
             // the authenticated credentials and the client registration id
         }
-        Response response = accessTokenService.form(form);
-        final Map<String, String> map;
-        try {
-            map = response.getMediaType() == null
-                    || response.getMediaType().isCompatible(MediaType.APPLICATION_JSON_TYPE)
-                            ? new OAuthJSONProvider().readJSONResponse((InputStream) response.getEntity())
-                            : Collections.emptyMap();
-        } catch (Exception ex) {
-            throw new ResponseProcessingException(response, ex);
-        }
-        if (200 == response.getStatus()) {
-            ClientAccessToken token = fromMapToClientToken(map, defaultTokenType);
-            if (token == null) {
-                throw new OAuthServiceException(OAuthConstants.SERVER_ERROR);
+        try (Response response = accessTokenService.form(form)) {
+            final Map<String, String> map;
+            try {
+                map = response.getMediaType() == null
+                        || response.getMediaType().isCompatible(MediaType.APPLICATION_JSON_TYPE)
+                                ? new OAuthJSONProvider().readJSONResponse((InputStream) response.getEntity())
+                                : Collections.emptyMap();
+            } catch (Exception ex) {
+                throw new ResponseProcessingException(response, ex);
             }
-            return token;
-        } else if (response.getStatus() >= 400 && map.containsKey(OAuthConstants.ERROR_KEY)) {
-            OAuthError error = new OAuthError(map.get(OAuthConstants.ERROR_KEY),
-                                              map.get(OAuthConstants.ERROR_DESCRIPTION_KEY));
-            error.setErrorUri(map.get(OAuthConstants.ERROR_URI_KEY));
-            throw new OAuthServiceException(error);
+            if (200 == response.getStatus()) {
+                ClientAccessToken token = fromMapToClientToken(map, defaultTokenType);
+                if (token == null) {
+                    throw new OAuthServiceException(OAuthConstants.SERVER_ERROR);
+                }
+                return token;
+            } else if (response.getStatus() >= 400 && map.containsKey(OAuthConstants.ERROR_KEY)) {
+                OAuthError error = new OAuthError(map.get(OAuthConstants.ERROR_KEY),
+                                                  map.get(OAuthConstants.ERROR_DESCRIPTION_KEY));
+                error.setErrorUri(map.get(OAuthConstants.ERROR_URI_KEY));
+                throw new OAuthServiceException(error);
+            }
+            throw new OAuthServiceException(OAuthConstants.SERVER_ERROR);
         }
-        throw new OAuthServiceException(OAuthConstants.SERVER_ERROR);
     }
 
     public static ClientAccessToken fromMapToClientToken(Map<String, String> map) {

--- a/rt/rs/security/sso/oidc/src/main/java/org/apache/cxf/rs/security/oidc/utils/OidcUtils.java
+++ b/rt/rs/security/sso/oidc/src/main/java/org/apache/cxf/rs/security/oidc/utils/OidcUtils.java
@@ -218,12 +218,17 @@ public final class OidcUtils {
     }
 
     public static OidcProviderMetadata getOidcProviderMetadata(String issuerURL) {
-        Response response = WebClient.create(issuerURL).path("/.well-known/openid-configuration")
-            .accept(MediaType.APPLICATION_JSON).get();
-        if (Status.OK.getStatusCode() != response.getStatus()) {
-            throw ExceptionUtils.toWebApplicationException(response);
+        try (WebClient webClient = WebClient.create(issuerURL)) {
+            try (Response response = webClient.path("/.well-known/openid-configuration")
+                    .accept(MediaType.APPLICATION_JSON).get()) {
+                if (Status.OK.getStatusCode() != response.getStatus()) {
+                    throw ExceptionUtils.toWebApplicationException(response);
+                }
+
+                return new OidcProviderMetadata(new JsonMapObjectReaderWriter()
+                        .fromJson(response.readEntity(String.class)));
+            }
         }
-        return new OidcProviderMetadata(new JsonMapObjectReaderWriter().fromJson(response.readEntity(String.class)));
     }
 
 }

--- a/systests/rs-security/src/test/java/org/apache/cxf/systest/jaxrs/security/oauth2/common/OAuth2TestUtils.java
+++ b/systests/rs-security/src/test/java/org/apache/cxf/systest/jaxrs/security/oauth2/common/OAuth2TestUtils.java
@@ -162,18 +162,15 @@ public final class OAuth2TestUtils {
         form.param("response_type", authzData.getResponseType());
         form.param("oauthDecision", "allow");
 
-        Response response = client.post(form);
-        String location;
-        try {
-            location = response.getHeaderString("Location");
-        } finally {
-            response.close();
-        }
-        if (state != null) {
-            Assert.assertTrue(location.contains("state=" + state));
-        }
+        try (Response response = client.post(form)) {
+            String location  = response.getHeaderString("Location");
 
-        return location;
+            if (state != null) {
+                Assert.assertTrue(location.contains("state=" + state));
+            }
+
+            return location;
+        }
     }
 
     public static ClientAccessToken getAccessTokenWithAuthorizationCode(WebClient client, String code) {

--- a/systests/rs-security/src/test/java/org/apache/cxf/systest/jaxrs/security/oidc/OIDCFlowTest.java
+++ b/systests/rs-security/src/test/java/org/apache/cxf/systest/jaxrs/security/oidc/OIDCFlowTest.java
@@ -126,7 +126,7 @@ public class OIDCFlowTest extends AbstractBusClientServerTestBase {
         return new Object[][]{
             new Object[] {JCACHE_SERVER.getPort(), Map.of()},
             new Object[] {JWT_JCACHE_SERVER.getPort(), Map.of()},
-            new Object[] {JPA_SERVER.getPort(), Map.of("share.httpclient.http.conduit", false)},
+            new Object[] {JPA_SERVER.getPort(), Map.of()},
             new Object[] {JWT_NON_PERSIST_JCACHE_SERVER.getPort(), Map.of()}
         };
     }
@@ -134,31 +134,34 @@ public class OIDCFlowTest extends AbstractBusClientServerTestBase {
     @org.junit.Test
     public void testAuthorizationCodeFlow() throws Exception {
         String address = "https://localhost:" + port + "/services/";
-        WebClient client = WebClient.create(address, OAuth2TestUtils.setupProviders(),
-                                            "alice", "security", null);
+        String code = null;
+        
+        try (WebClient client = WebClient.create(address, OAuth2TestUtils.setupProviders(),
+                                            "alice", "security", null)) {
 
-        // Save the Cookie for the second request...
-        WebClient.getConfig(client).getRequestContext().put(
-            org.apache.cxf.message.Message.MAINTAIN_SESSION, Boolean.TRUE);
-
-        // Get Authorization Code
-        String code = OAuth2TestUtils.getAuthorizationCode(client, "openid");
-        assertNotNull(code);
+            // Save the Cookie for the second request...
+            WebClient.getConfig(client).getRequestContext().put(
+                org.apache.cxf.message.Message.MAINTAIN_SESSION, Boolean.TRUE);
+    
+            // Get Authorization Code
+            code = OAuth2TestUtils.getAuthorizationCode(client, "openid");
+            assertNotNull(code);
+        }
 
         // Now get the access token
-        client = WebClient.create(address, "consumer-id", "this-is-a-secret", null);
-
-        ClientAccessToken accessToken =
-            OAuth2TestUtils.getAccessTokenWithAuthorizationCode(client, code);
-        assertNotNull(accessToken.getTokenKey());
-        assertTrue(accessToken.getApprovedScope().contains("openid"));
-
-        String idToken = accessToken.getParameters().get("id_token");
-        assertNotNull(idToken);
-        validateIdToken(idToken, null);
-
-        if (isAccessTokenInJWTFormat()) {
-            validateAccessToken(accessToken.getTokenKey());
+        try (WebClient client = WebClient.create(address, "consumer-id", "this-is-a-secret", null)) {
+            ClientAccessToken accessToken =
+                OAuth2TestUtils.getAccessTokenWithAuthorizationCode(client, code);
+            assertNotNull(accessToken.getTokenKey());
+            assertTrue(accessToken.getApprovedScope().contains("openid"));
+    
+            String idToken = accessToken.getParameters().get("id_token");
+            assertNotNull(idToken);
+            validateIdToken(idToken, null);
+    
+            if (isAccessTokenInJWTFormat()) {
+                validateAccessToken(accessToken.getTokenKey());
+            }
         }
     }
 
@@ -167,44 +170,46 @@ public class OIDCFlowTest extends AbstractBusClientServerTestBase {
     @org.junit.Test
     public void testAuthorizationCodeFlowPOST() throws Exception {
         String address = "https://localhost:" + port + "/services/";
-        WebClient client = WebClient.create(address, OAuth2TestUtils.setupProviders(),
-                                            "alice", "security", null);
+        String code = null;
 
-        // Save the Cookie for the second request...
-        WebClient.getConfig(client).getRequestContext().put(
-            org.apache.cxf.message.Message.MAINTAIN_SESSION, Boolean.TRUE);
-
-        // Make initial authorization request
-        client.type("application/x-www-form-urlencoded");
-
-        client.path("authorize/");
-
-        Form form = new Form();
-        form.param("client_id", "consumer-id");
-        form.param("scope", "openid");
-        form.param("redirect_uri", "http://www.blah.apache.org");
-        form.param("response_type", "code");
-        Response response = client.post(form);
-
-        OAuthAuthorizationData authzData = response.readEntity(OAuthAuthorizationData.class);
-        String location = OAuth2TestUtils.getLocation(client, authzData, null);
-        String code =  OAuth2TestUtils.getSubstring(location, "code");
-        assertNotNull(code);
+        try (WebClient client = WebClient.create(address, OAuth2TestUtils.setupProviders(),
+                                            "alice", "security", null)) {
+            // Save the Cookie for the second request...
+            WebClient.getConfig(client).getRequestContext().put(
+                org.apache.cxf.message.Message.MAINTAIN_SESSION, Boolean.TRUE);
+    
+            // Make initial authorization request
+            client.type("application/x-www-form-urlencoded");
+    
+            client.path("authorize/");
+    
+            Form form = new Form();
+            form.param("client_id", "consumer-id");
+            form.param("scope", "openid");
+            form.param("redirect_uri", "http://www.blah.apache.org");
+            form.param("response_type", "code");
+            try (Response response = client.post(form)) {
+                OAuthAuthorizationData authzData = response.readEntity(OAuthAuthorizationData.class);
+                String location = OAuth2TestUtils.getLocation(client, authzData, null);
+                code =  OAuth2TestUtils.getSubstring(location, "code");
+                assertNotNull(code);
+            }
+        }
 
         // Now get the access token
-        client = WebClient.create(address, "consumer-id", "this-is-a-secret", null);
-
-        ClientAccessToken accessToken =
-            OAuth2TestUtils.getAccessTokenWithAuthorizationCode(client, code);
-        assertNotNull(accessToken.getTokenKey());
-        assertTrue(accessToken.getApprovedScope().contains("openid"));
-
-        String idToken = accessToken.getParameters().get("id_token");
-        assertNotNull(idToken);
-        validateIdToken(idToken, null);
-
-        if (isAccessTokenInJWTFormat()) {
-            validateAccessToken(accessToken.getTokenKey());
+        try (WebClient client = WebClient.create(address, "consumer-id", "this-is-a-secret", null)) {
+            ClientAccessToken accessToken =
+                OAuth2TestUtils.getAccessTokenWithAuthorizationCode(client, code);
+            assertNotNull(accessToken.getTokenKey());
+            assertTrue(accessToken.getApprovedScope().contains("openid"));
+    
+            String idToken = accessToken.getParameters().get("id_token");
+            assertNotNull(idToken);
+            validateIdToken(idToken, null);
+    
+            if (isAccessTokenInJWTFormat()) {
+                validateAccessToken(accessToken.getTokenKey());
+            }
         }
     }
 
@@ -212,298 +217,326 @@ public class OIDCFlowTest extends AbstractBusClientServerTestBase {
     @org.junit.Test
     public void testAuthorizationCodeOAuth() throws Exception {
         String address = "https://localhost:" + port + "/services/";
-        WebClient client = WebClient.create(address,  OAuth2TestUtils.setupProviders(),
-                                            "alice", "security", null);
-        // Save the Cookie for the second request...
-        WebClient.getConfig(client).getRequestContext().put(
-            org.apache.cxf.message.Message.MAINTAIN_SESSION, Boolean.TRUE);
+        String code = null;
 
-        // Get Authorization Code
-        String code = OAuth2TestUtils.getAuthorizationCode(client, "read_balance");
-        assertNotNull(code);
+        try (WebClient client = WebClient.create(address,  OAuth2TestUtils.setupProviders(),
+                                                "alice", "security", null)) {
+            // Save the Cookie for the second request...
+            WebClient.getConfig(client).getRequestContext().put(
+                org.apache.cxf.message.Message.MAINTAIN_SESSION, Boolean.TRUE);
+    
+            // Get Authorization Code
+            code = OAuth2TestUtils.getAuthorizationCode(client, "read_balance");
+            assertNotNull(code);
+        }
 
         // Now get the access token
-        client = WebClient.create(address, "consumer-id", "this-is-a-secret", null);
-
-        ClientAccessToken accessToken =
-            OAuth2TestUtils.getAccessTokenWithAuthorizationCode(client, code);
-        assertNotNull(accessToken.getTokenKey());
-        // We should not have an IdToken here
-        String idToken = accessToken.getParameters().get("id_token");
-        assertNull(idToken);
-        assertFalse(accessToken.getApprovedScope().contains("openid"));
-
-        if (isAccessTokenInJWTFormat()) {
-            validateAccessToken(accessToken.getTokenKey());
+        try (WebClient client = WebClient.create(address, "consumer-id", "this-is-a-secret", null)) {
+            ClientAccessToken accessToken =
+                OAuth2TestUtils.getAccessTokenWithAuthorizationCode(client, code);
+            assertNotNull(accessToken.getTokenKey());
+            // We should not have an IdToken here
+            String idToken = accessToken.getParameters().get("id_token");
+            assertNull(idToken);
+            assertFalse(accessToken.getApprovedScope().contains("openid"));
+    
+            if (isAccessTokenInJWTFormat()) {
+                validateAccessToken(accessToken.getTokenKey());
+            }
         }
     }
 
     @org.junit.Test
     public void testAuthorizationCodeFlowWithNonce() throws Exception {
         String address = "https://localhost:" + port + "/services/";
-        WebClient client = WebClient.create(address,  OAuth2TestUtils.setupProviders(),
-                                            "alice", "security", null);
-        // Save the Cookie for the second request...
-        WebClient.getConfig(client).getRequestContext().put(
-            org.apache.cxf.message.Message.MAINTAIN_SESSION, Boolean.TRUE);
+        String code = null;
 
-        // Get Authorization Code
-        String code = OAuth2TestUtils.getAuthorizationCode(client, "openid", "consumer-id",
-                                                           "123456789", null);
-        assertNotNull(code);
+        try (WebClient client = WebClient.create(address,  OAuth2TestUtils.setupProviders(),
+                                            "alice", "security", null)) {
+            // Save the Cookie for the second request...
+            WebClient.getConfig(client).getRequestContext().put(
+                org.apache.cxf.message.Message.MAINTAIN_SESSION, Boolean.TRUE);
+
+            // Get Authorization Code
+            code = OAuth2TestUtils.getAuthorizationCode(client, "openid", "consumer-id",
+                                                               "123456789", null);
+            assertNotNull(code);
+        }
 
         // Now get the access token
-        client = WebClient.create(address, "consumer-id", "this-is-a-secret", null);
+        try (WebClient client = WebClient.create(address, "consumer-id", "this-is-a-secret", null)) {
+            ClientAccessToken accessToken =
+                OAuth2TestUtils.getAccessTokenWithAuthorizationCode(client, code);
+            assertNotNull(accessToken.getTokenKey());
+            assertTrue(accessToken.getApprovedScope().contains("openid"));
 
-        ClientAccessToken accessToken =
-            OAuth2TestUtils.getAccessTokenWithAuthorizationCode(client, code);
-        assertNotNull(accessToken.getTokenKey());
-        assertTrue(accessToken.getApprovedScope().contains("openid"));
+            String idToken = accessToken.getParameters().get("id_token");
+            assertNotNull(idToken);
+            validateIdToken(idToken, "123456789");
 
-        String idToken = accessToken.getParameters().get("id_token");
-        assertNotNull(idToken);
-        validateIdToken(idToken, "123456789");
-
-        if (isAccessTokenInJWTFormat()) {
-            validateAccessToken(accessToken.getTokenKey());
+            if (isAccessTokenInJWTFormat()) {
+                validateAccessToken(accessToken.getTokenKey());
+            }
         }
     }
 
     @org.junit.Test
     public void testAuthorizationCodeFlowWithScope() throws Exception {
         String address = "https://localhost:" + port + "/services/";
-        WebClient client = WebClient.create(address,  OAuth2TestUtils.setupProviders(),
-                                            "alice", "security", null);
-        // Save the Cookie for the second request...
-        WebClient.getConfig(client).getRequestContext().put(
-            org.apache.cxf.message.Message.MAINTAIN_SESSION, Boolean.TRUE);
+        String code = null;
 
-        // Get Authorization Code
-        String code = OAuth2TestUtils.getAuthorizationCode(client, "openid read_balance");
-        assertNotNull(code);
+        try (WebClient client = WebClient.create(address,  OAuth2TestUtils.setupProviders(),
+                                            "alice", "security", null)) {
+            // Save the Cookie for the second request...
+            WebClient.getConfig(client).getRequestContext().put(
+                org.apache.cxf.message.Message.MAINTAIN_SESSION, Boolean.TRUE);
+    
+            // Get Authorization Code
+            code = OAuth2TestUtils.getAuthorizationCode(client, "openid read_balance");
+            assertNotNull(code);
+        }
 
         // Now get the access token
-        client = WebClient.create(address, "consumer-id", "this-is-a-secret", null);
-
-        ClientAccessToken accessToken =
-            OAuth2TestUtils.getAccessTokenWithAuthorizationCode(client, code);
-        assertNotNull(accessToken.getTokenKey());
-        assertTrue(accessToken.getApprovedScope().contains("openid"));
-        assertTrue(accessToken.getApprovedScope().contains("read_balance"));
-
-        String idToken = accessToken.getParameters().get("id_token");
-        assertNotNull(idToken);
-        validateIdToken(idToken, null);
-
-        if (isAccessTokenInJWTFormat()) {
-            validateAccessToken(accessToken.getTokenKey());
+        try (WebClient client = WebClient.create(address, "consumer-id", "this-is-a-secret", null)) {
+            ClientAccessToken accessToken =
+                OAuth2TestUtils.getAccessTokenWithAuthorizationCode(client, code);
+            assertNotNull(accessToken.getTokenKey());
+            assertTrue(accessToken.getApprovedScope().contains("openid"));
+            assertTrue(accessToken.getApprovedScope().contains("read_balance"));
+    
+            String idToken = accessToken.getParameters().get("id_token");
+            assertNotNull(idToken);
+            validateIdToken(idToken, null);
+    
+            if (isAccessTokenInJWTFormat()) {
+                validateAccessToken(accessToken.getTokenKey());
+            }
         }
     }
 
     @org.junit.Test
     public void testAuthorizationCodeFlowWithRefresh() throws Exception {
         String address = "https://localhost:" + port + "/services/";
-        WebClient client = WebClient.create(address, OAuth2TestUtils.setupProviders(),
-                                            "alice", "security", null);
-        // Save the Cookie for the second request...
-        WebClient.getConfig(client).getRequestContext().put(
-            org.apache.cxf.message.Message.MAINTAIN_SESSION, Boolean.TRUE);
+        String code = null;
+        String idToken = null;
+        ClientAccessToken accessToken = null;
 
-        // Get Authorization Code
-        String code = OAuth2TestUtils.getAuthorizationCode(client, "openid");
-        assertNotNull(code);
+        try (WebClient client = WebClient.create(address, OAuth2TestUtils.setupProviders(),
+                                            "alice", "security", null)) {
+            // Save the Cookie for the second request...
+            WebClient.getConfig(client).getRequestContext().put(
+                org.apache.cxf.message.Message.MAINTAIN_SESSION, Boolean.TRUE);
+    
+            // Get Authorization Code
+            code = OAuth2TestUtils.getAuthorizationCode(client, "openid");
+            assertNotNull(code);
+        }
 
+        
         // Now get the access token
-        client = WebClient.create(address, "consumer-id", "this-is-a-secret", null);
+        try (WebClient client = WebClient.create(address, "consumer-id", "this-is-a-secret", null)) {
+            accessToken = OAuth2TestUtils.getAccessTokenWithAuthorizationCode(client, code);
+            assertNotNull(accessToken.getTokenKey());
+            assertTrue(accessToken.getApprovedScope().contains("openid"));
+            assertNotNull(accessToken.getRefreshToken());
+    
+            idToken = accessToken.getParameters().get("id_token");
+            assertNotNull(idToken);
+            validateIdToken(idToken, null);
+        }
+    
+            // Refresh the access token
+        try (WebClient client = WebClient.create(address, OAuth2TestUtils.setupProviders(),
+                "consumer-id", "this-is-a-secret", null)) {
+            client.path("token");
+            client.type("application/x-www-form-urlencoded").accept("application/json");
+    
+            Form form = new Form();
+            form.param("grant_type", "refresh_token");
+            form.param("refresh_token", accessToken.getRefreshToken());
+            form.param("client_id", "consumer-id");
+            form.param("scope", "openid");
+            try (Response response = client.post(form)) {
+                accessToken = response.readEntity(ClientAccessToken.class);
 
-        ClientAccessToken accessToken =
-            OAuth2TestUtils.getAccessTokenWithAuthorizationCode(client, code);
-        assertNotNull(accessToken.getTokenKey());
-        assertTrue(accessToken.getApprovedScope().contains("openid"));
-        assertNotNull(accessToken.getRefreshToken());
-
-        String idToken = accessToken.getParameters().get("id_token");
-        assertNotNull(idToken);
-        validateIdToken(idToken, null);
-
-        // Refresh the access token
-        client = WebClient.create(address, OAuth2TestUtils.setupProviders(),
-            "consumer-id", "this-is-a-secret", null);
-        client.path("token");
-        client.type("application/x-www-form-urlencoded").accept("application/json");
-
-        Form form = new Form();
-        form.param("grant_type", "refresh_token");
-        form.param("refresh_token", accessToken.getRefreshToken());
-        form.param("client_id", "consumer-id");
-        form.param("scope", "openid");
-        Response response = client.post(form);
-
-        accessToken = response.readEntity(ClientAccessToken.class);
-        assertNotNull(accessToken.getTokenKey());
-        assertNotNull(accessToken.getRefreshToken());
-        assertNotNull(accessToken.getParameters().get("id_token"));
-        assertNotNull(idToken);
-
-        if (isAccessTokenInJWTFormat()) {
-            validateAccessToken(accessToken.getTokenKey());
+                assertNotNull(accessToken.getTokenKey());
+                assertNotNull(accessToken.getRefreshToken());
+                assertNotNull(accessToken.getParameters().get("id_token"));
+                assertNotNull(idToken);
+        
+                if (isAccessTokenInJWTFormat()) {
+                    validateAccessToken(accessToken.getTokenKey());
+                }
+            }
         }
     }
 
     @org.junit.Test
     public void testAuthorizationCodeFlowWithState() throws Exception {
         String address = "https://localhost:" + port + "/services/";
-        WebClient client = WebClient.create(address,  OAuth2TestUtils.setupProviders(),
-                                            "alice", "security", null);
-        // Save the Cookie for the second request...
-        WebClient.getConfig(client).getRequestContext().put(
-            org.apache.cxf.message.Message.MAINTAIN_SESSION, Boolean.TRUE);
+        String code = null;
 
-        // Get Authorization Code
-        String code = OAuth2TestUtils.getAuthorizationCode(client, "openid", "consumer-id",
-                                                           null, "123456789");
-        assertNotNull(code);
+        try (WebClient client = WebClient.create(address,  OAuth2TestUtils.setupProviders(),
+                                            "alice", "security", null)) {
+            // Save the Cookie for the second request...
+            WebClient.getConfig(client).getRequestContext().put(
+                org.apache.cxf.message.Message.MAINTAIN_SESSION, Boolean.TRUE);
+    
+            // Get Authorization Code
+            code = OAuth2TestUtils.getAuthorizationCode(client, "openid", "consumer-id",
+                                                               null, "123456789");
+            assertNotNull(code);
+        }
 
         // Now get the access token
-        client = WebClient.create(address, "consumer-id", "this-is-a-secret", null);
-
-        ClientAccessToken accessToken =
-            OAuth2TestUtils.getAccessTokenWithAuthorizationCode(client, code);
-        assertNotNull(accessToken.getTokenKey());
-        assertTrue(accessToken.getApprovedScope().contains("openid"));
-
-        String idToken = accessToken.getParameters().get("id_token");
-        assertNotNull(idToken);
-        validateIdToken(idToken, null);
-
-        if (isAccessTokenInJWTFormat()) {
-            validateAccessToken(accessToken.getTokenKey());
+        try (WebClient client = WebClient.create(address, "consumer-id", "this-is-a-secret", null)) {
+            ClientAccessToken accessToken =
+                OAuth2TestUtils.getAccessTokenWithAuthorizationCode(client, code);
+            assertNotNull(accessToken.getTokenKey());
+            assertTrue(accessToken.getApprovedScope().contains("openid"));
+    
+            String idToken = accessToken.getParameters().get("id_token");
+            assertNotNull(idToken);
+            validateIdToken(idToken, null);
+    
+            if (isAccessTokenInJWTFormat()) {
+                validateAccessToken(accessToken.getTokenKey());
+            }
         }
     }
 
     @org.junit.Test
     public void testAuthorizationCodeFlowWithAudience() throws Exception {
         String address = "https://localhost:" + port + "/services/";
-        WebClient client = WebClient.create(address,  OAuth2TestUtils.setupProviders(),
-                                            "alice", "security", null);
-        // Save the Cookie for the second request...
-        WebClient.getConfig(client).getRequestContext().put(
-            org.apache.cxf.message.Message.MAINTAIN_SESSION, Boolean.TRUE);
+        String code = null;
 
-        // Get Authorization Code
-        String code = OAuth2TestUtils.getAuthorizationCode(client, "openid", "consumer-id-aud",
-                                                           null, null);
-        assertNotNull(code);
+        try (WebClient client = WebClient.create(address,  OAuth2TestUtils.setupProviders(),
+                                            "alice", "security", null)) {
+            // Save the Cookie for the second request...
+            WebClient.getConfig(client).getRequestContext().put(
+                org.apache.cxf.message.Message.MAINTAIN_SESSION, Boolean.TRUE);
+    
+            // Get Authorization Code
+            code = OAuth2TestUtils.getAuthorizationCode(client, "openid", "consumer-id-aud",
+                                                               null, null);
+            assertNotNull(code);
+        }
 
         // Now get the access token
-        client = WebClient.create(address, "consumer-id-aud", "this-is-a-secret", null);
-
-        String audience = "https://localhost:" + port + "/secured/bookstore/books";
-        ClientAccessToken accessToken =
-            OAuth2TestUtils.getAccessTokenWithAuthorizationCode(client, code, "consumer-id-aud", audience);
-        assertNotNull(accessToken.getTokenKey());
-
-        if (isAccessTokenInJWTFormat()) {
-            validateAccessToken(accessToken.getTokenKey());
+        try (WebClient client = WebClient.create(address, "consumer-id-aud", "this-is-a-secret", null)) {
+            String audience = "https://localhost:" + port + "/secured/bookstore/books";
+            ClientAccessToken accessToken =
+                OAuth2TestUtils.getAccessTokenWithAuthorizationCode(client, code, "consumer-id-aud", audience);
+            assertNotNull(accessToken.getTokenKey());
+    
+            if (isAccessTokenInJWTFormat()) {
+                validateAccessToken(accessToken.getTokenKey());
+            }
         }
     }
 
     @org.junit.Test
     public void testAuthorizationCodeFlowWithPKCE() throws Exception {
         String address = "https://localhost:" + port + "/services/";
-        WebClient client = WebClient.create(address,  OAuth2TestUtils.setupProviders(),
-                                            "alice", "security", null);
-        // Save the Cookie for the second request...
-        WebClient.getConfig(client).getRequestContext().put(
-            org.apache.cxf.message.Message.MAINTAIN_SESSION, Boolean.TRUE);
-
-        // Get Authorization Code
-        AuthorizationCodeParameters parameters = new AuthorizationCodeParameters();
-        parameters.setConsumerId("consumer-id");
-        parameters.setScope(OidcUtils.OPENID_SCOPE);
-        parameters.setResponseType(OAuthConstants.CODE_RESPONSE_TYPE);
-        parameters.setPath("authorize/");
         String codeVerifier = Base64UrlUtility.encode(CryptoUtils.generateSecureRandomBytes(32));
-        CodeVerifierTransformer transformer = new DigestCodeVerifier();
-        parameters.setCodeChallenge(transformer.transformCodeVerifier(codeVerifier));
-        parameters.setCodeChallengeMethod(transformer.getChallengeMethod());
+        String code = null;
 
-        String location = OAuth2TestUtils.getLocation(client, parameters);
-        String code = OAuth2TestUtils.getSubstring(location, "code");
-
-        assertNotNull(code);
+        try (WebClient client = WebClient.create(address,  OAuth2TestUtils.setupProviders(),
+                                            "alice", "security", null)) {
+            // Save the Cookie for the second request...
+            WebClient.getConfig(client).getRequestContext().put(
+                org.apache.cxf.message.Message.MAINTAIN_SESSION, Boolean.TRUE);
+    
+            // Get Authorization Code
+            AuthorizationCodeParameters parameters = new AuthorizationCodeParameters();
+            parameters.setConsumerId("consumer-id");
+            parameters.setScope(OidcUtils.OPENID_SCOPE);
+            parameters.setResponseType(OAuthConstants.CODE_RESPONSE_TYPE);
+            parameters.setPath("authorize/");
+            CodeVerifierTransformer transformer = new DigestCodeVerifier();
+            parameters.setCodeChallenge(transformer.transformCodeVerifier(codeVerifier));
+            parameters.setCodeChallengeMethod(transformer.getChallengeMethod());
+    
+            String location = OAuth2TestUtils.getLocation(client, parameters);
+            code = OAuth2TestUtils.getSubstring(location, "code");
+    
+            assertNotNull(code);
+        }
 
         // Now get the access token
-        client = WebClient.create(address, "consumer-id", "this-is-a-secret", null);
-
-        ClientAccessToken accessToken =
-            OAuth2TestUtils.getAccessTokenWithAuthorizationCode(client, code, "consumer-id", null, codeVerifier);
-        assertNotNull(accessToken.getTokenKey());
-
-        if (isAccessTokenInJWTFormat()) {
-            validateAccessToken(accessToken.getTokenKey());
+        try (WebClient client = WebClient.create(address, "consumer-id", "this-is-a-secret", null)) {
+            ClientAccessToken accessToken =
+                OAuth2TestUtils.getAccessTokenWithAuthorizationCode(client, code, "consumer-id", null, codeVerifier);
+            assertNotNull(accessToken.getTokenKey());
+    
+            if (isAccessTokenInJWTFormat()) {
+                validateAccessToken(accessToken.getTokenKey());
+            }
         }
     }
 
     @org.junit.Test
     public void testImplicitFlow() throws Exception {
         String address = "https://localhost:" + port + "/services/";
-        WebClient client = WebClient.create(address, OAuth2TestUtils.setupProviders(),
-                                            "alice", "security", null);
-        // Save the Cookie for the second request...
-        WebClient.getConfig(client).getRequestContext().put(
-            org.apache.cxf.message.Message.MAINTAIN_SESSION, Boolean.TRUE);
+        try (WebClient client = WebClient.create(address, OAuth2TestUtils.setupProviders(),
+                                            "alice", "security", null)) {
+            // Save the Cookie for the second request...
+            WebClient.getConfig(client).getRequestContext().put(
+                org.apache.cxf.message.Message.MAINTAIN_SESSION, Boolean.TRUE);
+    
+            // Get Access Token
+            client.type("application/json").accept("application/json");
+            client.query("client_id", "consumer-id");
+            client.query("redirect_uri", "http://www.blah.apache.org");
+            client.query("scope", "openid");
+            client.query("response_type", "id_token token");
+            client.query("nonce", "123456789");
+            client.path("authorize-implicit/");
 
-        // Get Access Token
-        client.type("application/json").accept("application/json");
-        client.query("client_id", "consumer-id");
-        client.query("redirect_uri", "http://www.blah.apache.org");
-        client.query("scope", "openid");
-        client.query("response_type", "id_token token");
-        client.query("nonce", "123456789");
-        client.path("authorize-implicit/");
-        Response response = client.get();
-
-        OAuthAuthorizationData authzData = response.readEntity(OAuthAuthorizationData.class);
-
-        // Now call "decision" to get the access token
-        client.path("decision");
-        client.type("application/x-www-form-urlencoded");
-
-        Form form = new Form();
-        form.param("session_authenticity_token", authzData.getAuthenticityToken());
-        form.param("client_id", authzData.getClientId());
-        form.param("redirect_uri", authzData.getRedirectUri());
-        form.param("scope", authzData.getProposedScope());
-        if (authzData.getResponseType() != null) {
-            form.param("response_type", authzData.getResponseType());
-        }
-        if (authzData.getNonce() != null) {
-            form.param("nonce", authzData.getNonce());
-        }
-        form.param("oauthDecision", "allow");
-
-        response = client.post(form);
-
-        String location = response.getHeaderString("Location");
-
-        // Check Access Token
-        String accessToken = OAuth2TestUtils.getSubstring(location, "access_token");
-        assertNotNull(accessToken);
-
-        // Check IdToken
-        String idToken = OAuth2TestUtils.getSubstring(location, "id_token");
-        assertNotNull(idToken);
-        validateIdToken(idToken, null);
-
-        JwsJwtCompactConsumer jwtConsumer = new JwsJwtCompactConsumer(idToken);
-        JwtToken jwt = jwtConsumer.getJwtToken();
-        assertNotNull(jwt.getClaims().getClaim(IdToken.ACCESS_TOKEN_HASH_CLAIM));
-        assertNotNull(jwt.getClaims().getClaim(IdToken.NONCE_CLAIM));
-        OidcUtils.validateAccessTokenHash(accessToken, jwt, true);
-
-        if (isAccessTokenInJWTFormat()) {
-            validateAccessToken(accessToken);
+            OAuthAuthorizationData authzData = null;
+            try (Response response = client.get()) {
+                authzData = response.readEntity(OAuthAuthorizationData.class);
+            }
+    
+            // Now call "decision" to get the access token
+            client.path("decision");
+            client.type("application/x-www-form-urlencoded");
+    
+            Form form = new Form();
+            form.param("session_authenticity_token", authzData.getAuthenticityToken());
+            form.param("client_id", authzData.getClientId());
+            form.param("redirect_uri", authzData.getRedirectUri());
+            form.param("scope", authzData.getProposedScope());
+            if (authzData.getResponseType() != null) {
+                form.param("response_type", authzData.getResponseType());
+            }
+            if (authzData.getNonce() != null) {
+                form.param("nonce", authzData.getNonce());
+            }
+            form.param("oauthDecision", "allow");
+    
+            try (Response response = client.post(form)) {
+                String location = response.getHeaderString("Location");
+        
+                // Check Access Token
+                String accessToken = OAuth2TestUtils.getSubstring(location, "access_token");
+                assertNotNull(accessToken);
+        
+                // Check IdToken
+                String idToken = OAuth2TestUtils.getSubstring(location, "id_token");
+                assertNotNull(idToken);
+                validateIdToken(idToken, null);
+        
+                JwsJwtCompactConsumer jwtConsumer = new JwsJwtCompactConsumer(idToken);
+                JwtToken jwt = jwtConsumer.getJwtToken();
+                assertNotNull(jwt.getClaims().getClaim(IdToken.ACCESS_TOKEN_HASH_CLAIM));
+                assertNotNull(jwt.getClaims().getClaim(IdToken.NONCE_CLAIM));
+                OidcUtils.validateAccessTokenHash(accessToken, jwt, true);
+        
+                if (isAccessTokenInJWTFormat()) {
+                    validateAccessToken(accessToken);
+                }
+            }
         }
     }
 
@@ -512,451 +545,485 @@ public class OIDCFlowTest extends AbstractBusClientServerTestBase {
     @org.junit.Test
     public void testImplicitFlowPOST() throws Exception {
         String address = "https://localhost:" + port + "/services/";
-        WebClient client = WebClient.create(address, OAuth2TestUtils.setupProviders(),
-                                            "alice", "security", null);
-        // Save the Cookie for the second request...
-        WebClient.getConfig(client).getRequestContext().put(
-            org.apache.cxf.message.Message.MAINTAIN_SESSION, Boolean.TRUE);
-
-        // Get Access Token
-        client.type("application/x-www-form-urlencoded");
-
-        client.path("authorize-implicit/");
-
-        Form form = new Form();
-        form.param("client_id", "consumer-id");
-        form.param("scope", "openid");
-        form.param("redirect_uri", "http://www.blah.apache.org");
-        form.param("response_type", "id_token token");
-        form.param("nonce", "123456789");
-        Response response = client.post(form);
-
-        OAuthAuthorizationData authzData = response.readEntity(OAuthAuthorizationData.class);
-
-        // Now call "decision" to get the access token
-        client.path("decision");
-        client.type("application/x-www-form-urlencoded");
-
-        form = new Form();
-        form.param("session_authenticity_token", authzData.getAuthenticityToken());
-        form.param("client_id", authzData.getClientId());
-        form.param("redirect_uri", authzData.getRedirectUri());
-        form.param("scope", authzData.getProposedScope());
-        if (authzData.getResponseType() != null) {
-            form.param("response_type", authzData.getResponseType());
-        }
-        if (authzData.getNonce() != null) {
-            form.param("nonce", authzData.getNonce());
-        }
-        form.param("oauthDecision", "allow");
-
-        response = client.post(form);
-
-        String location = response.getHeaderString("Location");
-
-        // Check Access Token
-        String accessToken = OAuth2TestUtils.getSubstring(location, "access_token");
-        assertNotNull(accessToken);
-
-        // Check IdToken
-        String idToken = OAuth2TestUtils.getSubstring(location, "id_token");
-        assertNotNull(idToken);
-        validateIdToken(idToken, null);
-
-        JwsJwtCompactConsumer jwtConsumer = new JwsJwtCompactConsumer(idToken);
-        JwtToken jwt = jwtConsumer.getJwtToken();
-        assertNotNull(jwt.getClaims().getClaim(IdToken.ACCESS_TOKEN_HASH_CLAIM));
-        assertNotNull(jwt.getClaims().getClaim(IdToken.NONCE_CLAIM));
-        OidcUtils.validateAccessTokenHash(accessToken, jwt, true);
-
-        if (isAccessTokenInJWTFormat()) {
-            validateAccessToken(accessToken);
+        try (WebClient client = WebClient.create(address, OAuth2TestUtils.setupProviders(),
+                                            "alice", "security", null)) {
+            // Save the Cookie for the second request...
+            WebClient.getConfig(client).getRequestContext().put(
+                org.apache.cxf.message.Message.MAINTAIN_SESSION, Boolean.TRUE);
+    
+            // Get Access Token
+            client.type("application/x-www-form-urlencoded");
+    
+            client.path("authorize-implicit/");
+    
+            Form form = new Form();
+            form.param("client_id", "consumer-id");
+            form.param("scope", "openid");
+            form.param("redirect_uri", "http://www.blah.apache.org");
+            form.param("response_type", "id_token token");
+            form.param("nonce", "123456789");
+            
+            OAuthAuthorizationData authzData = null;
+            try (Response response = client.post(form)) {
+                authzData = response.readEntity(OAuthAuthorizationData.class);
+            }
+    
+            // Now call "decision" to get the access token
+            client.path("decision");
+            client.type("application/x-www-form-urlencoded");
+    
+            form = new Form();
+            form.param("session_authenticity_token", authzData.getAuthenticityToken());
+            form.param("client_id", authzData.getClientId());
+            form.param("redirect_uri", authzData.getRedirectUri());
+            form.param("scope", authzData.getProposedScope());
+            if (authzData.getResponseType() != null) {
+                form.param("response_type", authzData.getResponseType());
+            }
+            if (authzData.getNonce() != null) {
+                form.param("nonce", authzData.getNonce());
+            }
+            form.param("oauthDecision", "allow");
+    
+            try (Response response = client.post(form)) {
+                String location = response.getHeaderString("Location");
+        
+                // Check Access Token
+                String accessToken = OAuth2TestUtils.getSubstring(location, "access_token");
+                assertNotNull(accessToken);
+        
+                // Check IdToken
+                String idToken = OAuth2TestUtils.getSubstring(location, "id_token");
+                assertNotNull(idToken);
+                validateIdToken(idToken, null);
+        
+                JwsJwtCompactConsumer jwtConsumer = new JwsJwtCompactConsumer(idToken);
+                JwtToken jwt = jwtConsumer.getJwtToken();
+                assertNotNull(jwt.getClaims().getClaim(IdToken.ACCESS_TOKEN_HASH_CLAIM));
+                assertNotNull(jwt.getClaims().getClaim(IdToken.NONCE_CLAIM));
+                OidcUtils.validateAccessTokenHash(accessToken, jwt, true);
+        
+                if (isAccessTokenInJWTFormat()) {
+                    validateAccessToken(accessToken);
+                }
+            }
         }
     }
 
     @org.junit.Test
     public void testImplicitFlowNoAccessToken() throws Exception {
         String address = "https://localhost:" + port + "/services/";
-        WebClient client = WebClient.create(address, OAuth2TestUtils.setupProviders(),
-                                            "alice", "security", null);
-        // Save the Cookie for the second request...
-        WebClient.getConfig(client).getRequestContext().put(
-            org.apache.cxf.message.Message.MAINTAIN_SESSION, Boolean.TRUE);
-
-        // Get Access Token
-        client.type("application/json").accept("application/json");
-        client.query("client_id", "consumer-id");
-        client.query("redirect_uri", "http://www.blah.apache.org");
-        client.query("scope", "openid");
-        client.query("response_type", "id_token");
-        client.query("nonce", "123456789");
-        client.path("authorize-implicit/");
-        Response response = client.get();
-
-        OAuthAuthorizationData authzData = response.readEntity(OAuthAuthorizationData.class);
-
-        // Now call "decision" to get the access token
-        client.path("decision");
-        client.type("application/x-www-form-urlencoded");
-
-        Form form = new Form();
-        form.param("session_authenticity_token", authzData.getAuthenticityToken());
-        form.param("client_id", authzData.getClientId());
-        form.param("redirect_uri", authzData.getRedirectUri());
-        form.param("scope", authzData.getProposedScope());
-        if (authzData.getResponseType() != null) {
-            form.param("response_type", authzData.getResponseType());
+        try (WebClient client = WebClient.create(address, OAuth2TestUtils.setupProviders(),
+                                            "alice", "security", null)) {
+            // Save the Cookie for the second request...
+            WebClient.getConfig(client).getRequestContext().put(
+                org.apache.cxf.message.Message.MAINTAIN_SESSION, Boolean.TRUE);
+    
+            // Get Access Token
+            client.type("application/json").accept("application/json");
+            client.query("client_id", "consumer-id");
+            client.query("redirect_uri", "http://www.blah.apache.org");
+            client.query("scope", "openid");
+            client.query("response_type", "id_token");
+            client.query("nonce", "123456789");
+            client.path("authorize-implicit/");
+            
+            OAuthAuthorizationData authzData = null;
+            try (Response response = client.get()) {
+                authzData = response.readEntity(OAuthAuthorizationData.class);
+            }
+    
+            // Now call "decision" to get the access token
+            client.path("decision");
+            client.type("application/x-www-form-urlencoded");
+    
+            Form form = new Form();
+            form.param("session_authenticity_token", authzData.getAuthenticityToken());
+            form.param("client_id", authzData.getClientId());
+            form.param("redirect_uri", authzData.getRedirectUri());
+            form.param("scope", authzData.getProposedScope());
+            if (authzData.getResponseType() != null) {
+                form.param("response_type", authzData.getResponseType());
+            }
+            if (authzData.getNonce() != null) {
+                form.param("nonce", authzData.getNonce());
+            }
+            form.param("oauthDecision", "allow");
+    
+            try (Response response = client.post(form)) {
+                String location = response.getHeaderString("Location");
+        
+                // Check Access Token - it should not be present
+                String accessToken = OAuth2TestUtils.getSubstring(location, "access_token");
+                assertNull(accessToken);
+        
+                // Check IdToken
+                String idToken = OAuth2TestUtils.getSubstring(location, "id_token");
+                assertNotNull(idToken);
+                validateIdToken(idToken, null);
+        
+                JwsJwtCompactConsumer jwtConsumer = new JwsJwtCompactConsumer(idToken);
+                JwtToken jwt = jwtConsumer.getJwtToken();
+                assertNull(jwt.getClaims().getClaim(IdToken.ACCESS_TOKEN_HASH_CLAIM));
+                assertNotNull(jwt.getClaims().getClaim(IdToken.NONCE_CLAIM));
+            }
         }
-        if (authzData.getNonce() != null) {
-            form.param("nonce", authzData.getNonce());
-        }
-        form.param("oauthDecision", "allow");
-
-        response = client.post(form);
-
-        String location = response.getHeaderString("Location");
-
-        // Check Access Token - it should not be present
-        String accessToken = OAuth2TestUtils.getSubstring(location, "access_token");
-        assertNull(accessToken);
-
-        // Check IdToken
-        String idToken = OAuth2TestUtils.getSubstring(location, "id_token");
-        assertNotNull(idToken);
-        validateIdToken(idToken, null);
-
-        JwsJwtCompactConsumer jwtConsumer = new JwsJwtCompactConsumer(idToken);
-        JwtToken jwt = jwtConsumer.getJwtToken();
-        assertNull(jwt.getClaims().getClaim(IdToken.ACCESS_TOKEN_HASH_CLAIM));
-        assertNotNull(jwt.getClaims().getClaim(IdToken.NONCE_CLAIM));
     }
 
     @org.junit.Test
     public void testHybridCodeIdToken() throws Exception {
         String address = "https://localhost:" + port + "/services/";
-        WebClient client = WebClient.create(address, OAuth2TestUtils.setupProviders(),
-                                            "alice", "security", null);
-        WebClient.getConfig(client).getHttpConduit().getClient().setReceiveTimeout(100000000);
-        // Save the Cookie for the second request...
-        WebClient.getConfig(client).getRequestContext().put(
-            org.apache.cxf.message.Message.MAINTAIN_SESSION, Boolean.TRUE);
+        String idToken = null;
+        String code = null;
 
-        // Get location
-        AuthorizationCodeParameters parameters = new AuthorizationCodeParameters();
-        parameters.setConsumerId("consumer-id");
-        parameters.setScope("openid");
-        parameters.setNonce("123456789");
-        parameters.setResponseType("code id_token");
-        parameters.setPath("authorize-hybrid/");
-
-        String location = OAuth2TestUtils.getLocation(client, parameters);
-        assertNotNull(location);
-
-        // Check code
-        String code = OAuth2TestUtils.getSubstring(location, "code");
-        assertNotNull(code);
-
-        // Check id_token
-        String idToken = OAuth2TestUtils.getSubstring(location, "id_token");
-        assertNotNull(idToken);
-        validateIdToken(idToken, "123456789");
-        // check the code hash is returned from the implicit authorization endpoint
-        JwsJwtCompactConsumer jwtConsumer = new JwsJwtCompactConsumer(idToken);
-        JwtToken jwt = jwtConsumer.getJwtToken();
-        assertNotNull(jwt.getClaims().getClaim(IdToken.AUTH_CODE_HASH_CLAIM));
+        try (WebClient client = WebClient.create(address, OAuth2TestUtils.setupProviders(),
+                                            "alice", "security", null)) {
+            WebClient.getConfig(client).getHttpConduit().getClient().setReceiveTimeout(100000000);
+            // Save the Cookie for the second request...
+            WebClient.getConfig(client).getRequestContext().put(
+                org.apache.cxf.message.Message.MAINTAIN_SESSION, Boolean.TRUE);
+    
+            // Get location
+            AuthorizationCodeParameters parameters = new AuthorizationCodeParameters();
+            parameters.setConsumerId("consumer-id");
+            parameters.setScope("openid");
+            parameters.setNonce("123456789");
+            parameters.setResponseType("code id_token");
+            parameters.setPath("authorize-hybrid/");
+    
+            String location = OAuth2TestUtils.getLocation(client, parameters);
+            assertNotNull(location);
+    
+            // Check code
+            code = OAuth2TestUtils.getSubstring(location, "code");
+            assertNotNull(code);
+    
+            // Check id_token
+            idToken = OAuth2TestUtils.getSubstring(location, "id_token");
+            assertNotNull(idToken);
+            validateIdToken(idToken, "123456789");
+            // check the code hash is returned from the implicit authorization endpoint
+            JwsJwtCompactConsumer jwtConsumer = new JwsJwtCompactConsumer(idToken);
+            JwtToken jwt = jwtConsumer.getJwtToken();
+            assertNotNull(jwt.getClaims().getClaim(IdToken.AUTH_CODE_HASH_CLAIM));
+        }
 
         // Now get the access token
-        client = WebClient.create(address, "consumer-id", "this-is-a-secret", null);
-
-        ClientAccessToken accessToken =
-            OAuth2TestUtils.getAccessTokenWithAuthorizationCode(client, code);
-        assertNotNull(accessToken.getTokenKey());
-        assertTrue(accessToken.getApprovedScope().contains("openid"));
-        assertEquals(OidcUtils.CODE_ID_TOKEN_RESPONSE_TYPE,
-                     accessToken.getParameters().get(OAuthConstants.RESPONSE_TYPE));
-
-        // Check id_token from the token endpoint
-        idToken = accessToken.getParameters().get("id_token");
-        assertNotNull(idToken);
-        validateIdToken(idToken, null);
-        // check the code hash is returned from the token endpoint
-        jwtConsumer = new JwsJwtCompactConsumer(idToken);
-        jwt = jwtConsumer.getJwtToken();
-        assertNotNull(jwt.getClaims().getClaim(IdToken.AUTH_CODE_HASH_CLAIM));
-
-        if (isAccessTokenInJWTFormat()) {
-            validateAccessToken(accessToken.getTokenKey());
+        try (WebClient client = WebClient.create(address, "consumer-id", "this-is-a-secret", null)) {
+            ClientAccessToken accessToken =
+                OAuth2TestUtils.getAccessTokenWithAuthorizationCode(client, code);
+            assertNotNull(accessToken.getTokenKey());
+            assertTrue(accessToken.getApprovedScope().contains("openid"));
+            assertEquals(OidcUtils.CODE_ID_TOKEN_RESPONSE_TYPE,
+                         accessToken.getParameters().get(OAuthConstants.RESPONSE_TYPE));
+    
+            // Check id_token from the token endpoint
+            idToken = accessToken.getParameters().get("id_token");
+            assertNotNull(idToken);
+            validateIdToken(idToken, null);
+            // check the code hash is returned from the token endpoint
+            JwsJwtCompactConsumer jwtConsumer = new JwsJwtCompactConsumer(idToken);
+            JwtToken jwt = jwtConsumer.getJwtToken();
+            assertNotNull(jwt.getClaims().getClaim(IdToken.AUTH_CODE_HASH_CLAIM));
+    
+            if (isAccessTokenInJWTFormat()) {
+                validateAccessToken(accessToken.getTokenKey());
+            }
         }
     }
 
     @org.junit.Test
     public void testHybridCodeToken() throws Exception {
         String address = "https://localhost:" + port + "/services/";
-        WebClient client = WebClient.create(address, OAuth2TestUtils.setupProviders(),
-                                            "alice", "security", null);
-        // Save the Cookie for the second request...
-        WebClient.getConfig(client).getRequestContext().put(
-            org.apache.cxf.message.Message.MAINTAIN_SESSION, Boolean.TRUE);
+        String idToken = null;
+        String code = null;
 
-        // Get location
-        AuthorizationCodeParameters parameters = new AuthorizationCodeParameters();
-        parameters.setConsumerId("consumer-id");
-        parameters.setScope("openid");
-        parameters.setNonce("123456789");
-        parameters.setResponseType("code token");
-        parameters.setPath("authorize-hybrid/");
-
-        String location = OAuth2TestUtils.getLocation(client, parameters);
-        assertNotNull(location);
-
-        // Check code
-        String code = OAuth2TestUtils.getSubstring(location, "code");
-        assertNotNull(code);
-
-        // Check id_token
-        String idToken = OAuth2TestUtils.getSubstring(location, "id_token");
-        assertNull(idToken);
-
-        // Check Access Token
-        String implicitAccessToken = OAuth2TestUtils.getSubstring(location, "access_token");
-        assertNotNull(implicitAccessToken);
-
-        idToken = OAuth2TestUtils.getSubstring(location, "id_token");
-        assertNull(idToken);
-
-        // Now get the access token with the code
-        client = WebClient.create(address, "consumer-id", "this-is-a-secret", null);
-
-        ClientAccessToken accessToken =
-            OAuth2TestUtils.getAccessTokenWithAuthorizationCode(client, code);
-        assertNotNull(accessToken.getTokenKey());
-        assertTrue(accessToken.getApprovedScope().contains("openid"));
-
-        // Check id_token from the token endpoint
-        idToken = accessToken.getParameters().get("id_token");
-        assertNotNull(idToken);
-        validateIdToken(idToken, null);
-        // check the code hash is returned from the token endpoint
-        JwsJwtCompactConsumer jwtConsumer = new JwsJwtCompactConsumer(idToken);
-        // returning c_hash in the id_token returned after exchanging the code is optional
-        assertNull(jwtConsumer.getJwtClaims().getClaim(IdToken.AUTH_CODE_HASH_CLAIM));
-
-        if (isAccessTokenInJWTFormat()) {
-            validateAccessToken(accessToken.getTokenKey());
+        try (WebClient client = WebClient.create(address, OAuth2TestUtils.setupProviders(),
+                                            "alice", "security", null)) {
+            // Save the Cookie for the second request...
+            WebClient.getConfig(client).getRequestContext().put(
+                org.apache.cxf.message.Message.MAINTAIN_SESSION, Boolean.TRUE);
+    
+            // Get location
+            AuthorizationCodeParameters parameters = new AuthorizationCodeParameters();
+            parameters.setConsumerId("consumer-id");
+            parameters.setScope("openid");
+            parameters.setNonce("123456789");
+            parameters.setResponseType("code token");
+            parameters.setPath("authorize-hybrid/");
+    
+            String location = OAuth2TestUtils.getLocation(client, parameters);
+            assertNotNull(location);
+    
+            // Check code
+            code = OAuth2TestUtils.getSubstring(location, "code");
+            assertNotNull(code);
+    
+            // Check id_token
+            idToken = OAuth2TestUtils.getSubstring(location, "id_token");
+            assertNull(idToken);
+    
+            // Check Access Token
+            String implicitAccessToken = OAuth2TestUtils.getSubstring(location, "access_token");
+            assertNotNull(implicitAccessToken);
+    
+            idToken = OAuth2TestUtils.getSubstring(location, "id_token");
+            assertNull(idToken);
+        }
+        
+            // Now get the access token with the code
+        try (WebClient client = WebClient.create(address, "consumer-id", "this-is-a-secret", null)) {
+            ClientAccessToken accessToken =
+                OAuth2TestUtils.getAccessTokenWithAuthorizationCode(client, code);
+            assertNotNull(accessToken.getTokenKey());
+            assertTrue(accessToken.getApprovedScope().contains("openid"));
+    
+            // Check id_token from the token endpoint
+            idToken = accessToken.getParameters().get("id_token");
+            assertNotNull(idToken);
+            validateIdToken(idToken, null);
+            // check the code hash is returned from the token endpoint
+            JwsJwtCompactConsumer jwtConsumer = new JwsJwtCompactConsumer(idToken);
+            // returning c_hash in the id_token returned after exchanging the code is optional
+            assertNull(jwtConsumer.getJwtClaims().getClaim(IdToken.AUTH_CODE_HASH_CLAIM));
+    
+            if (isAccessTokenInJWTFormat()) {
+                validateAccessToken(accessToken.getTokenKey());
+            }
         }
     }
 
     @org.junit.Test
     public void testHybridCodeIdTokenToken() throws Exception {
         String address = "https://localhost:" + port + "/services/";
-        WebClient client = WebClient.create(address, OAuth2TestUtils.setupProviders(),
-                                            "alice", "security", null);
-        // Save the Cookie for the second request...
-        WebClient.getConfig(client).getRequestContext().put(
-            org.apache.cxf.message.Message.MAINTAIN_SESSION, Boolean.TRUE);
-
-        // Get location
-        AuthorizationCodeParameters parameters = new AuthorizationCodeParameters();
-        parameters.setConsumerId("consumer-id");
-        parameters.setScope("openid");
-        parameters.setNonce("123456789");
-        parameters.setResponseType("code id_token token");
-        parameters.setPath("authorize-hybrid/");
-
-        String location = OAuth2TestUtils.getLocation(client, parameters);
-        assertNotNull(location);
-
-        // Check code
-        String code = OAuth2TestUtils.getSubstring(location, "code");
-        assertNotNull(code);
-
-        // Check id_token
-        String idToken = OAuth2TestUtils.getSubstring(location, "id_token");
-        assertNotNull(idToken);
-        validateIdToken(idToken, "123456789");
-
-        // check the code hash is returned from the implicit authorization endpoint
-        JwsJwtCompactConsumer jwtConsumer = new JwsJwtCompactConsumer(idToken);
-        JwtToken jwt = jwtConsumer.getJwtToken();
-        assertNotNull(jwt.getClaims().getClaim(IdToken.AUTH_CODE_HASH_CLAIM));
-
-        // Check Access Token
-        String accessToken = OAuth2TestUtils.getSubstring(location, "access_token");
-        assertNotNull(accessToken);
-
-        jwtConsumer = new JwsJwtCompactConsumer(idToken);
-        jwt = jwtConsumer.getJwtToken();
-        assertNotNull(jwt.getClaims().getClaim(IdToken.ACCESS_TOKEN_HASH_CLAIM));
-        OidcUtils.validateAccessTokenHash(accessToken, jwt, true);
-        assertNotNull(jwt.getClaims().getClaim(IdToken.AUTH_CODE_HASH_CLAIM));
-
-        if (isAccessTokenInJWTFormat()) {
-            validateAccessToken(accessToken);
+        try (WebClient client = WebClient.create(address, OAuth2TestUtils.setupProviders(),
+                                            "alice", "security", null)) {
+            // Save the Cookie for the second request...
+            WebClient.getConfig(client).getRequestContext().put(
+                org.apache.cxf.message.Message.MAINTAIN_SESSION, Boolean.TRUE);
+    
+            // Get location
+            AuthorizationCodeParameters parameters = new AuthorizationCodeParameters();
+            parameters.setConsumerId("consumer-id");
+            parameters.setScope("openid");
+            parameters.setNonce("123456789");
+            parameters.setResponseType("code id_token token");
+            parameters.setPath("authorize-hybrid/");
+    
+            String location = OAuth2TestUtils.getLocation(client, parameters);
+            assertNotNull(location);
+    
+            // Check code
+            String code = OAuth2TestUtils.getSubstring(location, "code");
+            assertNotNull(code);
+    
+            // Check id_token
+            String idToken = OAuth2TestUtils.getSubstring(location, "id_token");
+            assertNotNull(idToken);
+            validateIdToken(idToken, "123456789");
+    
+            // check the code hash is returned from the implicit authorization endpoint
+            JwsJwtCompactConsumer jwtConsumer = new JwsJwtCompactConsumer(idToken);
+            JwtToken jwt = jwtConsumer.getJwtToken();
+            assertNotNull(jwt.getClaims().getClaim(IdToken.AUTH_CODE_HASH_CLAIM));
+    
+            // Check Access Token
+            String accessToken = OAuth2TestUtils.getSubstring(location, "access_token");
+            assertNotNull(accessToken);
+    
+            jwtConsumer = new JwsJwtCompactConsumer(idToken);
+            jwt = jwtConsumer.getJwtToken();
+            assertNotNull(jwt.getClaims().getClaim(IdToken.ACCESS_TOKEN_HASH_CLAIM));
+            OidcUtils.validateAccessTokenHash(accessToken, jwt, true);
+            assertNotNull(jwt.getClaims().getClaim(IdToken.AUTH_CODE_HASH_CLAIM));
+    
+            if (isAccessTokenInJWTFormat()) {
+                validateAccessToken(accessToken);
+            }
         }
     }
 
     @org.junit.Test
     public void testAuthorizationCodeFlowUnsignedJWT() throws Exception {
         String address = "https://localhost:" + port + "/unsignedjwtservices/";
-        WebClient client = WebClient.create(address, OAuth2TestUtils.setupProviders(),
-                                            "alice", "security", null);
-        // Save the Cookie for the second request...
-        WebClient.getConfig(client).getRequestContext().put(
-            org.apache.cxf.message.Message.MAINTAIN_SESSION, Boolean.TRUE);
-
-        JwtClaims claims = new JwtClaims();
-        claims.setIssuer("consumer-id");
-        claims.setIssuedAt(Instant.now().getEpochSecond());
-        claims.setAudiences(
-            Collections.singletonList("https://localhost:" + port + "/unsignedjwtservices/"));
-
-        JwsHeaders headers = new JwsHeaders();
-        headers.setAlgorithm("none");
-
-        JwtToken token = new JwtToken(headers, claims);
-
-        JwsJwtCompactProducer jws = new JwsJwtCompactProducer(token);
-        String request = jws.getSignedEncodedJws();
-
-        // Get Authorization Code
-        AuthorizationCodeParameters parameters = new AuthorizationCodeParameters();
-        parameters.setConsumerId("consumer-id");
-        parameters.setScope("openid");
-        parameters.setResponseType("code");
-        parameters.setPath("authorize/");
-        parameters.setRequest(request);
-
-        String location = OAuth2TestUtils.getLocation(client, parameters);
-        String code = OAuth2TestUtils.getSubstring(location, "code");
-        assertNotNull(code);
+        try (WebClient client = WebClient.create(address, OAuth2TestUtils.setupProviders(),
+                                            "alice", "security", null)) {
+            // Save the Cookie for the second request...
+            WebClient.getConfig(client).getRequestContext().put(
+                org.apache.cxf.message.Message.MAINTAIN_SESSION, Boolean.TRUE);
+    
+            JwtClaims claims = new JwtClaims();
+            claims.setIssuer("consumer-id");
+            claims.setIssuedAt(Instant.now().getEpochSecond());
+            claims.setAudiences(
+                Collections.singletonList("https://localhost:" + port + "/unsignedjwtservices/"));
+    
+            JwsHeaders headers = new JwsHeaders();
+            headers.setAlgorithm("none");
+    
+            JwtToken token = new JwtToken(headers, claims);
+    
+            JwsJwtCompactProducer jws = new JwsJwtCompactProducer(token);
+            String request = jws.getSignedEncodedJws();
+    
+            // Get Authorization Code
+            AuthorizationCodeParameters parameters = new AuthorizationCodeParameters();
+            parameters.setConsumerId("consumer-id");
+            parameters.setScope("openid");
+            parameters.setResponseType("code");
+            parameters.setPath("authorize/");
+            parameters.setRequest(request);
+    
+            String location = OAuth2TestUtils.getLocation(client, parameters);
+            String code = OAuth2TestUtils.getSubstring(location, "code");
+            assertNotNull(code);
+        }
     }
 
     @org.junit.Test
     public void testAuthorizationCodeFlowUnsignedJWTWithState() throws Exception {
         String address = "https://localhost:" + port + "/unsignedjwtservices/";
-        WebClient client = WebClient.create(address, OAuth2TestUtils.setupProviders(),
-                                            "alice", "security", null);
-        // Save the Cookie for the second request...
-        WebClient.getConfig(client).getRequestContext().put(
-            org.apache.cxf.message.Message.MAINTAIN_SESSION, Boolean.TRUE);
-
-        JwtClaims claims = new JwtClaims();
-        claims.setIssuer("consumer-id");
-        claims.setIssuedAt(Instant.now().getEpochSecond());
-        claims.setAudiences(
-            Collections.singletonList("https://localhost:" + port + "/unsignedjwtservices/"));
-
-        JwsHeaders headers = new JwsHeaders();
-        headers.setAlgorithm("none");
-
-        JwtToken token = new JwtToken(headers, claims);
-
-        JwsJwtCompactProducer jws = new JwsJwtCompactProducer(token);
-        String request = jws.getSignedEncodedJws();
-
-        // Get Authorization Code
-        AuthorizationCodeParameters parameters = new AuthorizationCodeParameters();
-        parameters.setConsumerId("consumer-id");
-        parameters.setScope("openid");
-        parameters.setResponseType("code");
-        parameters.setPath("authorize/");
-        parameters.setState("123456789");
-        parameters.setRequest(request);
-
-        String location = OAuth2TestUtils.getLocation(client, parameters);
-        String code = OAuth2TestUtils.getSubstring(location, "code");
-        assertNotNull(code);
+        try (WebClient client = WebClient.create(address, OAuth2TestUtils.setupProviders(),
+                                            "alice", "security", null)) {
+            // Save the Cookie for the second request...
+            WebClient.getConfig(client).getRequestContext().put(
+                org.apache.cxf.message.Message.MAINTAIN_SESSION, Boolean.TRUE);
+    
+            JwtClaims claims = new JwtClaims();
+            claims.setIssuer("consumer-id");
+            claims.setIssuedAt(Instant.now().getEpochSecond());
+            claims.setAudiences(
+                Collections.singletonList("https://localhost:" + port + "/unsignedjwtservices/"));
+    
+            JwsHeaders headers = new JwsHeaders();
+            headers.setAlgorithm("none");
+    
+            JwtToken token = new JwtToken(headers, claims);
+    
+            JwsJwtCompactProducer jws = new JwsJwtCompactProducer(token);
+            String request = jws.getSignedEncodedJws();
+    
+            // Get Authorization Code
+            AuthorizationCodeParameters parameters = new AuthorizationCodeParameters();
+            parameters.setConsumerId("consumer-id");
+            parameters.setScope("openid");
+            parameters.setResponseType("code");
+            parameters.setPath("authorize/");
+            parameters.setState("123456789");
+            parameters.setRequest(request);
+    
+            String location = OAuth2TestUtils.getLocation(client, parameters);
+            String code = OAuth2TestUtils.getSubstring(location, "code");
+            assertNotNull(code);
+        }
     }
 
     @org.junit.Test
     public void testGetKeys() throws Exception {
         String address = "https://localhost:" + port + "/services/";
-        WebClient client = WebClient.create(address, OAuth2TestUtils.setupProviders(),
-                                            "alice", "security", null);
-        client.accept("application/json");
-
-        client.path("keys/");
-        Response response = client.get();
-        JsonWebKeys jsonWebKeys = response.readEntity(JsonWebKeys.class);
-
-        assertEquals(1, jsonWebKeys.getKeys().size());
+        try (WebClient client = WebClient.create(address, OAuth2TestUtils.setupProviders(),
+                                            "alice", "security", null)) {
+            client.accept("application/json");
+    
+            client.path("keys/");
+            try (Response response = client.get()) {
+                JsonWebKeys jsonWebKeys = response.readEntity(JsonWebKeys.class);
+        
+                assertEquals(1, jsonWebKeys.getKeys().size());
+            }
+        }
     }
 
     @org.junit.Test
     public void testAuthorizationCodeFlowWithKey() throws Exception {
         String address = "https://localhost:" + port + "/services/";
-        WebClient client = WebClient.create(address, OAuth2TestUtils.setupProviders(),
-                                            "alice", "security", null);
-        // Save the Cookie for the second request...
-        WebClient.getConfig(client).getRequestContext().put(
-            org.apache.cxf.message.Message.MAINTAIN_SESSION, Boolean.TRUE);
+        String code = null;
+        String idToken = null;
 
-        // Get Authorization Code
-        String code = OAuth2TestUtils.getAuthorizationCode(client, "openid");
-        assertNotNull(code);
-
-        // Now get the access token
-        client = WebClient.create(address, "consumer-id", "this-is-a-secret", null);
-
-        ClientAccessToken accessToken =
-            OAuth2TestUtils.getAccessTokenWithAuthorizationCode(client, code);
-        assertNotNull(accessToken.getTokenKey());
-        assertTrue(accessToken.getApprovedScope().contains("openid"));
-
-        String idToken = accessToken.getParameters().get("id_token");
-        assertNotNull(idToken);
+        try (WebClient client = WebClient.create(address, OAuth2TestUtils.setupProviders(),
+                                            "alice", "security", null)) {
+            // Save the Cookie for the second request...
+            WebClient.getConfig(client).getRequestContext().put(
+                org.apache.cxf.message.Message.MAINTAIN_SESSION, Boolean.TRUE);
+    
+            // Get Authorization Code
+            code = OAuth2TestUtils.getAuthorizationCode(client, "openid");
+            assertNotNull(code);
+        }
+        
+            // Now get the access token
+        try (WebClient client = WebClient.create(address, "consumer-id", "this-is-a-secret", null)) {
+            ClientAccessToken accessToken =
+                OAuth2TestUtils.getAccessTokenWithAuthorizationCode(client, code);
+            assertNotNull(accessToken.getTokenKey());
+            assertTrue(accessToken.getApprovedScope().contains("openid"));
+    
+            idToken = accessToken.getParameters().get("id_token");
+            assertNotNull(idToken);
+        }
 
         JwsJwtCompactConsumer jwtConsumer = new JwsJwtCompactConsumer(idToken);
+        
 
         // Now get the key to validate the token
-        client = WebClient.create(address, OAuth2TestUtils.setupProviders(),
-                                  "alice", "security", null);
-        client.accept("application/json");
-
-        client.path("keys/");
-        Response response = client.get();
-        JsonWebKeys jsonWebKeys = response.readEntity(JsonWebKeys.class);
-
-        assertTrue(jwtConsumer.verifySignatureWith(jsonWebKeys.getKeys().get(0),
-                                                          SignatureAlgorithm.RS256));
+        try (WebClient client = WebClient.create(address, OAuth2TestUtils.setupProviders(),
+                                  "alice", "security", null)) {
+            client.accept("application/json");
+    
+            client.path("keys/");
+            try (Response response = client.get()) {
+                JsonWebKeys jsonWebKeys = response.readEntity(JsonWebKeys.class);
+        
+                assertTrue(jwtConsumer.verifySignatureWith(jsonWebKeys.getKeys().get(0),
+                                                              SignatureAlgorithm.RS256));
+            }
+        }
     }
 
     @org.junit.Test
     public void testAuthorizationCodeFlowRefreshToken() throws Exception {
+        IdToken idToken = null;
+        ClientAccessToken accessToken = null;
         String address = "https://localhost:" + port + "/services/";
-        WebClient client = WebClient.create(address, OAuth2TestUtils.setupProviders(),
-                                            "alice", "security", null);
-        // Save the Cookie for the second request...
-        WebClient.getConfig(client).getRequestContext().put(
-            org.apache.cxf.message.Message.MAINTAIN_SESSION, Boolean.TRUE);
+        String code = null;
 
-        // Get Authorization Code
-        String code = OAuth2TestUtils.getAuthorizationCode(client,
-            String.join(" ", OidcUtils.getOpenIdScope(), OAuthConstants.REFRESH_TOKEN_SCOPE),
-            "consumer-id-oidc");
-        assertNotNull(code);
+        try (WebClient client = WebClient.create(address, OAuth2TestUtils.setupProviders(),
+                                            "alice", "security", null)) {
+            // Save the Cookie for the second request...
+            WebClient.getConfig(client).getRequestContext().put(
+                org.apache.cxf.message.Message.MAINTAIN_SESSION, Boolean.TRUE);
+    
+            // Get Authorization Code
+            code = OAuth2TestUtils.getAuthorizationCode(client,
+                String.join(" ", OidcUtils.getOpenIdScope(), OAuthConstants.REFRESH_TOKEN_SCOPE),
+                "consumer-id-oidc");
+            assertNotNull(code);
+        }
 
         // Now get the access token
-        client = WebClient.create(address, "consumer-id-oidc", "this-is-a-secret", null);
+        try (WebClient client = WebClient.create(address, "consumer-id-oidc", "this-is-a-secret", null)) {
+            accessToken =
+                OAuth2TestUtils.getAccessTokenWithAuthorizationCode(client, code, "consumer-id-oidc", null);
+            assertNotNull(accessToken.getTokenKey());
+            assertTrue(accessToken.getApprovedScope().contains("openid"));
+    
+            idToken = getIdToken(accessToken, address + "keys/", "consumer-id-oidc");
+            assertNotNull(idToken);
+        }
 
-        ClientAccessToken accessToken =
-            OAuth2TestUtils.getAccessTokenWithAuthorizationCode(client, code, "consumer-id-oidc", null);
-        assertNotNull(accessToken.getTokenKey());
-        assertTrue(accessToken.getApprovedScope().contains("openid"));
+        // Now get the access token
+        try (WebClient client = WebClient.create(address, "consumer-id-oidc", "this-is-a-secret", null)) {
+            Long issuedAt = idToken.getIssuedAt();
+            TimeUnit.SECONDS.sleep(1L);
 
-        IdToken idToken = getIdToken(accessToken, address + "keys/", "consumer-id-oidc");
-        assertNotNull(idToken);
-        Long issuedAt = idToken.getIssuedAt();
-
-        TimeUnit.SECONDS.sleep(1L);
-
-        accessToken = OAuthClientUtils.refreshAccessToken(
-            client,
-            new Consumer("consumer-id-oidc"),
-            accessToken);
-        idToken = getIdToken(accessToken, address + "keys/", "consumer-id-oidc");
-
-        assertNotEquals(issuedAt, idToken.getIssuedAt());
+            accessToken = OAuthClientUtils.refreshAccessToken(
+                client.path("token"),
+                new Consumer("consumer-id-oidc"),
+                accessToken);
+            idToken = getIdToken(accessToken, address + "keys/", "consumer-id-oidc");
+    
+            assertNotEquals(issuedAt, idToken.getIssuedAt());
+        }
     }
 
     @org.junit.Test
@@ -1014,15 +1081,17 @@ public class OIDCFlowTest extends AbstractBusClientServerTestBase {
     }
 
     private static IdToken getIdToken(ClientAccessToken accessToken, String jwksUri, String clientId) {
-        WebClient c = WebClient.create(jwksUri,
+        try (WebClient c = WebClient.create(jwksUri,
             Collections.singletonList(new JsonWebKeysProvider()),
             "alice", "security", null)
-            .accept(MediaType.APPLICATION_JSON);
-        IdTokenReader idTokenReader = new IdTokenReader();
-        idTokenReader.setJwkSetClient(c);
-        idTokenReader.setIssuerId("OIDC IdP");
+            .accept(MediaType.APPLICATION_JSON)) {
 
-        return idTokenReader.getIdToken(accessToken, new Consumer(clientId));
+            IdTokenReader idTokenReader = new IdTokenReader();
+            idTokenReader.setJwkSetClient(c);
+            idTokenReader.setIssuerId("OIDC IdP");
+
+            return idTokenReader.getIdToken(accessToken, new Consumer(clientId));
+        }
     }
 
     private boolean isAccessTokenInJWTFormat() {


### PR DESCRIPTION
Some of the OIDCFlowTest fail with timeout (JPA only) when `HttpClient` instance is shared