### PR TITLE
CXF-9219: cxf-bom manages dependencies for 4.x that no longer exist or are not published

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -31,11 +31,6 @@
         <dependencies>
             <dependency>
                 <groupId>org.apache.cxf</groupId>
-                <artifactId>cxf-bundle-compatible</artifactId>
-                <version>${project.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.cxf</groupId>
                 <artifactId>cxf-core</artifactId>
                 <version>${project.version}</version>
             </dependency>
@@ -276,6 +271,11 @@
             </dependency>
             <dependency>
                 <groupId>org.apache.cxf</groupId>
+                <artifactId>cxf-rt-rs-service-description-common-openapi</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.cxf</groupId>
                 <artifactId>cxf-rt-rs-service-description-openapi-v3</artifactId>
                 <version>${project.version}</version>
             </dependency>
@@ -472,16 +472,6 @@
             <dependency>
                 <groupId>org.apache.cxf.archetype</groupId>
                 <artifactId>cxf-jaxws-wsdlfirst</artifactId>
-                <version>${project.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.cxf.benchmark</groupId>
-                <artifactId>cxf-benchmark-base</artifactId>
-                <version>${project.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.cxf.benchmark</groupId>
-                <artifactId>cxf-benchmark-soapdoclit</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>


### PR DESCRIPTION
- Removed: `cxf-bundle-compatible`
- Removed: all dependencies under the groupId `org.apache.cxf.benchmark`
- Added: `cxf-rt-rs-service-description-common-openapi`