### PR TITLE
 (3.6.x) [CXF-9227] - Fix SecurityManager permission regressions

### DIFF
--- a/core/src/main/java/org/apache/cxf/resource/URIResolver.java
+++ b/core/src/main/java/org/apache/cxf/resource/URIResolver.java
@@ -32,6 +32,8 @@ import java.net.URLDecoder;
 import java.nio.file.Files;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
+import java.security.PrivilegedActionException;
+import java.security.PrivilegedExceptionAction;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
@@ -270,7 +272,16 @@ public class URIResolver implements AutoCloseable {
 
     private HttpURLConnection createInputStream() throws IOException {
         checkAllowedScheme(url);
-        HttpURLConnection huc = (HttpURLConnection)url.openConnection();
+        // Wrap the network connection in doPrivileged so that callers (including
+        // user deployments) do not need SocketPermission for the target host.
+        final HttpURLConnection huc;
+        try {
+            huc = AccessController.doPrivileged(
+                (PrivilegedExceptionAction<HttpURLConnection>) () ->
+                    (HttpURLConnection)url.openConnection());
+        } catch (PrivilegedActionException e) {
+            throw (IOException) e.getException();
+        }
 
         String host = SystemPropertyAction.getPropertyOrNull("http.proxyHost");
         if (host != null) {

--- a/core/src/main/java/org/apache/cxf/ws/addressing/EndpointReferenceUtils.java
+++ b/core/src/main/java/org/apache/cxf/ws/addressing/EndpointReferenceUtils.java
@@ -27,6 +27,8 @@ import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.security.AccessController;
+import java.security.PrivilegedAction;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -199,7 +201,15 @@ public final class EndpointReferenceUtils {
                     systemId = publicId;
                 }
                 if (systemId != null) {
-                    InputSource source = resolver.resolve(systemId, baseURI);
+                    // Run inside doPrivileged so that sm.checkPermission() calls
+                    // inside the resolver chain (SecurityActions.fileExists) stop
+                    // at this boundary and check only CXF's own permissions rather
+                    // than walking up through the JAXP schema-validator frames that
+                    // lack CXF-internal permissions.
+                    final String sid = systemId;
+                    final String buri = baseURI;
+                    InputSource source = AccessController.doPrivileged(
+                        (PrivilegedAction<InputSource>) () -> resolver.resolve(sid, buri));
                     if (source != null) {
                         impl = new LSInputImpl();
                         impl.setByteStream(source.getByteStream());


### PR DESCRIPTION
Based on the changes in #3256.

ProxyFactory.java is not in scope since it does not rely on ProxySelector in 3.6.x.

@coheigea, @ffang WDYT? 