### PR TITLE
[CXF-9227] Fix SecurityManager permission regressions introduced in 4…

### DIFF
--- a/core/src/main/java/org/apache/cxf/resource/URIResolver.java
+++ b/core/src/main/java/org/apache/cxf/resource/URIResolver.java
@@ -32,6 +32,8 @@ import java.net.URLDecoder;
 import java.nio.file.Files;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
+import java.security.PrivilegedActionException;
+import java.security.PrivilegedExceptionAction;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
@@ -271,7 +273,16 @@ public class URIResolver implements AutoCloseable {
 
     private HttpURLConnection createInputStream() throws IOException {
         checkAllowedScheme(url);
-        HttpURLConnection huc = (HttpURLConnection)url.openConnection();
+        // Wrap the network connection in doPrivileged so that callers (including
+        // user deployments) do not need SocketPermission for the target host.
+        final HttpURLConnection huc;
+        try {
+            huc = AccessController.doPrivileged(
+                (PrivilegedExceptionAction<HttpURLConnection>) () ->
+                    (HttpURLConnection)url.openConnection());
+        } catch (PrivilegedActionException e) {
+            throw (IOException) e.getException();
+        }
 
         String host = SystemPropertyAction.getPropertyOrNull("http.proxyHost");
         if (host != null) {

--- a/core/src/main/java/org/apache/cxf/ws/addressing/EndpointReferenceUtils.java
+++ b/core/src/main/java/org/apache/cxf/ws/addressing/EndpointReferenceUtils.java
@@ -27,6 +27,8 @@ import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.security.AccessController;
+import java.security.PrivilegedAction;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -199,7 +201,15 @@ public final class EndpointReferenceUtils {
                     systemId = publicId;
                 }
                 if (systemId != null) {
-                    InputSource source = resolver.resolve(systemId, baseURI);
+                    // Run inside doPrivileged so that sm.checkPermission() calls
+                    // inside the resolver chain (SecurityActions.fileExists) stop
+                    // at this boundary and check only CXF's own permissions rather
+                    // than walking up through the JAXP schema-validator frames that
+                    // lack CXF-internal permissions.
+                    final String sid = systemId;
+                    final String buri = baseURI;
+                    InputSource source = AccessController.doPrivileged(
+                        (PrivilegedAction<InputSource>) () -> resolver.resolve(sid, buri));
                     if (source != null) {
                         impl = new LSInputImpl();
                         impl.setByteStream(source.getByteStream());

--- a/rt/transports/http/src/main/java/org/apache/cxf/transport/http/ProxyFactory.java
+++ b/rt/transports/http/src/main/java/org/apache/cxf/transport/http/ProxyFactory.java
@@ -22,6 +22,8 @@ import java.net.InetSocketAddress;
 import java.net.Proxy;
 import java.net.ProxySelector;
 import java.net.URI;
+import java.security.AccessController;
+import java.security.PrivilegedAction;
 import java.util.List;
 import java.util.regex.Pattern;
 
@@ -50,7 +52,8 @@ public class ProxyFactory {
      * are honoured rather than bypassed.
      */
     private Proxy getSystemProxy(URI uri) {
-        ProxySelector selector = ProxySelector.getDefault();
+        ProxySelector selector = AccessController.doPrivileged(
+            (PrivilegedAction<ProxySelector>) ProxySelector::getDefault);
         if (selector == null) {
             return null;
         }


### PR DESCRIPTION
….1.7

## Summary

Fixes three SecurityManager permission regressions introduced in CXF 4.1.7
that break deployments running under a tight SecurityManager policy (reported
by the WildFly team during their 4.1.6 → 4.1.7 upgrade CI checks).

## Root Cause

**Issue 1 — `NetPermission("getProxySelector")`** (introduced by #3154)

`ProxyFactory.getSystemProxy()` calls `ProxySelector.getDefault()` without
`doPrivileged`, forcing all callers including user deployments to hold this
permission.

**Issues 2 & 3 — `RuntimePermission("org.apache.cxf.permission")` and
`SocketPermission`** (introduced by #3157)

Setting `ACCESS_EXTERNAL_SCHEMA=""` on `SchemaFactory` routes all schema
resolution through `SchemaLSResourceResolver` → `ExtendedURIResolver` →
`URIResolver.tryFileSystem()` — a code path never previously reached in this
context under a SecurityManager. This exposed two pre-existing gaps:
- `SecurityActions.fileExists()` called `sm.checkPermission()` **outside**
  `doPrivileged`, walking the full call stack into user deployment code.
- `URIResolver.createInputStream()` called `url.openConnection()` without
  `doPrivileged`, requiring callers to hold `SocketPermission`.

## Fix

| File | Change |
|------|--------|
| `ProxyFactory.java` | Wrap `ProxySelector.getDefault()` in `doPrivileged` |
| `SecurityActions.java` | Move `sm.checkPermission()` inside the `doPrivileged` block so the stack walk stops at the CXF privilege boundary (confused-deputy guard preserved) |
| `URIResolver.java` | Wrap `url.openConnection()` in `doPrivileged` |
