### PR TITLE
CXF-9233: AbstractLoggingInterceptor.LIVE_LOGGING_PROP already set in the message properties, so RESP_OUT is not logged

### DIFF
--- a/rt/features/logging/src/main/java/org/apache/cxf/ext/logging/AbstractLoggingInterceptor.java
+++ b/rt/features/logging/src/main/java/org/apache/cxf/ext/logging/AbstractLoggingInterceptor.java
@@ -64,8 +64,12 @@ public abstract class AbstractLoggingInterceptor extends AbstractPhaseIntercepto
     }
 
     protected static boolean isLoggingDisabledNow(Message message) throws Fault {
+        // Some frameworks (like Camel) do copy the context (properties) from in- to out-
+        // messages as-is, so it is very possible that LIVE_LOGGING_PROP will end up in the
+        // in / out message by mistake. To track that, adding the requestor message property
+        // to distinguish between such messages.
         final Object liveLoggingProp = message.getContextualProperty(LIVE_LOGGING_PROP + "."
-            + MessageUtils.isRequestor(message));
+            + getRequestorSuffix(message));
         return liveLoggingProp != null && PropertyUtils.isFalse(liveLoggingProp);
     }
 
@@ -235,5 +239,9 @@ public abstract class AbstractLoggingInterceptor extends AbstractPhaseIntercepto
         // Use regex to get the boundary and return null if it's not found
         Matcher m = BOUNDARY_PATTERN.matcher(payload);
         return m.find() ? "--" + m.group(1) : null;
+    }
+
+    static String getRequestorSuffix(Message message) {
+        return MessageUtils.isRequestor(message) ? "in" : "out";
     }
 }

--- a/rt/features/logging/src/main/java/org/apache/cxf/ext/logging/AbstractLoggingInterceptor.java
+++ b/rt/features/logging/src/main/java/org/apache/cxf/ext/logging/AbstractLoggingInterceptor.java
@@ -64,12 +64,16 @@ public abstract class AbstractLoggingInterceptor extends AbstractPhaseIntercepto
     }
 
     protected static boolean isLoggingDisabledNow(Message message) throws Fault {
+        // For backward compatibility, check the old LIVE_LOGGING_PROP property first
+        Object liveLoggingProp = message.getContextualProperty(LIVE_LOGGING_PROP);
+        if (liveLoggingProp != null) {
+            return PropertyUtils.isFalse(liveLoggingProp);
+        }
         // Some frameworks (like Camel) do copy the context (properties) from in- to out-
         // messages as-is, so it is very possible that LIVE_LOGGING_PROP will end up in the
         // in / out message by mistake. To track that, adding the requestor message property
         // to distinguish between such messages.
-        final Object liveLoggingProp = message.getContextualProperty(LIVE_LOGGING_PROP + "."
-            + getRequestorSuffix(message));
+        liveLoggingProp = message.getContextualProperty(LIVE_LOGGING_PROP + "." + getRequestorSuffix(message));
         return liveLoggingProp != null && PropertyUtils.isFalse(liveLoggingProp);
     }
 

--- a/rt/features/logging/src/main/java/org/apache/cxf/ext/logging/AbstractLoggingInterceptor.java
+++ b/rt/features/logging/src/main/java/org/apache/cxf/ext/logging/AbstractLoggingInterceptor.java
@@ -32,6 +32,7 @@ import org.apache.cxf.ext.logging.event.PrettyLoggingFilter;
 import org.apache.cxf.interceptor.Fault;
 import org.apache.cxf.message.Exchange;
 import org.apache.cxf.message.Message;
+import org.apache.cxf.message.MessageUtils;
 import org.apache.cxf.phase.AbstractPhaseInterceptor;
 
 public abstract class AbstractLoggingInterceptor extends AbstractPhaseInterceptor<Message> {
@@ -63,7 +64,8 @@ public abstract class AbstractLoggingInterceptor extends AbstractPhaseIntercepto
     }
 
     protected static boolean isLoggingDisabledNow(Message message) throws Fault {
-        Object liveLoggingProp = message.getContextualProperty(LIVE_LOGGING_PROP);
+        final Object liveLoggingProp = message.getContextualProperty(LIVE_LOGGING_PROP + "."
+            + MessageUtils.isRequestor(message));
         return liveLoggingProp != null && PropertyUtils.isFalse(liveLoggingProp);
     }
 

