### PR TITLE
CXF-9221: JCache providers use inverted isExpired() logic causing expired tokens/codes to never be evicted

### DIFF
--- a/rt/rs/security/oauth-parent/oauth2/src/main/java/org/apache/cxf/rs/security/oauth2/grants/code/JCacheCodeDataProvider.java
+++ b/rt/rs/security/oauth-parent/oauth2/src/main/java/org/apache/cxf/rs/security/oauth2/grants/code/JCacheCodeDataProvider.java
@@ -32,6 +32,7 @@ import org.apache.cxf.rs.security.oauth2.common.Client;
 import org.apache.cxf.rs.security.oauth2.common.UserSubject;
 import org.apache.cxf.rs.security.oauth2.provider.JCacheOAuthDataProvider;
 import org.apache.cxf.rs.security.oauth2.provider.OAuthServiceException;
+import org.apache.cxf.rs.security.oauth2.utils.OAuthUtils;
 
 public class JCacheCodeDataProvider extends JCacheOAuthDataProvider
     implements AuthorizationCodeDataProvider {
@@ -133,7 +134,7 @@ public class JCacheCodeDataProvider extends JCacheOAuthDataProvider
     }
 
     protected static boolean isExpired(ServerAuthorizationCodeGrant grant) {
-        return System.currentTimeMillis() < (grant.getIssuedAt() + grant.getExpiresIn());
+        return OAuthUtils.isExpired(grant.getIssuedAt(), grant.getExpiresIn());
     }
 
     @Override

--- a/rt/rs/security/oauth-parent/oauth2/src/main/java/org/apache/cxf/rs/security/oauth2/provider/JCacheOAuthDataProvider.java
+++ b/rt/rs/security/oauth-parent/oauth2/src/main/java/org/apache/cxf/rs/security/oauth2/provider/JCacheOAuthDataProvider.java
@@ -39,6 +39,7 @@ import org.apache.cxf.rs.security.oauth2.common.ServerAccessToken;
 import org.apache.cxf.rs.security.oauth2.common.UserSubject;
 import org.apache.cxf.rs.security.oauth2.tokens.refresh.RefreshToken;
 import org.apache.cxf.rs.security.oauth2.utils.JwtTokenUtils;
+import org.apache.cxf.rs.security.oauth2.utils.OAuthUtils;
 
 import static org.apache.cxf.jaxrs.utils.ResourceUtils.getClasspathResourceURL;
 
@@ -274,7 +275,7 @@ public class JCacheOAuthDataProvider extends AbstractOAuthDataProvider {
     }
 
     protected static boolean isExpired(ServerAccessToken token) {
-        return System.currentTimeMillis() < (token.getIssuedAt() + token.getExpiresIn());
+        return OAuthUtils.isExpired(token.getIssuedAt(), token.getExpiresIn());
     }
 
     protected static CacheManager createCacheManager(String configFile, Bus bus) {

--- a/rt/rs/security/oauth-parent/oauth2/src/test/java/org/apache/cxf/rs/security/oauth2/grants/code/JCacheCodeDataProviderTest.java
+++ b/rt/rs/security/oauth-parent/oauth2/src/test/java/org/apache/cxf/rs/security/oauth2/grants/code/JCacheCodeDataProviderTest.java
@@ -87,6 +87,32 @@ public class JCacheCodeDataProviderTest {
         assertNotNull(grants);
         assertEquals(0, grants.size());
     }
+    
+    @Test
+    public void testAddGetExpiredCodeGrants() throws InterruptedException {
+        Client c = addClient("111", "bob");
+
+        AuthorizationCodeRegistration atr = new AuthorizationCodeRegistration();
+        atr.setClient(c);
+        atr.setApprovedScope(Collections.singletonList("a"));
+        atr.setSubject(c.getResourceOwnerSubject());
+
+        provider.setCodeLifetime(2 /* 2 seconds */);
+        provider.createCodeGrant(atr);
+
+        List<ServerAuthorizationCodeGrant> grants = provider.getCodeGrants(c, c.getResourceOwnerSubject());
+        assertNotNull(grants);
+        assertEquals(1, grants.size());
+
+        Thread.sleep(3000); /* 3 seconds, grant definitely expires */
+        grants = provider.getCodeGrants(c, c.getResourceOwnerSubject());
+        assertEquals(0, grants.size());
+
+        provider.removeClient(c.getClientId());
+        grants = provider.getCodeGrants(c, c.getResourceOwnerSubject());
+        assertNotNull(grants);
+        assertEquals(0, grants.size());
+    }
 
     private Client addClient(String clientId, String userLogin) {
         Client c = new Client();

--- a/rt/rs/security/oauth-parent/oauth2/src/test/java/org/apache/cxf/rs/security/oauth2/provider/JCacheOAuthDataProviderTest.java
+++ b/rt/rs/security/oauth-parent/oauth2/src/test/java/org/apache/cxf/rs/security/oauth2/provider/JCacheOAuthDataProviderTest.java
@@ -18,7 +18,18 @@
  */
 package org.apache.cxf.rs.security.oauth2.provider;
 
+import java.util.Collections;
+import java.util.List;
+
+import org.apache.cxf.rs.security.oauth2.common.AccessTokenRegistration;
+import org.apache.cxf.rs.security.oauth2.common.Client;
+import org.apache.cxf.rs.security.oauth2.common.ServerAccessToken;
+
 import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 
 public class JCacheOAuthDataProviderTest extends AbstractOAuthDataProviderTest {
 
@@ -29,4 +40,25 @@ public class JCacheOAuthDataProviderTest extends AbstractOAuthDataProviderTest {
         setProvider(provider);
     }
 
+    @Test
+    public void testAddGetExpiredAccessToken() throws InterruptedException {
+        Client c = addClient("102", "bob");
+
+        AccessTokenRegistration atr = new AccessTokenRegistration();
+        atr.setClient(c);
+        atr.setApprovedScope(Collections.singletonList("a"));
+        atr.setSubject(c.getResourceOwnerSubject());
+
+        getProvider().setAccessTokenLifetime(2 /* 2 seconds */); 
+        getProvider().createAccessToken(atr);
+        List<ServerAccessToken> tokens = getProvider().getAccessTokens(c, null);
+        assertNotNull(tokens);
+        assertEquals(1, tokens.size());
+
+        Thread.sleep(3000); /* 3 seconds, token definitely expires */
+        tokens = getProvider().getAccessTokens(c, null);
+        assertEquals(0, tokens.size());
+
+        getProvider().removeClient(c.getClientId());
+    }
 }


### PR DESCRIPTION
JCache providers use inverted isExpired() logic causing expired tokens/codes to never be evicted