### PR TITLE
Remove TLS v1 + 1.1 from the default protocol list

### DIFF
--- a/core/src/main/java/org/apache/cxf/configuration/jsse/TLSParameterBase.java
+++ b/core/src/main/java/org/apache/cxf/configuration/jsse/TLSParameterBase.java
@@ -37,8 +37,6 @@ import org.apache.cxf.configuration.security.FiltersType;
 public class TLSParameterBase {
     protected static final Collection<String> DEFAULT_HTTPS_PROTOCOLS = 
         Arrays.asList(
-            "TLSv1", 
-            "TLSv1.1", 
             "TLSv1.2", 
             "TLSv1.3" 
         ); 

--- a/core/src/test/java/org/apache/cxf/configuration/jsse/TLSClientParametersTest.java
+++ b/core/src/test/java/org/apache/cxf/configuration/jsse/TLSClientParametersTest.java
@@ -53,8 +53,7 @@ public class TLSClientParametersTest {
     
     @Test
     public void testDefaultHttpsProtocols() {
-        assertThat(TLSClientParameters.getPreferredClientProtocols(), arrayContainingInAnyOrder("TLSv1", 
-            "TLSv1.1", 
+        assertThat(TLSClientParameters.getPreferredClientProtocols(), arrayContainingInAnyOrder(
             "TLSv1.2", 
             "TLSv1.3"));
     }
@@ -69,8 +68,7 @@ public class TLSClientParametersTest {
     public void testIgnoreConfiguredHttpsProtocols() {
         System.setProperty(TLSClientParameters.IGNORE_CONFIGURED_HTTPS_PROTOCOLS, "true");
         System.setProperty(TLSClientParameters.CONFIGURED_HTTPS_PROTOCOLS, "SSLv3,");
-        assertThat(TLSClientParameters.getPreferredClientProtocols(), arrayContainingInAnyOrder("TLSv1", 
-            "TLSv1.1", 
+        assertThat(TLSClientParameters.getPreferredClientProtocols(), arrayContainingInAnyOrder(
             "TLSv1.2", 
             "TLSv1.3"));
     }

--- a/systests/forked/src/test/resources/org/apache/cxf/systests/forked/ssl3/sslv3-server.xml
+++ b/systests/forked/src/test/resources/org/apache/cxf/systests/forked/ssl3/sslv3-server.xml
@@ -97,8 +97,6 @@
                 <sec:clientAuthentication want="true" required="false"/>
                 <sec:excludeProtocols>
                     <sec:excludeProtocol>TLS</sec:excludeProtocol>
-                    <sec:excludeProtocol>TLSv1</sec:excludeProtocol>
-                    <sec:excludeProtocol>TLSv1.1</sec:excludeProtocol>
                     <sec:excludeProtocol>TLSv1.2</sec:excludeProtocol>
                 </sec:excludeProtocols>
                 <sec:cipherSuitesFilter>


### PR DESCRIPTION
It's time we removed these, any modern Java version will have them disabled anyway. I will merge to main only.