### PR TITLE
Fix encrypted properties tests to work with WSS4J 4.0.2

### DIFF
--- a/systests/ws-security/src/test/java/org/apache/cxf/systest/ws/action/ActionTest.java
+++ b/systests/ws-security/src/test/java/org/apache/cxf/systest/ws/action/ActionTest.java
@@ -246,25 +246,32 @@ public class ActionTest extends AbstractBusClientServerTestBase {
             return;
         }
 
-        SpringBusFactory bf = new SpringBusFactory();
-        URL busFile = ActionTest.class.getResource(
-                      JavaUtils.isFIPSEnabled() 
-                      ? "client-fips.xml" : "client.xml");
+        try {
+            if (!JavaUtils.isFIPSEnabled()) {
+                System.setProperty("org.apache.wss4j.crypto.jasypt.useLegacyDefaultAlgorithm", "true");
+            }
+            SpringBusFactory bf = new SpringBusFactory();
+            URL busFile = ActionTest.class.getResource(
+                        JavaUtils.isFIPSEnabled() 
+                        ? "client-fips.xml" : "client.xml");
 
-        Bus bus = bf.createBus(busFile.toString());
-        BusFactory.setDefaultBus(bus);
-        BusFactory.setThreadDefaultBus(bus);
+            Bus bus = bf.createBus(busFile.toString());
+            BusFactory.setDefaultBus(bus);
+            BusFactory.setThreadDefaultBus(bus);
 
-        URL wsdl = ActionTest.class.getResource("DoubleItAction.wsdl");
-        Service service = Service.create(wsdl, SERVICE_QNAME);
-        QName portQName = new QName(NAMESPACE, "DoubleItEncryptedPasswordPort");
-        DoubleItPortType port =
-                service.getPort(portQName, DoubleItPortType.class);
-        updateAddressPort(port, PORT);
-        assertEquals(50, port.doubleIt(25));
+            URL wsdl = ActionTest.class.getResource("DoubleItAction.wsdl");
+            Service service = Service.create(wsdl, SERVICE_QNAME);
+            QName portQName = new QName(NAMESPACE, "DoubleItEncryptedPasswordPort");
+            DoubleItPortType port =
+                    service.getPort(portQName, DoubleItPortType.class);
+            updateAddressPort(port, PORT);
+            assertEquals(50, port.doubleIt(25));
 
-        ((java.io.Closeable)port).close();
-        bus.shutdown(true);
+            ((java.io.Closeable)port).close();
+            bus.shutdown(true);
+        } finally {
+            System.clearProperty("org.apache.wss4j.crypto.jasypt.useLegacyDefaultAlgorithm");
+        }
     }
 
     @org.junit.Test

--- a/systests/ws-security/src/test/java/org/apache/cxf/systest/ws/fault/ModifiedRequestTest.java
+++ b/systests/ws-security/src/test/java/org/apache/cxf/systest/ws/fault/ModifiedRequestTest.java
@@ -74,11 +74,15 @@ public class ModifiedRequestTest extends AbstractBusClientServerTestBase {
             // set this to false to fork
             launchServer(ModifiedRequestServer.class, true)
         );
+        if (!JavaUtils.isFIPSEnabled()) {
+            System.setProperty("org.apache.wss4j.crypto.jasypt.useLegacyDefaultAlgorithm", "true");
+        }
     }
 
     @org.junit.AfterClass
     public static void cleanup() throws Exception {
         stopAllServers();
+        System.clearProperty("org.apache.wss4j.crypto.jasypt.useLegacyDefaultAlgorithm");
     }
 
     @org.junit.Test

--- a/systests/ws-security/src/test/java/org/apache/cxf/systest/ws/x509/X509TokenTest.java
+++ b/systests/ws-security/src/test/java/org/apache/cxf/systest/ws/x509/X509TokenTest.java
@@ -845,33 +845,41 @@ public class X509TokenTest extends AbstractBusClientServerTestBase {
             return;
         }
 
-        SpringBusFactory bf = new SpringBusFactory();
-        URL busFile = X509TokenTest.class.getResource(
-                      JavaUtils.isFIPSEnabled() 
-                      ? "client-fips.xml"
-                          : "client.xml");
+        try {
+            if (!JavaUtils.isFIPSEnabled()) {
+                System.setProperty("org.apache.wss4j.crypto.jasypt.useLegacyDefaultAlgorithm", "true");
+            }
 
-        Bus bus = bf.createBus(busFile.toString());
-        BusFactory.setDefaultBus(bus);
-        BusFactory.setThreadDefaultBus(bus);
+            SpringBusFactory bf = new SpringBusFactory();
+            URL busFile = X509TokenTest.class.getResource(
+                        JavaUtils.isFIPSEnabled() 
+                        ? "client-fips.xml"
+                            : "client.xml");
 
-        URL wsdl = X509TokenTest.class.getResource(JavaUtils.isFIPSEnabled()
-                                                   ? "DoubleItX509-fips.wsdl"
-                                                       : "DoubleItX509.wsdl");
-        Service service = Service.create(wsdl, SERVICE_QNAME);
-        QName portQName = new QName(NAMESPACE, "DoubleItAsymmetricEncryptedPasswordPort");
-        DoubleItPortType x509Port =
-                service.getPort(portQName, DoubleItPortType.class);
-        updateAddressPort(x509Port, test.getPort());
+            Bus bus = bf.createBus(busFile.toString());
+            BusFactory.setDefaultBus(bus);
+            BusFactory.setThreadDefaultBus(bus);
 
-        if (test.isStreaming()) {
-            SecurityTestUtil.enableStreaming(x509Port);
+            URL wsdl = X509TokenTest.class.getResource(JavaUtils.isFIPSEnabled()
+                                                    ? "DoubleItX509-fips.wsdl"
+                                                        : "DoubleItX509.wsdl");
+            Service service = Service.create(wsdl, SERVICE_QNAME);
+            QName portQName = new QName(NAMESPACE, "DoubleItAsymmetricEncryptedPasswordPort");
+            DoubleItPortType x509Port =
+                    service.getPort(portQName, DoubleItPortType.class);
+            updateAddressPort(x509Port, test.getPort());
+
+            if (test.isStreaming()) {
+                SecurityTestUtil.enableStreaming(x509Port);
+            }
+
+            assertEquals(50, x509Port.doubleIt(25));
+
+            ((java.io.Closeable)x509Port).close();
+            bus.shutdown(true);
+        } finally {
+            System.clearProperty("org.apache.wss4j.crypto.jasypt.useLegacyDefaultAlgorithm");
         }
-
-        assertEquals(50, x509Port.doubleIt(25));
-
-        ((java.io.Closeable)x509Port).close();
-        bus.shutdown(true);
     }
 
     @org.junit.Test


### PR DESCRIPTION
The Jasypt algorithm changed, for now we'll just use the old encrypted values in the CXF tests until we pick up WSS4J 4.0.2 properly.