--- a/rt/features/logging/src/main/java/org/apache/cxf/ext/logging/LoggingInInterceptor.java
+++ b/rt/features/logging/src/main/java/org/apache/cxf/ext/logging/LoggingInInterceptor.java
@@ -34,7 +34,6 @@ import org.apache.cxf.interceptor.Fault;
 import org.apache.cxf.io.CachedOutputStream;
 import org.apache.cxf.io.CachedWriter;
 import org.apache.cxf.message.Message;
-import org.apache.cxf.message.MessageUtils;
 import org.apache.cxf.phase.AbstractPhaseInterceptor;
 import org.apache.cxf.phase.Phase;
 import org.apache.cxf.phase.PhaseInterceptor;
@@ -88,7 +87,7 @@ public class LoggingInInterceptor extends AbstractLoggingInterceptor {
             //ensure only logging once for a certain message
             //this can prevent message logging again when fault
             //happen after PRE_INVOKE phase(rewind calls into LoggingInFaultInterceptor)
-            message.put(LIVE_LOGGING_PROP + "." + MessageUtils.isRequestor(message), Boolean.FALSE);
+            message.put(LIVE_LOGGING_PROP + "." + getRequestorSuffix(message), Boolean.FALSE);
         }
         createExchangeId(message);
         final LogEvent event = eventMapper.map(message, sensitiveProtocolHeaderNames);

--- a/rt/features/logging/src/main/java/org/apache/cxf/ext/logging/LoggingInInterceptor.java
+++ b/rt/features/logging/src/main/java/org/apache/cxf/ext/logging/LoggingInInterceptor.java
@@ -34,6 +34,7 @@ import org.apache.cxf.interceptor.Fault;
 import org.apache.cxf.io.CachedOutputStream;
 import org.apache.cxf.io.CachedWriter;
 import org.apache.cxf.message.Message;
+import org.apache.cxf.message.MessageUtils;
 import org.apache.cxf.phase.AbstractPhaseInterceptor;
 import org.apache.cxf.phase.Phase;
 import org.apache.cxf.phase.PhaseInterceptor;
@@ -87,7 +88,7 @@ public class LoggingInInterceptor extends AbstractLoggingInterceptor {
             //ensure only logging once for a certain message
             //this can prevent message logging again when fault
             //happen after PRE_INVOKE phase(rewind calls into LoggingInFaultInterceptor)
-            message.put(LIVE_LOGGING_PROP, Boolean.FALSE);
+            message.put(LIVE_LOGGING_PROP + "." + MessageUtils.isRequestor(message), Boolean.FALSE);
         }
         createExchangeId(message);
         final LogEvent event = eventMapper.map(message, sensitiveProtocolHeaderNames);

--- a/rt/features/logging/src/main/java/org/apache/cxf/ext/logging/LoggingOutInterceptor.java
+++ b/rt/features/logging/src/main/java/org/apache/cxf/ext/logging/LoggingOutInterceptor.java
@@ -37,6 +37,7 @@ import org.apache.cxf.io.CacheAndWriteOutputStream;
 import org.apache.cxf.io.CachedOutputStream;
 import org.apache.cxf.io.CachedOutputStreamCallback;
 import org.apache.cxf.message.Message;
