### PR TITLE
More SchemaFactory hardenings (CVE-2026-49875)

### DIFF
--- a/core/src/main/java/org/apache/cxf/staxutils/validation/W3CMultiSchemaFactory.java
+++ b/core/src/main/java/org/apache/cxf/staxutils/validation/W3CMultiSchemaFactory.java
@@ -29,7 +29,11 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
+import javax.xml.XMLConstants;
+import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.parsers.SAXParserFactory;
 import javax.xml.stream.XMLStreamException;
 import javax.xml.transform.Source;
@@ -40,6 +44,8 @@ import org.w3c.dom.Element;
 import org.w3c.dom.Node;
 
 import org.xml.sax.Locator;
+import org.xml.sax.SAXNotRecognizedException;
+import org.xml.sax.SAXNotSupportedException;
 
 import com.ctc.wstx.msv.W3CSchema;
 import com.sun.msv.grammar.ExpressionPool;
@@ -53,14 +59,17 @@ import com.sun.msv.reader.xmlschema.SchemaState;
 import com.sun.msv.reader.xmlschema.WSDLGrammarReaderController;
 import com.sun.msv.reader.xmlschema.XMLSchemaReader;
 
+import org.apache.cxf.common.logging.LogUtils;
 import org.codehaus.stax2.validation.XMLValidationSchema;
 
 /**
  * Legacy implementation for Woostox 5.x. For Woodstox 6.2+, use W3CMultiSchemaFactory in
  * Woodstox itself.
  */
+@Deprecated(forRemoval = true, since = "4.2.1")
 public class W3CMultiSchemaFactory {
-
+    private static final Logger LOG = LogUtils.getL7dLogger(W3CMultiSchemaFactory.class);
+            
     private MultiSchemaReader multiSchemaReader;
     private SAXParserFactory parserFactory;
     private RecursiveAllowedXMLSchemaReader xmlSchemaReader;
@@ -139,6 +148,17 @@ public class W3CMultiSchemaFactory {
             }
         }
         parserFactory = SAXParserFactory.newInstance();
+        try {
+            parserFactory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, Boolean.TRUE);
+        } catch (SAXNotRecognizedException | SAXNotSupportedException | ParserConfigurationException e) {
+            LOG.log(Level.WARNING, "The property '" + XMLConstants.FEATURE_SECURE_PROCESSING + "', is not supported.");
+        }
+        try {
+            parserFactory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+        } catch (SAXNotRecognizedException | SAXNotSupportedException | ParserConfigurationException e) {
+            LOG.log(Level.WARNING, "The property 'http://apache.org/xml/features/disallow-doctype-decl'"
+                    + " is not supported.");
+        }
         parserFactory.setNamespaceAware(true);
 
         WSDLGrammarReaderController ctrl = new WSDLGrammarReaderController(null, baseURI, embeddedSources);

--- a/core/src/main/java/org/apache/cxf/ws/addressing/EndpointReferenceUtils.java
+++ b/core/src/main/java/org/apache/cxf/ws/addressing/EndpointReferenceUtils.java
@@ -55,6 +55,8 @@ import org.w3c.dom.ls.LSInput;
 import org.w3c.dom.ls.LSResourceResolver;
 
 import org.xml.sax.InputSource;
+import org.xml.sax.SAXNotRecognizedException;
+import org.xml.sax.SAXNotSupportedException;
 
 import org.apache.cxf.Bus;
 import org.apache.cxf.BusFactory;
