### PR TITLE
strip cr/lf from attachment part headers in writeHeaders

### DIFF
--- a/core/src/main/java/org/apache/cxf/attachment/AttachmentSerializer.java
+++ b/core/src/main/java/org/apache/cxf/attachment/AttachmentSerializer.java
@@ -266,11 +266,11 @@ public class AttachmentSerializer {
                 || "Content-Transfer-Encoding".equalsIgnoreCase(name)) {
                 continue;
             }
-            writer.write(name);
+            writer.write(stripLineBreaks(name));
             writer.write(": ");
             List<String> values = entry.getValue();
             for (int i = 0; i < values.size(); i++) {
-                writer.write(values.get(i));
+                writer.write(stripLineBreaks(values.get(i)));
                 if (i + 1 < values.size()) {
                     writer.write(",");
                 }
@@ -279,6 +279,23 @@ public class AttachmentSerializer {
         }
 
         writer.write("\r\n");
+    }
+
+    // A part header value such as the Content-Disposition filename can carry an
+    // attacker-supplied name. Bare CR or LF in it would otherwise terminate the
+    // header line and let extra part headers be injected into the MIME stream.
+    private static String stripLineBreaks(String value) {
+        if (value == null || (value.indexOf('\r') < 0 && value.indexOf('\n') < 0)) {
+            return value;
+        }
+        StringBuilder sb = new StringBuilder(value.length());
+        for (int i = 0; i < value.length(); i++) {
+            char c = value.charAt(i);
+            if (c != '\r' && c != '\n') {
+                sb.append(c);
+            }
+        }
+        return sb.toString();
     }
 
     private static String checkAngleBrackets(String value) {

--- a/core/src/test/java/org/apache/cxf/attachment/AttachmentSerializerTest.java
+++ b/core/src/test/java/org/apache/cxf/attachment/AttachmentSerializerTest.java
@@ -263,6 +263,48 @@ public class AttachmentSerializerTest {
 
     }
 
+    @Test
+    public void testHeaderValueLineBreaksAreStripped() throws Exception {
+        MessageImpl msg = new MessageImpl();
+
+        Collection<Attachment> atts = new ArrayList<>();
+        AttachmentImpl a = new AttachmentImpl("test.xml");
+        InputStream is = getClass().getResourceAsStream("my.wav");
+        ByteArrayDataSource ds = new ByteArrayDataSource(is, "application/octet-stream");
+        a.setDataHandler(new DataHandler(ds));
+        // a filename carrying CR/LF, e.g. taken from an uploaded part name
+        a.setHeader("Content-Disposition",
+            "attachment; filename=\"evil\r\nX-Injected: yes\"");
+        atts.add(a);
+        msg.setAttachments(atts);
+
+        msg.put(Message.CONTENT_TYPE, "application/soap+xml");
+
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        msg.setContent(OutputStream.class, out);
+
+        AttachmentSerializer serializer = new AttachmentSerializer(msg);
+        serializer.writeProlog();
+        out.write("<soap:Body/>".getBytes());
+        serializer.writeAttachments();
+        out.flush();
+
+        String wire = out.toString();
+        assertTrue("the line break must not survive into the MIME stream",
+            wire.contains("filename=\"evilX-Injected: yes\""));
+
+        String ct = (String) msg.get(Message.CONTENT_TYPE);
+        DataSource source = new ByteArrayDataSource(new ByteArrayInputStream(out.toByteArray()), ct);
+        MimeMultipart mpart = new MimeMultipart(source);
+        Session session = Session.getDefaultInstance(new Properties());
+        MimeMessage inMsg = new MimeMessage(session);
+        inMsg.setContent(mpart);
+        inMsg.addHeaderLine("Content-Type: " + ct);
+        MimeMultipart multipart = (MimeMultipart) inMsg.getContent();
+        MimeBodyPart part = (MimeBodyPart) multipart.getBodyPart(1);
+        assertEquals(null, part.getHeader("X-Injected"));
+    }
+
     private static String escapeQuotes(String s) {
         return s.indexOf('"') != 0 ? s.replace("\"", "\\\"") : s;
     }


### PR DESCRIPTION
AttachmentSerializer.writeHeaders writes each part header name and value straight into the multipart stream, so an attachment whose Content-Disposition carries a filename with a bare CR or LF (for instance a filename taken from an uploaded part) ends the header line early and injects extra part headers into the serialised MTOM or multipart body. It seemed safest to handle this where the bytes are actually written rather than at each place a header gets built, so this strips CR and LF from the header name and values in writeHeaders itself. There is a test that serialises an attachment with an embedded line break and checks the injected header does not appear.