### PR TITLE
CXF-9223 - Disable audienceIsEndpointAddress on main only

### DIFF
--- a/rt/rs/security/oauth-parent/oauth2/src/main/java/org/apache/cxf/rs/security/oauth2/filters/OAuthRequestFilter.java
+++ b/rt/rs/security/oauth-parent/oauth2/src/main/java/org/apache/cxf/rs/security/oauth2/filters/OAuthRequestFilter.java
@@ -74,7 +74,7 @@ public class OAuthRequestFilter extends AbstractAccessTokenValidator
     private String audience;
     private String issuer;
     private boolean completeAudienceMatch;
-    private boolean audienceIsEndpointAddress = true;
+    private boolean audienceIsEndpointAddress;
     private boolean checkFormData;
     private List<String> requiredScopes = Collections.emptyList();
     private boolean allPermissionsMatch;

--- a/rt/rs/security/oauth-parent/oauth2/src/test/java/org/apache/cxf/rs/security/oauth2/filters/OAuthRequestFilterTest.java
+++ b/rt/rs/security/oauth-parent/oauth2/src/test/java/org/apache/cxf/rs/security/oauth2/filters/OAuthRequestFilterTest.java
@@ -83,9 +83,8 @@ public class OAuthRequestFilterTest {
     }
 
     @Test
-    public void testValidateAudiencesSkipsEndpointCheckWhenDisabled() {
+    public void testValidateAudiencesSkipsEndpointCheckByDefault() {
         OAuthRequestFilter filter = new OAuthRequestFilter();
-        filter.setAudienceIsEndpointAddress(false);
 
         String result = filter.validateAudiences(Collections.singletonList("/api/read"));
         assertNull(result);
@@ -103,6 +102,22 @@ public class OAuthRequestFilterTest {
 
         String result = filter.validateAudiences(Collections.singletonList("/api/read"));
         assertEquals("/api/read", result);
+    }
+
+    @Test
+    public void testValidateAudiencesRequiresEndpointCheckEnabledForAudienceMatch() throws Exception {
+        OAuthRequestFilter filter = new OAuthRequestFilter();
+        filter.setCompleteAudienceMatch(false);
+
+        Message message = new MessageImpl();
+        message.put(Message.REQUEST_URL, "/api/read/item");
+        setThreadLocalMessage(message);
+
+        // Default is disabled, so endpoint-address audience matching is skipped.
+        assertNull(filter.validateAudiences(Collections.singletonList("/api/read")));
+
+        filter.setAudienceIsEndpointAddress(true);
+        assertEquals("/api/read", filter.validateAudiences(Collections.singletonList("/api/read")));
     }
 
     private static void setThreadLocalMessage(Message message) throws Exception {


### PR DESCRIPTION
Will be applied for CXF 4.2.x only for backwards compatibility.