@@ -488,6 +490,25 @@ public final class EndpointReferenceUtils {
         Schema schema = serviceInfo.getProperty(Schema.class.getName(), Schema.class);
         if (schema == null) {
             SchemaFactory factory = SchemaFactory.newInstance(XMLConstants.W3C_XML_SCHEMA_NS_URI);
+            try {
+                factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, Boolean.TRUE);
+            } catch (SAXNotRecognizedException | SAXNotSupportedException e) {
+                LOG.log(Level.WARNING, "The property '" + XMLConstants.FEATURE_SECURE_PROCESSING
+                    + "' is not supported.");
+            }
+
+            try {
+                factory.setProperty(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+            } catch (SAXNotRecognizedException | SAXNotSupportedException e) {
+                LOG.log(Level.WARNING, "The property '" + XMLConstants.ACCESS_EXTERNAL_DTD + "' is not supported.");
+            }
+
+            try {
+                factory.setProperty(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
+            } catch (SAXNotRecognizedException | SAXNotSupportedException e) {
+                LOG.log(Level.WARNING, "The property '" + XMLConstants.ACCESS_EXTERNAL_SCHEMA + "' is not supported.");
+            }
+
             Map<String, byte[]> schemaSourcesMap = new LinkedHashMap<>();
             Map<String, Source> schemaSourcesMap2 = new LinkedHashMap<>();
 

--- a/rt/databinding/aegis/src/main/java/org/apache/cxf/aegis/type/XMLTypeCreator.java
+++ b/rt/databinding/aegis/src/main/java/org/apache/cxf/aegis/type/XMLTypeCreator.java
@@ -126,6 +126,7 @@ public class XMLTypeCreator extends AbstractTypeCreator {
         try (InputStream is = XMLTypeCreator.class.getResourceAsStream(path)) {
             if (is != null) {
                 SchemaFactory schemaFactory = SchemaFactory.newInstance(XMLConstants.W3C_XML_SCHEMA_NS_URI);
+                schemaFactory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, Boolean.TRUE);
                 Schema aegisSchema = schemaFactory.newSchema(new StreamSource(is));
                 AEGIS_DOCUMENT_BUILDER_FACTORY.setSchema(aegisSchema);
             }

--- a/rt/ws/rm/src/main/java/org/apache/cxf/ws/rm/RMEndpoint.java
+++ b/rt/ws/rm/src/main/java/org/apache/cxf/ws/rm/RMEndpoint.java
@@ -385,6 +385,7 @@ public class RMEndpoint {
         if (rmSchema == null) {
             try {
                 SchemaFactory factory = SchemaFactory.newInstance(XMLConstants.W3C_XML_SCHEMA_NS_URI);
+                factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, Boolean.TRUE);
                 javax.xml.transform.Source ad = new StreamSource(RMEndpoint.class
                                              .getResource("/schemas/wsdl/addressing.xsd")
                                              .openStream(),

--- a/tools/common/src/main/java/org/apache/cxf/tools/common/dom/ExtendedDocumentBuilder.java
+++ b/tools/common/src/main/java/org/apache/cxf/tools/common/dom/ExtendedDocumentBuilder.java
@@ -38,6 +38,8 @@ import javax.xml.validation.SchemaFactory;
 import org.w3c.dom.Document;
 
 import org.xml.sax.SAXException;
+import org.xml.sax.SAXNotRecognizedException;
+import org.xml.sax.SAXNotSupportedException;
 
 import org.apache.cxf.common.logging.LogUtils;
 import org.apache.cxf.staxutils.StaxUtils;
@@ -65,6 +67,25 @@ public class ExtendedDocumentBuilder {
     public void setValidating(boolean validate) {
         if (validate) {
             this.schemaFactory = SchemaFactory.newInstance(XMLConstants.W3C_XML_SCHEMA_NS_URI);
+            try {
+                schemaFactory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, Boolean.TRUE);
+            } catch (SAXNotRecognizedException | SAXNotSupportedException e) {
+                LOG.log(Level.WARNING, "The property '" + XMLConstants.FEATURE_SECURE_PROCESSING
+                    + "' is not supported.");
+            }
+
+            try {
+                schemaFactory.setProperty(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+            } catch (SAXNotRecognizedException | SAXNotSupportedException e) {
+                LOG.log(Level.WARNING, "The property '" + XMLConstants.ACCESS_EXTERNAL_DTD + "' is not supported.");
+            }
+
+            try {
+                schemaFactory.setProperty(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
+            } catch (SAXNotRecognizedException | SAXNotSupportedException e) {
+                LOG.log(Level.WARNING, "The property '" + XMLConstants.ACCESS_EXTERNAL_SCHEMA + "' is not supported.");
+            }
+
             try {
                 this.schema = schemaFactory.newSchema(new StreamSource(getSchemaLocation()));
             } catch (SAXException e) {

--- a/tools/wsdlto/databinding/jaxb/src/main/java/org/apache/cxf/tools/wsdlto/databinding/jaxb/JAXBDataBinding.java
+++ b/tools/wsdlto/databinding/jaxb/src/main/java/org/apache/cxf/tools/wsdlto/databinding/jaxb/JAXBDataBinding.java
@@ -67,6 +67,8 @@ import org.xml.sax.Attributes;
 import org.xml.sax.InputSource;
 import org.xml.sax.Locator;
 import org.xml.sax.SAXException;
+import org.xml.sax.SAXNotRecognizedException;
+import org.xml.sax.SAXNotSupportedException;
 import org.xml.sax.SAXParseException;
 import org.xml.sax.helpers.XMLFilterImpl;
 
@@ -980,6 +982,12 @@ public class JAXBDataBinding implements DataBindingProfile {
                                final OASISCatalogManager catalog,
                                final SchemaCollection schemaCollection) throws ToolException {
         SchemaFactory schemaFact = SchemaFactory.newInstance(XMLConstants.W3C_XML_SCHEMA_NS_URI);
+        try {
+            schemaFact.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, Boolean.TRUE);
+        } catch (SAXNotRecognizedException | SAXNotSupportedException e) {
+            LOG.log(Level.WARNING, "The property '" + XMLConstants.FEATURE_SECURE_PROCESSING
+                + "' is not supported.");
+        }
         schemaFact.setResourceResolver(new LSResourceResolver() {
             public LSInput resolveResource(String type,
                                            String namespaceURI,


### PR DESCRIPTION
### More SchemaFactory hardenings

This is a cherry picked from commit 7cfa2fb7ba0bdfe16f149257769ea5e7c6953bf9 to fix critical CVE [CVE-2026-49875](https://github.com/advisories/GHSA-xw5h-cmh3-8j6j)

I know that 3.6 is EOL but since this CVE is rated 9.8 and since the fix is very easy please consider to include it

Migration from 3.6 to 4 is a huge step and cannot be quickly achieved by everyone.
Considering the criticity of the CVE is would be nice to protected all existing systems


