### PR TITLE
compare pkce code verifier and client secret hash in constant time

### DIFF
--- a/rt/rs/security/oauth-parent/oauth2/src/main/java/org/apache/cxf/rs/security/oauth2/grants/code/AuthorizationCodeGrantHandler.java
+++ b/rt/rs/security/oauth-parent/oauth2/src/main/java/org/apache/cxf/rs/security/oauth2/grants/code/AuthorizationCodeGrantHandler.java
@@ -19,6 +19,8 @@
 
 package org.apache.cxf.rs.security.oauth2.grants.code;
 
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -183,7 +185,9 @@ public class AuthorizationCodeGrantHandler extends AbstractGrantHandler {
                 codeVerifierTransformer = defaultCodeVerifierTransformer;
             }
             String transformedCodeVerifier = codeVerifierTransformer.transformCodeVerifier(clientCodeVerifier);
-            return clientCodeChallenge.equals(transformedCodeVerifier);
+            return transformedCodeVerifier != null
+                && MessageDigest.isEqual(clientCodeChallenge.getBytes(StandardCharsets.UTF_8),
+                                         transformedCodeVerifier.getBytes(StandardCharsets.UTF_8));
         }
     }
 

--- a/rt/rs/security/oauth-parent/oauth2/src/main/java/org/apache/cxf/rs/security/oauth2/grants/code/AuthorizationCodeGrantHandler.java
+++ b/rt/rs/security/oauth-parent/oauth2/src/main/java/org/apache/cxf/rs/security/oauth2/grants/code/AuthorizationCodeGrantHandler.java
@@ -19,8 +19,6 @@
 
 package org.apache.cxf.rs.security.oauth2.grants.code;
 
-import java.nio.charset.StandardCharsets;
-import java.security.MessageDigest;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -185,9 +183,7 @@ public class AuthorizationCodeGrantHandler extends AbstractGrantHandler {
                 codeVerifierTransformer = defaultCodeVerifierTransformer;
             }
             String transformedCodeVerifier = codeVerifierTransformer.transformCodeVerifier(clientCodeVerifier);
-            return transformedCodeVerifier != null
-                && MessageDigest.isEqual(clientCodeChallenge.getBytes(StandardCharsets.UTF_8),
-                                         transformedCodeVerifier.getBytes(StandardCharsets.UTF_8));
+            return OAuthUtils.compareTokens(clientCodeChallenge, transformedCodeVerifier);
         }
     }
 

--- a/rt/rs/security/oauth-parent/oauth2/src/main/java/org/apache/cxf/rs/security/oauth2/provider/ClientSecretHashVerifier.java
+++ b/rt/rs/security/oauth-parent/oauth2/src/main/java/org/apache/cxf/rs/security/oauth2/provider/ClientSecretHashVerifier.java
@@ -19,6 +19,9 @@
 
 package org.apache.cxf.rs.security.oauth2.provider;
 
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+
 import org.apache.cxf.common.util.StringUtils;
 import org.apache.cxf.rs.security.oauth2.common.Client;
 import org.apache.cxf.rt.security.crypto.MessageDigestUtils;
@@ -31,7 +34,9 @@ public class ClientSecretHashVerifier implements ClientSecretVerifier {
     public boolean validateClientSecret(Client client, String clientSecret) {
         String hash = MessageDigestUtils.generate(StringUtils.toBytesUTF8(clientSecret),
                                                   hashAlgorithm);
-        return hash.equals(client.getClientSecret());
+        return client.getClientSecret() != null
+            && MessageDigest.isEqual(hash.getBytes(StandardCharsets.UTF_8),
+                                     client.getClientSecret().getBytes(StandardCharsets.UTF_8));
     }
     public void setHashAlgorithm(String hashAlgorithm) {
         this.hashAlgorithm = hashAlgorithm;

--- a/rt/rs/security/oauth-parent/oauth2/src/main/java/org/apache/cxf/rs/security/oauth2/provider/ClientSecretHashVerifier.java
+++ b/rt/rs/security/oauth-parent/oauth2/src/main/java/org/apache/cxf/rs/security/oauth2/provider/ClientSecretHashVerifier.java
@@ -19,11 +19,9 @@
 
 package org.apache.cxf.rs.security.oauth2.provider;
 
-import java.nio.charset.StandardCharsets;
-import java.security.MessageDigest;
-
 import org.apache.cxf.common.util.StringUtils;
 import org.apache.cxf.rs.security.oauth2.common.Client;
+import org.apache.cxf.rs.security.oauth2.utils.OAuthUtils;
 import org.apache.cxf.rt.security.crypto.MessageDigestUtils;
 
 /**
@@ -34,9 +32,7 @@ public class ClientSecretHashVerifier implements ClientSecretVerifier {
     public boolean validateClientSecret(Client client, String clientSecret) {
         String hash = MessageDigestUtils.generate(StringUtils.toBytesUTF8(clientSecret),
                                                   hashAlgorithm);
-        return client.getClientSecret() != null
-            && MessageDigest.isEqual(hash.getBytes(StandardCharsets.UTF_8),
-                                     client.getClientSecret().getBytes(StandardCharsets.UTF_8));
+        return OAuthUtils.compareTokens(hash, client.getClientSecret());
     }
     public void setHashAlgorithm(String hashAlgorithm) {
         this.hashAlgorithm = hashAlgorithm;


### PR DESCRIPTION
Two token-endpoint checks still compare a client-supplied secret against a server-held value with String.equals. compareCodeVerifierWithChallenge matches the stored PKCE code_challenge against the transformed code_verifier, and with the plain transformer the challenge is the verifier itself, so the secret leaks byte by byte through timing. validateClientSecret in ClientSecretHashVerifier compares the secret hashes the same way. Route both through MessageDigest.isEqual, as the default client-secret check in AbstractTokenService and the OAuth2 token comparisons already do.