### PR TITLE
compare username token password and digest in constant time

### DIFF
--- a/rt/ws/security/src/main/java/org/apache/cxf/ws/security/trust/STSStaxTokenValidator.java
+++ b/rt/ws/security/src/main/java/org/apache/cxf/ws/security/trust/STSStaxTokenValidator.java
@@ -18,6 +18,9 @@
  */
 package org.apache.cxf.ws.security.trust;
 
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+
 import javax.security.auth.callback.CallbackHandler;
 
 import org.w3c.dom.Document;
@@ -331,7 +334,7 @@ public class STSStaxTokenValidator
         }
 
         String passDigest = UsernameTokenUtil.doPasswordDigest(nonceVal, created, pwCb.getPassword());
-        if (!passwordType.getValue().equals(passDigest)) {
+        if (!constantTimeEquals(passwordType.getValue(), passDigest)) {
             throw new WSSecurityException(WSSecurityException.ErrorCode.FAILED_AUTHENTICATION);
         }
         passwordType.setValue(pwCb.getPassword());
@@ -359,10 +362,20 @@ public class STSStaxTokenValidator
             throw new WSSecurityException(WSSecurityException.ErrorCode.FAILED_AUTHENTICATION);
         }
 
-        if (!passwordType.getValue().equals(pwCb.getPassword())) {
+        if (!constantTimeEquals(passwordType.getValue(), pwCb.getPassword())) {
             throw new WSSecurityException(WSSecurityException.ErrorCode.FAILED_AUTHENTICATION);
         }
         passwordType.setValue(pwCb.getPassword());
+    }
+
+    // Compare a client-supplied password (or password digest) against the expected value without
+    // leaking, through the time taken to fail, how many leading characters matched.
+    private static boolean constantTimeEquals(String provided, String expected) {
+        if (provided == null || expected == null) {
+            return false;
+        }
+        return MessageDigest.isEqual(provided.getBytes(StandardCharsets.UTF_8),
+                                     expected.getBytes(StandardCharsets.UTF_8));
     }
 
     // Convert to DOM to send the token to the STS - it does not copy Nonce/Created/Iteration


### PR DESCRIPTION
reading through STSStaxTokenValidator i noticed the local UsernameToken path checks the client-supplied password and password digest with String.equals, which bails out at the first mismatching character. that timing difference looks like enough to recover the expected digest (for a chosen nonce/created) or the plaintext password byte by byte and then authenticate. routed both comparisons through MessageDigest.isEqual over utf-8 bytes, which is the constant-time idiom already used elsewhere in cxf (OAuthUtils.compareTokens, HmacJwsSignatureVerifier). also made it null-safe so a missing password value just fails authentication instead of throwing.