### PR TITLE
validate hex digits when decoding quoted-printable attachments

### DIFF
--- a/core/src/main/java/org/apache/cxf/attachment/QuotedPrintableDecoderStream.java
+++ b/core/src/main/java/org/apache/cxf/attachment/QuotedPrintableDecoderStream.java
@@ -22,23 +22,6 @@ import java.io.IOException;
 import java.io.InputStream;
 
 public class QuotedPrintableDecoderStream extends InputStream {
-    private static final byte[] ENCODING_TABLE = {
-        (byte)'0', (byte)'1', (byte)'2', (byte)'3', (byte)'4', (byte)'5', (byte)'6', (byte)'7', (byte)'8',
-        (byte)'9', (byte)'A', (byte)'B', (byte)'C', (byte)'D', (byte)'E', (byte)'F'
-    };
-
-    /*
-     * set up the decoding table.
-     */
-    private static final byte[] DECODING_TABLE = new byte[128];
-
-    static {
-        // initialize the decoding table
-        for (int i = 0; i < ENCODING_TABLE.length; i++) {
-            DECODING_TABLE[ENCODING_TABLE[i]] = (byte)i;
-        }
-    }
-
     private int deferredWhitespace;
     private int cachedCharacter = -1;
     private final InputStream in;
@@ -66,9 +49,16 @@ public class QuotedPrintableDecoderStream extends InputStream {
             return read();
         }
         // this is a hex pair we need to convert back to a single byte.
-        b[0] = DECODING_TABLE[b[0]];
-        b[1] = DECODING_TABLE[b[1]];
-        return (b[0] << 4) | b[1];
+        return (decodeHexDigit(b[0]) << 4) | decodeHexDigit(b[1]);
+    }
+
+    private static int decodeHexDigit(byte b) throws IOException {
+        // mask to an unsigned value first so a high-bit byte does not index negatively
+        int value = Character.digit(b & 0xff, 16);
+        if (value < 0) {
+            throw new IOException("Invalid quoted printable encoding");
+        }
+        return value;
     }
 
     @Override

--- a/core/src/main/java/org/apache/cxf/attachment/QuotedPrintableDecoderStream.java
+++ b/core/src/main/java/org/apache/cxf/attachment/QuotedPrintableDecoderStream.java
@@ -20,6 +20,7 @@ package org.apache.cxf.attachment;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.HexFormat;
 
 public class QuotedPrintableDecoderStream extends InputStream {
     private int deferredWhitespace;
@@ -53,12 +54,12 @@ public class QuotedPrintableDecoderStream extends InputStream {
     }
 
     private static int decodeHexDigit(byte b) throws IOException {
-        // mask to an unsigned value first so a high-bit byte does not index negatively
-        int value = Character.digit(b & 0xff, 16);
-        if (value < 0) {
-            throw new IOException("Invalid quoted printable encoding");
+        // mask to an unsigned value first so a high-bit byte is treated as a codepoint rather than indexing negatively
+        try {
+            return HexFormat.fromHexDigit(b & 0xff);
+        } catch (NumberFormatException e) {
+            throw new IOException("Invalid quoted printable encoding", e);
         }
-        return value;
     }
 
     @Override

--- a/core/src/test/java/org/apache/cxf/attachment/QuotedPrintableDecoderStreamTest.java
+++ b/core/src/test/java/org/apache/cxf/attachment/QuotedPrintableDecoderStreamTest.java
@@ -1,0 +1,66 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.cxf.attachment;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertThrows;
+
+public class QuotedPrintableDecoderStreamTest {
+
+    private static byte[] decode(byte[] encoded) throws IOException {
+        InputStream in = new QuotedPrintableDecoderStream(new ByteArrayInputStream(encoded));
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        int b;
+        while ((b = in.read()) != -1) {
+            out.write(b);
+        }
+        return out.toByteArray();
+    }
+
+    @Test
+    public void testDecodesHexPair() throws Exception {
+        assertArrayEquals("hello world".getBytes("US-ASCII"),
+                          decode("hello=20world".getBytes("US-ASCII")));
+    }
+
+    @Test
+    public void testDecodesLowerCaseHex() throws Exception {
+        // a lower case hex pair must decode to the same byte as the upper case form
+        assertArrayEquals(new byte[] {(byte)0xe2}, decode("=e2".getBytes("US-ASCII")));
+        assertArrayEquals(new byte[] {(byte)0xe2}, decode("=E2".getBytes("US-ASCII")));
+    }
+
+    @Test
+    public void testRejectsNonHexCharacters() {
+        assertThrows(IOException.class, () -> decode("=GG".getBytes("US-ASCII")));
+    }
+
+    @Test
+    public void testRejectsHighBitByteAfterMarker() {
+        // a byte >= 0x80 following the '=' marker must not index the decode table negatively
+        assertThrows(IOException.class, () -> decode(new byte[] {'=', (byte)0xff, 'A'}));
+    }
+}

--- a/core/src/test/java/org/apache/cxf/attachment/QuotedPrintableDecoderStreamTest.java
+++ b/core/src/test/java/org/apache/cxf/attachment/QuotedPrintableDecoderStreamTest.java
@@ -22,6 +22,7 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 
 import org.junit.Test;
 
@@ -42,20 +43,20 @@ public class QuotedPrintableDecoderStreamTest {
 
     @Test
     public void testDecodesHexPair() throws Exception {
-        assertArrayEquals("hello world".getBytes("US-ASCII"),
-                          decode("hello=20world".getBytes("US-ASCII")));
+        assertArrayEquals("hello world".getBytes(StandardCharsets.US_ASCII),
+                          decode("hello=20world".getBytes(StandardCharsets.US_ASCII)));
     }
 
     @Test
     public void testDecodesLowerCaseHex() throws Exception {
         // a lower case hex pair must decode to the same byte as the upper case form
-        assertArrayEquals(new byte[] {(byte)0xe2}, decode("=e2".getBytes("US-ASCII")));
-        assertArrayEquals(new byte[] {(byte)0xe2}, decode("=E2".getBytes("US-ASCII")));
+        assertArrayEquals(new byte[] {(byte)0xe2}, decode("=e2".getBytes(StandardCharsets.US_ASCII)));
+        assertArrayEquals(new byte[] {(byte)0xe2}, decode("=E2".getBytes(StandardCharsets.US_ASCII)));
     }
 
     @Test
     public void testRejectsNonHexCharacters() {
-        assertThrows(IOException.class, () -> decode("=GG".getBytes("US-ASCII")));
+        assertThrows(IOException.class, () -> decode("=GG".getBytes(StandardCharsets.US_ASCII)));
     }
 
     @Test


### PR DESCRIPTION
an inbound multipart attachment whose Content-Transfer-Encoding is quoted-printable is decoded by QuotedPrintableDecoderStream, which looks each of the two bytes following an '=' up in a 128 entry table without checking they are hex digits. a byte of 0x80 or above arrives as a negative java byte and throws ArrayIndexOutOfBoundsException, an invalid ascii pair like =GG is silently turned into 0x00, and a lowercase pair like =e2 decodes to the wrong byte because the table only holds the uppercase forms. this decodes each nibble with Character.digit over the unsigned byte and refuses anything that isn't valid hex, so malformed input is rejected rather than mis-decoded or crashing the parser.