### PR TITLE
Fix Tika 4 detector context handling

### DIFF
--- a/rt/rs/extensions/search/src/test/java/org/apache/cxf/jaxrs/ext/search/tika/TikaContentExtractorTest.java
+++ b/rt/rs/extensions/search/src/test/java/org/apache/cxf/jaxrs/ext/search/tika/TikaContentExtractorTest.java
@@ -18,12 +18,16 @@
  */
 package org.apache.cxf.jaxrs.ext.search.tika;
 
+import java.io.ByteArrayInputStream;
 import java.io.InputStream;
+import java.util.Collections;
 
 import org.apache.cxf.jaxrs.ext.search.SearchBean;
 import org.apache.cxf.jaxrs.ext.search.SearchCondition;
 import org.apache.cxf.jaxrs.ext.search.SearchConditionParser;
 import org.apache.cxf.jaxrs.ext.search.fiql.FiqlParser;
+import org.apache.tika.mime.MediaType;
+import org.apache.tika.parser.ParseContext;
 import org.apache.tika.parser.pdf.PDFParser;
 
 import org.junit.Before;
@@ -83,5 +87,20 @@ public class TikaContentExtractorTest {
     @Test
     public void testExtractionFromNullInputStreamFails() {
         assertNull("Document should be null, it is encrypted", extractor.extract((InputStream)null));
+    }
+
+    @Test
+    public void testDetectorReceivesParseContext() {
+        ParseContext[] detectorContext = new ParseContext[1];
+        TikaContentExtractor another = new TikaContentExtractor(
+            Collections.singletonList(new PDFParser()),
+            (stream, metadata, context) -> {
+                detectorContext[0] = context;
+                return MediaType.OCTET_STREAM;
+            });
+
+        another.extract(new ByteArrayInputStream(new byte[0]));
+
+        assertNotNull(detectorContext[0]);
     }
 }


### PR DESCRIPTION
Companion repair for #3409.

Tika 4 adds ParseContext to Detector.detect. This initializes or reuses the extraction context before media-type detection and passes the same context through detector, parser selection, and parsing. The focused regression test verifies that detection receives a context.

Verification (JDK 17):
- mvn -pl rt/rs/extensions/search -DskipTests compile — passed; Checkstyle and PMD included
- mvn -pl rt/rs/extensions/search -Dtest=TikaContentExtractorTest test — 7 tests passed; 0 failures, errors, or skips
- git diff --check — passed

JAIPilot Remote was also attempted on the exact source archive, but its environment could not resolve CXF build-utils 4.1.5-SNAPSHOT after repository.apache.org reset the connection, so no remote pass is claimed.