### PR TITLE
require azp when oidc id token has multiple audiences

### DIFF
--- a/rt/rs/security/sso/oidc/src/main/java/org/apache/cxf/rs/security/oidc/rp/OidcClaimsValidator.java
+++ b/rt/rs/security/sso/oidc/src/main/java/org/apache/cxf/rs/security/oidc/rp/OidcClaimsValidator.java
@@ -69,16 +69,20 @@ public class OidcClaimsValidator extends OAuthJoseJwtConsumer {
                 throw new OAuthServiceException("Invalid subject");
             }
 
-            // validate authorized party
-            String authorizedParty = (String)claims.getClaim(IdToken.AZP_CLAIM);
-            if (authorizedParty != null && !authorizedParty.equals(clientId)) {
-                throw new OAuthServiceException("Invalid authorized party");
-            }
             // validate audience
             List<String> audiences = claims.getAudiences();
             if (StringUtils.isEmpty(audiences) && validateClaimsAlways
                 || !StringUtils.isEmpty(audiences) && !audiences.contains(clientId)) {
                 throw new OAuthServiceException("Invalid audience");
+            }
+            // validate authorized party. An azp claim is required when the token has more than
+            // one audience, and when present it must match the client id (OIDC Core 3.1.3.7).
+            String authorizedParty = (String)claims.getClaim(IdToken.AZP_CLAIM);
+            if (authorizedParty == null && audiences != null && audiences.size() > 1) {
+                throw new OAuthServiceException("Invalid authorized party");
+            }
+            if (authorizedParty != null && !authorizedParty.equals(clientId)) {
+                throw new OAuthServiceException("Invalid authorized party");
             }
 
             // If strict time validation: if no issuedTime claim is set then an expiresAt claim must be set


### PR DESCRIPTION
Noticed OidcClaimsValidator only checks the azp claim when it is present. A multi-audience ID token that omits azp is accepted as long as the aud array contains the client id, so a token minted for a different relying party can be replayed here. OIDC Core 3.1.3.7 requires azp to be present once a token lists more than one audience; this rejects that case while leaving single-audience tokens unchanged.