### PR TITLE
Respect the AsyncRequestProducer contract by properly implementing available() method

### DIFF
--- a/rt/transports/http-hc5/src/main/java/org/apache/cxf/transport/http/asyncclient/hc5/CXFHttpAsyncRequestProducer.java
+++ b/rt/transports/http-hc5/src/main/java/org/apache/cxf/transport/http/asyncclient/hc5/CXFHttpAsyncRequestProducer.java
@@ -94,24 +94,7 @@ public class CXFHttpAsyncRequestProducer implements AsyncRequestProducer {
 
     @Override
     public int available() {
-        if (content != null) {
-            final ByteBuffer b = buffer;
-            if (b != null && b.hasRemaining()) {
-                return b.remaining();
-            } 
-            final InputStream in = fis;
-            if (in != null) {
-                try {
-                    return in.available();
-                } catch (final IOException ex) {
-                    /* Nothing to do */
-                }
-            }
-        } else if (buf != null && buf.hasData()) {
-            return buf.length(); /* returns remaining */
-        }
-
-        return 0; /* no more data */
+        return Integer.MAX_VALUE;
     }
 
     @Override

--- a/rt/transports/http-hc5/src/main/java/org/apache/cxf/transport/http/asyncclient/hc5/CXFHttpAsyncRequestProducer.java
+++ b/rt/transports/http-hc5/src/main/java/org/apache/cxf/transport/http/asyncclient/hc5/CXFHttpAsyncRequestProducer.java
@@ -94,7 +94,24 @@ public class CXFHttpAsyncRequestProducer implements AsyncRequestProducer {
 
     @Override
     public int available() {
-        return 0;
+        if (content != null) {
+            final ByteBuffer b = buffer;
+            if (b != null && b.hasRemaining()) {
+                return b.remaining();
+            } 
+            final InputStream in = fis;
+            if (in != null) {
+                try {
+                    return in.available();
+                } catch (final IOException ex) {
+                    /* Nothing to do */
+                }
+            }
+        } else if (buf != null && buf.hasData()) {
+            return buf.length(); /* returns remaining */
+        }
+
+        return 0; /* no more data */
     }
 
     @Override


### PR DESCRIPTION
Respect the `AsyncRequestProducer` contract by properly implementing available() method. Full credit goes to @rschmitt and @ok2c for pointing out at the issue (see please https://github.com/apache/httpcomponents-core/pull/674).