+import org.apache.cxf.message.MessageUtils;
 import org.apache.cxf.phase.Phase;
 
 /**
@@ -65,7 +66,7 @@ public class LoggingOutInterceptor extends AbstractLoggingInterceptor {
             //ensure only logging once for a certain message
             //this can prevent message logging again when fault
             //happen after PRE_STREAM phase(LoggingOutInterceptor is called both in out chain and fault out chain)
-            message.put(LIVE_LOGGING_PROP, Boolean.FALSE);
+            message.put(LIVE_LOGGING_PROP + "." + MessageUtils.isRequestor(message), Boolean.FALSE);
         }
         createExchangeId(message);
         final OutputStream os = message.getContent(OutputStream.class);

--- a/rt/features/logging/src/main/java/org/apache/cxf/ext/logging/LoggingOutInterceptor.java
+++ b/rt/features/logging/src/main/java/org/apache/cxf/ext/logging/LoggingOutInterceptor.java
@@ -37,7 +37,6 @@ import org.apache.cxf.io.CacheAndWriteOutputStream;
 import org.apache.cxf.io.CachedOutputStream;
 import org.apache.cxf.io.CachedOutputStreamCallback;
 import org.apache.cxf.message.Message;
-import org.apache.cxf.message.MessageUtils;
 import org.apache.cxf.phase.Phase;
 
 /**
@@ -66,7 +65,7 @@ public class LoggingOutInterceptor extends AbstractLoggingInterceptor {
             //ensure only logging once for a certain message
             //this can prevent message logging again when fault
             //happen after PRE_STREAM phase(LoggingOutInterceptor is called both in out chain and fault out chain)
-            message.put(LIVE_LOGGING_PROP + "." + MessageUtils.isRequestor(message), Boolean.FALSE);
+            message.put(LIVE_LOGGING_PROP + "." + getRequestorSuffix(message), Boolean.FALSE);
         }
         createExchangeId(message);
         final OutputStream os = message.getContent(OutputStream.class);

--- a/rt/frontend/jaxws/src/test/java/org/apache/cxf/jaxws/JaxWsClientTest.java
+++ b/rt/frontend/jaxws/src/test/java/org/apache/cxf/jaxws/JaxWsClientTest.java
@@ -22,6 +22,7 @@ package org.apache.cxf.jaxws;
 import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.Proxy;
 import java.net.URL;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -44,6 +45,9 @@ import jakarta.xml.ws.handler.soap.SOAPHandler;
 import jakarta.xml.ws.handler.soap.SOAPMessageContext;
 import org.apache.cxf.endpoint.Client;
 import org.apache.cxf.endpoint.ClientImpl;
+import org.apache.cxf.ext.logging.LoggingFeature;
+import org.apache.cxf.ext.logging.event.LogEvent;
+import org.apache.cxf.ext.logging.event.LogEventSender;
 import org.apache.cxf.frontend.ClientProxy;
 import org.apache.cxf.helpers.CastUtils;
 import org.apache.cxf.interceptor.Fault;
@@ -58,10 +62,12 @@ import org.apache.cxf.service.model.BindingOperationInfo;
 import org.apache.cxf.service.model.EndpointInfo;
 import org.apache.cxf.service.model.MessagePartInfo;
 import org.apache.cxf.transport.Destination;
+import org.apache.cxf.transport.local.LocalTransportFactory;
 import org.apache.cxf.wsdl.service.factory.ReflectionServiceFactoryBean;
 import org.apache.hello_world_soap_http.BadRecordLitFault;
 import org.apache.hello_world_soap_http.Greeter;
 import org.apache.hello_world_soap_http.GreeterImpl;
+import org.apache.hello_world_soap_http.types.SayHi;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -249,6 +255,7 @@ public class JaxWsClientTest extends AbstractJaxWsTest {
         EndpointInfo ei = service.getServiceInfos().get(0).getEndpoint(new QName(namespace, "SoapPort"));
         JaxWsEndpointImpl endpoint = new JaxWsEndpointImpl(getBus(), service, ei);
 
+        getBus().setFeatures(List.of(new LoggingFeature()));
         ClientImpl client = new ClientImpl(getBus(), endpoint);
 
         BindingOperationInfo bop = ei.getBinding().getOperation(new QName(namespace, "sayHi"));
@@ -305,6 +312,42 @@ public class JaxWsClientTest extends AbstractJaxWsTest {
 
     }
 
+    @Test
+    public void testEndpointWithLogging() throws Exception {
+        GreeterImpl service = new GreeterImpl();
+        String namespace = "http://apache.org/hello_world_soap_http";
+        try (EndpointImpl ep = new EndpointImpl(getBus(), service, (String) null)) {
+            ep.publish("local://localhost:9092/hello");
+
+            EndpointInfo ei = ep.getService().getServiceInfos().get(0).getEndpoint(new QName(namespace, "SoapPort"));
+            JaxWsEndpointImpl endpoint = new JaxWsEndpointImpl(getBus(), ep.getService(), ei);
+
+            final List<LogEvent> events = new ArrayList<>();
+            final LoggingFeature loggingFeature = new LoggingFeature();
+            loggingFeature.setSender(new LogEventSender() {
+                @Override
+                public void send(LogEvent event) {
+                    events.add(event);
+                }
+            });
+            getBus().setFeatures(List.of(loggingFeature));
+
+            ClientImpl client = new ClientImpl(getBus(), endpoint);
+            client.getRequestContext().put(LocalTransportFactory.MESSAGE_INCLUDE_PROPERTIES,
+                    Collections.singleton("org.apache.cxf.logging.enable"));
+
+            BindingOperationInfo bop = ei.getBinding().getOperation(new QName(namespace, "sayHi"));
+            assertNotNull(bop);
+
+            Object[] ret = client.invoke(bop, new Object[] {new SayHi()}, null);
+            assertNotNull(ret);
+            assertEquals("Wrong number of return objects", 1, ret.length);
+
+            assertEquals(4, events.size());
+            client.close();
+        }
+    }
+    
     @Test
     public void testClientProxyFactory() {
         JaxWsProxyFactoryBean cf = new JaxWsProxyFactoryBean();

--- a/rt/frontend/jaxws/src/test/java/org/apache/cxf/jaxws/JaxWsClientTest.java
+++ b/rt/frontend/jaxws/src/test/java/org/apache/cxf/jaxws/JaxWsClientTest.java
@@ -334,7 +334,7 @@ public class JaxWsClientTest extends AbstractJaxWsTest {
 
             ClientImpl client = new ClientImpl(getBus(), endpoint);
             client.getRequestContext().put(LocalTransportFactory.MESSAGE_INCLUDE_PROPERTIES,
-                    Collections.singleton("org.apache.cxf.logging.enable"));
+                    Set.of("org.apache.cxf.logging.enable.out", "org.apache.cxf.logging.enable.in"));
 
             BindingOperationInfo bop = ei.getBinding().getOperation(new QName(namespace, "sayHi"));
             assertNotNull(bop);

--- a/rt/rs/client/src/test/java/org/apache/cxf/jaxrs/client/logging/RESTLoggingTest.java
+++ b/rt/rs/client/src/test/java/org/apache/cxf/jaxrs/client/logging/RESTLoggingTest.java
@@ -192,12 +192,45 @@ public class RESTLoggingTest {
         checkResponseIn(events.get(3));
     }
     
+    @Test
+    public void testEventsWithProxy() throws MalformedURLException {
+        LoggingFeature loggingFeature = new LoggingFeature();
+        loggingFeature.setLogBinary(true);
+        TestEventSender sender = new TestEventSender();
+        loggingFeature.setSender(sender);
+        Server server = createService(SERVICE_URI, new TestServiceRest(), loggingFeature);
+        server.start();
+        TestService client = createClient(SERVICE_URI, TestService.class, loggingFeature);
+        String result = client.echo("test1");
+        Assert.assertEquals("test1", result);
+
+        List<LogEvent> events = sender.getEvents();
+        await().until(() -> events.size(), is(4));
+        server.stop();
+        server.destroy();
+
+        Assert.assertEquals(4, events.size());
+        checkRequestOut(events.get(0));
+        checkRequestIn(events.get(1));
+        checkResponseOut(events.get(2));
+        checkResponseIn(events.get(3));
+    }
+    
+    
     private void assertContentLogged(LogEvent event) {
         Assert.assertNotEquals(AbstractLoggingInterceptor.CONTENT_SUPPRESSED, event.getPayload());
     }
 
     private void assertContentNotLogged(LogEvent event) {
         Assert.assertEquals(AbstractLoggingInterceptor.CONTENT_SUPPRESSED, event.getPayload());
+    }
+
+    private <T> T createClient(String serviceURI, Class<T> contract, LoggingFeature loggingFeature) {
+        JAXRSClientFactoryBean bean = new JAXRSClientFactoryBean();
+        bean.setAddress(serviceURI);
+        bean.setFeatures(Collections.singletonList(loggingFeature));
+        bean.setResourceClass(contract);
+        return bean.create(contract);
     }
 
     private WebClient createClient(String serviceURI, LoggingFeature loggingFeature) {

--- a/rt/rs/client/src/test/java/org/apache/cxf/jaxrs/client/logging/TestService.java
+++ b/rt/rs/client/src/test/java/org/apache/cxf/jaxrs/client/logging/TestService.java
@@ -18,15 +18,18 @@
  */
 package org.apache.cxf.jaxrs.client.logging;
 
-public class TestServiceRest implements TestService {
-    @Override
-    public String echo(String msg) {
-        return msg;
-    }
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
 
-    @Override
-    public String post(String msg) {
-        return msg;
-    }
+public interface TestService {
+    @GET
+    @Path("{msg}")
+    @Produces("application/octet-stream")
+    String echo(@PathParam("msg") String msg);
+
+    @POST
+    String post(String msg);
 }
-


### PR DESCRIPTION
It turned out that `ClientImpl::onMessage` may create in-message (response) from the out message (request), copying the contextual properties but changing the message requestor role. That would lead to logging interceptor to mistakenly mark that the message as already logged.