### PR TITLE
Fix flaky SSE system tests

### DIFF
--- a/systests/rs-sse/rs-sse-base/src/main/java/org/apache/cxf/systest/jaxrs/sse/BookStoreClientCloseable.java
+++ b/systests/rs-sse/rs-sse-base/src/main/java/org/apache/cxf/systest/jaxrs/sse/BookStoreClientCloseable.java
@@ -99,16 +99,18 @@ abstract class BookStoreClientCloseable {
                 Thread.sleep(500);
                 localBroadcaster.broadcast(createEvent(builder.name("book"), id + 4))
                     .whenComplete((r, ex) -> {
-                        // we expect the sink to be closed at this point
-                        if (ex != null || !sink.isClosed()) {
+                        // Count only an unexpected successful delivery after client close.
+                        if (ex == null && !sink.isClosed()) {
                             stats.inc();
                         }   
                     });
 
-                stats.setWasClosed(sink.isClosed());
-                phaser.arriveAndDeregister();
-                
-                sink.close();
+                try {
+                    sink.close();
+                } finally {
+                    stats.setWasClosed(sink.isClosed());
+                    phaser.arriveAndDeregister();
+                }
             } catch (final InterruptedException ex) {
                 LOG.error("Communication error", ex);
             } catch (final IOException ex) {


### PR DESCRIPTION
The Tomcat SSE tests almost always fail on my machine, the Undertow tests sporadically. There are two changes:

- moved the close-state check to happen after the server actually closes the connection.
- fixed the last event counter so it only increments when an event was unexpectedly delivered, not when failure was expected after close.