### PR TITLE
Properly handle nested arrays in json parsing

### DIFF
--- a/rt/rs/extensions/json-basic/src/main/java/org/apache/cxf/jaxrs/json/basic/JsonMapObjectReaderWriter.java
+++ b/rt/rs/extensions/json-basic/src/main/java/org/apache/cxf/jaxrs/json/basic/JsonMapObjectReaderWriter.java
@@ -285,6 +285,10 @@ public class JsonMapObjectReaderWriter {
                 readJsonObjectAsSettable(nextMap, json.substring(i + 1, closingIndex), depth + 1);
                 values.add(nextMap.map);
                 i = closingIndex + 1;
+            } else if (json.charAt(i) == ARRAY_START) {
+                int closingIndex = getClosingIndex(json, ARRAY_START, ARRAY_END, i);
+                values.add(internalFromJsonAsList(name, json.substring(i + 1, closingIndex), depth + 1));
+                i = closingIndex + 1;
             } else {
                 int commaIndex = getCommaIndex(json, i);
                 Object value = readPrimitiveValue(name, json, i, commaIndex);

--- a/rt/rs/extensions/json-basic/src/main/java/org/apache/cxf/jaxrs/json/basic/JsonMapObjectReaderWriter.java
+++ b/rt/rs/extensions/json-basic/src/main/java/org/apache/cxf/jaxrs/json/basic/JsonMapObjectReaderWriter.java
@@ -245,6 +245,7 @@ public class JsonMapObjectReaderWriter {
             }
             if (json.charAt(sepIndex + j) == OBJECT_START) {
                 int closingIndex = getClosingIndex(json, OBJECT_START, OBJECT_END, sepIndex + j);
+                closingIndex = requireClosingIndex(closingIndex, OBJECT_START, OBJECT_END);
                 String newJson = json.substring(sepIndex + j + 1, closingIndex);
                 MapSettable nextMap = new MapSettable();
                 readJsonObjectAsSettable(nextMap, newJson, depth + 1);
@@ -252,6 +253,7 @@ public class JsonMapObjectReaderWriter {
                 i = closingIndex + 1;
             } else if (json.charAt(sepIndex + j) == ARRAY_START) {
                 int closingIndex = getClosingIndex(json, ARRAY_START, ARRAY_END, sepIndex + j);
+                closingIndex = requireClosingIndex(closingIndex, ARRAY_START, ARRAY_END);
                 String newJson = json.substring(sepIndex + j + 1, closingIndex);
                 values.put(name, internalFromJsonAsList(name, newJson, depth + 1));
                 i = closingIndex + 1;
@@ -281,12 +283,14 @@ public class JsonMapObjectReaderWriter {
             }
             if (json.charAt(i) == OBJECT_START) {
                 int closingIndex = getClosingIndex(json, OBJECT_START, OBJECT_END, i);
+                closingIndex = requireClosingIndex(closingIndex, OBJECT_START, OBJECT_END);
                 MapSettable nextMap = new MapSettable();
                 readJsonObjectAsSettable(nextMap, json.substring(i + 1, closingIndex), depth + 1);
                 values.add(nextMap.map);
                 i = closingIndex + 1;
             } else if (json.charAt(i) == ARRAY_START) {
                 int closingIndex = getClosingIndex(json, ARRAY_START, ARRAY_END, i);
+                closingIndex = requireClosingIndex(closingIndex, ARRAY_START, ARRAY_END);
                 values.add(internalFromJsonAsList(name, json.substring(i + 1, closingIndex), depth + 1));
                 i = closingIndex + 1;
             } else {
@@ -339,6 +343,15 @@ public class JsonMapObjectReaderWriter {
         while (nextOpenIndex != -1 && nextOpenIndex < closingIndex) {
             nextOpenIndex = getNextSepCharIndex(json, openChar, nextOpenIndex + 1);
             closingIndex = getNextSepCharIndex(json, closeChar, closingIndex + 1);
+        }
+        return closingIndex;
+    }
+
+    private static int requireClosingIndex(int closingIndex, char openChar, char closeChar) {
+        if (closingIndex == -1) {
+            throw new UncheckedIOException(new IOException(
+                    "Error in parsing json: missing closing '" + closeChar
+                    + "' for '" + openChar + "'"));
         }
         return closingIndex;
     }

--- a/rt/rs/extensions/json-basic/src/test/java/org/apache/cxf/jaxrs/json/basic/JsonMapObjectReaderWriterTest.java
+++ b/rt/rs/extensions/json-basic/src/test/java/org/apache/cxf/jaxrs/json/basic/JsonMapObjectReaderWriterTest.java
@@ -382,6 +382,13 @@ public class JsonMapObjectReaderWriterTest {
         assertInvalidNumericLiteral("NaN");
     }
 
+    @Test
+    public void testNestedArrayValueParsesSuccessfully() {
+        Map<String, Object> map = new JsonMapObjectReaderWriter().fromJson("{\"a\":[[]]}");
+        assertEquals(1, map.size());
+        assertEquals(Collections.singletonList(Collections.emptyList()), map.get("a"));
+    }
+
     private void assertInvalidNumericLiteral(String value) {
         JsonMapObjectReaderWriter jsonMapObjectReaderWriter = new JsonMapObjectReaderWriter();
         try {


### PR DESCRIPTION
The issue was a bug in the JSON parser when it read arrays inside arrays.

Before the fix:

It knew how to handle objects inside a list, like [[{"a":1}]](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html).
But it did not handle nested lists, like [[]] or [[1,2]].
So it tried to read the inner list as if it were a number/text value.
That caused an unexpected NumberFormatException crash.