### PR TITLE
compare oauth2 secret tokens with constant-time MessageDigest.isEqual

### DIFF
--- a/rt/rs/security/oauth-parent/oauth2/src/main/java/org/apache/cxf/rs/security/oauth2/client/MemoryClientCodeStateManager.java
+++ b/rt/rs/security/oauth-parent/oauth2/src/main/java/org/apache/cxf/rs/security/oauth2/client/MemoryClientCodeStateManager.java
@@ -58,7 +58,7 @@ public class MemoryClientCodeStateManager implements ClientCodeStateManager {
                                                             MultivaluedMap<String, String> redirectState) {
         String stateParam = redirectState.getFirst(OAuthConstants.STATE);
         String sessionToken = OAuthUtils.getSessionToken(mc, "state");
-        if (sessionToken == null || !sessionToken.equals(stateParam)) {
+        if (!OAuthUtils.compareTokens(sessionToken, stateParam)) {
             throw new OAuthServiceException("Invalid session token");
         }
         return map.remove(stateParam);

--- a/rt/rs/security/oauth-parent/oauth2/src/main/java/org/apache/cxf/rs/security/oauth2/services/DynamicRegistrationService.java
+++ b/rt/rs/security/oauth-parent/oauth2/src/main/java/org/apache/cxf/rs/security/oauth2/services/DynamicRegistrationService.java
@@ -76,7 +76,7 @@ public class DynamicRegistrationService {
     protected void checkInitialAuthentication() {
         if (initialAccessToken != null) {
             String accessToken = getRequestAccessToken();
-            if (!initialAccessToken.equals(accessToken)) {
+            if (!OAuthUtils.compareTokens(initialAccessToken, accessToken)) {
                 throw ExceptionUtils.toNotAuthorizedException(null, null);
             }
         } else {
@@ -105,7 +105,7 @@ public class DynamicRegistrationService {
     protected void checkRegistrationAccessToken(Client c, String accessToken) {
         String regAccessToken = c.getProperties().get(ClientRegistrationResponse.REG_ACCESS_TOKEN);
 
-        if (regAccessToken == null || !regAccessToken.equals(accessToken)) {
+        if (!OAuthUtils.compareTokens(regAccessToken, accessToken)) {
             throw ExceptionUtils.toNotAuthorizedException(null, null);
         }
     }

--- a/rt/rs/security/oauth-parent/oauth2/src/main/java/org/apache/cxf/rs/security/oauth2/services/RedirectionBasedGrantService.java
+++ b/rt/rs/security/oauth-parent/oauth2/src/main/java/org/apache/cxf/rs/security/oauth2/services/RedirectionBasedGrantService.java
@@ -529,7 +529,7 @@ public abstract class RedirectionBasedGrantService extends AbstractOAuthService 
         if (StringUtils.isEmpty(sessionToken)) {
             return false;
         }
-        return requestToken.equals(sessionToken);
+        return OAuthUtils.compareTokens(requestToken, sessionToken);
     }
 
     /**

--- a/rt/rs/security/oauth-parent/oauth2/src/main/java/org/apache/cxf/rs/security/oauth2/utils/OAuthUtils.java
+++ b/rt/rs/security/oauth-parent/oauth2/src/main/java/org/apache/cxf/rs/security/oauth2/utils/OAuthUtils.java
@@ -88,6 +88,13 @@ public final class OAuthUtils {
         }
     }
 
+    public static boolean compareTokens(String token1, String token2) {
+        if (token1 == null || token2 == null) {
+            return false;
+        }
+        return MessageDigest.isEqual(StringUtils.toBytesUTF8(token1), StringUtils.toBytesUTF8(token2));
+    }
+
     public static boolean compareCertificateThumbprints(X509Certificate cert, String encodedThumbprint) {
         try {
             byte[] thumbprint = createCertificateThumbprint(cert);


### PR DESCRIPTION
The registration access-token checks in DynamicRegistrationService, the session authenticity token in RedirectionBasedGrantService, and the state token in MemoryClientCodeStateManager all authenticate a request-supplied secret with String.equals, which returns on the first differing byte.
Route them through a new OAuthUtils.compareTokens that wraps MessageDigest.isEqual, the same constant-time idiom already used by compareCertificateThumbprints and the JOSE verifiers.